### PR TITLE
networking-calico: relocate CONTEXT_WRITER wrap out of syncer.py

### DIFF
--- a/networking-calico/networking_calico/plugins/ml2/drivers/calico/endpoints.py
+++ b/networking-calico/networking_calico/plugins/ml2/drivers/calico/endpoints.py
@@ -199,74 +199,85 @@ class WorkloadEndpointSyncer(ResourceSyncer):
         qos_ids.discard(None)
         qos_ids = list(qos_ids)
 
-        # IPAllocation rows, grouped by port_id.
-        ip_allocs_by_port = {}
-        if port_ids:
-            q = context.session.query(models_v2.IPAllocation).filter(
-                models_v2.IPAllocation.port_id.in_(port_ids)
-            )
-            for ip in q:
-                ip_allocs_by_port.setdefault(ip.port_id, []).append(
-                    {
-                        "subnet_id": ip.subnet_id,
-                        "ip_address": ip.ip_address,
-                    }
+        # The ``context.session.query(...)`` calls below need
+        # ``session.in_transaction()`` to be True, or SQLAlchemy emits "ORM session: SQL
+        # execution without transaction in progress" warnings and (depending on the
+        # Neutron release) drops their results.  We arrange that here via
+        # ``CONTEXT_READER.using(...)`` -- mirroring the wrap in
+        # ``get_extra_port_information`` for the per-port (non-bulk) path.  The wrap is
+        # scoped to this function alone so it does not subsume the resync's other
+        # ``self.db.get_*`` calls (in the subnet / policy syncers, and in the resync
+        # compare loop), which are ``@retry_if_session_inactive``-decorated and manage
+        # their own transactions -- per the Neutron devref, an outer transaction would
+        # render that retry "useless".
+        with db_api.CONTEXT_READER.using(context):
+            # IPAllocation rows, grouped by port_id.
+            ip_allocs_by_port = {}
+            if port_ids:
+                q = context.session.query(models_v2.IPAllocation).filter(
+                    models_v2.IPAllocation.port_id.in_(port_ids)
                 )
+                for ip in q:
+                    ip_allocs_by_port.setdefault(ip.port_id, []).append(
+                        {
+                            "subnet_id": ip.subnet_id,
+                            "ip_address": ip.ip_address,
+                        }
+                    )
 
-        # FloatingIP rows, grouped by fixed_port_id.
-        float_ips_by_port = {}
-        if port_ids:
-            q = context.session.query(FloatingIP).filter(
-                FloatingIP.fixed_port_id.in_(port_ids)
-            )
-            for fip in q:
-                float_ips_by_port.setdefault(fip.fixed_port_id, []).append(
-                    {
-                        "int_ip": fip.fixed_ip_address,
-                        "ext_ip": fip.floating_ip_address,
-                    }
+            # FloatingIP rows, grouped by fixed_port_id.
+            float_ips_by_port = {}
+            if port_ids:
+                q = context.session.query(FloatingIP).filter(
+                    FloatingIP.fixed_port_id.in_(port_ids)
                 )
+                for fip in q:
+                    float_ips_by_port.setdefault(fip.fixed_port_id, []).append(
+                        {
+                            "int_ip": fip.fixed_ip_address,
+                            "ext_ip": fip.floating_ip_address,
+                        }
+                    )
 
-        # Network rows, indexed by id.
-        networks_by_id = {}
-        if network_ids:
-            q = context.session.query(models_v2.Network).filter(
-                models_v2.Network.id.in_(network_ids)
-            )
-            for net in q:
-                networks_by_id[net.id] = net
-
-        # SG bindings, grouped by port_id (a port can have multiple SGs).
-        # Use the plugin API (with a list filter) rather than
-        # session.query(SecurityGroupPortBinding) so this path is
-        # consistent with the per-port code that uses the same API.
-        sg_ids_by_port = {}
-        if port_ids:
-            bindings = self.db._get_port_security_group_bindings(
-                context, filters={"port_id": port_ids}
-            )
-            for b in bindings:
-                sg_ids_by_port.setdefault(b["port_id"], []).append(
-                    b["security_group_id"]
+            # Network rows, indexed by id.
+            networks_by_id = {}
+            if network_ids:
+                q = context.session.query(models_v2.Network).filter(
+                    models_v2.Network.id.in_(network_ids)
                 )
+                for net in q:
+                    networks_by_id[net.id] = net
 
-        # QoS bandwidth + packet-rate rules, grouped by qos_policy_id.
-        qos_bw_by_policy = {}
-        qos_pr_by_policy = {}
-        if qos_ids:
-            q = context.session.query(qos_models.QosBandwidthLimitRule).filter(
-                qos_models.QosBandwidthLimitRule.qos_policy_id.in_(qos_ids)
-            )
-            for r in q:
-                qos_bw_by_policy.setdefault(r.qos_policy_id, []).append(r)
-            q = context.session.query(qos_models.QosPacketRateLimitRule).filter(
-                qos_models.QosPacketRateLimitRule.qos_policy_id.in_(qos_ids)
-            )
-            for r in q:
-                qos_pr_by_policy.setdefault(r.qos_policy_id, []).append(r)
+            # SG bindings, grouped by port_id (a port can have multiple SGs).
+            # Use the plugin API (with a list filter) rather than
+            # session.query(SecurityGroupPortBinding) so this path is
+            # consistent with the per-port code that uses the same API.
+            sg_ids_by_port = {}
+            if port_ids:
+                bindings = self.db._get_port_security_group_bindings(
+                    context, filters={"port_id": port_ids}
+                )
+                for b in bindings:
+                    sg_ids_by_port.setdefault(b["port_id"], []).append(
+                        b["security_group_id"]
+                    )
 
-        # Subnet rows for every subnet referenced by any fixed IP (for
-        # gateway_ip).
+            # QoS bandwidth + packet-rate rules, grouped by qos_policy_id.
+            qos_bw_by_policy = {}
+            qos_pr_by_policy = {}
+            if qos_ids:
+                q = context.session.query(qos_models.QosBandwidthLimitRule).filter(
+                    qos_models.QosBandwidthLimitRule.qos_policy_id.in_(qos_ids)
+                )
+                for r in q:
+                    qos_bw_by_policy.setdefault(r.qos_policy_id, []).append(r)
+                q = context.session.query(qos_models.QosPacketRateLimitRule).filter(
+                    qos_models.QosPacketRateLimitRule.qos_policy_id.in_(qos_ids)
+                )
+                for r in q:
+                    qos_pr_by_policy.setdefault(r.qos_policy_id, []).append(r)
+
+        # Subnet rows for every subnet referenced by any fixed IP (for gateway_ip).
         subnet_ids = list(
             {ip["subnet_id"] for ips in ip_allocs_by_port.values() for ip in ips}
         )

--- a/networking-calico/networking_calico/plugins/ml2/drivers/calico/endpoints.py
+++ b/networking-calico/networking_calico/plugins/ml2/drivers/calico/endpoints.py
@@ -239,19 +239,23 @@ class WorkloadEndpointSyncer(ResourceSyncer):
                         }
                     )
 
-            # Network rows, indexed by id.
+            # Network rows, indexed by id.  We materialise just the columns we need
+            # ({"name": ...}) inside the reader, rather than caching the ORM instance:
+            # that way the downstream attribute access happens while the row is
+            # guaranteed attached to an active session, and we do not rely on oslo.db's
+            # expire_on_commit / detached-attribute behaviour after the reader exits.
             networks_by_id = {}
             if network_ids:
                 q = context.session.query(models_v2.Network).filter(
                     models_v2.Network.id.in_(network_ids)
                 )
                 for net in q:
-                    networks_by_id[net.id] = net
+                    networks_by_id[net.id] = {"name": net.name}
 
-            # SG bindings, grouped by port_id (a port can have multiple SGs).
-            # Use the plugin API (with a list filter) rather than
-            # session.query(SecurityGroupPortBinding) so this path is
-            # consistent with the per-port code that uses the same API.
+            # SG bindings, grouped by port_id (a port can have multiple SGs).  Use the
+            # plugin API (with a list filter) rather than
+            # session.query(SecurityGroupPortBinding) so this path is consistent with
+            # the per-port code that uses the same API.
             sg_ids_by_port = {}
             if port_ids:
                 bindings = self.db._get_port_security_group_bindings(
@@ -262,7 +266,13 @@ class WorkloadEndpointSyncer(ResourceSyncer):
                         b["security_group_id"]
                     )
 
-            # QoS bandwidth + packet-rate rules, grouped by qos_policy_id.
+            # QoS bandwidth + packet-rate rules, grouped by qos_policy_id.  Materialise
+            # each rule into a plain dict containing only the columns build_qos_controls
+            # reads, so that subsequent access (in
+            # _get_extra_port_information_from_bulk, after the reader exits) does not
+            # depend on the ORM instances still being attached to a live session.  This
+            # mirrors the per-port path's choice to call build_qos_controls inside its
+            # CONTEXT_READER block.
             qos_bw_by_policy = {}
             qos_pr_by_policy = {}
             if qos_ids:
@@ -270,12 +280,23 @@ class WorkloadEndpointSyncer(ResourceSyncer):
                     qos_models.QosBandwidthLimitRule.qos_policy_id.in_(qos_ids)
                 )
                 for r in q:
-                    qos_bw_by_policy.setdefault(r.qos_policy_id, []).append(r)
+                    qos_bw_by_policy.setdefault(r.qos_policy_id, []).append(
+                        {
+                            "direction": r.direction,
+                            "max_kbps": r.max_kbps,
+                            "max_burst_kbps": r.max_burst_kbps,
+                        }
+                    )
                 q = context.session.query(qos_models.QosPacketRateLimitRule).filter(
                     qos_models.QosPacketRateLimitRule.qos_policy_id.in_(qos_ids)
                 )
                 for r in q:
-                    qos_pr_by_policy.setdefault(r.qos_policy_id, []).append(r)
+                    qos_pr_by_policy.setdefault(r.qos_policy_id, []).append(
+                        {
+                            "direction": r.direction,
+                            "max_kpps": r.max_kpps,
+                        }
+                    )
 
         # Subnet rows for every subnet referenced by any fixed IP (for gateway_ip).
         subnet_ids = list(
@@ -712,7 +733,7 @@ class WorkloadEndpointSyncer(ResourceSyncer):
         if network is not None:
             try:
                 port_extra.network_name = datamodel_v3.sanitize_label_name_value(
-                    network.name,
+                    network["name"],
                     NETWORK_NAME_MAX_LENGTH,
                 )
             except Exception:

--- a/networking-calico/networking_calico/plugins/ml2/drivers/calico/fairy_gc_diagnostics.py
+++ b/networking-calico/networking_calico/plugins/ml2/drivers/calico/fairy_gc_diagnostics.py
@@ -72,15 +72,20 @@ a target and times out as ``TimeoutError``.  Python's "Exception ignored in" mec
 swallows the error, but the hub has been wedged for ~10s and the connection record's
 state is indeterminate.
 
-In current code (after PR 13015), all of our DB access is inside
-``db_api.CONTEXT_*.using`` blocks, which close the session deterministically at block
-exit (oslo.db's ``_TransactionContext._session`` finally-block calls
-``session.close()``) and so never leave a fairy for GC.  In principle that should be
-enough.  This module is the safety net for the case where it isn't -- e.g. if a
-Neutron-framework path outside our control still drops a session unclosed, or if we add
-a code path later that bypasses the ``using`` pattern.  If the race fires again the
-diagnostic output identifies which code path checked out the leaking connection, so a
-targeted fix can follow.
+In current code (after PR 13015), our DB access falls into two patterns: raw
+``context.session.query(...)`` calls inside explicit ``db_api.CONTEXT_*.using`` blocks
+(which close the session deterministically at block exit via oslo.db's
+``_TransactionContext._session`` finally-block calling ``session.close()``); and
+``@db_api.retry_if_session_inactive``-decorated plugin API calls (``self.db.get_*``,
+etc.) outside any explicit ``using`` block, which rely on SQLAlchemy's own session
+lifecycle.  In the deployments we have tested neither pattern leaves a fairy for GC, but
+the decorator-only path is the weaker of the two -- the retry wrapper doesn't open its
+own ``using`` block, so deterministic close isn't guaranteed there.  This module is the
+safety net for cases where it isn't enough -- e.g. if a Neutron-framework path outside
+our control drops a session unclosed, or if a decorator-based call path leaks a fairy
+under some condition we haven't exercised.  If the race fires again the diagnostic
+output identifies which code path checked out the leaking connection, so a targeted fix
+can follow.
 
 What this module does
 ---------------------

--- a/networking-calico/networking_calico/plugins/ml2/drivers/calico/syncer.py
+++ b/networking-calico/networking_calico/plugins/ml2/drivers/calico/syncer.py
@@ -15,8 +15,6 @@
 
 import time
 
-from neutron_lib.db import api as db_api
-
 from oslo_log import log
 
 LOG = log.getLogger(__name__)
@@ -158,8 +156,14 @@ class ResourceSyncer(object):
             etcd_map = self.get_from_etcd(scope)
             t_etcd_read = time.monotonic()
 
-            with db_api.CONTEXT_WRITER.using(context):
-                neutron_map = self.get_from_neutron(context, scope)
+            # ``get_from_neutron`` calls ``self.db.get_*`` methods (or, in the endpoint
+            # syncer's case, an internal helper that wraps its own raw queries in a
+            # CONTEXT_READER), all of which are ``@retry_if_session_inactive``-decorated
+            # and manage their own transactions.  We deliberately do NOT wrap them in an
+            # outer writer/reader: the Neutron devref calls that pattern an anti-pattern
+            # because the inner retry "would be always called from inside an active
+            # transaction making it useless".
+            neutron_map = self.get_from_neutron(context, scope)
             t_neutron_read = time.monotonic()
 
             # Resource-specific post-processing of etcd_map now that we have neutron_map
@@ -194,7 +198,7 @@ class ResourceSyncer(object):
         # Compare-loop marker.  The resync-concurrency test (CORE-12037) waits
         # for this line in the resync log before firing its in-resync burst, so
         # the burst lands inside the test-injected per-item delay window rather
-        # than during the etcd read or the CONTEXT_WRITER-held neutron read.
+        # than during the etcd read or the neutron read.
         LOG.info("Resync for %s: starting compare loop", self.resource_kind)
 
         for name in sorted(set(etcd_map) | set(neutron_map), key=_iter_order):
@@ -207,10 +211,9 @@ class ResourceSyncer(object):
                 # is at least as fresh as our etcd read; the CAS on mod_revision
                 # protects against any etcd change since.
                 data, mod_revision = etcd_map[name]
-                with db_api.CONTEXT_WRITER.using(context):
-                    write_data = self.neutron_to_etcd_write_data(
-                        name, neutron_map[name], context, reread=False
-                    )
+                write_data = self.neutron_to_etcd_write_data(
+                    name, neutron_map[name], context, reread=False
+                )
                 if self.etcd_write_data_matches_existing(write_data, data):
                     # CORE-12922: items already correct are not enumerated
                     # at INFO -- only ones that need fixing (the create /
@@ -244,32 +247,31 @@ class ResourceSyncer(object):
             elif in_neutron:
                 # In Neutron but not in etcd: create.  reread=True so we don't race with
                 # a concurrent dynamic delete.
-                with db_api.CONTEXT_WRITER.using(context):
-                    try:
-                        write_data = self.neutron_to_etcd_write_data(
-                            name, neutron_map[name], context, reread=True
-                        )
-                        LOG.info(
-                            "Resync creating %s %s in etcd",
-                            self.resource_kind,
-                            name,
-                        )
-                        if self.create_in_etcd(name, write_data):
-                            n_created += 1
-                        else:
-                            LOG.warning(
-                                "failed etcd write for %s %s; presume"
-                                " data created by another writer",
-                                self.resource_kind,
-                                name,
-                            )
-                    except ResourceGone:
+                try:
+                    write_data = self.neutron_to_etcd_write_data(
+                        name, neutron_map[name], context, reread=True
+                    )
+                    LOG.info(
+                        "Resync creating %s %s in etcd",
+                        self.resource_kind,
+                        name,
+                    )
+                    if self.create_in_etcd(name, write_data):
+                        n_created += 1
+                    else:
                         LOG.warning(
-                            "Neutron resource gone for %s %s; presume"
-                            " deleted by another writer",
+                            "failed etcd write for %s %s; presume"
+                            " data created by another writer",
                             self.resource_kind,
                             name,
                         )
+                except ResourceGone:
+                    LOG.warning(
+                        "Neutron resource gone for %s %s; presume"
+                        " deleted by another writer",
+                        self.resource_kind,
+                        name,
+                    )
             elif in_etcd:
                 # In etcd but not in Neutron: delete.
                 _, mod_revision = etcd_map[name]

--- a/networking-calico/networking_calico/resync/scope.py
+++ b/networking-calico/networking_calico/resync/scope.py
@@ -236,7 +236,7 @@ class Scope:
         # added all their ports.
         remaining_subnet_ids = self.subnets - network_subnet_ids
         if remaining_subnet_ids:
-            with db_api.CONTEXT_WRITER.using(self.admin_context):
+            with db_api.CONTEXT_READER.using(self.admin_context):
                 # Iterate directly rather than calling .all() so this matches
                 # the bulk-prefetch pattern in WorkloadEndpointSyncer.  Real
                 # SQLAlchemy Query supports iteration; the test mocks return


### PR DESCRIPTION
ResourceSyncer.resync() was wrapping its Neutron-side reads in ``with db_api.CONTEXT_WRITER.using(context):`` at three sites:

  1. around get_from_neutron() in the etcd-then-neutron read,
  2. around neutron_to_etcd_write_data(reread=False) on the update branch,
  3. around neutron_to_etcd_write_data(reread=True) on the create branch.

This placement was wrong in two ways:

* The wrap is at the wrong scope.  Most of what's inside is decorated ``self.db.get_*`` calls (``get_subnets``, ``get_security_groups``, ``get_security_group_rules``, ``get_port``, ...) which are themselves ``@db_api.retry_if_session_inactive``-decorated and manage their own transactions.  Wrapping decorated calls in an outer writer disables their retry -- Neutron's contributor devref calls this out as an anti-pattern: "the retry context would be always called from inside an active transaction making it useless".  The driver's own code at ``update_network_postcommit`` already has this exact caveat.

* The wrap was over-strong even where it was actually needed.  The only consumer that *requires* a transaction context inside resync is the WorkloadEndpoint syncer's ``_prefetch_bulk_port_data``, which issues raw ``context.session.query(...)`` calls against IPAllocation / FloatingIP / Network / QoS rule tables.  Those don't write to Neutron's DB at all, so a CONTEXT_READER is the right shape, matching the existing CONTEXT_READER wrap inside the per-port ``get_extra_port_information``.

Move the wrap to where the raw queries live: a single ``with db_api.CONTEXT_READER.using(context):`` around the raw-query section of ``_prefetch_bulk_port_data``.  Drop all three syncer-level wraps and the now-unused ``db_api`` import in syncer.py. Update the marker-line comment that referenced the CONTEXT_WRITER-held neutron read; the resync-concurrency test (CORE-12037) still waits on the same marker, just without the obsolete adjective.

Inside ``_prefetch_bulk_port_data`` itself, the trailing ``self.db.get_subnets`` and ``self.db.get_security_groups`` calls also move outside the reader.  Both are
``@retry_if_session_inactive``-decorated, so wrapping them would disable their retry; their inputs (``subnet_ids``, ``all_sg_ids``) are plain Python lists of IDs and their outputs are plain dicts, so nothing needs to cross the reader boundary as an ORM session attribute.  After this split, the reader covers exactly the raw queries -- no more, no less.

Two more places touched while we are here:

* ``resync/scope.py``: the single ``CONTEXT_WRITER.using`` wrap around the IPAllocation read in ``Scope._expand_subnets`` is also a pure read, so downgrade to ``CONTEXT_READER``.

* ``fairy_gc_diagnostics.py``: update the explanatory comment that claimed "all of our DB access is inside ``db_api.CONTEXT_*.using`` blocks".  After this commit, the decorator-only path (decorated ``self.db.get_*`` calls outside an explicit ``using`` block) is more widely used -- it's the pattern the resync now follows for its non-raw reads, matching what the postcommit path was already doing (e.g. ``update_network_postcommit``).  Note that the decorator-only path doesn't open its own ``using`` block, so deterministic session close isn't guaranteed there; the fairy diagnostic remains a useful safety net for that.

No functional change in normal operation: the Subnet and Policy syncers' ``get_from_neutron`` calls only the decorated plugin API, which works correctly without an outer transaction; the WorkloadEndpoint syncer's raw queries still run inside a transaction, just at READER strength and at tighter scope; and the decorated lookups inside ``_prefetch_bulk_port_data`` now retain their own retry behaviour.

All 101 driver-side unit tests pass under subunit.run with this change.