### PR TITLE
fix(release): handle master image tag and support upload excludes

### DIFF
--- a/release/internal/hashreleaseserver/server.go
+++ b/release/internal/hashreleaseserver/server.go
@@ -67,6 +67,10 @@ type Hashrelease struct {
 	Latest bool `yaml:"latest,omitempty"`
 
 	ImageScanResultURL string `yaml:"iss_url,omitempty"`
+
+	// UploadExcludes are regex patterns (matched against the source-relative
+	// path) for artifacts under Source that must not be uploaded to the server.
+	UploadExcludes []string `yaml:"-"`
 }
 
 func (h *Hashrelease) URL() string {
@@ -118,6 +122,9 @@ func publishFiles(h *Hashrelease, cfg *Config) error {
 		"storage", "rsync",
 		h.Source, fmt.Sprintf("gs://%s/%s", cfg.BucketName, h.Name),
 		"--recursive", "--delete-unmatched-destination-objects",
+	}
+	for _, e := range h.UploadExcludes {
+		args = append(args, "--exclude="+e)
 	}
 	if logrus.IsLevelEnabled(logrus.DebugLevel) {
 		args = append(args, "--verbosity=debug")

--- a/release/internal/version/version.go
+++ b/release/internal/version/version.go
@@ -294,6 +294,11 @@ func versionFromManifest(repoRoot, manifest, imgMatch string) (Version, error) {
 		if strings.Contains(i, imgMatch) {
 			splits := strings.SplitAfter(i, ":")
 			ver := splits[len(splits)-1]
+			// On the default branch the image is tagged "master", which is not a
+			// valid semver; treat it as the v0.0.0 dev version.
+			if ver == utils.DefaultBranch {
+				ver = "v0.0.0"
+			}
 			return New(ver), nil
 		}
 	}


### PR DESCRIPTION
## Summary
Two standalone release-tooling fixes:
- `versionFromManifest` treats the non-semver `master` image tag (used on the default branch) as `v0.0.0`.
- `Hashrelease` gains an `UploadExcludes` field so callers can exclude artifacts from the bucket upload (`gcloud storage rsync --exclude`).

## Test plan
`go test ./release/internal/version/... ./release/internal/hashreleaseserver/...`

## Release Note
```release-note
None
```