### PR TITLE
Fix BGPFilter k8st test: ensure egress node owns an IPAM block

### DIFF
--- a/node/tests/k8st/tests/bgp_filter_test.go
+++ b/node/tests/k8st/tests/bgp_filter_test.go
@@ -34,6 +34,7 @@ import (
 	. "github.com/onsi/gomega"
 	v3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
 	"github.com/projectcalico/api/pkg/lib/numorstring"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -73,6 +74,10 @@ protocol bgp Mesh_with_node_1 from bgp_template {
 const (
 	externalNodeV4 = "kube-node-extra"
 	externalNodeV6 = "kube-node-extra-v6"
+
+	// anchorNamespace holds the idle pod that pins an IPAM block to the egress
+	// node so it has something to advertise to the external routers.
+	anchorNamespace = "bgp-filter-anchor"
 
 	peerNameV4 = "node-extra.peer"
 	peerNameV6 = "node-extra-v6.peer"
@@ -173,11 +178,39 @@ func setupBGPFilterEnv(t *testing.T, ctx context.Context, g *WithT) *bgpFilterEn
 	// Mark the egress node so the node-selected BGPPeers attach to it.
 	labelNode(t, ctx, env.egressNode, "egress", "true")
 
+	ensureEgressNodeOwnsBlock(t, ctx, g, cli, env.egressNode)
+
 	// Establish BGPPeers from the egress node to each external router.
 	createBGPPeer(t, ctx, g, cli, peerNameV4, env.externalNodeIP)
 	createBGPPeer(t, ctx, g, cli, peerNameV6, env.externalNodeIP6)
 
 	return env
+}
+
+// ensureEgressNodeOwnsBlock pins an idle pod to the egress node so it owns an
+// IPAM block to advertise — otherwise the export assertions are checking a node
+// that may host no pods (and thus no block, especially for IPv6). The pod uses
+// the default pools so its block CIDRs match clusterRouteRegexV4/V6; waiting for
+// both IPs claims a block in each family before any assertion runs.
+func ensureEgressNodeOwnsBlock(t *testing.T, ctx context.Context, g *WithT, cli ctrlclient.Client, node string) {
+	t.Helper()
+
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: anchorNamespace}}
+	g.Expect(cli.Create(ctx, ns)).To(Succeed(), "creating anchor namespace")
+	t.Cleanup(func() { _ = cli.Delete(context.Background(), ns) })
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "block-anchor", Namespace: anchorNamespace},
+		Spec: corev1.PodSpec{
+			NodeName:   node,
+			Containers: []corev1.Container{{Name: "anchor", Image: utils.Agnhost, Args: []string{"pause"}}},
+		},
+	}
+	g.Expect(cli.Create(ctx, pod)).To(Succeed(), "creating block-anchor pod on egress node %s", node)
+	t.Cleanup(func() { _ = cli.Delete(context.Background(), pod) })
+
+	waitForPodIP(ctx, g, cli, pod, corev1.IPv4Protocol)
+	waitForPodIP(ctx, g, cli, pod, corev1.IPv6Protocol)
 }
 
 // testBGPFilterBasic adds a route to the external router, verifies import and


### PR DESCRIPTION
### Description

`TestBGPFilter` (`node/tests/k8st/tests/bgp_filter_test.go`) fails deterministically on its IPv6 subtests (`basic_v6`, `basic_v4v6`) on master:

```
--- FAIL: TestBGPFilter/basic_v6
--- FAIL: TestBGPFilter/basic_v4v6
bgp_filter_test.go:211: external route check failed for fd00:10:244:.*/\d+ on kube-node-extra-v6:
    route fd00:10:244:.*/\d+ not present when it should be (13 attempts within 1m0s)
```

**Root cause:** the test's export assertions check that the egress node (`nodes[1]`) advertises its *own* default-pool IPAM block to the external BGP routers, but nothing guarantees a pod is actually scheduled on that node. In a dual-stack kind cluster the scheduler can place every application pod on the other nodes, leaving the egress node with only a stale/empty IPv4 block affinity (so the v4 checks pass by luck) and **no IPv6 block at all** (so the v6 checks time out). Calico is behaving correctly — the egress node genuinely has no v6 block to advertise.

Confirmed from collected diags: the v6 `/122` blocks are owned only by the three nodes that host pods; the egress node owns none, and there is no `via <egress-v6>` route anywhere in the mesh.

**Fix:** pin an idle "anchor" pod to the egress node in the shared fixture, using the default pools (no IPAM annotation) so its block CIDRs match the assertions' regexes, and wait for both its IPv4 and IPv6 addresses. A single dual-stack pod claims a block affinity in each family, so the egress node reliably has something to advertise before any export assertion runs. This reuses the existing `waitForPodIP` helper and the node-pinning pattern from `cluster_routes_test.go`.

### Testing

- `go vet ./node/tests/k8st/tests/` and `go test -c` pass (compiles clean).
- Full validation is the `node` `k8s-test` (kind) job in CI.

**Release note:**
```release-note
NONE
```