### PR TITLE
Make kind deploy agnostic to cluster name

### DIFF
--- a/hack/test/kind/deploy_resources.sh
+++ b/hack/test/kind/deploy_resources.sh
@@ -138,10 +138,10 @@ function wait_pod_ready() {
       ${kubectl} get po -o wide $args || true
       sleep 1
     done;
-    ${kubectl} wait pod --for=condition=Ready --timeout=300s $args
+    ${kubectl} wait pod --for=condition=Ready --timeout=480s $args
   ) & pid=$!
   # Start a second background process that implements the actual timeout.
-  ( sleep 300; kill $pid ) 2>/dev/null & watchdog=$!
+  ( sleep 480; kill $pid ) 2>/dev/null & watchdog=$!
   set +e
 
   wait $pid 2>/dev/null
@@ -150,7 +150,7 @@ function wait_pod_ready() {
   wait $watchdog 2>/dev/null
 
   if [ $rc -ne 0 ]; then
-    echo "Pod $args failed to become ready within 300s"
+    echo "Pod $args failed to become ready within 8m"
   fi
 
   set -e

--- a/hack/test/kind/deploy_resources.sh
+++ b/hack/test/kind/deploy_resources.sh
@@ -158,16 +158,19 @@ function wait_pod_ready() {
 }
 
 echo "Set ipv6 address on each node"
-# Iterate over the actual node containers for this KIND_NAME rather than
-# hardcoding kind-* names, so the script works for clusters with a non-default
-# name or a different worker count.
-i=1
+# Assign each node a fixed IPv6 address derived from its name so this works for
+# any kind cluster name. The mapping has to match what the k8st tests expect
+# (node/tests/k8st/utils/utils.py): the control-plane is ::8 and worker N is
+# ::N, where the first worker ("<cluster>-worker", no suffix) is ::1. Deriving
+# the address from the name avoids depending on the order "kind get nodes" returns.
 for node in $(${KIND} get nodes --name "${KIND_NAME}"); do
   case "${node}" in
-    *-control-plane) docker exec "${node}" ip -6 addr replace 2001:20::8/64 dev eth0 ;;
-    *)               docker exec "${node}" ip -6 addr replace "2001:20::${i}/64" dev eth0
-                     i=$((i+1)) ;;
+    *-control-plane) addr=8 ;;
+    *-worker)        addr=1 ;;
+    *-worker*)       addr="${node##*-worker}" ;;
+    *)               continue ;;
   esac
+  docker exec "${node}" ip -6 addr replace "2001:20::${addr}/64" dev eth0
 done
 
 echo

--- a/hack/test/kind/deploy_resources.sh
+++ b/hack/test/kind/deploy_resources.sh
@@ -160,7 +160,7 @@ function wait_pod_ready() {
 echo "Set ipv6 address on each node"
 # Iterate over the actual node containers for this KIND_NAME rather than
 # hardcoding kind-* names, so the script works for clusters with a non-default
-# name or a different worker count (e.g. the MCM rig).
+# name or a different worker count.
 #
 # The suffix is derived from the node's name, NOT iteration order: kind names
 # workers "<name>-worker", "<name>-worker2", "<name>-worker3", ... so the bare
@@ -218,19 +218,16 @@ ${kubectl} wait --for=condition=Established --timeout=2m \
 # Wait for ALL tigerastatus resources to become Available. This ensures every
 # component the operator manages is fully ready before tests begin.
 #
-# The MCM rig bringup sets KIND_SKIP_TIGERASTATUS_WAIT=true for the managed
-# cluster - intrusion-detection, log-collector, and log-storage on a managed
-# cluster depend on linseed in the mgmt cluster, which is only reachable once
-# bootstrap-managed.sh establishes the tunnel. The bootstrap script handles
-# the final wait itself.
+# Callers that handle component readiness themselves can skip this wait by
+# setting KIND_SKIP_TIGERASTATUS_WAIT=true.
 if [ "${KIND_SKIP_TIGERASTATUS_WAIT:-false}" = "true" ]; then
   echo "KIND_SKIP_TIGERASTATUS_WAIT=true - skipping TigeraStatus wait"
   exit 0
 fi
-# The full Enterprise stack (Elasticsearch + Prometheus) can take well over 10m
-# to settle on a cold boot, especially in CI. Wait generously - this is a
-# ceiling, not a fixed sleep, so a healthy cluster still exits as soon as every
-# TigeraStatus is Available. Override with TIGERASTATUS_WAIT_TIMEOUT (seconds).
+# Components can take a while to settle on a cold boot, especially in CI. Wait
+# generously - this is a ceiling, not a fixed sleep, so a healthy cluster still
+# exits as soon as every TigeraStatus is Available. Override with
+# TIGERASTATUS_WAIT_TIMEOUT (seconds).
 ts_timeout=${TIGERASTATUS_WAIT_TIMEOUT:-1200}
 ts_interval=5
 ts_attempts=$(( ts_timeout / ts_interval ))

--- a/hack/test/kind/deploy_resources.sh
+++ b/hack/test/kind/deploy_resources.sh
@@ -158,10 +158,17 @@ function wait_pod_ready() {
 }
 
 echo "Set ipv6 address on each node"
-docker exec kind-control-plane ip -6 addr replace 2001:20::8/64 dev eth0
-docker exec kind-worker ip -6 addr replace 2001:20::1/64 dev eth0
-docker exec kind-worker2 ip -6 addr replace 2001:20::2/64 dev eth0
-docker exec kind-worker3 ip -6 addr replace 2001:20::3/64 dev eth0
+# Iterate over the actual node containers for this KIND_NAME rather than
+# hardcoding kind-* names, so the script works for clusters with a non-default
+# name or a different worker count.
+i=1
+for node in $(${KIND} get nodes --name "${KIND_NAME}"); do
+  case "${node}" in
+    *-control-plane) docker exec "${node}" ip -6 addr replace 2001:20::8/64 dev eth0 ;;
+    *)               docker exec "${node}" ip -6 addr replace "2001:20::${i}/64" dev eth0
+                     i=$((i+1)) ;;
+  esac
+done
 
 echo
 

--- a/hack/test/kind/deploy_resources.sh
+++ b/hack/test/kind/deploy_resources.sh
@@ -138,10 +138,10 @@ function wait_pod_ready() {
       ${kubectl} get po -o wide $args || true
       sleep 1
     done;
-    ${kubectl} wait pod --for=condition=Ready --timeout=480s $args
+    ${kubectl} wait pod --for=condition=Ready --timeout=600s $args
   ) & pid=$!
   # Start a second background process that implements the actual timeout.
-  ( sleep 480; kill $pid ) 2>/dev/null & watchdog=$!
+  ( sleep 600; kill $pid ) 2>/dev/null & watchdog=$!
   set +e
 
   wait $pid 2>/dev/null
@@ -150,7 +150,7 @@ function wait_pod_ready() {
   wait $watchdog 2>/dev/null
 
   if [ $rc -ne 0 ]; then
-    echo "Pod $args failed to become ready within 8m"
+    echo "Pod $args failed to become ready within 10m"
   fi
 
   set -e
@@ -158,19 +158,25 @@ function wait_pod_ready() {
 }
 
 echo "Set ipv6 address on each node"
-# Assign each node a fixed IPv6 address derived from its name so this works for
-# any kind cluster name. The mapping has to match what the k8st tests expect
-# (node/tests/k8st/utils/utils.py): the control-plane is ::8 and worker N is
-# ::N, where the first worker ("<cluster>-worker", no suffix) is ::1. Deriving
-# the address from the name avoids depending on the order "kind get nodes" returns.
+# Iterate over the actual node containers for this KIND_NAME rather than
+# hardcoding kind-* names, so the script works for clusters with a non-default
+# name or a different worker count (e.g. the MCM rig).
+#
+# The suffix is derived from the node's name, NOT iteration order: kind names
+# workers "<name>-worker", "<name>-worker2", "<name>-worker3", ... so the bare
+# worker is ::1 and "-worker<N>" is ::<N>; the control-plane is ::8. This must
+# stay in lockstep with ipv6_map in node/tests/k8st/utils/utils.py, which the
+# k8st BGP tests use to peer to a specific node's address. `kind get nodes`
+# order is not guaranteed, so a running counter would assign the wrong address
+# to a node and break that peering.
 for node in $(${KIND} get nodes --name "${KIND_NAME}"); do
   case "${node}" in
-    *-control-plane) addr=8 ;;
-    *-worker)        addr=1 ;;
-    *-worker*)       addr="${node##*-worker}" ;;
+    *-control-plane) suffix=8 ;;
+    *-worker)        suffix=1 ;;
+    *-worker*)       suffix="${node##*-worker}" ;;
     *)               continue ;;
   esac
-  docker exec "${node}" ip -6 addr replace "2001:20::${addr}/64" dev eth0
+  docker exec "${node}" ip -6 addr replace "2001:20::${suffix}/64" dev eth0
 done
 
 echo
@@ -211,8 +217,25 @@ ${kubectl} wait --for=condition=Established --timeout=2m \
 
 # Wait for ALL tigerastatus resources to become Available. This ensures every
 # component the operator manages is fully ready before tests begin.
-echo "Wait for all TigeraStatus resources to become Available"
-for attempt in $(seq 1 120); do
+#
+# The MCM rig bringup sets KIND_SKIP_TIGERASTATUS_WAIT=true for the managed
+# cluster - intrusion-detection, log-collector, and log-storage on a managed
+# cluster depend on linseed in the mgmt cluster, which is only reachable once
+# bootstrap-managed.sh establishes the tunnel. The bootstrap script handles
+# the final wait itself.
+if [ "${KIND_SKIP_TIGERASTATUS_WAIT:-false}" = "true" ]; then
+  echo "KIND_SKIP_TIGERASTATUS_WAIT=true - skipping TigeraStatus wait"
+  exit 0
+fi
+# The full Enterprise stack (Elasticsearch + Prometheus) can take well over 10m
+# to settle on a cold boot, especially in CI. Wait generously - this is a
+# ceiling, not a fixed sleep, so a healthy cluster still exits as soon as every
+# TigeraStatus is Available. Override with TIGERASTATUS_WAIT_TIMEOUT (seconds).
+ts_timeout=${TIGERASTATUS_WAIT_TIMEOUT:-1200}
+ts_interval=5
+ts_attempts=$(( ts_timeout / ts_interval ))
+echo "Wait for all TigeraStatus resources to become Available (up to ${ts_timeout}s)"
+for attempt in $(seq 1 ${ts_attempts}); do
   # Get all tigerastatus resources and check if any are not Available.
   not_ready=$(${kubectl} get tigerastatus -o jsonpath='{range .items[*]}{.metadata.name}{" "}{range .status.conditions[?(@.type=="Available")]}{.status}{end}{"\n"}{end}' 2>/dev/null \
     | grep -v "True$" || true)
@@ -227,8 +250,8 @@ for attempt in $(seq 1 120); do
     fi
   fi
 
-  if [ "$attempt" -eq 120 ]; then
-    echo "FAIL: Timed out waiting for all TigeraStatus to become Available after 600s"
+  if [ "$attempt" -eq "${ts_attempts}" ]; then
+    echo "FAIL: Timed out waiting for all TigeraStatus to become Available after ${ts_timeout}s"
     ${kubectl} get tigerastatus 2>&1 || true
     echo "Not ready:"
     echo "$not_ready"
@@ -242,7 +265,7 @@ for attempt in $(seq 1 120); do
     ${kubectl} annotate installation default --overwrite triggerReconcile=$(date +%s) 2>/dev/null || true
   fi
 
-  sleep 5
+  sleep ${ts_interval}
 done
 
 echo "Wait for Calico to be ready..."

--- a/hack/test/kind/infra/calicoctl.yaml
+++ b/hack/test/kind/infra/calicoctl.yaml
@@ -23,7 +23,9 @@ spec:
   nodeSelector:
     # Important: This makes sure that calicoctl is installed on the control plane node,
     # where it will not be subjected to potentially disruptive actions taken by our test code.
-    kubernetes.io/hostname: kind-control-plane
+    # Using the control-plane role label rather than a specific hostname so this
+    # works for any kind cluster name.
+    node-role.kubernetes.io/control-plane: ""
   hostNetwork: true
   serviceAccountName: calicoctl
   containers:


### PR DESCRIPTION
These are the generic, non-Enterprise changes from the new MCM kind rig that merged downstream, pulled up here so the shared kind scripts stay in sync and future cross-repo merges don't conflict. The functional changes match what landed downstream; the comments are reworded to make sense upstream.

- `calicoctl.yaml` pins to the control-plane via the `node-role.kubernetes.io/control-plane` role label instead of a hardcoded `kind-control-plane` hostname.
- The ipv6 setup loop in `deploy_resources.sh` iterates the actual node containers for `KIND_NAME` and derives each node's address from its name, rather than assuming `kind-*` names in a fixed `kind get nodes` order (which broke the v6 BGP advertisement tests).
- Bumps the pod-ready wait from 5m to 10m, and makes the TigeraStatus wait timeout configurable via `TIGERASTATUS_WAIT_TIMEOUT` (default 20m) with an optional `KIND_SKIP_TIGERASTATUS_WAIT` escape hatch. These two are no-ops for a normal upstream bringup.

## Release Note

```release-note
None
```
