### PR TITLE
felix/bpf: add per-rule Match summary to policy debug dump

### DIFF
--- a/felix/bpf/polprog/pol_prog_builder.go
+++ b/felix/bpf/polprog/pol_prog_builder.go
@@ -544,9 +544,22 @@ func (p *Builder) writePolicyRules(policy Policy, actionLabels map[string]string
 	for ruleIdx, rule := range policy.Rules {
 		log.Debugf("Start of %s rule %d", policy.NamespacedName(), ruleIdx)
 		p.b.AddCommentF("Start of rule %s %s", policy.NamespacedName(), rule)
-		ipsets := p.printIPSetIDs(rule)
-		if ipsets != "" {
-			p.b.AddCommentF("IPSets %s", p.printIPSetIDs(rule))
+		// Emit the positive match summary directly under the rule header so it
+		// sits next to "Rule:" in the dump, ahead of the hit count. Selector IP
+		// sets are folded into the src/dst tokens as hex IDs and resolved to
+		// live member IPs by the dump.
+		if p.policyDebugEnabled {
+			if filtered := rules.FilterRuleToIPVersion(p.ipVersion(), rule.Rule); filtered != nil {
+				s := formatRuleMatch(filtered,
+					p.ipSetHexIDs(filtered.SrcIpSetIds),
+					p.ipSetHexIDs(filtered.NotSrcIpSetIds),
+					p.ipSetHexIDs(filtered.DstIpSetIds),
+					p.ipSetHexIDs(filtered.NotDstIpSetIds),
+				)
+				if s != "" {
+					p.b.AddCommentF("Match: %s", s)
+				}
+			}
 		}
 		p.b.AddCommentF("Rule MatchID: %d", rule.MatchID)
 		action := strings.ToLower(rule.Action)
@@ -925,35 +938,21 @@ func (p *Builder) writeCIDRSMatch(negate bool, leg matchLeg, cidrs []string) {
 	}
 }
 
-func (p *Builder) printIPSetIDs(r Rule) string {
-	str := ""
-	joinIDs := func(ipSets []string) string {
-		idString := []string{}
-		for _, ipSetID := range ipSets {
-			id := p.ipSetIDProvider.GetNoAlloc(ipSetID)
-			if id != 0 {
-				idString = append(idString, fmt.Sprintf("0x%x", id))
-			}
+// ipSetHexIDs maps a leg's selector IP set string IDs to their BPF hex IDs
+// (e.g. "0x1a2b"), skipping any that aren't currently programmed. The hex IDs
+// are folded into the rule's "Match:" summary and resolved to live member IPs
+// by the dump.
+func (p *Builder) ipSetHexIDs(ipSetIDs []string) []string {
+	if len(ipSetIDs) == 0 {
+		return nil
+	}
+	hexIDs := make([]string, 0, len(ipSetIDs))
+	for _, ipSetID := range ipSetIDs {
+		if id := p.ipSetIDProvider.GetNoAlloc(ipSetID); id != 0 {
+			hexIDs = append(hexIDs, fmt.Sprintf("0x%x", id))
 		}
-		return strings.Join(idString[:], ",")
 	}
-	srcIDString := joinIDs(r.SrcIpSetIds)
-	if srcIDString != "" {
-		str = str + fmt.Sprintf("src_ip_set_ids:<%s> ", srcIDString)
-	}
-	notSrcIDString := joinIDs(r.NotSrcIpSetIds)
-	if notSrcIDString != "" {
-		str = str + fmt.Sprintf("not_src_ip_set_ids:<%s> ", notSrcIDString)
-	}
-	dstIDString := joinIDs(r.DstIpSetIds)
-	if dstIDString != "" {
-		str = str + fmt.Sprintf("dst_ip_set_ids:<%s> ", dstIDString)
-	}
-	notDstIDString := joinIDs(r.NotDstIpSetIds)
-	if notDstIDString != "" {
-		str = str + fmt.Sprintf("not_dst_ip_set_ids:<%s> ", notDstIDString)
-	}
-	return str
+	return hexIDs
 }
 
 func (p *Builder) writeIPSetMatch(negate bool, leg matchLeg, ipSets []string) {
@@ -1334,4 +1333,114 @@ func protoPortRangeToString(portRange *proto.PortRange) string {
 		return fmt.Sprintf("%d", portRange.First)
 	}
 	return fmt.Sprintf("%d-%d", portRange.First, portRange.Last)
+}
+
+// formatPortRanges renders a list of numeric port ranges plus an optional
+// count of named-port IP sets as a brace-enclosed token, e.g. "{8055,100-105}"
+// or "{8055,named(2)}". Returns "" when there is nothing to render.
+func formatPortRanges(ports []*proto.PortRange, namedPortSetIDs []string) string {
+	if len(ports) == 0 && len(namedPortSetIDs) == 0 {
+		return ""
+	}
+	parts := make([]string, 0, len(ports)+1)
+	for _, portRange := range ports {
+		parts = append(parts, protoPortRangeToString(portRange))
+	}
+	if len(namedPortSetIDs) > 0 {
+		parts = append(parts, fmt.Sprintf("named(%d)", len(namedPortSetIDs)))
+	}
+	return "{" + strings.Join(parts, ",") + "}"
+}
+
+// formatICMP renders an ICMP type (and optional code) match as "type[/code]".
+func formatICMP(icmp, notICMP interface{}) string {
+	switch v := icmp.(type) {
+	case *proto.Rule_IcmpType:
+		return fmt.Sprintf("%d", v.IcmpType)
+	case *proto.Rule_IcmpTypeCode:
+		return fmt.Sprintf("%d/%d", v.IcmpTypeCode.Type, v.IcmpTypeCode.Code)
+	}
+	switch v := notICMP.(type) {
+	case *proto.Rule_NotIcmpType:
+		return fmt.Sprintf("%d", v.NotIcmpType)
+	case *proto.Rule_NotIcmpTypeCode:
+		return fmt.Sprintf("%d/%d", v.NotIcmpTypeCode.Type, v.NotIcmpTypeCode.Code)
+	}
+	return ""
+}
+
+// joinNetsAndSets renders the combined L3 match for one leg: literal CIDRs
+// plus any selector-resolved IP sets (passed as "0x..." hex IDs) as a single
+// brace-enclosed token, e.g. "{11.0.0.8/32,10.0.0.8/32,0x1a2b}". The hex IDs
+// are resolved to live member IPs later, by the dump. Returns "" when the leg
+// has no criteria.
+func joinNetsAndSets(nets, setHexIDs []string) string {
+	if len(nets) == 0 && len(setHexIDs) == 0 {
+		return ""
+	}
+	parts := make([]string, 0, len(nets)+len(setHexIDs))
+	parts = append(parts, nets...)
+	parts = append(parts, setHexIDs...)
+	return "{" + strings.Join(parts, ",") + "}"
+}
+
+// formatRuleMatch renders a rule's positive L3/L4 match criteria as a one-line
+// summary, e.g.
+//
+//	proto=tcp src={11.0.0.8/32,10.0.0.8/32} sports={8055,100-105} dst={12.0.0.8/32} dports={9055,200-205}
+//
+// Negated fields are prefixed with '!' (e.g. "!proto=tcp", "!dports={...}").
+// Selector-resolved IP sets are folded into the matching src/dst token as
+// "0x..." hex IDs (one per leg argument); the dump resolves those to live
+// member IPs. Returns "" when the rule has no L3/L4 criteria (e.g. the implicit
+// default-deny rule), so the caller can skip emitting an empty "Match:" comment.
+//
+// The fields are walked in the same order that writeRule enforces them.
+func formatRuleMatch(rule *proto.Rule, srcSets, notSrcSets, dstSets, notDstSets []string) string {
+	var tokens []string
+	add := func(format string, args ...interface{}) {
+		tokens = append(tokens, fmt.Sprintf(format, args...))
+	}
+
+	if rule.Protocol != nil {
+		add("proto=%s", protocolToName(rule.Protocol))
+	}
+	if rule.NotProtocol != nil {
+		add("!proto=%s", protocolToName(rule.NotProtocol))
+	}
+
+	if s := joinNetsAndSets(rule.SrcNet, srcSets); s != "" {
+		add("src=%s", s)
+	}
+	if s := joinNetsAndSets(rule.NotSrcNet, notSrcSets); s != "" {
+		add("!src=%s", s)
+	}
+	if s := joinNetsAndSets(rule.DstNet, dstSets); s != "" {
+		add("dst=%s", s)
+	}
+	if s := joinNetsAndSets(rule.NotDstNet, notDstSets); s != "" {
+		add("!dst=%s", s)
+	}
+
+	if s := formatPortRanges(rule.SrcPorts, rule.SrcNamedPortIpSetIds); s != "" {
+		add("sports=%s", s)
+	}
+	if s := formatPortRanges(rule.NotSrcPorts, rule.NotSrcNamedPortIpSetIds); s != "" {
+		add("!sports=%s", s)
+	}
+	if s := formatPortRanges(rule.DstPorts, rule.DstNamedPortIpSetIds); s != "" {
+		add("dports=%s", s)
+	}
+	if s := formatPortRanges(rule.NotDstPorts, rule.NotDstNamedPortIpSetIds); s != "" {
+		add("!dports=%s", s)
+	}
+
+	if rule.Icmp != nil {
+		add("icmp=%s", formatICMP(rule.Icmp, nil))
+	}
+	if rule.NotIcmp != nil {
+		add("!icmp=%s", formatICMP(nil, rule.NotIcmp))
+	}
+
+	return strings.Join(tokens, " ")
 }

--- a/felix/bpf/polprog/pol_prog_builder_test.go
+++ b/felix/bpf/polprog/pol_prog_builder_test.go
@@ -16,6 +16,7 @@ package polprog
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -142,6 +143,74 @@ func TestPolicyDump(t *testing.T) {
 	checkLabelsAndComments(&proto.Rule{NotIcmp: &proto.Rule_NotIcmpType{NotIcmpType: 10}}, "If ICMP type == 10, skip to next rule", "comment")
 }
 
+// TestPolicyDumpMatchComment checks the end-to-end wiring of the per-rule
+// "Match:" summary in the policy-debug build: that it is emitted with the
+// selector IP sets folded into the src/dst tokens as hex IDs, that the old
+// standalone "IPSets ..." summary comment is gone, and that it sits directly
+// under the rule header (ahead of the "Rule MatchID" hit-count comment).
+func TestPolicyDumpMatchComment(t *testing.T) {
+	RegisterTestingT(t)
+
+	alloc := idalloc.New()
+	const srcSet = "s:sbcdef1234567890"
+	const notDstSet = "d:sbcdef1234567890"
+	alloc.GetOrAlloc(srcSet)
+	alloc.GetOrAlloc(notDstSet)
+	srcHex := fmt.Sprintf("0x%x", alloc.GetNoAlloc(srcSet))
+	notDstHex := fmt.Sprintf("0x%x", alloc.GetNoAlloc(notDstSet))
+
+	pg := NewBuilder(alloc, 1, 2, 3, 4, WithAllowDenyJumps(666, 777), WithPolicyDebugEnabled())
+	insns, err := pg.Instructions(Rules{
+		Tiers: []Tier{{
+			Policies: []Policy{{
+				Rules: []Rule{{
+					Rule: &proto.Rule{
+						Action:         "Allow",
+						IpVersion:      4,
+						Protocol:       &proto.Protocol{NumberOrName: &proto.Protocol_Number{Number: 6}},
+						SrcNet:         []string{"11.0.0.8/32", "10.0.0.8/32"},
+						SrcIpSetIds:    []string{srcSet},
+						NotDstNet:      []string{"13.0.0.8/32"},
+						NotDstIpSetIds: []string{notDstSet},
+					},
+				}},
+			}},
+		}},
+	})
+	Expect(err).NotTo(HaveOccurred())
+
+	_, comments := aggregateCommentsAndLabels(&insns[0])
+
+	// The selector IP sets are folded into the src/!dst tokens as hex IDs; the
+	// dump resolves those to live member IPs.
+	expectedMatch := fmt.Sprintf(
+		"Match: proto=tcp src={11.0.0.8/32,10.0.0.8/32,%s} !dst={13.0.0.8/32,%s}",
+		srcHex, notDstHex)
+	Expect(comments).To(ContainElement(expectedMatch))
+
+	// The standalone "IPSets ..." summary comment is no longer emitted.
+	for _, c := range comments {
+		Expect(c).NotTo(HavePrefix("IPSets "))
+	}
+
+	// The Match line sits directly under the rule header, ahead of the hit
+	// count ("Rule MatchID").
+	idxOf := func(prefix string) int {
+		for i, c := range comments {
+			if strings.HasPrefix(c, prefix) {
+				return i
+			}
+		}
+		return -1
+	}
+	startIdx := idxOf("Start of rule ")
+	matchIdx := idxOf("Match: ")
+	matchIDIdx := idxOf("Rule MatchID")
+	Expect(startIdx).To(BeNumerically(">=", 0), "missing 'Start of rule' comment")
+	Expect(matchIdx).To(BeNumerically(">", startIdx), "Match should follow the rule header")
+	Expect(matchIDIdx).To(BeNumerically(">", matchIdx), "Match should precede the hit count")
+}
+
 func aggregateCommentsAndLabels(insns *asm.Insns) ([]string, []string) {
 	labels := []string{}
 	comments := []string{}
@@ -207,4 +276,92 @@ func TestProgramSplitting(t *testing.T) {
 	// Allow leeway in program size for enterprise.
 	Expect(len(progs)).To(BeNumerically(">=", 6))
 	Expect(len(progs)).To(BeNumerically("<=", 8))
+}
+
+func TestFormatRuleMatch(t *testing.T) {
+	RegisterTestingT(t)
+
+	tcp := &proto.Protocol{NumberOrName: &proto.Protocol_Number{Number: 6}}
+	udp := &proto.Protocol{NumberOrName: &proto.Protocol_Name{Name: "UDP"}}
+
+	for _, tc := range []struct {
+		name                                     string
+		rule                                     *proto.Rule
+		srcSets, notSrcSets, dstSets, notDstSets []string
+		expected                                 string
+	}{
+		{
+			name:     "empty rule (default deny)",
+			rule:     &proto.Rule{},
+			expected: "",
+		},
+		{
+			name:     "action only, no L3/L4 match",
+			rule:     &proto.Rule{Action: "Allow"},
+			expected: "",
+		},
+		{
+			name: "tcp with nets and ports",
+			rule: &proto.Rule{
+				Protocol: tcp,
+				SrcNet:   []string{"11.0.0.8/32", "10.0.0.8/32"},
+				DstNet:   []string{"12.0.0.8/32"},
+				SrcPorts: []*proto.PortRange{{First: 8055, Last: 8055}, {First: 100, Last: 105}},
+				DstPorts: []*proto.PortRange{{First: 9055, Last: 9055}, {First: 200, Last: 205}},
+			},
+			expected: "proto=tcp src={11.0.0.8/32,10.0.0.8/32} dst={12.0.0.8/32} sports={8055,100-105} dports={9055,200-205}",
+		},
+		{
+			name: "negated protocol, nets and ports",
+			rule: &proto.Rule{
+				NotProtocol: tcp,
+				NotSrcNet:   []string{"11.0.0.8/32"},
+				NotDstNet:   []string{"13.0.0.8/32"},
+				NotSrcPorts: []*proto.PortRange{{First: 8055, Last: 8055}},
+				NotDstPorts: []*proto.PortRange{{First: 200, Last: 205}},
+			},
+			expected: "!proto=tcp !src={11.0.0.8/32} !dst={13.0.0.8/32} !sports={8055} !dports={200-205}",
+		},
+		{
+			name: "named ports marker",
+			rule: &proto.Rule{
+				Protocol:             udp,
+				SrcNamedPortIpSetIds: []string{"a", "b"},
+				DstPorts:             []*proto.PortRange{{First: 53, Last: 53}},
+				DstNamedPortIpSetIds: []string{"c"},
+			},
+			expected: "proto=udp sports={named(2)} dports={53,named(1)}",
+		},
+		{
+			name: "icmp type",
+			rule: &proto.Rule{
+				Protocol: &proto.Protocol{NumberOrName: &proto.Protocol_Number{Number: 1}},
+				Icmp:     &proto.Rule_IcmpType{IcmpType: 8},
+			},
+			expected: "proto=icmp icmp=8",
+		},
+		{
+			name: "icmp type/code and negated icmp",
+			rule: &proto.Rule{
+				Icmp:    &proto.Rule_IcmpTypeCode{IcmpTypeCode: &proto.IcmpTypeAndCode{Type: 10, Code: 12}},
+				NotIcmp: &proto.Rule_NotIcmpType{NotIcmpType: 3},
+			},
+			expected: "icmp=10/12 !icmp=3",
+		},
+		{
+			name: "selector IP sets folded into src/dst as hex IDs",
+			rule: &proto.Rule{
+				Protocol: tcp,
+				SrcNet:   []string{"11.0.0.8/32", "10.0.0.8/32"},
+			},
+			srcSets:    []string{"0x1a2b"},
+			notDstSets: []string{"0x3c4d", "0x5e6f"},
+			expected:   "proto=tcp src={11.0.0.8/32,10.0.0.8/32,0x1a2b} !dst={0x3c4d,0x5e6f}",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			RegisterTestingT(t)
+			Expect(formatRuleMatch(tc.rule, tc.srcSets, tc.notSrcSets, tc.dstSets, tc.notDstSets)).To(Equal(tc.expected))
+		})
+	}
 }

--- a/felix/cmd/calico-bpf/commands/policy_debug.go
+++ b/felix/cmd/calico-bpf/commands/policy_debug.go
@@ -197,39 +197,29 @@ func loadIPSetMembers() map[uint64][]string {
 // ipsetHexIDRegex matches hex IP set IDs like "0x1234abcd5678ef90".
 var ipsetHexIDRegex = regexp.MustCompile(`0x[0-9a-fA-F]+`)
 
-// formatIPSets converts a raw IPSets comment into a more readable form,
-// resolving hex IDs to their members when available.
-// Input:  `IPSets src_ip_set_ids:<0x1234>`
-// Output without resolution: `IP sets: src=0x1234`
-// Output with resolution:    `IP sets: src={10.0.0.0/8, 192.168.0.0/16}`
-func formatIPSets(comment string, membersBySet map[uint64][]string) string {
-	after := strings.TrimPrefix(comment, "IPSets ")
-	// Replace the verbose field names with shorter labels.
-	r := strings.NewReplacer(
-		"src_ip_set_ids:<", "src=",
-		"dst_ip_set_ids:<", "dst=",
-		"not_src_ip_set_ids:<", "!src=",
-		"not_dst_ip_set_ids:<", "!dst=",
-		">", "",
-		" ,", ",",
-	)
-	formatted := strings.TrimSpace(r.Replace(after))
-
-	if membersBySet != nil {
-		formatted = ipsetHexIDRegex.ReplaceAllStringFunc(formatted, func(hexID string) string {
-			id, err := strconv.ParseUint(hexID, 0, 64)
-			if err != nil {
-				return hexID
-			}
-			members, ok := membersBySet[id]
-			if !ok || len(members) == 0 {
-				return hexID
-			}
-			return "{" + strings.Join(members, ", ") + "}"
-		})
+// resolveMatchIPSets resolves any "0x..." IP set hex IDs embedded in a "Match:"
+// comment to their live member IPs, joining multiple members with "," so they
+// sit naturally inside the surrounding src/dst brace token, e.g.
+//
+//	Match: proto=tcp src={11.0.0.8/32,0x1a2b} ...
+//	  -> Match: proto=tcp src={11.0.0.8/32,10.65.0.3/32} ...
+//
+// Unresolvable IDs (map unavailable or set not programmed) are left as-is.
+func resolveMatchIPSets(comment string, membersBySet map[uint64][]string) string {
+	if membersBySet == nil {
+		return comment
 	}
-
-	return "IP sets: " + formatted
+	return ipsetHexIDRegex.ReplaceAllStringFunc(comment, func(hexID string) string {
+		id, err := strconv.ParseUint(hexID, 0, 64)
+		if err != nil {
+			return hexID
+		}
+		members, ok := membersBySet[id]
+		if !ok || len(members) == 0 {
+			return hexID
+		}
+		return strings.Join(members, ",")
+	})
 }
 
 // formatTierEnd converts "End of tier <name>: <action>" into a readable form.
@@ -318,8 +308,15 @@ func dumpPolicyInfo(cmd *cobra.Command, iface string, h hook.Hook, m counters.Po
 				cmd.Printf("%sEnd Policy: %s\n", indent(depth), policyName)
 				depth = 1
 
-			case strings.HasPrefix(comment, "IPSets "):
-				cmd.Printf("%s%s\n", indent(depth), formatIPSets(comment, ipsetMembers))
+			case strings.HasPrefix(comment, "Match: "):
+				// Positive per-rule match summary (protocol/nets/ports/ICMP,
+				// plus any selector IP sets folded into the src/dst tokens as
+				// hex IDs, resolved here to live member IPs). Only shown in the
+				// plain dump; the asm (-a) dump already prints the per-criterion
+				// "If ..." match comments inline with the instructions.
+				if !verboseFlagSet {
+					cmd.Printf("%s%s\n", indent(depth), resolveMatchIPSets(comment, ipsetMembers))
+				}
 
 			case strings.HasPrefix(comment, "##### Start of program"):
 				if verboseFlagSet {

--- a/felix/cmd/calico-bpf/commands/policy_debug_test.go
+++ b/felix/cmd/calico-bpf/commands/policy_debug_test.go
@@ -101,7 +101,7 @@ func TestExtractProtoField(t *testing.T) {
 	}
 }
 
-func TestFormatIPSets(t *testing.T) {
+func TestResolveMatchIPSets(t *testing.T) {
 	tests := []struct {
 		name     string
 		comment  string
@@ -109,55 +109,49 @@ func TestFormatIPSets(t *testing.T) {
 		expected string
 	}{
 		{
-			name:     "src only, no resolution",
-			comment:  "IPSets src_ip_set_ids:<0x1234abcd>",
+			name:     "no members map, hex IDs left as-is",
+			comment:  "Match: proto=tcp src={11.0.0.8/32,0x1234abcd}",
 			members:  nil,
-			expected: "IP sets: src=0x1234abcd",
+			expected: "Match: proto=tcp src={11.0.0.8/32,0x1234abcd}",
 		},
 		{
-			name:     "src and dst, no resolution",
-			comment:  "IPSets src_ip_set_ids:<0x1234> dst_ip_set_ids:<0x5678>",
-			members:  nil,
-			expected: "IP sets: src=0x1234 dst=0x5678",
-		},
-		{
-			name:     "negated sets, no resolution",
-			comment:  "IPSets not_src_ip_set_ids:<0xaaaa> not_dst_ip_set_ids:<0xbbbb>",
-			members:  nil,
-			expected: "IP sets: !src=0xaaaa !dst=0xbbbb",
-		},
-		{
-			name:    "resolved src",
-			comment: "IPSets src_ip_set_ids:<0xff>",
+			name:    "resolved src set folded next to nets",
+			comment: "Match: proto=tcp src={11.0.0.8/32,0xff} dport={9055}",
 			members: map[uint64][]string{
 				0xff: {"10.0.0.0/8", "192.168.0.0/16"},
 			},
-			expected: "IP sets: src={10.0.0.0/8, 192.168.0.0/16}",
+			expected: "Match: proto=tcp src={11.0.0.8/32,10.0.0.0/8,192.168.0.0/16} dport={9055}",
 		},
 		{
-			name:    "resolved src and dst",
-			comment: "IPSets src_ip_set_ids:<0xaa> dst_ip_set_ids:<0xbb>",
+			name:    "resolved src and negated dst sets",
+			comment: "Match: src={0xaa} !dst={12.0.0.8/32,0xbb}",
 			members: map[uint64][]string{
 				0xaa: {"10.0.0.1/32"},
 				0xbb: {"172.16.0.0/12", "192.168.1.0/24"},
 			},
-			expected: "IP sets: src={10.0.0.1/32} dst={172.16.0.0/12, 192.168.1.0/24}",
+			expected: "Match: src={10.0.0.1/32} !dst={12.0.0.8/32,172.16.0.0/12,192.168.1.0/24}",
 		},
 		{
-			name:    "partial resolution",
-			comment: "IPSets src_ip_set_ids:<0xaa> dst_ip_set_ids:<0xcc>",
+			name:    "partial resolution leaves unknown ID",
+			comment: "Match: src={0xaa} dst={0xcc}",
 			members: map[uint64][]string{
 				0xaa: {"10.0.0.1/32"},
 			},
-			expected: "IP sets: src={10.0.0.1/32} dst=0xcc",
+			expected: "Match: src={10.0.0.1/32} dst={0xcc}",
+		},
+		{
+			name:     "no hex IDs is a no-op",
+			comment:  "Match: proto=tcp src={11.0.0.8/32} dports={9055,200-205}",
+			members:  map[uint64][]string{0xff: {"10.0.0.1/32"}},
+			expected: "Match: proto=tcp src={11.0.0.8/32} dports={9055,200-205}",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := formatIPSets(tt.comment, tt.members)
+			got := resolveMatchIPSets(tt.comment, tt.members)
 			if got != tt.expected {
-				t.Errorf("formatIPSets(%q) = %q, want %q", tt.comment, got, tt.expected)
+				t.Errorf("resolveMatchIPSets(%q) = %q, want %q", tt.comment, got, tt.expected)
 			}
 		})
 	}

--- a/felix/fv/bpf_policy_dump_test.go
+++ b/felix/fv/bpf_policy_dump_test.go
@@ -111,26 +111,36 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ Felix bpf test policy dump"
 			return out
 		}, "10s", "200ms").Should(And(
 			ContainSubstring("Policy: GlobalNetworkPolicy policy-tcp"),
-			ContainSubstring("IP sets: src="),
+			ContainSubstring("Match: proto=tcp"),
 		))
 
 		outStr := out
 		Expect(outStr).To(ContainSubstring("Rule: policy-tcp  Action: allow"))
-		// The source selector matches w[1], so the resolved IP set should
-		// contain w[1]'s IP.  If resolution fails (e.g. map not available)
-		// it falls back to a hex ID, so accept either form.
-		ipSetFound := false
+		// The plain (non-asm) dump should surface the rule's match criteria
+		// (protocol, nets and ports) on a single positive "Match:" line.  The
+		// source selector matches w[1], so its IP set is folded into the src
+		// token; the open brace below is intentional (the resolved member or
+		// a hex-ID fallback follows the literal nets).
+		Expect(outStr).To(ContainSubstring("Match: proto=tcp"))
+		Expect(outStr).To(ContainSubstring("src={11.0.0.8/32,10.0.0.8/32"))
+		Expect(outStr).To(ContainSubstring("dst={12.0.0.8/32,13.0.0.8/32}"))
+		Expect(outStr).To(ContainSubstring("sports={8055,100-105}"))
+		Expect(outStr).To(ContainSubstring("dports={9055,200-205}"))
+		// The folded source IP set should resolve to w[1]'s IP within the src
+		// token.  If resolution fails (e.g. map not available) it falls back to
+		// a hex ID, so accept either form.
+		matchFound := false
 		for tmp := range strings.SplitSeq(outStr, "\n") {
-			if strings.Contains(tmp, "IP sets: src=") {
-				log.WithField("line", tmp).Info("Examining line for IP set")
+			if strings.Contains(tmp, "Match: proto=tcp") {
+				log.WithField("line", tmp).Info("Examining Match line for resolved IP set")
 				Expect(tmp).To(SatisfyAny(
 					ContainSubstring(w[1].IP),
-					MatchRegexp(`0x[0-9a-fA-F]+`),
-				), "Resolved IP set should contain workload IP %s or hex ID fallback", w[1].IP)
-				ipSetFound = true
+					MatchRegexp(`src=\{[^}]*0x[0-9a-fA-F]+`),
+				), "src token should include resolved IP set member %s or hex ID fallback", w[1].IP)
+				matchFound = true
 			}
 		}
-		Expect(ipSetFound).To(BeTrue(), fmt.Sprintf("IP set was missing in output: %q", out))
+		Expect(matchFound).To(BeTrue(), fmt.Sprintf("Match line was missing in output: %q", out))
 		// check ingress policy dump with eBPF assembler code
 		Eventually(func() string {
 			out, err = tc.Felixes[0].ExecOutput("calico-bpf", "policy", "dump", w[0].InterfaceName, "ingress", "-a")
@@ -149,6 +159,9 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ Felix bpf test policy dump"
 		Expect(outStr).To(ContainSubstring("If dest not in {12.0.0.8/32,13.0.0.8/32}, skip to next rule"))
 		Expect(outStr).To(ContainSubstring("If source port is not within any of {8055,100-105}, skip to next rule"))
 		Expect(outStr).To(ContainSubstring("If dest port is not within any of {9055,200-205}, skip to next rule"))
+		// The asm (-a) dump shows the per-criterion match comments inline, so
+		// the summary "Match:" line is intentionally omitted there.
+		Expect(outStr).NotTo(ContainSubstring("Match: "))
 
 		// check egress policy dump with eBPF assembler code
 		out = ""
@@ -160,20 +173,30 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ Felix bpf test policy dump"
 
 		outStr = string(out)
 		Expect(outStr).To(ContainSubstring("Rule: policy-tcp  Action: deny"))
-		// The egress rule has NotSelector on w[1], so the resolved IP set
-		// should contain w[1]'s IP.  Accept hex fallback too.
-		ipSetFound = false
+		// The plain (non-asm) dump should surface the egress rule's match
+		// criteria, including the negated protocol/nets/ports.  The !dst brace
+		// is left open below because the NotSelector IP set is folded into the
+		// !dst token after the literal nets.
+		Expect(outStr).To(ContainSubstring("proto=udp"))
+		Expect(outStr).To(ContainSubstring("!proto=tcp"))
+		Expect(outStr).To(ContainSubstring("!src={11.0.0.8/32,10.0.0.8/32}"))
+		Expect(outStr).To(ContainSubstring("!dst={12.0.0.8/32,13.0.0.8/32"))
+		Expect(outStr).To(ContainSubstring("!sports={8055,100-105}"))
+		Expect(outStr).To(ContainSubstring("!dports={9055,200-205}"))
+		// The egress rule has NotSelector on w[1], so the folded IP set should
+		// resolve to w[1]'s IP within the !dst token.  Accept hex fallback too.
+		matchFound = false
 		for tmp := range strings.SplitSeq(outStr, "\n") {
-			if strings.Contains(tmp, "IP sets: !dst=") {
-				log.WithField("line", tmp).Info("Examining line for IP set")
+			if strings.Contains(tmp, "Match: proto=udp") {
+				log.WithField("line", tmp).Info("Examining Match line for resolved IP set")
 				Expect(tmp).To(SatisfyAny(
 					ContainSubstring(w[1].IP),
-					MatchRegexp(`0x[0-9a-fA-F]+`),
-				), "Resolved IP set should contain workload IP %s or hex ID fallback", w[1].IP)
-				ipSetFound = true
+					MatchRegexp(`!dst=\{[^}]*0x[0-9a-fA-F]+`),
+				), "!dst token should include resolved IP set member %s or hex ID fallback", w[1].IP)
+				matchFound = true
 			}
 		}
-		Expect(ipSetFound).To(BeTrue())
+		Expect(matchFound).To(BeTrue())
 
 		Eventually(func() string {
 			out, err = tc.Felixes[0].ExecOutput("calico-bpf", "policy", "dump", w[0].InterfaceName, "egress", "-a")
@@ -192,6 +215,7 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ Felix bpf test policy dump"
 		Expect(outStr).To(ContainSubstring("If dest in {12.0.0.8/32,13.0.0.8/32}, skip to next rule"))
 		Expect(outStr).To(ContainSubstring("If source port is within any of {8055,100-105}, skip to next rule"))
 		Expect(outStr).To(ContainSubstring("If dest port is within any of {9055,200-205}, skip to next rule"))
+		Expect(outStr).NotTo(ContainSubstring("Match: "))
 
 		// Test calico-bpf policy dump all with eBPF assembler code
 		out = ""
@@ -213,6 +237,7 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ Felix bpf test policy dump"
 		Expect(outStr).To(ContainSubstring("If dest not in {12.0.0.8/32,13.0.0.8/32}, skip to next rule"))
 		Expect(outStr).To(ContainSubstring("If source port is not within any of {8055,100-105}, skip to next rule"))
 		Expect(outStr).To(ContainSubstring("If dest port is not within any of {9055,200-205}, skip to next rule"))
+		Expect(outStr).NotTo(ContainSubstring("Match: "))
 	})
 
 	It("should dump policy debug information with ICMP", func() {


### PR DESCRIPTION
### Description

The plain eBPF policy debug dump (`calico-bpf policy dump <iface> <hook>`) now prints a single positive **`Match:`** line directly under each rule header, summarising the rule's L3/L4 criteria on one line: protocol, source/destination nets, ports and ICMP type/code, with negated fields prefixed by `!`.

Selector-resolved IP sets are folded into the matching `src=`/`dst=` token: the builder emits them as hex IDs and the dump resolves those to live member IPs. This **replaces the previous standalone `IP sets:` line**, so the complete match (literal nets *plus* selector members) reads on a single line, e.g.:

```
Rule: policy-tcp  Action: allow
Match: proto=tcp src={11.0.0.8/32,10.0.0.8/32,10.65.0.3/32} dst={12.0.0.8/32,13.0.0.8/32} sports={8055,100-105} dports={9055,200-205}
Hit count: 0
```

The summary is shown **only in the plain dump**. The asm (`-a`) dump already prints the equivalent per-criterion `// If ... skip to next rule` comments inline with the instructions, so the summary is omitted there to avoid redundancy.

### Testing done

- Unit tests:
  - `TestFormatRuleMatch` — match-line formatting incl. folded selector IP sets, negation, named-port markers, ICMP.
  - `TestResolveMatchIPSets` — hex-ID → live-member-IP resolution (full / partial / no-map / no-op).
  - `TestPolicyDumpMatchComment` — end-to-end builder wiring: `Match:` emitted with folded hex IDs, old `IPSets` summary comment gone, ordered between the rule header and the hit count.
- FV: `felix/fv/bpf_policy_dump_test.go` updated — asserts the folded/resolved `Match:` line in the plain dump and that it is absent from every `-a` dump.

<!-- For any user-visible change, replace TBD with a one-line description. -->
**Release note:**
```release-note
None
```
