### PR TITLE
e2e: port packet-size dataplane server into multi-arch rapidclient

### DIFF
--- a/.semaphore/end-to-end/scripts/README.md
+++ b/.semaphore/end-to-end/scripts/README.md
@@ -20,6 +20,7 @@ sourced individually when reproducing part of a CI run locally.
 | `phases/install.sh` | `bz install` (install Calico on the provisioned cluster) |
 | `phases/configure.sh` | Post-install env setup: PATH, external-node creds, IPAM pool, failsafe ports |
 | `phases/migrate.sh` | Optional operator migration, AKS migration, `bz upgrade` |
+| `phases/load_images.sh` | Side-load PR-built helper images (rapidclient) onto nodes; no-op except on the local-binary gcp-kubeadm PR path |
 | `phases/run_tests.sh` | Acquire and run the e2e binary (local build, hashrelease download, or `bz tests` fallback) |
 | `phases/hcp.sh` | Hosted control plane flow (separate provision + test tooling) |
 

--- a/.semaphore/end-to-end/scripts/body_standard.sh
+++ b/.semaphore/end-to-end/scripts/body_standard.sh
@@ -47,4 +47,8 @@ fi
 echo "[INFO] Test logs will be available here after the run: ${SEMAPHORE_ORGANIZATION_URL}/artifacts/jobs/${SEMAPHORE_JOB_ID}?path=semaphore%2Flogs"
 echo "[INFO] Alternatively, you can view logs while job is running using 'sem attach ${SEMAPHORE_JOB_ID}' and then 'tail -f ${BZ_LOGS_DIR}/${TEST_TYPE}-tests.log'"
 
+# Side-load PR-built helper images (rapidclient) onto the nodes before testing;
+# no-op except on the local-binary gcp-kubeadm PR path. See load_images.sh.
+source "${PHASES}/load_images.sh"
+
 source "${PHASES}/run_tests.sh"

--- a/.semaphore/end-to-end/scripts/phases/load_images.sh
+++ b/.semaphore/end-to-end/scripts/phases/load_images.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# load_images.sh - side-load PR-built e2e helper images onto the cluster.
+#
+# PR CI has no registry push credential (fork PRs are untrusted), so an image
+# built from the PR source cannot be pushed to quay for the nodes to pull. For
+# the rapidclient image (used by the packet-size and maglev tests) we instead
+# build it locally and import it straight into each node's container runtime:
+#   - worker nodes  -> containerd `k8s.io` namespace (pods run it, PullPolicy=Never)
+#   - external node -> docker (maglev runs it via `docker run`)
+# and export RAPIDCLIENT_TAG so images.RapidClientImage() pins that exact copy.
+#
+# Scope: only the local-binary gcp-kubeadm PR path. Node access here relies on the
+# gcp-kubeadm CRC terraform outputs + master_ssh_key, which don't exist on other
+# providers; those runs skip this phase and fall back to the published :latest
+# (unchanged behaviour). Scheduled runs (no RUN_LOCAL_TESTS) test the published
+# hashrelease images, so they also skip and use :latest.
+#
+# Required env:
+#   BZ_LOCAL_DIR, HOME
+# Optional env (set by the gcp-kubeadm block / configure.sh):
+#   RUN_LOCAL_TESTS, PROVISIONER, SEMAPHORE_GIT_PR_NUMBER, SEMAPHORE_GIT_SHA,
+#   EXT_IP, EXT_KEY, EXT_USER
+# Exports consumed by later phases:
+#   RAPIDCLIENT_TAG, K8S_E2E_DOCKER_EXTRA_FLAGS
+#
+# Sourced from body_*.sh (inherits `set -eo pipefail`, so any build/load failure
+# aborts the job — preferable to a later ErrImageNeverPull mid-test).
+
+if [[ -z "${RUN_LOCAL_TESTS:-}" || "${PROVISIONER:-}" != "gcp-kubeadm" ]]; then
+  echo "[INFO] load_images: skipping (only for local-binary gcp-kubeadm PR builds;" \
+       "PROVISIONER=${PROVISIONER:-unset}, RUN_LOCAL_TESTS=${RUN_LOCAL_TESTS:-unset})." \
+       "Tests will use the published rapidclient :latest."
+else
+  # Immutable, unique per PR (falls back to the commit sha off-PR). Pods pin this
+  # tag with ImagePullPolicy=Never, so it must match what we import below exactly.
+  if [[ -n "${SEMAPHORE_GIT_PR_NUMBER:-}" ]]; then
+    _tag="pr-${SEMAPHORE_GIT_PR_NUMBER}"
+  else
+    _tag="e2e-${SEMAPHORE_GIT_SHA:0:12}"
+  fi
+  _img="quay.io/tigeradev/rapidclient:${_tag}"
+
+  echo "[INFO] load_images: building ${_img} from local source (no registry push)"
+  make -C "${HOME}/calico/e2e/images/rapidclient" image TAG_NAME="${_tag}"
+
+  # --- worker nodes: import into containerd's k8s.io namespace ---------------
+  _plat="${BZ_LOCAL_DIR}/crc/kubeadm/1.6"
+  _key="${_plat}/master_ssh_key"
+  _tf_out="${_plat}/terraform_output.json"
+  if [[ ! -f "${_tf_out}" ]]; then echo "[ERROR] load_images: ${_tf_out} not found"; exit 1; fi
+  if [[ ! -f "${_key}" ]]; then echo "[ERROR] load_images: ssh key ${_key} not found"; exit 1; fi
+  _ssh_opts=(-i "${_key}" -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o ConnectTimeout=30)
+
+  mapfile -t _node_ips < <(jq -r '.node_connect_commands.value[]' "${_tf_out}" \
+                             | grep -oE 'ubuntu@[0-9.]+' | cut -d@ -f2)
+  if [[ ${#_node_ips[@]} -eq 0 ]]; then
+    echo "[ERROR] load_images: no worker node IPs parsed from ${_tf_out}"; exit 1
+  fi
+  echo "[INFO] load_images: importing into containerd on ${#_node_ips[@]} worker node(s): ${_node_ips[*]}"
+  for _ip in "${_node_ips[@]}"; do
+    echo "[INFO]   -> ${_ip} (containerd)"
+    docker save "${_img}" | ssh "${_ssh_opts[@]}" "ubuntu@${_ip}" -- 'sudo ctr -n k8s.io images import -'
+  done
+
+  # --- external node: load into docker (maglev uses `docker run`) ------------
+  if [[ -n "${EXT_IP:-}" && -n "${EXT_KEY:-}" ]]; then
+    echo "[INFO] load_images: loading into external node docker (${EXT_IP})"
+    docker save "${_img}" | ssh -i "${EXT_KEY}" \
+      -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o ConnectTimeout=30 \
+      "${EXT_USER:-ubuntu}@${EXT_IP}" -- 'docker load'
+  fi
+
+  # Pin the tests to the loaded image and forward the tag into the e2e container
+  # (run_tests.sh passes ${K8S_E2E_DOCKER_EXTRA_FLAGS} to its `docker run`).
+  export RAPIDCLIENT_TAG="${_tag}"
+  export K8S_E2E_DOCKER_EXTRA_FLAGS="--env RAPIDCLIENT_TAG ${K8S_E2E_DOCKER_EXTRA_FLAGS:-}"
+  echo "[INFO] load_images: RAPIDCLIENT_TAG=${RAPIDCLIENT_TAG} (pods pin this tag, ImagePullPolicy=Never)"
+fi

--- a/.semaphore/end-to-end/scripts/phases/load_images.sh
+++ b/.semaphore/end-to-end/scripts/phases/load_images.sh
@@ -80,6 +80,7 @@ else
   fi
 
   rm -f "${_tar}"
+  trap - EXIT  # cleanup done on the happy path; don't leak the trap into run_tests.sh
 
   # Pin the tests to the loaded image and forward the tag into the e2e container
   # (run_tests.sh passes ${K8S_E2E_DOCKER_EXTRA_FLAGS} to its `docker run`).

--- a/.semaphore/end-to-end/scripts/phases/load_images.sh
+++ b/.semaphore/end-to-end/scripts/phases/load_images.sh
@@ -59,7 +59,10 @@ else
 
   # Serialize the image once and reuse the tarball for every node (docker save is
   # the expensive part; re-running it per node would re-export the whole image).
+  # The EXIT trap frees the tarball even if a save/ssh/load aborts the job under
+  # `set -eo pipefail` (this phase is sourced and nothing else sets an EXIT trap).
   _tar="$(mktemp -t rapidclient.XXXXXX.tar)"
+  trap 'rm -f "${_tar}"' EXIT
   docker save "${_img}" -o "${_tar}"
 
   echo "[INFO] load_images: importing into containerd on ${#_node_ips[@]} worker node(s): ${_node_ips[*]}"

--- a/.semaphore/end-to-end/scripts/phases/load_images.sh
+++ b/.semaphore/end-to-end/scripts/phases/load_images.sh
@@ -67,7 +67,7 @@ else
     echo "[INFO] load_images: loading into external node docker (${EXT_IP})"
     docker save "${_img}" | ssh -i "${EXT_KEY}" \
       -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o ConnectTimeout=30 \
-      "${EXT_USER:-ubuntu}@${EXT_IP}" -- 'docker load'
+      "${EXT_USER:-ubuntu}@${EXT_IP}" -- 'sudo docker load'
   fi
 
   # Pin the tests to the loaded image and forward the tag into the e2e container

--- a/.semaphore/end-to-end/scripts/phases/load_images.sh
+++ b/.semaphore/end-to-end/scripts/phases/load_images.sh
@@ -56,19 +56,27 @@ else
   if [[ ${#_node_ips[@]} -eq 0 ]]; then
     echo "[ERROR] load_images: no worker node IPs parsed from ${_tf_out}"; exit 1
   fi
+
+  # Serialize the image once and reuse the tarball for every node (docker save is
+  # the expensive part; re-running it per node would re-export the whole image).
+  _tar="$(mktemp -t rapidclient.XXXXXX.tar)"
+  docker save "${_img}" -o "${_tar}"
+
   echo "[INFO] load_images: importing into containerd on ${#_node_ips[@]} worker node(s): ${_node_ips[*]}"
   for _ip in "${_node_ips[@]}"; do
     echo "[INFO]   -> ${_ip} (containerd)"
-    docker save "${_img}" | ssh "${_ssh_opts[@]}" "ubuntu@${_ip}" -- 'sudo ctr -n k8s.io images import -'
+    ssh "${_ssh_opts[@]}" "ubuntu@${_ip}" -- 'sudo ctr -n k8s.io images import -' < "${_tar}"
   done
 
   # --- external node: load into docker (maglev uses `docker run`) ------------
   if [[ -n "${EXT_IP:-}" && -n "${EXT_KEY:-}" ]]; then
     echo "[INFO] load_images: loading into external node docker (${EXT_IP})"
-    docker save "${_img}" | ssh -i "${EXT_KEY}" \
+    ssh -i "${EXT_KEY}" \
       -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o ConnectTimeout=30 \
-      "${EXT_USER:-ubuntu}@${EXT_IP}" -- 'sudo docker load'
+      "${EXT_USER:-ubuntu}@${EXT_IP}" -- 'sudo docker load' < "${_tar}"
   fi
+
+  rm -f "${_tar}"
 
   # Pin the tests to the loaded image and forward the tag into the e2e container
   # (run_tests.sh passes ${K8S_E2E_DOCKER_EXTRA_FLAGS} to its `docker run`).

--- a/.semaphore/semaphore-scheduled-builds.yml
+++ b/.semaphore/semaphore-scheduled-builds.yml
@@ -863,6 +863,21 @@ blocks:
               values: ["operator"]
             - env_var: DATAPLANE
               values: ["CalicoBPF"]
+  - name: "E2E images"
+    run:
+      when: >-
+        true or change_in(['/metadata.mk', '/lib.Makefile', '/e2e/images/'],
+        {pipeline_file: 'ignore', exclude: ['/**/.gitignore', '/**/README.md', '/**/LICENSE']})
+    dependencies:
+      - Prerequisites
+    task:
+      env_vars:
+        - name: BUILD_CACHE_GROUP
+          value: "calico"
+      jobs:
+        - name: "E2E images: rapidclient CI"
+          commands:
+            - .semaphore/run-and-monitor rapidclient-ci.log make -C e2e/images/rapidclient ci
   - name: E2E script & pipeline validations
     run:
       when: >-

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -2656,6 +2656,21 @@ blocks:
               values: ["operator"]
             - env_var: DATAPLANE
               values: ["CalicoBPF"]
+  - name: "E2E images"
+    run:
+      when: >-
+        false or change_in(['/metadata.mk', '/lib.Makefile', '/e2e/images/'],
+        {pipeline_file: 'ignore', exclude: ['/**/.gitignore', '/**/README.md', '/**/LICENSE']})
+    dependencies:
+      - Prerequisites
+    task:
+      env_vars:
+        - name: BUILD_CACHE_GROUP
+          value: "calico"
+      jobs:
+        - name: "E2E images: rapidclient CI"
+          commands:
+            - .semaphore/run-and-monitor rapidclient-ci.log make -C e2e/images/rapidclient ci
   - name: E2E script & pipeline validations
     run:
       when: >-

--- a/.semaphore/semaphore.yml.d/blocks/20-e2e-images.yml
+++ b/.semaphore/semaphore.yml.d/blocks/20-e2e-images.yml
@@ -1,0 +1,13 @@
+- name: "E2E images"
+  run:
+    when: "${FORCE_RUN} or change_in(['/metadata.mk', '/lib.Makefile', '/e2e/images/'], {pipeline_file: 'ignore', exclude: ['/**/.gitignore', '/**/README.md', '/**/LICENSE']})"
+  dependencies:
+    - Prerequisites
+  task:
+    env_vars:
+      - name: BUILD_CACHE_GROUP
+        value: "calico"
+    jobs:
+      - name: "E2E images: rapidclient CI"
+        commands:
+          - .semaphore/run-and-monitor rapidclient-ci.log make -C e2e/images/rapidclient ci

--- a/Makefile
+++ b/Makefile
@@ -247,6 +247,18 @@ K8S_NETPOL_SUPPORTED_FEATURES ?= "ClusterNetworkPolicy,ClusterNetworkPolicyNamed
 K8S_NETPOL_UNSUPPORTED_FEATURES ?= ""
 CLUSTER_ROUTING ?= BIRD
 
+# rapidclient (packet-size / maglev helper image) for the kind e2e lanes. Fork PRs
+# can't push to quay, so the packet-size lane (e2e-test-bpf) builds the image from PR
+# source and loads it straight into the kind nodes + external node; pods then pin this
+# exact tag with ImagePullPolicy=Never (see images.RapidClientImage / packet_size.go).
+# This mirrors the gcp-kubeadm side-load in .semaphore/.../load_images.sh (pr-<N>).
+# ?= so the gcp path's own RAPIDCLIENT_TAG wins if it ever runs through here; exported
+# so the ginkgo e2e process (which reads os.Getenv) inherits it across the sub-make.
+RAPIDCLIENT_TAG ?= kind-e2e
+export RAPIDCLIENT_TAG
+RAPIDCLIENT_IMAGE := quay.io/tigeradev/rapidclient
+EXTERNAL_NODE_NAME ?= kind-external-node
+
 ## Build all test images, create a kind cluster, and deploy Calico on it.
 .PHONY: kind-up
 kind-up:
@@ -275,7 +287,9 @@ e2e-test:
 e2e-test-bpf:
 	$(MAKE) -C e2e build
 	$(MAKE) kind-up KIND_NAME=kind KIND_CONFIG=$(KIND_DIR)/kind-bpf.config EXTRA_VALUES_FILES=$(KIND_INFRA_DIR)/values-bpf.yaml
+	$(MAKE) kind-load-rapidclient KIND_NAME=kind
 	$(KIND_DIR)/external-node.sh up
+	$(MAKE) external-node-load-rapidclient
 	# EXT_* / SSH_AUTH_SOCK are passed as environment (the e2e binary reads them
 	# via os.Getenv); KIND_NAME/KUBECONFIG/E2E_TEST_CONFIG are make variables.
 	# SSH_AUTH_SOCK is cleared so the framework's ssh uses only EXT_KEY and does
@@ -288,6 +302,25 @@ e2e-test-bpf:
 		KIND_NAME=kind \
 		KUBECONFIG=$(KIND_KUBECONFIG) \
 		E2E_TEST_CONFIG=$(REPO_ROOT)/e2e/config/kind-bpf.yaml
+
+## Build the rapidclient helper image from PR source and load it into the kind
+## nodes so the packet-size server pods (ImagePullPolicy=Never) find it. Note:
+## unlike the rest of the kind image flow (local registry + PullAlways), rapidclient
+## is loaded directly with `kind load` to match the containerd-import + PullNever
+## model that images.RapidClientImage()/packet_size.go already use for gcp.
+.PHONY: kind-load-rapidclient
+kind-load-rapidclient:
+	$(MAKE) -C e2e/images/rapidclient image TAG_NAME=$(RAPIDCLIENT_TAG)
+	$(KIND) load docker-image $(RAPIDCLIENT_IMAGE):$(RAPIDCLIENT_TAG) --name $(KIND_NAME)
+
+## Load the (already-built) rapidclient image into the external node's inner docker
+## daemon, for the ExternalNode packet-size spec and maglev's `docker run`. The node
+## is a dind container, so we `docker exec` its dockerd directly as root (no sudo /
+## ssh, unlike the gcp external node in load_images.sh). Run after kind-load-rapidclient
+## (builds the host image) and external-node.sh up (creates the container).
+.PHONY: external-node-load-rapidclient
+external-node-load-rapidclient:
+	docker save $(RAPIDCLIENT_IMAGE):$(RAPIDCLIENT_TAG) | docker exec -i $(EXTERNAL_NODE_NAME) docker load
 
 ## Create a kind cluster and run the ClusterNetworkPolicy specific e2e tests.
 e2e-test-clusternetworkpolicy:

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -52,10 +52,13 @@ build-all: $(addprefix bin/k8s/e2e-linux-,$(addsuffix .test,$(VALIDARCHES)))
 ###############################################################################
 # test images
 ###############################################################################
+# test-images builds a local single-arch image for development (kind etc.).
 test-images:
 	$(MAKE) -C images/rapidclient image
 
-publish-test-images: test-images
+# publish does its own multi-arch buildx build+push, so it must NOT depend on the
+# single-arch test-images target (that build would be wasted work).
+publish-test-images:
 	$(MAKE) -C images/rapidclient publish
 
 clean:

--- a/e2e/images/rapidclient/DESIGN.md
+++ b/e2e/images/rapidclient/DESIGN.md
@@ -2,317 +2,149 @@
 
 ## Goal
 
-Turn the existing single-purpose `rapidclient` e2e image into a **multi-mode Go
-binary** dispatched by a `MODE` env var, and **port the `k8s-e2e-dataplane-server`**
-(currently a Flask + socat image in `tigera/k8s-e2e/images/flask`) into it as a
-new `server` mode.
+`rapidclient` is a multi-mode Go binary for e2e tests, dispatched by a `MODE`
+environment variable. It hosts two modes:
 
-Primary motivations:
+- `client` — a minimal HTTP client that forces source-port reuse (used by the
+  maglev consistent-hashing tests).
+- `server` — the datapath test server (HTTP length/echo endpoints + UDP echo)
+  used by the `Packet Size Verification` suite.
 
-1. **Fix the arm64 gap.** `calico/k8s-e2e-dataplane-server:stable` is published
-   **amd64-only** (verified: single-arch manifest). On arm64 clusters (azr-aks
-   ARM lane) the server container runs the amd64 binary and crashes instantly
-   (exitCode 255), so every `Packet Size Verification` spec fails — chronic for
-   6+ weeks. An in-repo Go binary built via Calico's `buildx` gets arm64 for free.
-2. **Remove an external dependency.** The packet-size server source lives outside
-   the monorepo (`tigera/k8s-e2e`) and is pinned to a floating `:stable` tag,
-   which is how the arm64 regression went unnoticed. Bringing it in-repo puts it
-   under the same review/build/multi-arch guarantees as other code.
-3. **Establish a reusable pattern.** A mode-dispatched utility image lets future
-   e2e helpers be added as new modes instead of new external images.
+The image is built as a **multi-arch manifest list** (`amd64` + `arm64`) and
+published to `quay.io/tigeradev/rapidclient`.
+
+Motivations:
+
+1. **arm64 coverage.** The `server` mode replaces the external
+   `calico/k8s-e2e-dataplane-server:stable` image, which is published amd64-only.
+   On arm64 clusters (e.g. the azr-aks ARM lane) the amd64 server binary crashes
+   on start (exitCode 255) and every `Packet Size Verification` spec fails. An
+   in-repo Go binary built via Calico's `buildx` is multi-arch by construction.
+2. **No external dependency.** The datapath server source lives in-repo rather
+   than in `tigera/k8s-e2e` behind a floating `:stable` tag, so it is covered by
+   the same review/build/multi-arch guarantees as the rest of the code.
+3. **A reusable pattern.** Mode dispatch lets future e2e helpers be added as new
+   modes of one image instead of new external images.
 
 ## Non-goals
 
 - Re-implementing third-party upstream test images (agnhost, test-webserver,
-  iperf3, socat, netshoot). Those stay as upstream references in `images.go`;
+  iperf3, socat, netshoot). They remain upstream references in `images.go`;
   they are already multi-arch and not Calico-owned.
-- Changing the `Packet Size Verification` test logic or what it asserts. This is
-  a like-for-like server replacement; the suite must pass unchanged on amd64 and
-  newly pass on arm64.
-- Changing the client (maglev) invocation. The `docker run … -url … -port …`
-  call in `maglev.go` keeps working verbatim (only its image ref changes, via
+- Altering `Packet Size Verification` test logic or assertions. `server` mode is
+  a like-for-like replacement of the flask server.
+- Altering the maglev client invocation. The `docker run … -url … -port …` call
+  in `maglev.go` is unchanged except for its image ref (now via
   `RapidClientImage()`).
-- Pinning image tags to immutable **digests**. This PR does select a per-PR tag
-  for CI (`RAPIDCLIENT_TAG`; see the side-load section) so the test runs against
-  the PR-built image, but digest-pinning the published image is separate future
-  hardening, not in scope here.
-- Deleting anything in `tigera/k8s-e2e`. We stop *referencing* the flask image;
-  retiring it there is a separate follow-up.
+- Digest-pinning the published image. CI runs against a per-lane tag loaded onto
+  the nodes (see *Image delivery to test nodes*); pinning the published `:latest`
+  to an immutable digest is separate future hardening.
+- Deleting `tigera/k8s-e2e/images/flask`. This binary stops *referencing* the
+  flask image; retiring it there is a follow-up.
 
-## Approach
+## Design
 
-### Dispatch (decided: default-client + `MODE=server`)
+### Mode dispatch
 
-`main.go` reads the `MODE` env var and dispatches through a **mode registry**:
+`main.go` reads `MODE` and dispatches through a small registry:
 
-- `MODE` unset/empty → **`client`** mode (backward-compatible default; preserves
-  the existing flag interface and the `maglev.go` invocation with zero change).
-- `MODE=server` → `server` mode (the ported dataplane server), injected by the
-  packet_size pod customizer.
-- Unknown `MODE` → exit non-zero with a clear error listing registered modes.
+- `MODE` unset/empty → `client` (backward-compatible default; the maglev
+  invocation and the old flag interface work unchanged).
+- `MODE=server` → `server`, set by the packet-size pod customizer.
+- Unknown `MODE` → exit non-zero with an error listing the registered modes.
 
-Each mode owns its **own `flag.FlagSet`** parsed from `os.Args[1:]`, so modes
-have independent flag/arg surfaces. This is the "general multi-tool framework"
-shape (decided), kept minimal: a registry + interface now, only `client` and
-`server` implemented. Adding a mode later = one `registerMode` call in an
-`init()`.
-
-### Package layout (`e2e/images/rapidclient/`, name kept)
-
-```
-main.go        # dispatch: read MODE (default "client"), look up mode, run
-mode.go        # Mode interface + registry (registerMode / lookupMode / modeNames)
-client.go      # client mode: today's rapidclient logic, registered via init()
-server.go      # server mode: HTTP /length//post// + UDP echo, registered via init()
-server_test.go # unit tests for server endpoints + UDP echo
-Dockerfile     # unchanged (FROM scratch; ENTRYPOINT ["/rapidclient"])
-Makefile       # CHANGED: multi-arch buildx manifest push (amd64 + arm64)
-README.md      # updated to document modes
-```
-
-Image name, dir name, quay repo (`quay.io/tigeradev/rapidclient`), CI push job,
-and the `change_in('/e2e/images/rapidclient/*.go')` trigger all stay as-is.
-
-### `images.go` change
-
-Both the client (maglev) and the server (packet-size) use the **same** image, so
-the two former constants (`RapidClient`, `PacketSizeServer`) are replaced by one
-env-aware helper. It composes the ref from `RAPIDCLIENT_TAG` and reports whether
-the image was side-loaded onto the nodes (see the side-load section below):
-
-```go
-const rapidClientRepo = "quay.io/tigeradev/rapidclient"
-
-// RapidClientImage returns the image ref and whether it was side-loaded.
-func RapidClientImage() (ref string, preloaded bool) {
-    if tag := os.Getenv("RAPIDCLIENT_TAG"); tag != "" {
-        return rapidClientRepo + ":" + tag, true   // PR CI: pinned, imported onto nodes
-    }
-    return rapidClientRepo + ":latest", false       // other providers / local: published image
-}
-```
-
-The consumers are `packet_size.go` (server pod) and `maglev.go` (client on the
-external node). The doc comment carries the client/server mode contract and a
-pointer to `e2e/images/rapidclient/server.go` (replacing the old
-`// Source: tigera/k8s-e2e/images/flask.`).
-
-### `packet_size.go` change
-
-`withPacketSizeServer` currently swaps the image, nils args, and sets the
-readiness path to `/length/1`. Add the mode env:
-
-```go
-func withPacketSizeServer(pod *v1.Pod) {
-    image, preloaded := images.RapidClientImage()
-    for i := range pod.Spec.Containers {
-        pod.Spec.Containers[i].Image = image
-        pod.Spec.Containers[i].Args  = nil
-        if preloaded {
-            // Side-loaded onto the node (PR CI) — pin to the loaded copy and fail
-            // loudly if it's absent rather than pulling a stale published image.
-            pod.Spec.Containers[i].ImagePullPolicy = v1.PullNever
-        }
-        pod.Spec.Containers[i].Env   = append(pod.Spec.Containers[i].Env,
-            v1.EnvVar{Name: "MODE", Value: "server"})
-        if rp := pod.Spec.Containers[i].ReadinessProbe; rp != nil && rp.HTTPGet != nil {
-            rp.HTTPGet.Path = "/length/1"
-        }
-    }
-}
-```
-
-`PORT` is left unset → server defaults to 5000 (matches `packetServerPort` and
-the container port already in the base conncheck server pod).
-
-### PR-image side-load (`RAPIDCLIENT_TAG` + `load_images.sh`)
-
-**Problem.** The packet-size test must run against the `rapidclient` image built
-*from the PR under test* — but calico deliberately withholds registry push
-credentials from PR builds (fork PRs are untrusted;
-`.semaphore/…/blocks/10-prerequisites.yml`). So the PR-built image can't be
-pushed to quay, and a floating `:latest` reference would silently run the
-*pre-existing* published image (old single-mode client) — the server pod exits 1
-and every spec times out. This is the exact failure this section prevents.
-
-**Mechanism (no registry push).** On the local-binary **gcp-kubeadm** PR path,
-build the image locally and import it straight into the nodes' runtimes:
-
-- New phase `.semaphore/end-to-end/scripts/phases/load_images.sh`, sourced from
-  `body_standard.sh` after `configure.sh`, before `run_tests.sh`. It:
-  1. builds `quay.io/tigeradev/rapidclient:$TAG` from PR source (`TAG` =
-     `pr-$SEMAPHORE_GIT_PR_NUMBER`, or `e2e-<sha>` off-PR) — no push;
-  2. `docker save`s it once, then `ssh 'sudo ctr -n k8s.io images import'` onto
-     every worker node's containerd and `ssh 'sudo docker load'` onto the
-     external node (maglev runs the image via `docker run`);
-  3. exports `RAPIDCLIENT_TAG=$TAG` and forwards it into the e2e container via
-     `K8S_E2E_DOCKER_EXTRA_FLAGS` (`--env RAPIDCLIENT_TAG`), which `run_tests.sh`
-     already passes to its `docker run` → read by `RapidClientImage()`.
-- `RapidClientImage()` returns `preloaded=true` when `RAPIDCLIENT_TAG` is set, and
-  `withPacketSizeServer` then sets `ImagePullPolicy: Never` — a missing/failed
-  load fails loudly instead of masking with a stale registry pull.
-
-**Scope & fallback.** Node enumeration relies on the gcp-kubeadm CRC terraform
-outputs (`terraform_output.json`) + `master_ssh_key`, which don't exist on other
-providers. So the phase no-ops unless `RUN_LOCAL_TESTS` *and*
-`PROVISIONER=gcp-kubeadm`; every other run (other providers, scheduled hashrelease
-runs, local dev) leaves `RAPIDCLIENT_TAG` unset and uses the published `:latest`
-with default pull policy — unchanged behaviour. The phase fails loudly
-(`set -eo pipefail`, inherited) on any build/import error rather than letting a
-later `ErrImageNeverPull` surface mid-test.
-
-### Multi-arch build (the actual bug fix)
-
-**Current state** (verbatim, so the diff is unambiguous).
-`e2e/images/rapidclient/Makefile`:
-
-```makefile
-include ../../../metadata.mk
-PACKAGE_NAME=github.com/projectcalico/calico/e2e/images/rapidclient
-include ../../../lib.Makefile
-QUAY_REGISTRY ?= quay.io/tigeradev
-TAG_NAME ?= $(shell git branch --show-current)
-
-bin/rapidclient: main.go
-	mkdir -p bin
-	$(DOCKER_RUN) -e CGO_ENABLED=0 $(CALICO_BUILD) go build -o $@ -ldflags "-s -w" .
-
-image: bin/rapidclient
-	docker buildx build --load --platform=linux/$(ARCH) --pull \
-		--build-arg BINARY_PATH=bin/rapidclient -f Dockerfile \
-		-t $(QUAY_REGISTRY)/rapidclient:$(TAG_NAME) .
-
-publish: image
-	docker push $(QUAY_REGISTRY)/rapidclient:$(TAG_NAME)
-	@if [ "$(TAG_NAME)" = "master" ]; then \
-		docker tag  ...:$(TAG_NAME) ...:latest; docker push ...:latest; fi
-```
-
-`Dockerfile`: `FROM scratch` / `COPY ${BINARY_PATH} /rapidclient` /
-`ENTRYPOINT ["/rapidclient"]`. CGO is already disabled, so the binary is static
-and `FROM scratch` is correct — no Dockerfile change needed for the binary
-itself (only inputs change).
-
-CI: `.semaphore/push-images/e2e-test.yml` already logs into quay
-(`quay-tigeradev-hashrelease` secret) in its prologue and runs
-`make -C e2e publish-test-images CONFIRM=true` (which calls this Makefile's
-`publish`). Triggered by `change_in('/e2e/images/rapidclient/*.go')` in
-`.semaphore/semaphore.yml`. **Authentication and the publish job already exist** —
-we are not adding CI wiring, only changing the Makefile to emit a manifest list.
-
-**The defect:** `image` uses `--load --platform=linux/$(ARCH)` (default
-`ARCH=amd64`) — a single-arch image loaded locally, so the published tag is
-amd64-only. That is the arm64 bug.
-
-**Change** — build both arch binaries and push one **manifest list**:
-
-```makefile
-ARCHES = amd64 arm64
-
-bin/rapidclient-%:
-	mkdir -p bin
-	$(DOCKER_RUN) -e CGO_ENABLED=0 -e GOARCH=$* $(CALICO_BUILD) \
-		go build -o $@ -ldflags "-s -w" .
-
-# Dockerfile takes BINARY_PATH; buildx selects the right per-arch binary via
-# TARGETARCH. Build all platforms in one manifest and --push (cannot --load a
-# multi-platform build).
-publish: $(addprefix bin/rapidclient-,$(ARCHES))
-	docker buildx build --platform=$(subst $(space),$(comma),$(addprefix linux/,$(ARCHES))) \
-		--push --pull -f Dockerfile \
-		-t $(QUAY_REGISTRY)/rapidclient:$(TAG_NAME) .
-	@if [ "$(TAG_NAME)" = "master" ]; then \
-		docker buildx imagetools create -t $(QUAY_REGISTRY)/rapidclient:latest \
-			$(QUAY_REGISTRY)/rapidclient:$(TAG_NAME); fi
-```
-
-The `Dockerfile` gains a `TARGETARCH` arg so buildx copies the matching binary:
-`ARG TARGETARCH` / `COPY bin/rapidclient-${TARGETARCH} /rapidclient`. (Confirm
-the exact lib.Makefile multi-arch idiom during implementation — Calico already
-has `ARCHES`/manifest helpers in `lib.Makefile`; prefer reusing them over the
-hand-rolled `subst` above if a helper exists.)
-
-**Regression guard:** after publish, assert the tag is a manifest list with both
-platforms — `docker buildx imagetools inspect $(QUAY_REGISTRY)/rapidclient:$(TAG_NAME)`
-must list `linux/amd64` and `linux/arm64`; fail the target otherwise. This is the
-specific check that stops a silent regression to single-arch.
-
-This Makefile change is what resolves the arm64 failure; everything else just
-makes the server available to build in the first place.
-
-## Interfaces / data shapes
-
-### Mode registry (`mode.go`)
+Each mode owns its own `flag.FlagSet` parsed from `os.Args[1:]`, so modes have
+independent flag/arg surfaces. The framework is deliberately minimal — a registry
+plus a `Mode` interface, with only `client` and `server` implemented. A new mode
+is one `registerMode` call in an `init()`.
 
 ```go
 type Mode interface {
     Name() string
-    // Run parses its own flags from args and executes. Returns an error;
-    // main() maps non-nil to a non-zero exit.
+    // Run parses its own flags from args and executes. main() maps a non-nil
+    // return to a non-zero exit.
     Run(args []string) error
 }
 
-func registerMode(m Mode)          // called from each mode's init()
+func registerMode(m Mode)
 func lookupMode(name string) (Mode, bool)
-func modeNames() []string          // for the unknown-mode error message
+func modeNames() []string   // for the unknown-mode error
 ```
 
-`main()`:
 ```go
+// main()
 mode := os.Getenv("MODE")
-if mode == "" { mode = "client" }   // back-compat default
+if mode == "" { mode = "client" }
 m, ok := lookupMode(mode)
 if !ok { fatalf("unknown MODE %q; known modes: %v", mode, modeNames()) }
 if err := m.Run(os.Args[1:]); err != nil { log.Fatal(err) }
 ```
 
-### `client` mode (`client.go`) — behaviour preserved exactly
+### Package layout
 
-Flags (unchanged): `-url` (required), `-port` (default 12345), `-timeout`
-(30s), `-v`. Single GET from a fixed source port with `SO_REUSEADDR` and
-keep-alives disabled; prints the response body. Identical to today's `main.go`.
-
-The only consumer is `maglev.go:594`, which runs it on an **external node**:
-
-```go
-rapidClient, _ := images.RapidClientImage()
-cmd := fmt.Sprintf("sudo docker run --rm --net=host %s -url http://%s/shell?cmd=hostname -port %d",
-    rapidClient, ep, m.maglevConfig.SourcePort)
+```
+main.go        # dispatch: read MODE (default "client"), look up mode, run
+mode.go        # Mode interface + registry (registerMode / lookupMode / modeNames)
+client.go      # client mode, registered via init()
+server.go      # server mode: HTTP /length//post/ + UDP echo, registered via init()
+server_test.go # unit tests for server endpoints + UDP echo
+Dockerfile     # FROM scratch; TARGETARCH selects the per-arch binary
+Makefile       # multi-arch manifest build/publish + ut/ci
+README.md      # documents the modes
 ```
 
-`MODE` is unset here → defaults to `client` → flags parse exactly as today. The
-**invocation is unchanged**; the only edit is the image ref, now via
-`RapidClientImage()` (so the external node's side-loaded `RAPIDCLIENT_TAG` copy is
-used on PR CI, else the published `:latest`). (Note: the `/shell?cmd=hostname` URL
-is an endpoint on the *maglev backend* being load-balanced, not on our `server`
-mode — client mode is a generic HTTP GET tool and is agnostic to it.)
+The image name, directory, quay repo, and the `change_in('/e2e/images/rapidclient/*.go')`
+CI trigger are unchanged.
 
-### `server` mode (`server.go`) — ported contract
+### One image, two modes (`images.go`)
 
-Listens on `PORT` (env, default 5000). TCP HTTP and UDP echo on the **same port
-number**. Port comes from `PORT` env only — the `-p=`/`--port=` CLI override the
-old flask `runme.sh` accepted is **intentionally not replicated** (no consumer
-passes it; `withPacketSizeServer` sets `Args = nil`). This is the single
-deliberate functional difference from the python version.
+Both consumers use the same image, so a single env-aware helper composes the ref
+and reports whether the image was loaded onto the nodes (see *Image delivery*):
 
-**Dual-stack (decided, no fallback):** bind each listener to the unspecified
-address so Linux serves both IPv4 and v4-mapped IPv6 from one socket, matching
-flask's `host="::"`:
-- HTTP: `net.Listen("tcp", ":"+port)` then `http.Serve`.
-- UDP: `net.ListenPacket("udp", ":"+port)`.
+```go
+const rapidClientRepo = "quay.io/tigeradev/rapidclient"
 
-On Linux these bind dual-stack by default (`IPV6_V6ONLY=0`), which is all the
-test needs (it connects via IPv4 pod IP / ClusterIP / NodePort, and IPv6 in
-dual-stack configs). We do **not** implement a two-socket fallback unless a
-concrete CI failure proves the single socket insufficient — keeping the
-implementation deterministic. If that ever happens, the fix is two listeners
-(`0.0.0.0` + `[::]` with `IPV6_V6ONLY=1`); recorded here so the option isn't
-re-litigated.
+// RapidClientImage returns the image ref and whether it was pre-loaded onto the
+// test nodes (RAPIDCLIENT_TAG set by a CI lane) rather than pulled from quay.
+func RapidClientImage() (ref string, preloaded bool) {
+    if tag := os.Getenv("RAPIDCLIENT_TAG"); tag != "" {
+        return rapidClientRepo + ":" + tag, true
+    }
+    return rapidClientRepo + ":latest", false
+}
+```
 
-**Invalid `PORT`:** non-numeric or out-of-range (`<1` or `>65535`) → log and
-exit non-zero immediately (visible pod `Failed`, not a silent hang).
+Consumers:
 
-HTTP endpoints (must match what `packet_size.go` drives):
+- `packet_size.go` — `withPacketSizeServer` sets the server pod's image, clears
+  `Args`, adds `MODE=server`, and sets the readiness path to `/length/1`. When
+  `preloaded`, it sets `ImagePullPolicy: Never` so a missing/failed load fails
+  loudly instead of masking with a stale published image. `PORT` is left unset,
+  so the server defaults to 5000 (matching the base conncheck server pod's
+  container port).
+- `maglev.go` — runs `client` mode on the external node via
+  `sudo docker run … -url … -port …`. `MODE` is unset, so it defaults to `client`
+  and the flags parse as before; only the image ref changes.
+
+### `server` mode contract
+
+Listens on `PORT` (env, default 5000), serving TCP HTTP and UDP echo on the
+**same port number**. `PORT` is the only port knob — the `-p=`/`--port=` CLI
+override the old flask wrapper accepted is intentionally not replicated (no
+consumer passes it; `withPacketSizeServer` clears `Args`). A non-numeric or
+out-of-range `PORT` logs and exits non-zero immediately (visible pod `Failed`,
+not a silent hang).
+
+**Dual-stack (single socket).** Each listener binds the unspecified address
+(`net.Listen("tcp", ":"+port)`, `net.ListenPacket("udp", ":"+port)`). On Linux
+this serves both IPv4 and v4-mapped IPv6 from one socket (`IPV6_V6ONLY=0`),
+matching flask's `host="::"`, which is all the suite needs (it connects via IPv4
+pod IP / ClusterIP / NodePort, plus IPv6 in dual-stack configs). There is
+deliberately no two-socket fallback; if a concrete CI failure ever proves one
+socket insufficient, the fix is two listeners (`0.0.0.0` + `[::]` with
+`IPV6_V6ONLY=1`).
+
+HTTP endpoints (must satisfy what `packet_size.go` drives):
 
 | Route | Method | Response | Status |
 |---|---|---|---|
@@ -320,144 +152,138 @@ HTTP endpoints (must match what `packet_size.go` drives):
 | `/length/{N}` | GET | exactly **N whitespace-free bytes** (N≥1) | 200 |
 | `/length/{N}` | GET | empty body when `N==0` | 200 |
 | `/length/{N}` | GET | `N` non-integer or `<0` | 400 |
-| `/post` | POST | the request body's byte count, as a decimal string | 200 |
-| `/post` | GET | static help string (parity with flask) | 200 |
-| anything else | any | not-found | 404 |
+| `/post` | POST | received body's byte count, as a decimal string | 200 |
+| `/post` | GET | static help string (flask parity) | 200 |
+| anything else | any | not found | 404 |
 
-**`/length/{N}` body — pinned charset.** Emit N bytes by repeating the fixed
-36-byte alphabet `abcdefghijklmnopqrstuvwxyz0123456789` and truncating to N. This
-alphabet is **whitespace-free**, so the test's `len(strings.TrimSpace(body))`
-equals N. Content is otherwise irrelevant (the suite asserts only length —
-verified in `packet_size.go`), but the charset is pinned so the unit test is
-exact and a future content-sensitive test would be a deliberate change, not an
-accident. Write all N bytes in the response and set `Content-Length` (no chunked
-framing surprises); `http.Server` is concurrent by default — no extra handling.
+- **`/length/{N}` charset.** N bytes are emitted by repeating the fixed 36-byte
+  alphabet `abcdefghijklmnopqrstuvwxyz0123456789` and truncating. It is
+  whitespace-free, so the suite's `len(strings.TrimSpace(body)) == N` holds. The
+  full N bytes are written with `Content-Length` set (no chunked framing). Pinning
+  the charset keeps the unit test exact and makes any future content-sensitive
+  test a deliberate change.
+- **`/post`.** The body is streamed with `io.Copy(io.Discard, r.Body)` and the
+  count returned via `strconv.FormatInt`, so a 10 000-byte body is never buffered
+  and the reported count is the exact bytes received.
+- **UDP echo.** A single read→write loop: `n, addr, _ := pc.ReadFrom(buf)` then
+  `pc.WriteTo(buf[:n], addr)`, echoing exactly the `n` bytes read from a
+  65535-byte buffer (full UDP payload space; test payloads are `< MTU`). One
+  goroutine is correct for any number of peers — each datagram is echoed to its
+  own source `addr`, replies leave from the bound port (what NodePort/ClusterIP
+  conntrack keys on), and the reused buffer is race-free because one goroutine
+  reads then writes sequentially. `fork`-style per-peer parallelism (as in socat)
+  is unnecessary for echo correctness.
+  - *Concurrency caveat (documented at `serveUDP`):* the suite fires probes
+    serially and wraps the UDP check in `Eventually`. If it is ever parallelised,
+    a single goroutine can drain `SO_RCVBUF` slower than a concurrent burst
+    arrives and silently drop datagrams. The remedy then is
+    `SetReadBuffer(...)` plus goroutine-per-datagram echo that **copies `buf[:n]`
+    first** (the shared buffer is reused on the next `ReadFrom`).
 
-**`/post` — count, don't buffer.** Stream the body with
-`n, _ := io.Copy(io.Discard, r.Body)` and return `strconv.FormatInt(n, 10)`.
-This avoids holding the (up to 10000-byte) body in memory and reports the exact
-received byte count (equivalent to flask's `request.content_length` for the
-curl-set Content-Length the test uses).
+Readiness/liveness, port, and `restartPolicy: Never` are inherited from the base
+conncheck server pod; the customizer overrides only image, args, the `MODE=server`
+env, and the readiness path.
 
-**UDP echo.** Loop: `n, addr, _ := pc.ReadFrom(buf)`, then
-`pc.WriteTo(buf[:n], addr)` — echo exactly the `n` bytes read (never the whole
-buffer). Use a 65535-byte `buf` (full UDP payload space; test payloads are
-`< MTU`, so never truncated; flask used socat `-b 10000`). Datagrams larger than
-the buffer would be truncated by the kernel — out of range for this test, noted
-as the cap.
+### `client` mode contract
 
-A single read→write goroutine is used instead of socat's `fork` (per-peer
-handler). This is **correct for any number of peers** — each datagram is echoed
-to its own source `addr`, and the reused `buf` is race-free because one goroutine
-reads then writes it sequentially. The only thing `fork` adds is parallelism
-across simultaneous senders, which doesn't affect echo correctness or the
-reply source port (both reply from the bound port, the thing NodePort/ClusterIP
-conntrack keys on).
+Flags: `-url` (required), `-port` (default 12345), `-timeout` (30s), `-v`. It
+performs a single GET from a fixed source port with `SO_REUSEADDR` and keep-alives
+disabled, and prints the response body. The only consumer is `maglev.go`, which
+runs it on the external node; `MODE` is unset there so `client` is selected. The
+`/shell?cmd=hostname` URL in that invocation is an endpoint on the maglev backend
+being load-balanced, not on `server` mode — `client` is a generic HTTP GET tool.
 
-**Caveat if `packet_size` is ever made concurrent** (a likely future speedup —
-the suite currently fires probes serially): a single goroutine drains
-`SO_RCVBUF` slower than parallel handlers, so a concurrent burst can overflow the
-kernel receive buffer and *silently drop* datagrams → missing echoes. Today this
-is harmless because the test is serial and wraps the UDP check in
-`Eventually(30s, 1s)`, which retries transient loss. If you parallelise the
-probes and see drops, harden the server with: (1)
-`pc.(*net.UDPConn).SetReadBuffer(...)` to absorb bursts, and (2) goroutine-per-
-datagram echo — **copying `buf[:n]` first**
-(`d := append([]byte(nil), buf[:n]...); go pc.WriteTo(d, addr)`), because the
-shared buffer is reused on the next `ReadFrom`; skipping the copy reintroduces a
-data race. This caveat is also recorded at `serveUDP` in `server.go`.
+### Multi-arch image build
 
-Readiness/liveness, port, and `restartPolicy: Never` are inherited unchanged
-from the base conncheck server pod; the customizer only overrides image, args,
-the `MODE=server` env, and the readiness path (`/length/1`). No probe-timing
-changes.
+`Dockerfile` is `FROM scratch` with `ARG TARGETARCH` /
+`COPY bin/rapidclient-${TARGETARCH} /rapidclient`, so one Dockerfile produces
+every platform. Per-arch static binaries are built with `CGO_ENABLED=0` and
+`GOARCH=$*` (clean cross-compilation, correct for `FROM scratch`).
 
-### Test assertions this server must satisfy (from `packet_size.go`)
+- `ARCHES := amd64 arm64` — assigned unconditionally because `lib.Makefile`
+  already sets a four-arch default; `?=` would leave `publish` building
+  `ppc64le`/`s390x` too. amd64-only is the bug this image fixes.
+- `publish` builds all `ARCHES` into a single manifest list and `--push`es it
+  (a multi-platform build cannot `--load`). A post-publish guard inspects the
+  pushed tag and fails unless it is a manifest list covering every arch in
+  `ARCHES` — this is what stops a silent regression to single-arch. On `master`
+  the tag is retagged to `:latest` via `buildx imagetools create`.
+- `image` builds a single-arch image locally (`--load`) for development.
+- Unit tests run via `ut` (repo convention; `lib.Makefile`'s `test: ut fv st`
+  aggregates it, and `fv`/`st` are no-ops for this image) and `ci`. They execute
+  in CI through the dedicated **"E2E images"** Semaphore block
+  (`.semaphore/semaphore.yml.d/blocks/20-e2e-images.yml`).
 
-- **GET** (`packetTestViaConncheck`, ~line 295): `len(strings.TrimSpace(out)) == length`.
-  ⇒ The N-byte body **must contain no leading/trailing whitespace**, or TrimSpace
-  shortens it and the check fails. (This is exactly why the flask lorem corpus is
-  one whitespace-free run-on string.) The Go generator emits N bytes drawn from a
-  whitespace-free charset (e.g. repeating `a–z0–9`).
-- **POST** (~line 313): `strconv.Atoi(strings.TrimSpace(out)) == length`, where the
-  client posts `strings.Repeat("X", length)`. ⇒ return the byte count of the
-  received body. Use bytes actually read (robust) — equals Content-Length here.
-- **UDP** (~line 334): `strings.TrimSpace(out) == payload`, payload =
-  `generateUDPPayload(length)` (digits `0–9`, no whitespace). ⇒ pure echo.
+Publishing to quay is done by the existing `.semaphore/push-images/e2e-test.yml`
+job (authenticated via the `quay-tigeradev-hashrelease` secret), triggered by the
+`change_in('/e2e/images/rapidclient/*.go')` rule.
 
-Readiness: `/length/1` must 200 with a 1-byte body.
+### Image delivery to test nodes
+
+Fork PR builds have no registry push credential, so the image built *from the PR
+under test* cannot be pushed to quay for nodes to pull; a `:latest` reference
+would silently run the previously-published image. Each CI lane that exercises the
+image therefore builds it from PR source and loads it directly onto its nodes,
+pinning the exact tag via `RAPIDCLIENT_TAG` (pods use `ImagePullPolicy: Never`).
+
+- **gcp-kubeadm** (`.semaphore/end-to-end/scripts/phases/load_images.sh`): builds
+  `rapidclient:pr-<N>`, `docker save`s it once, `ctr -n k8s.io images import`s it
+  onto every worker node's containerd and `docker load`s it onto the external
+  node, then exports `RAPIDCLIENT_TAG` (forwarded into the e2e container via
+  `K8S_E2E_DOCKER_EXTRA_FLAGS`). Runs only when `RUN_LOCAL_TESTS` and
+  `PROVISIONER=gcp-kubeadm` (it depends on the CRC terraform outputs + SSH key);
+  otherwise it no-ops.
+- **kind** (`e2e-test-bpf`, the sig-calico BPF lane that runs packet-size): builds
+  `rapidclient:kind-e2e`, `kind load docker-image`s it into the kind nodes, and
+  `docker load`s it into the external node's inner docker daemon (a `dind`
+  container). `RAPIDCLIENT_TAG=kind-e2e` is exported by the root `Makefile` so the
+  ginkgo process inherits it. The non-BPF `e2e-test` lane (`kind.yaml` focus
+  `Conformance && sig-calico`) does not run packet-size, and the CNP lane uses a
+  separate test binary, so only `e2e-test-bpf` is wired.
+
+When `RAPIDCLIENT_TAG` is unset — other providers, scheduled hashrelease runs,
+local dev — `RapidClientImage()` reports `preloaded=false` and the published
+`:latest` is used with the default pull policy.
 
 ## Edge cases & failure modes
 
-- **Whitespace in `/length` output** → breaks GET length assertion. Mitigation:
-  whitespace-free charset; unit test asserts `len(TrimSpace(body)) == N` for
-  several N including 1, 10, MTU-ish, 10000.
-- **`/length/0` or non-integer `{N}`** → flask would `int("abc")` 500. Match by
-  returning 400 on parse failure; `N=0` returns empty body (200). Document; tests
-  never send these but be defensive.
-- **Large GET (10000 bytes)** → must not be truncated by any default write
-  limits; stream/write fully.
-- **UDP datagram larger than read buffer** → would truncate the echo and fail the
-  equality check. 65535 buffer covers all test sizes; document the cap.
-- **Dual-stack binding** → on some kernels `[::]` won't accept IPv4 unless
-  `IPV6_V6ONLY=0`. Go's `net.Listen("tcp", ":5000")` already binds dual-stack via
-  IPv4-mapped addresses on Linux; verify both UDP and TCP accept v4 and v6. If a
-  single dual-stack socket is unreliable, fall back to two listeners (`0.0.0.0`
-  and `[::]`). Decide during implementation; note in README.
-- **Port already in use / bind failure** → log and exit non-zero promptly so the
-  pod goes `Failed` visibly (current behaviour) rather than hanging.
-- **`MODE=server` but stray args present** → server mode ignores all args (does
-  not fatal). The flask wrapper parsed a `-p=`/`--port=` arg; that override is
-  intentionally dropped (see the server-mode section) — `PORT` env is the only
-  port knob.
-- **Multi-arch manifest regression** → add a guard/check that the published image
-  is a manifest list with both `amd64` and `arm64` (e.g. assert in the Makefile
-  publish step or a CI check) so this can't silently regress to single-arch again.
+- **Whitespace in `/length` output** breaks the GET length assertion. Mitigated by
+  the whitespace-free charset; the unit test asserts `len(TrimSpace(body)) == N`
+  for N ∈ {1, 10, 1400, 10000}.
+- **`/length/0` or non-integer `{N}`.** `N==0` returns an empty 200; a parse
+  failure returns 400 (flask would 500). The suite never sends these; the server
+  is defensive.
+- **Large GET (10 000 bytes)** is written in full — no default write-limit
+  truncation.
+- **UDP datagram larger than the 65535-byte buffer** would truncate the echo.
+  Out of range for the suite; documented as the cap.
+- **Bind failure / port in use** logs and exits non-zero so the pod goes `Failed`
+  visibly rather than hanging.
+- **`MODE=server` with stray args** is tolerated (server mode ignores args); the
+  dropped `-p=`/`--port=` override is by design.
+- **Manifest-list regression** is caught by the post-publish guard asserting the
+  tag covers every arch in `ARCHES`.
+- **Missing node load with `RAPIDCLIENT_TAG` set** surfaces immediately as
+  `ErrImageNeverPull` (pods use `PullNever`) rather than a silent stale pull.
 
 ## Testing
 
-- **Unit (`server_test.go`)**, vanilla `go test` (no Ginkgo — new package):
-  - `GET /length/{N}` returns N bytes with `len(TrimSpace(body)) == N` for
-    N ∈ {1, 10, 1400, 10000}.
-  - `POST /post` with a body of K `X`s returns `"K"`.
-  - UDP echo returns the exact datagram for a digit payload.
-  - unknown `MODE` → error; empty `MODE` → client selected (dispatch test).
-- **Integration**: the existing `Packet Size Verification` suite is the real
-  proof. Must stay green on amd64 (gcp-kubeadm/aws-kubeadm) and newly pass on
-  arm64 (azr-aks ARM). No new e2e test needed; the change is covered by an
-  existing suite that currently fails on arm64.
+- **Unit (`server_test.go`, plain `go test`):** `GET /length/{N}` returns N bytes
+  with `len(TrimSpace(body)) == N` for N ∈ {1, 10, 1400, 10000}; `POST /post` with
+  K `X`s returns `"K"`; UDP echo returns the exact datagram; dispatch tests cover
+  unknown `MODE` (error) and empty `MODE` (client selected). Run in CI via the
+  "E2E images" block.
+- **Integration:** the existing `Packet Size Verification` suite is the real
+  proof — it must stay green on amd64 (gcp-kubeadm / aws-kubeadm, kind BPF) and
+  newly pass on arm64 (azr-aks ARM). No new e2e test is added.
 
-## Migration / rollout
+## Rollout & follow-ups
 
-1. Land the multi-mode binary + multi-arch Makefile; CI publishes
-   `quay.io/tigeradev/rapidclient` as a manifest list.
-2. Switch the customizer to `RapidClientImage()` + `MODE=server` and add the
-   `load_images.sh` side-load, in the **same PR** (so the suite runs the PR-built
-   server atomically, without a registry push).
-3. Verify packet_size on an arm64 azr-aks run goes green; confirm amd64 unaffected.
-4. Follow-up (separate): drop the flask image from `tigera/k8s-e2e`.
-
-## Explicitly out of scope (matching the disposable-test-server scope)
-
-The flask server had none of these and the replacement intentionally doesn't add
-them: TLS/HTTPS, request-body size limits (POST is streamed, not buffered — no
-OOM risk), graceful shutdown / signal handling (pod is killed, `restartPolicy:
-Never`), metrics/structured logging beyond startup + fatal logs, and rate
-limiting/concurrency caps (`http.Server`'s default per-connection goroutines are
-sufficient). If a future need arises it's a deliberate extension, not a gap here.
-
-## Follow-ups (deliberately not in this change)
-
-1. **Digest-pin the published image.** PR CI now runs against a per-PR tag
-   side-loaded onto the nodes (`RAPIDCLIENT_TAG`), but non-gcp-kubeadm and
-   scheduled runs still consume the floating published `:latest`. Pinning that
-   published image to an immutable digest with a documented bump process is
-   worthwhile hardening, but **deferred** — the side-load + multi-arch publish fix
-   the reported bug. Tracked as a separate change.
-2. **Retire the flask image.** Once this lands and packet_size is green on arm64,
-   drop `images/flask` from `tigera/k8s-e2e` (it will be unreferenced).
-
-(Resolved during review and folded into the body: dual-stack binding decision;
-`/length` charset pinned; multi-arch Makefile/CI mechanics made concrete;
-`maglev.go` invocation quoted to verify "zero change". Doc home: this file,
-`e2e/images/rapidclient/DESIGN.md`.)
+- The multi-mode binary, multi-arch publish, `RapidClientImage()` switch, and the
+  per-lane image loads land together so the packet-size suite runs against the
+  PR-built server atomically, without a registry push.
+- **Follow-up — retire the flask image.** Once packet-size is green on arm64, drop
+  `images/flask` from `tigera/k8s-e2e` (it becomes unreferenced).
+- **Follow-up — digest-pin the published image.** Non-gcp-kubeadm and scheduled
+  runs still consume the floating published `:latest`; pinning it to an immutable
+  digest with a documented bump process is worthwhile hardening.

--- a/e2e/images/rapidclient/DESIGN.md
+++ b/e2e/images/rapidclient/DESIGN.md
@@ -1,0 +1,403 @@
+# Design: multi-mode `rapidclient` e2e utility binary
+
+## Goal
+
+Turn the existing single-purpose `rapidclient` e2e image into a **multi-mode Go
+binary** dispatched by a `MODE` env var, and **port the `k8s-e2e-dataplane-server`**
+(currently a Flask + socat image in `tigera/k8s-e2e/images/flask`) into it as a
+new `server` mode.
+
+Primary motivations:
+
+1. **Fix the arm64 gap.** `calico/k8s-e2e-dataplane-server:stable` is published
+   **amd64-only** (verified: single-arch manifest). On arm64 clusters (azr-aks
+   ARM lane) the server container runs the amd64 binary and crashes instantly
+   (exitCode 255), so every `Packet Size Verification` spec fails — chronic for
+   6+ weeks. An in-repo Go binary built via Calico's `buildx` gets arm64 for free.
+2. **Remove an external dependency.** The packet-size server source lives outside
+   the monorepo (`tigera/k8s-e2e`) and is pinned to a floating `:stable` tag,
+   which is how the arm64 regression went unnoticed. Bringing it in-repo puts it
+   under the same review/build/multi-arch guarantees as other code.
+3. **Establish a reusable pattern.** A mode-dispatched utility image lets future
+   e2e helpers be added as new modes instead of new external images.
+
+## Non-goals
+
+- Re-implementing third-party upstream test images (agnhost, test-webserver,
+  iperf3, socat, netshoot). Those stay as upstream references in `images.go`;
+  they are already multi-arch and not Calico-owned.
+- Changing the `Packet Size Verification` test logic or what it asserts. This is
+  a like-for-like server replacement; the suite must pass unchanged on amd64 and
+  newly pass on arm64.
+- Changing the client (maglev) invocation. The `docker run … -url … -port …`
+  call in `maglev.go` must keep working verbatim.
+- Pinning image tags to digests / changing the tagging scheme. Noted as a future
+  hardening (see Open questions), not in scope here.
+- Deleting anything in `tigera/k8s-e2e`. We stop *referencing* the flask image;
+  retiring it there is a separate follow-up.
+
+## Approach
+
+### Dispatch (decided: default-client + `MODE=server`)
+
+`main.go` reads the `MODE` env var and dispatches through a **mode registry**:
+
+- `MODE` unset/empty → **`client`** mode (backward-compatible default; preserves
+  the existing flag interface and the `maglev.go` invocation with zero change).
+- `MODE=server` → `server` mode (the ported dataplane server), injected by the
+  packet_size pod customizer.
+- Unknown `MODE` → exit non-zero with a clear error listing registered modes.
+
+Each mode owns its **own `flag.FlagSet`** parsed from `os.Args[1:]`, so modes
+have independent flag/arg surfaces. This is the "general multi-tool framework"
+shape (decided), kept minimal: a registry + interface now, only `client` and
+`server` implemented. Adding a mode later = one `RegisterMode` call in an
+`init()`.
+
+### Package layout (`e2e/images/rapidclient/`, name kept)
+
+```
+main.go        # dispatch: read MODE (default "client"), look up mode, run
+mode.go        # Mode interface + registry (RegisterMode / lookup / list)
+client.go      # client mode: today's rapidclient logic, registered via init()
+server.go      # server mode: HTTP /length//post// + UDP echo, registered via init()
+server_test.go # unit tests for server endpoints + UDP echo
+Dockerfile     # unchanged (FROM scratch; ENTRYPOINT ["/rapidclient"])
+Makefile       # CHANGED: multi-arch buildx manifest push (amd64 + arm64)
+README.md      # updated to document modes
+```
+
+Image name, dir name, quay repo (`quay.io/tigeradev/rapidclient`), CI push job,
+and the `change_in('/e2e/images/rapidclient/*.go')` trigger all stay as-is.
+
+### `images.go` change
+
+```go
+// RapidClient (client mode, default) — unchanged ref.
+RapidClient      = "quay.io/tigeradev/rapidclient"
+// PacketSizeServer now points at the SAME image; server mode is selected by
+// the MODE=server env the packet_size pod customizer sets.
+PacketSizeServer = "quay.io/tigeradev/rapidclient"
+```
+
+The `// Source: tigera/k8s-e2e/images/flask.` comment is replaced with a pointer
+to `e2e/images/rapidclient/server.go`.
+
+### `packet_size.go` change
+
+`withPacketSizeServer` currently swaps the image, nils args, and sets the
+readiness path to `/length/1`. Add the mode env:
+
+```go
+func withPacketSizeServer(pod *v1.Pod) {
+    for i := range pod.Spec.Containers {
+        pod.Spec.Containers[i].Image = images.PacketSizeServer
+        pod.Spec.Containers[i].Args  = nil
+        pod.Spec.Containers[i].Env   = append(pod.Spec.Containers[i].Env,
+            v1.EnvVar{Name: "MODE", Value: "server"})
+        if rp := pod.Spec.Containers[i].ReadinessProbe; rp != nil && rp.HTTPGet != nil {
+            rp.HTTPGet.Path = "/length/1"
+        }
+    }
+}
+```
+
+`PORT` is left unset → server defaults to 5000 (matches `packetServerPort` and
+the container port already in the base conncheck server pod).
+
+### Multi-arch build (the actual bug fix)
+
+**Current state** (verbatim, so the diff is unambiguous).
+`e2e/images/rapidclient/Makefile`:
+
+```makefile
+include ../../../metadata.mk
+PACKAGE_NAME=github.com/projectcalico/calico/e2e/images/rapidclient
+include ../../../lib.Makefile
+QUAY_REGISTRY ?= quay.io/tigeradev
+TAG_NAME ?= $(shell git branch --show-current)
+
+bin/rapidclient: main.go
+	mkdir -p bin
+	$(DOCKER_RUN) -e CGO_ENABLED=0 $(CALICO_BUILD) go build -o $@ -ldflags "-s -w" .
+
+image: bin/rapidclient
+	docker buildx build --load --platform=linux/$(ARCH) --pull \
+		--build-arg BINARY_PATH=bin/rapidclient -f Dockerfile \
+		-t $(QUAY_REGISTRY)/rapidclient:$(TAG_NAME) .
+
+publish: image
+	docker push $(QUAY_REGISTRY)/rapidclient:$(TAG_NAME)
+	@if [ "$(TAG_NAME)" = "master" ]; then \
+		docker tag  ...:$(TAG_NAME) ...:latest; docker push ...:latest; fi
+```
+
+`Dockerfile`: `FROM scratch` / `COPY ${BINARY_PATH} /rapidclient` /
+`ENTRYPOINT ["/rapidclient"]`. CGO is already disabled, so the binary is static
+and `FROM scratch` is correct — no Dockerfile change needed for the binary
+itself (only inputs change).
+
+CI: `.semaphore/push-images/e2e-test.yml` already logs into quay
+(`quay-tigeradev-hashrelease` secret) in its prologue and runs
+`make -C e2e publish-test-images CONFIRM=true` (which calls this Makefile's
+`publish`). Triggered by `change_in('/e2e/images/rapidclient/*.go')` in
+`.semaphore/semaphore.yml`. **Authentication and the publish job already exist** —
+we are not adding CI wiring, only changing the Makefile to emit a manifest list.
+
+**The defect:** `image` uses `--load --platform=linux/$(ARCH)` (default
+`ARCH=amd64`) — a single-arch image loaded locally, so the published tag is
+amd64-only. That is the arm64 bug.
+
+**Change** — build both arch binaries and push one **manifest list**:
+
+```makefile
+ARCHES = amd64 arm64
+
+bin/rapidclient-%:
+	mkdir -p bin
+	$(DOCKER_RUN) -e CGO_ENABLED=0 -e GOARCH=$* $(CALICO_BUILD) \
+		go build -o $@ -ldflags "-s -w" .
+
+# Dockerfile takes BINARY_PATH; buildx selects the right per-arch binary via
+# TARGETARCH. Build all platforms in one manifest and --push (cannot --load a
+# multi-platform build).
+publish: $(addprefix bin/rapidclient-,$(ARCHES))
+	docker buildx build --platform=$(subst $(space),$(comma),$(addprefix linux/,$(ARCHES))) \
+		--push --pull -f Dockerfile \
+		-t $(QUAY_REGISTRY)/rapidclient:$(TAG_NAME) .
+	@if [ "$(TAG_NAME)" = "master" ]; then \
+		docker buildx imagetools create -t $(QUAY_REGISTRY)/rapidclient:latest \
+			$(QUAY_REGISTRY)/rapidclient:$(TAG_NAME); fi
+```
+
+The `Dockerfile` gains a `TARGETARCH` arg so buildx copies the matching binary:
+`ARG TARGETARCH` / `COPY bin/rapidclient-${TARGETARCH} /rapidclient`. (Confirm
+the exact lib.Makefile multi-arch idiom during implementation — Calico already
+has `ARCHES`/manifest helpers in `lib.Makefile`; prefer reusing them over the
+hand-rolled `subst` above if a helper exists.)
+
+**Regression guard:** after publish, assert the tag is a manifest list with both
+platforms — `docker buildx imagetools inspect $(QUAY_REGISTRY)/rapidclient:$(TAG_NAME)`
+must list `linux/amd64` and `linux/arm64`; fail the target otherwise. This is the
+specific check that stops a silent regression to single-arch.
+
+This Makefile change is what resolves the arm64 failure; everything else just
+makes the server available to build in the first place.
+
+## Interfaces / data shapes
+
+### Mode registry (`mode.go`)
+
+```go
+type Mode interface {
+    Name() string
+    // Run parses its own flags from args and executes. Returns an error;
+    // main() maps non-nil to a non-zero exit.
+    Run(args []string) error
+}
+
+func RegisterMode(m Mode)          // called from each mode's init()
+func lookup(name string) (Mode, bool)
+func modeNames() []string          // for the unknown-mode error message
+```
+
+`main()`:
+```go
+mode := os.Getenv("MODE")
+if mode == "" { mode = "client" }   // back-compat default
+m, ok := lookup(mode)
+if !ok { fatalf("unknown MODE %q; known modes: %v", mode, modeNames()) }
+if err := m.Run(os.Args[1:]); err != nil { log.Fatal(err) }
+```
+
+### `client` mode (`client.go`) — behaviour preserved exactly
+
+Flags (unchanged): `-url` (required), `-port` (default 12345), `-timeout`
+(30s), `-v`. Single GET from a fixed source port with `SO_REUSEADDR` and
+keep-alives disabled; prints the response body. Identical to today's `main.go`.
+
+The only consumer is `maglev.go:594`, which runs it on an **external node**:
+
+```go
+cmd := fmt.Sprintf("sudo docker run --rm --net=host %s -url http://%s/shell?cmd=hostname -port %d",
+    images.RapidClient, ep, m.maglevConfig.SourcePort)
+```
+
+`MODE` is unset here → defaults to `client` → flags parse exactly as today. **No
+change to `maglev.go`.** (Note: the `/shell?cmd=hostname` URL is an endpoint on
+the *maglev backend* being load-balanced, not on our `server` mode — client mode
+is a generic HTTP GET tool and is agnostic to it.)
+
+### `server` mode (`server.go`) — ported contract
+
+Listens on `PORT` (env, default 5000). TCP HTTP and UDP echo on the **same port
+number**. Port comes from `PORT` env only — the `-p=`/`--port=` CLI override the
+old flask `runme.sh` accepted is **intentionally not replicated** (no consumer
+passes it; `withPacketSizeServer` sets `Args = nil`). This is the single
+deliberate functional difference from the python version.
+
+**Dual-stack (decided, no fallback):** bind each listener to the unspecified
+address so Linux serves both IPv4 and v4-mapped IPv6 from one socket, matching
+flask's `host="::"`:
+- HTTP: `net.Listen("tcp", ":"+port)` then `http.Serve`.
+- UDP: `net.ListenPacket("udp", ":"+port)`.
+
+On Linux these bind dual-stack by default (`IPV6_V6ONLY=0`), which is all the
+test needs (it connects via IPv4 pod IP / ClusterIP / NodePort, and IPv6 in
+dual-stack configs). We do **not** implement a two-socket fallback unless a
+concrete CI failure proves the single socket insufficient — keeping the
+implementation deterministic. If that ever happens, the fix is two listeners
+(`0.0.0.0` + `[::]` with `IPV6_V6ONLY=1`); recorded here so the option isn't
+re-litigated.
+
+**Invalid `PORT`:** non-numeric or out-of-range (`<1` or `>65535`) → log and
+exit non-zero immediately (visible pod `Failed`, not a silent hang).
+
+HTTP endpoints (must match what `packet_size.go` drives):
+
+| Route | Method | Response | Status |
+|---|---|---|---|
+| `/` | GET | static non-empty string (sanity) | 200 |
+| `/length/{N}` | GET | exactly **N whitespace-free bytes** (N≥1) | 200 |
+| `/length/{N}` | GET | empty body when `N==0` | 200 |
+| `/length/{N}` | GET | `N` non-integer or `<0` | 400 |
+| `/post` | POST | the request body's byte count, as a decimal string | 200 |
+| `/post` | GET | static help string (parity with flask) | 200 |
+| anything else | any | not-found | 404 |
+
+**`/length/{N}` body — pinned charset.** Emit N bytes by repeating the fixed
+36-byte alphabet `abcdefghijklmnopqrstuvwxyz0123456789` and truncating to N. This
+alphabet is **whitespace-free**, so the test's `len(strings.TrimSpace(body))`
+equals N. Content is otherwise irrelevant (the suite asserts only length —
+verified in `packet_size.go`), but the charset is pinned so the unit test is
+exact and a future content-sensitive test would be a deliberate change, not an
+accident. Write all N bytes in the response and set `Content-Length` (no chunked
+framing surprises); `http.Server` is concurrent by default — no extra handling.
+
+**`/post` — count, don't buffer.** Stream the body with
+`n, _ := io.Copy(io.Discard, r.Body)` and return `strconv.FormatInt(n, 10)`.
+This avoids holding the (up to 10000-byte) body in memory and reports the exact
+received byte count (equivalent to flask's `request.content_length` for the
+curl-set Content-Length the test uses).
+
+**UDP echo.** Loop: `n, addr, _ := pc.ReadFrom(buf)`, then
+`pc.WriteTo(buf[:n], addr)` — echo exactly the `n` bytes read (never the whole
+buffer). Use a 65535-byte `buf` (full UDP payload space; test payloads are
+`< MTU`, so never truncated; flask used socat `-b 10000`). Datagrams larger than
+the buffer would be truncated by the kernel — out of range for this test, noted
+as the cap.
+
+A single read→write goroutine is used instead of socat's `fork` (per-peer
+handler). This is **correct for any number of peers** — each datagram is echoed
+to its own source `addr`, and the reused `buf` is race-free because one goroutine
+reads then writes it sequentially. The only thing `fork` adds is parallelism
+across simultaneous senders, which doesn't affect echo correctness or the
+reply source port (both reply from the bound port, the thing NodePort/ClusterIP
+conntrack keys on).
+
+**Caveat if `packet_size` is ever made concurrent** (a likely future speedup —
+the suite currently fires probes serially): a single goroutine drains
+`SO_RCVBUF` slower than parallel handlers, so a concurrent burst can overflow the
+kernel receive buffer and *silently drop* datagrams → missing echoes. Today this
+is harmless because the test is serial and wraps the UDP check in
+`Eventually(30s, 1s)`, which retries transient loss. If you parallelise the
+probes and see drops, harden the server with: (1)
+`pc.(*net.UDPConn).SetReadBuffer(...)` to absorb bursts, and (2) goroutine-per-
+datagram echo — **copying `buf[:n]` first**
+(`d := append([]byte(nil), buf[:n]...); go pc.WriteTo(d, addr)`), because the
+shared buffer is reused on the next `ReadFrom`; skipping the copy reintroduces a
+data race. This caveat is also recorded at `serveUDP` in `server.go`.
+
+Readiness/liveness, port, and `restartPolicy: Never` are inherited unchanged
+from the base conncheck server pod; the customizer only overrides image, args,
+the `MODE=server` env, and the readiness path (`/length/1`). No probe-timing
+changes.
+
+### Test assertions this server must satisfy (from `packet_size.go`)
+
+- **GET** (`packetTestViaConncheck`, line 284): `len(strings.TrimSpace(out)) == length`.
+  ⇒ The N-byte body **must contain no leading/trailing whitespace**, or TrimSpace
+  shortens it and the check fails. (This is exactly why the flask lorem corpus is
+  one whitespace-free run-on string.) The Go generator emits N bytes drawn from a
+  whitespace-free charset (e.g. repeating `a–z0–9`).
+- **POST** (line 301): `strconv.Atoi(strings.TrimSpace(out)) == length`, where the
+  client posts `strings.Repeat("X", length)`. ⇒ return the byte count of the
+  received body. Use bytes actually read (robust) — equals Content-Length here.
+- **UDP** (line 323): `strings.TrimSpace(out) == payload`, payload =
+  `generateUDPPayload(length)` (digits `0–9`, no whitespace). ⇒ pure echo.
+
+Readiness: `/length/1` must 200 with a 1-byte body.
+
+## Edge cases & failure modes
+
+- **Whitespace in `/length` output** → breaks GET length assertion. Mitigation:
+  whitespace-free charset; unit test asserts `len(TrimSpace(body)) == N` for
+  several N including 1, 10, MTU-ish, 10000.
+- **`/length/0` or non-integer `{N}`** → flask would `int("abc")` 500. Match by
+  returning 400 on parse failure; `N=0` returns empty body (200). Document; tests
+  never send these but be defensive.
+- **Large GET (10000 bytes)** → must not be truncated by any default write
+  limits; stream/write fully.
+- **UDP datagram larger than read buffer** → would truncate the echo and fail the
+  equality check. 65535 buffer covers all test sizes; document the cap.
+- **Dual-stack binding** → on some kernels `[::]` won't accept IPv4 unless
+  `IPV6_V6ONLY=0`. Go's `net.Listen("tcp", ":5000")` already binds dual-stack via
+  IPv4-mapped addresses on Linux; verify both UDP and TCP accept v4 and v6. If a
+  single dual-stack socket is unreliable, fall back to two listeners (`0.0.0.0`
+  and `[::]`). Decide during implementation; note in README.
+- **Port already in use / bind failure** → log and exit non-zero promptly so the
+  pod goes `Failed` visibly (current behaviour) rather than hanging.
+- **`MODE=server` but stray args present** → server mode ignores all args (does
+  not fatal). The flask wrapper parsed a `-p=`/`--port=` arg; that override is
+  intentionally dropped (see the server-mode section) — `PORT` env is the only
+  port knob.
+- **Multi-arch manifest regression** → add a guard/check that the published image
+  is a manifest list with both `amd64` and `arm64` (e.g. assert in the Makefile
+  publish step or a CI check) so this can't silently regress to single-arch again.
+
+## Testing
+
+- **Unit (`server_test.go`)**, vanilla `go test` (no Ginkgo — new package):
+  - `GET /length/{N}` returns N bytes with `len(TrimSpace(body)) == N` for
+    N ∈ {1, 10, 1400, 10000}.
+  - `POST /post` with a body of K `X`s returns `"K"`.
+  - UDP echo returns the exact datagram for a digit payload.
+  - unknown `MODE` → error; empty `MODE` → client selected (dispatch test).
+- **Integration**: the existing `Packet Size Verification` suite is the real
+  proof. Must stay green on amd64 (gcp-kubeadm/aws-kubeadm) and newly pass on
+  arm64 (azr-aks ARM). No new e2e test needed; the change is covered by an
+  existing suite that currently fails on arm64.
+
+## Migration / rollout
+
+1. Land the multi-mode binary + multi-arch Makefile; CI publishes
+   `quay.io/tigeradev/rapidclient` as a manifest list.
+2. Repoint `images.PacketSizeServer` and add `MODE=server` in the customizer in
+   the **same PR** (so the suite switches to the in-repo server atomically).
+3. Verify packet_size on an arm64 azr-aks run goes green; confirm amd64 unaffected.
+4. Follow-up (separate): drop the flask image from `tigera/k8s-e2e`; consider
+   pinning the image tag.
+
+## Explicitly out of scope (matching the disposable-test-server scope)
+
+The flask server had none of these and the replacement intentionally doesn't add
+them: TLS/HTTPS, request-body size limits (POST is streamed, not buffered — no
+OOM risk), graceful shutdown / signal handling (pod is killed, `restartPolicy:
+Never`), metrics/structured logging beyond startup + fatal logs, and rate
+limiting/concurrency caps (`http.Server`'s default per-connection goroutines are
+sufficient). If a future need arises it's a deliberate extension, not a gap here.
+
+## Follow-ups (deliberately not in this change)
+
+1. **Tag pinning.** `images.go` consumes a floating tag (`:latest`/branch). The
+   arm64 rot was masked partly by a floating, unpinned, external tag. Pinning the
+   e2e utility image to an immutable tag/digest with a documented bump process is
+   worthwhile hardening, but **deferred** — multi-arch publishing alone fixes the
+   reported bug. Tracked as a separate change.
+2. **Retire the flask image.** Once this lands and packet_size is green on arm64,
+   drop `images/flask` from `tigera/k8s-e2e` (it will be unreferenced).
+
+(Resolved during review and folded into the body: dual-stack binding decision;
+`/length` charset pinned; multi-arch Makefile/CI mechanics made concrete;
+`maglev.go` invocation quoted to verify "zero change". Doc home: this file,
+`e2e/images/rapidclient/DESIGN.md`.)

--- a/e2e/images/rapidclient/DESIGN.md
+++ b/e2e/images/rapidclient/DESIGN.md
@@ -51,14 +51,14 @@ Primary motivations:
 Each mode owns its **own `flag.FlagSet`** parsed from `os.Args[1:]`, so modes
 have independent flag/arg surfaces. This is the "general multi-tool framework"
 shape (decided), kept minimal: a registry + interface now, only `client` and
-`server` implemented. Adding a mode later = one `RegisterMode` call in an
+`server` implemented. Adding a mode later = one `registerMode` call in an
 `init()`.
 
 ### Package layout (`e2e/images/rapidclient/`, name kept)
 
 ```
 main.go        # dispatch: read MODE (default "client"), look up mode, run
-mode.go        # Mode interface + registry (RegisterMode / lookup / list)
+mode.go        # Mode interface + registry (registerMode / lookupMode / modeNames)
 client.go      # client mode: today's rapidclient logic, registered via init()
 server.go      # server mode: HTTP /length//post// + UDP echo, registered via init()
 server_test.go # unit tests for server endpoints + UDP echo
@@ -196,8 +196,8 @@ type Mode interface {
     Run(args []string) error
 }
 
-func RegisterMode(m Mode)          // called from each mode's init()
-func lookup(name string) (Mode, bool)
+func registerMode(m Mode)          // called from each mode's init()
+func lookupMode(name string) (Mode, bool)
 func modeNames() []string          // for the unknown-mode error message
 ```
 
@@ -205,7 +205,7 @@ func modeNames() []string          // for the unknown-mode error message
 ```go
 mode := os.Getenv("MODE")
 if mode == "" { mode = "client" }   // back-compat default
-m, ok := lookup(mode)
+m, ok := lookupMode(mode)
 if !ok { fatalf("unknown MODE %q; known modes: %v", mode, modeNames()) }
 if err := m.Run(os.Args[1:]); err != nil { log.Fatal(err) }
 ```

--- a/e2e/images/rapidclient/DESIGN.md
+++ b/e2e/images/rapidclient/DESIGN.md
@@ -30,9 +30,12 @@ Primary motivations:
   a like-for-like server replacement; the suite must pass unchanged on amd64 and
   newly pass on arm64.
 - Changing the client (maglev) invocation. The `docker run … -url … -port …`
-  call in `maglev.go` must keep working verbatim.
-- Pinning image tags to digests / changing the tagging scheme. Noted as a future
-  hardening (see Open questions), not in scope here.
+  call in `maglev.go` keeps working verbatim (only its image ref changes, via
+  `RapidClientImage()`).
+- Pinning image tags to immutable **digests**. This PR does select a per-PR tag
+  for CI (`RAPIDCLIENT_TAG`; see the side-load section) so the test runs against
+  the PR-built image, but digest-pinning the published image is separate future
+  hardening, not in scope here.
 - Deleting anything in `tigera/k8s-e2e`. We stop *referencing* the flask image;
   retiring it there is a separate follow-up.
 
@@ -72,16 +75,27 @@ and the `change_in('/e2e/images/rapidclient/*.go')` trigger all stay as-is.
 
 ### `images.go` change
 
+Both the client (maglev) and the server (packet-size) use the **same** image, so
+the two former constants (`RapidClient`, `PacketSizeServer`) are replaced by one
+env-aware helper. It composes the ref from `RAPIDCLIENT_TAG` and reports whether
+the image was side-loaded onto the nodes (see the side-load section below):
+
 ```go
-// RapidClient (client mode, default) — unchanged ref.
-RapidClient      = "quay.io/tigeradev/rapidclient"
-// PacketSizeServer now points at the SAME image; server mode is selected by
-// the MODE=server env the packet_size pod customizer sets.
-PacketSizeServer = "quay.io/tigeradev/rapidclient"
+const rapidClientRepo = "quay.io/tigeradev/rapidclient"
+
+// RapidClientImage returns the image ref and whether it was side-loaded.
+func RapidClientImage() (ref string, preloaded bool) {
+    if tag := os.Getenv("RAPIDCLIENT_TAG"); tag != "" {
+        return rapidClientRepo + ":" + tag, true   // PR CI: pinned, imported onto nodes
+    }
+    return rapidClientRepo + ":latest", false       // other providers / local: published image
+}
 ```
 
-The `// Source: tigera/k8s-e2e/images/flask.` comment is replaced with a pointer
-to `e2e/images/rapidclient/server.go`.
+The consumers are `packet_size.go` (server pod) and `maglev.go` (client on the
+external node). The doc comment carries the client/server mode contract and a
+pointer to `e2e/images/rapidclient/server.go` (replacing the old
+`// Source: tigera/k8s-e2e/images/flask.`).
 
 ### `packet_size.go` change
 
@@ -90,9 +104,15 @@ readiness path to `/length/1`. Add the mode env:
 
 ```go
 func withPacketSizeServer(pod *v1.Pod) {
+    image, preloaded := images.RapidClientImage()
     for i := range pod.Spec.Containers {
-        pod.Spec.Containers[i].Image = images.PacketSizeServer
+        pod.Spec.Containers[i].Image = image
         pod.Spec.Containers[i].Args  = nil
+        if preloaded {
+            // Side-loaded onto the node (PR CI) — pin to the loaded copy and fail
+            // loudly if it's absent rather than pulling a stale published image.
+            pod.Spec.Containers[i].ImagePullPolicy = v1.PullNever
+        }
         pod.Spec.Containers[i].Env   = append(pod.Spec.Containers[i].Env,
             v1.EnvVar{Name: "MODE", Value: "server"})
         if rp := pod.Spec.Containers[i].ReadinessProbe; rp != nil && rp.HTTPGet != nil {
@@ -104,6 +124,42 @@ func withPacketSizeServer(pod *v1.Pod) {
 
 `PORT` is left unset → server defaults to 5000 (matches `packetServerPort` and
 the container port already in the base conncheck server pod).
+
+### PR-image side-load (`RAPIDCLIENT_TAG` + `load_images.sh`)
+
+**Problem.** The packet-size test must run against the `rapidclient` image built
+*from the PR under test* — but calico deliberately withholds registry push
+credentials from PR builds (fork PRs are untrusted;
+`.semaphore/…/blocks/10-prerequisites.yml`). So the PR-built image can't be
+pushed to quay, and a floating `:latest` reference would silently run the
+*pre-existing* published image (old single-mode client) — the server pod exits 1
+and every spec times out. This is the exact failure this section prevents.
+
+**Mechanism (no registry push).** On the local-binary **gcp-kubeadm** PR path,
+build the image locally and import it straight into the nodes' runtimes:
+
+- New phase `.semaphore/end-to-end/scripts/phases/load_images.sh`, sourced from
+  `body_standard.sh` after `configure.sh`, before `run_tests.sh`. It:
+  1. builds `quay.io/tigeradev/rapidclient:$TAG` from PR source (`TAG` =
+     `pr-$SEMAPHORE_GIT_PR_NUMBER`, or `e2e-<sha>` off-PR) — no push;
+  2. `docker save`s it once, then `ssh 'sudo ctr -n k8s.io images import'` onto
+     every worker node's containerd and `ssh 'sudo docker load'` onto the
+     external node (maglev runs the image via `docker run`);
+  3. exports `RAPIDCLIENT_TAG=$TAG` and forwards it into the e2e container via
+     `K8S_E2E_DOCKER_EXTRA_FLAGS` (`--env RAPIDCLIENT_TAG`), which `run_tests.sh`
+     already passes to its `docker run` → read by `RapidClientImage()`.
+- `RapidClientImage()` returns `preloaded=true` when `RAPIDCLIENT_TAG` is set, and
+  `withPacketSizeServer` then sets `ImagePullPolicy: Never` — a missing/failed
+  load fails loudly instead of masking with a stale registry pull.
+
+**Scope & fallback.** Node enumeration relies on the gcp-kubeadm CRC terraform
+outputs (`terraform_output.json`) + `master_ssh_key`, which don't exist on other
+providers. So the phase no-ops unless `RUN_LOCAL_TESTS` *and*
+`PROVISIONER=gcp-kubeadm`; every other run (other providers, scheduled hashrelease
+runs, local dev) leaves `RAPIDCLIENT_TAG` unset and uses the published `:latest`
+with default pull policy — unchanged behaviour. The phase fails loudly
+(`set -eo pipefail`, inherited) on any build/import error rather than letting a
+later `ErrImageNeverPull` surface mid-test.
 
 ### Multi-arch build (the actual bug fix)
 
@@ -216,17 +272,20 @@ Flags (unchanged): `-url` (required), `-port` (default 12345), `-timeout`
 (30s), `-v`. Single GET from a fixed source port with `SO_REUSEADDR` and
 keep-alives disabled; prints the response body. Identical to today's `main.go`.
 
-The only consumer is `maglev.go:594`, which runs it on an **external node**:
+The only consumer is `maglev.go:596`, which runs it on an **external node**:
 
 ```go
+rapidClient, _ := images.RapidClientImage()
 cmd := fmt.Sprintf("sudo docker run --rm --net=host %s -url http://%s/shell?cmd=hostname -port %d",
-    images.RapidClient, ep, m.maglevConfig.SourcePort)
+    rapidClient, ep, m.maglevConfig.SourcePort)
 ```
 
-`MODE` is unset here → defaults to `client` → flags parse exactly as today. **No
-change to `maglev.go`.** (Note: the `/shell?cmd=hostname` URL is an endpoint on
-the *maglev backend* being load-balanced, not on our `server` mode — client mode
-is a generic HTTP GET tool and is agnostic to it.)
+`MODE` is unset here → defaults to `client` → flags parse exactly as today. The
+**invocation is unchanged**; the only edit is the image ref, now via
+`RapidClientImage()` (so the external node's side-loaded `RAPIDCLIENT_TAG` copy is
+used on PR CI, else the published `:latest`). (Note: the `/shell?cmd=hostname` URL
+is an endpoint on the *maglev backend* being load-balanced, not on our `server`
+mode — client mode is a generic HTTP GET tool and is agnostic to it.)
 
 ### `server` mode (`server.go`) — ported contract
 
@@ -372,11 +431,11 @@ Readiness: `/length/1` must 200 with a 1-byte body.
 
 1. Land the multi-mode binary + multi-arch Makefile; CI publishes
    `quay.io/tigeradev/rapidclient` as a manifest list.
-2. Repoint `images.PacketSizeServer` and add `MODE=server` in the customizer in
-   the **same PR** (so the suite switches to the in-repo server atomically).
+2. Switch the customizer to `RapidClientImage()` + `MODE=server` and add the
+   `load_images.sh` side-load, in the **same PR** (so the suite runs the PR-built
+   server atomically, without a registry push).
 3. Verify packet_size on an arm64 azr-aks run goes green; confirm amd64 unaffected.
-4. Follow-up (separate): drop the flask image from `tigera/k8s-e2e`; consider
-   pinning the image tag.
+4. Follow-up (separate): drop the flask image from `tigera/k8s-e2e`.
 
 ## Explicitly out of scope (matching the disposable-test-server scope)
 
@@ -389,11 +448,12 @@ sufficient). If a future need arises it's a deliberate extension, not a gap here
 
 ## Follow-ups (deliberately not in this change)
 
-1. **Tag pinning.** `images.go` consumes a floating tag (`:latest`/branch). The
-   arm64 rot was masked partly by a floating, unpinned, external tag. Pinning the
-   e2e utility image to an immutable tag/digest with a documented bump process is
-   worthwhile hardening, but **deferred** — multi-arch publishing alone fixes the
-   reported bug. Tracked as a separate change.
+1. **Digest-pin the published image.** PR CI now runs against a per-PR tag
+   side-loaded onto the nodes (`RAPIDCLIENT_TAG`), but non-gcp-kubeadm and
+   scheduled runs still consume the floating published `:latest`. Pinning that
+   published image to an immutable digest with a documented bump process is
+   worthwhile hardening, but **deferred** — the side-load + multi-arch publish fix
+   the reported bug. Tracked as a separate change.
 2. **Retire the flask image.** Once this lands and packet_size is green on arm64,
    drop `images/flask` from `tigera/k8s-e2e` (it will be unreferenced).
 

--- a/e2e/images/rapidclient/DESIGN.md
+++ b/e2e/images/rapidclient/DESIGN.md
@@ -272,7 +272,7 @@ Flags (unchanged): `-url` (required), `-port` (default 12345), `-timeout`
 (30s), `-v`. Single GET from a fixed source port with `SO_REUSEADDR` and
 keep-alives disabled; prints the response body. Identical to today's `main.go`.
 
-The only consumer is `maglev.go:596`, which runs it on an **external node**:
+The only consumer is `maglev.go:594`, which runs it on an **external node**:
 
 ```go
 rapidClient, _ := images.RapidClientImage()
@@ -374,15 +374,15 @@ changes.
 
 ### Test assertions this server must satisfy (from `packet_size.go`)
 
-- **GET** (`packetTestViaConncheck`, line 284): `len(strings.TrimSpace(out)) == length`.
+- **GET** (`packetTestViaConncheck`, ~line 295): `len(strings.TrimSpace(out)) == length`.
   ⇒ The N-byte body **must contain no leading/trailing whitespace**, or TrimSpace
   shortens it and the check fails. (This is exactly why the flask lorem corpus is
   one whitespace-free run-on string.) The Go generator emits N bytes drawn from a
   whitespace-free charset (e.g. repeating `a–z0–9`).
-- **POST** (line 301): `strconv.Atoi(strings.TrimSpace(out)) == length`, where the
+- **POST** (~line 313): `strconv.Atoi(strings.TrimSpace(out)) == length`, where the
   client posts `strings.Repeat("X", length)`. ⇒ return the byte count of the
   received body. Use bytes actually read (robust) — equals Content-Length here.
-- **UDP** (line 323): `strings.TrimSpace(out) == payload`, payload =
+- **UDP** (~line 334): `strings.TrimSpace(out) == payload`, payload =
   `generateUDPPayload(length)` (digits `0–9`, no whitespace). ⇒ pure echo.
 
 Readiness: `/length/1` must 200 with a 1-byte body.

--- a/e2e/images/rapidclient/Dockerfile
+++ b/e2e/images/rapidclient/Dockerfile
@@ -1,7 +1,10 @@
 FROM scratch
 
-ARG BINARY_PATH=rapidclient
+# TARGETARCH is set by buildx per target platform; it selects the matching
+# pre-built static binary (bin/rapidclient-<arch>) so a single Dockerfile
+# produces a multi-arch manifest.
+ARG TARGETARCH
 
-COPY ${BINARY_PATH} /rapidclient
+COPY bin/rapidclient-${TARGETARCH} /rapidclient
 
 ENTRYPOINT ["/rapidclient"]

--- a/e2e/images/rapidclient/Makefile
+++ b/e2e/images/rapidclient/Makefile
@@ -19,8 +19,9 @@ IMAGE = $(QUAY_REGISTRY)/rapidclient
 build: bin/rapidclient-$(ARCH)
 
 # Per-arch static binary. CGO is disabled so cross-compilation (via GOARCH) is
-# clean and the result runs on FROM scratch.
-bin/rapidclient-%: $(wildcard *.go)
+# clean and the result runs on FROM scratch. Exclude _test.go so editing a test
+# doesn't force a binary rebuild.
+bin/rapidclient-%: $(filter-out %_test.go,$(wildcard *.go))
 	mkdir -p bin
 	$(DOCKER_RUN) -e CGO_ENABLED=0 -e GOARCH=$* $(CALICO_BUILD) \
 		go build -o $@ -ldflags "-s -w" .

--- a/e2e/images/rapidclient/Makefile
+++ b/e2e/images/rapidclient/Makefile
@@ -9,12 +9,15 @@ TAG_NAME ?= $(shell git branch --show-current)
 
 # Architectures the published manifest list must cover. arm64 is required: the
 # packet-size server runs on arm64 clusters (e.g. azr-aks ARM), and an amd64-only
-# image is exactly the bug this image replaces.
-ARCHES ?= amd64 arm64
+# image is exactly the bug this image replaces. Assigned with := (not ?=) because
+# lib.Makefile, included above, already sets ARCHES to its four-arch default, so
+# ?= would be a no-op and publish would build ppc64le/s390x too. Still overridable
+# on the command line.
+ARCHES := amd64 arm64
 
 IMAGE = $(QUAY_REGISTRY)/rapidclient
 
-.PHONY: build image publish clean test
+.PHONY: build image publish clean ut fv st ci
 
 build: bin/rapidclient-$(ARCH)
 
@@ -26,8 +29,17 @@ bin/rapidclient-%: $(filter-out %_test.go,$(wildcard *.go))
 	$(DOCKER_RUN) -e CGO_ENABLED=0 -e GOARCH=$* $(CALICO_BUILD) \
 		go build -o $@ -ldflags "-s -w" .
 
-test:
+# ut is the repo-wide unit-test convention; lib.Makefile's `test: ut fv st`
+# aggregates it. This image has no fv/st layer, so those are no-ops (defining them
+# is what makes `make test` work rather than erroring on a missing `ut`/`fv`/`st`).
+ut:
 	$(DOCKER_RUN) $(CALICO_BUILD) go test ./...
+
+fv st:
+	@:
+
+# ci is the CI entrypoint (see .semaphore/.../20-e2e-images.yml).
+ci: ut
 
 # image builds a local, single-arch image for development (buildx --load cannot
 # load a multi-platform build). TARGETARCH drives the Dockerfile's binary COPY.

--- a/e2e/images/rapidclient/Makefile
+++ b/e2e/images/rapidclient/Makefile
@@ -1,31 +1,53 @@
 include ../../../metadata.mk
 
 PACKAGE_NAME=github.com/projectcalico/calico/e2e/images/rapidclient
+
 include ../../../lib.Makefile
 
 QUAY_REGISTRY ?= quay.io/tigeradev
 TAG_NAME ?= $(shell git branch --show-current)
 
-build: bin/rapidclient
+# Architectures the published manifest list must cover. arm64 is required: the
+# packet-size server runs on arm64 clusters (e.g. azr-aks ARM), and an amd64-only
+# image is exactly the bug this image replaces.
+ARCHES ?= amd64 arm64
 
-bin/rapidclient: main.go
+IMAGE = $(QUAY_REGISTRY)/rapidclient
+
+.PHONY: build image publish clean test
+
+build: bin/rapidclient-$(ARCH)
+
+# Per-arch static binary. CGO is disabled so cross-compilation (via GOARCH) is
+# clean and the result runs on FROM scratch.
+bin/rapidclient-%: $(wildcard *.go)
 	mkdir -p bin
-	$(DOCKER_RUN) -e CGO_ENABLED=0 $(CALICO_BUILD) go build -o $@ -ldflags "-s -w" .
+	$(DOCKER_RUN) -e CGO_ENABLED=0 -e GOARCH=$* $(CALICO_BUILD) \
+		go build -o $@ -ldflags "-s -w" .
 
-image: bin/rapidclient
+test:
+	$(DOCKER_RUN) $(CALICO_BUILD) go test ./...
+
+# image builds a local, single-arch image for development (buildx --load cannot
+# load a multi-platform build). TARGETARCH drives the Dockerfile's binary COPY.
+image: bin/rapidclient-$(ARCH)
 	docker buildx build --load --platform=linux/$(ARCH) --pull \
-		--build-arg BINARY_PATH=bin/rapidclient \
-		-f Dockerfile \
-		-t $(QUAY_REGISTRY)/rapidclient:$(TAG_NAME) .
+		-f Dockerfile -t $(IMAGE):$(TAG_NAME) .
 
-publish: image
-	docker push $(QUAY_REGISTRY)/rapidclient:$(TAG_NAME)
+# publish builds all architectures into a single manifest list and pushes it.
+publish: $(addprefix bin/rapidclient-,$(ARCHES))
+	docker buildx build --platform=$(shell echo $(ARCHES) | sed 's/ /,/g; s,[^,]*,linux/&,g') \
+		--push --pull -f Dockerfile -t $(IMAGE):$(TAG_NAME) .
+	# Guard against silently regressing to a single-arch image (the original bug):
+	# the published tag must be a manifest list covering every arch in ARCHES.
+	@for a in $(ARCHES); do \
+		docker buildx imagetools inspect $(IMAGE):$(TAG_NAME) | grep -q "linux/$$a" \
+			|| { echo "ERROR: $(IMAGE):$(TAG_NAME) missing linux/$$a"; exit 1; }; \
+	done
 	@if [ "$(TAG_NAME)" = "master" ]; then \
-		docker tag $(QUAY_REGISTRY)/rapidclient:$(TAG_NAME) $(QUAY_REGISTRY)/rapidclient:latest; \
-		docker push $(QUAY_REGISTRY)/rapidclient:latest; \
-		echo "Pushed $(QUAY_REGISTRY)/rapidclient:latest"; \
+		docker buildx imagetools create -t $(IMAGE):latest $(IMAGE):$(TAG_NAME); \
+		echo "Pushed $(IMAGE):latest"; \
 	fi
 
 clean:
 	rm -rf bin/
-

--- a/e2e/images/rapidclient/README.md
+++ b/e2e/images/rapidclient/README.md
@@ -111,6 +111,22 @@ Status: 200 OK
 Response: {"output":"backend-pod-5\n"}
 ```
 
+## How the e2e tests get this image
+
+The tests reference the image via `images.RapidClientImage()`
+(`e2e/pkg/utils/images/images.go`), which is env-driven:
+
+- **PR CI on gcp-kubeadm:** PR builds have no registry push credential, so
+  `.semaphore/end-to-end/scripts/phases/load_images.sh` builds this image from the
+  PR source and imports it straight into each node's containerd (and the external
+  node's docker), then exports `RAPIDCLIENT_TAG` (e.g. `pr-13105`). The tests pin
+  that tag with `ImagePullPolicy: Never`.
+- **Everything else** (other providers, scheduled runs, local dev): `RAPIDCLIENT_TAG`
+  is unset and the tests use the published `quay.io/tigeradev/rapidclient:latest`.
+  If you change this image and want a non-gcp-kubeadm run to use your build, publish
+  it (post-merge `push-images/e2e-test.yml` promotion) or set `RAPIDCLIENT_TAG`
+  yourself to a tag the cluster can pull.
+
 ## Integration with Tests
 
 This tool can replace curl commands in tests for better reliability:

--- a/e2e/images/rapidclient/README.md
+++ b/e2e/images/rapidclient/README.md
@@ -1,4 +1,31 @@
-# RapidClient
+# rapidclient
+
+A multi-mode e2e test utility image. The mode is selected by the `MODE`
+environment variable; an unset `MODE` defaults to `client` (the original
+behaviour). See [DESIGN.md](DESIGN.md) for the full contract and rationale.
+
+## Modes
+
+| `MODE` | Purpose |
+|---|---|
+| `client` (default) | HTTP client that forces source-port reuse — for Maglev / load-balancer tests. Configured via flags (below). |
+| `server` | HTTP + UDP "dataplane server" for packet-size tests (ports the former `k8s-e2e-dataplane-server` flask image). Configured via the `PORT` env (default 5000). |
+
+### `server` mode
+
+Listens for TCP HTTP and UDP echo on the same port (`PORT`, default 5000),
+dual-stack:
+
+- `GET /length/{N}` — response body of exactly `N` whitespace-free bytes.
+- `POST /post` — returns the number of bytes received (GET returns help text).
+- `GET /` — static sanity string.
+- UDP — echoes each datagram back verbatim.
+
+```bash
+docker run --rm -e MODE=server -p 5000:5000 quay.io/tigeradev/rapidclient
+```
+
+## `client` mode
 
 A simple HTTP client tool that forces source port reuse by bypassing TIME_WAIT state, designed for testing Maglev consistent hashing and load balancer behavior.
 

--- a/e2e/images/rapidclient/client.go
+++ b/e2e/images/rapidclient/client.go
@@ -1,0 +1,131 @@
+/*
+Copyright (c) 2025 Tigera, Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"net/http"
+	"os"
+	"syscall"
+	"time"
+)
+
+func init() { registerMode(clientMode{}) }
+
+// clientMode is the default mode: a simple HTTP client that forces source-port
+// reuse (SO_REUSEADDR, keep-alives disabled) so each call is a fresh TCP
+// connection from a fixed source port. Used to test Maglev consistent hashing
+// and load-balancer behaviour.
+type clientMode struct{}
+
+func (clientMode) Name() string { return "client" }
+
+func (clientMode) Run(args []string) error {
+	// ExitOnError mirrors the original behaviour: a bad flag prints usage to
+	// stderr and exits non-zero.
+	fs := flag.NewFlagSet("client", flag.ExitOnError)
+	var (
+		targetURL  = fs.String("url", "", "Target URL to send request to (required)")
+		sourcePort = fs.Int("port", 12345, "Source port to use for connection")
+		timeout    = fs.Duration("timeout", 30*time.Second, "Request timeout")
+		verbose    = fs.Bool("v", false, "Verbose logging")
+	)
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	if *targetURL == "" {
+		fmt.Fprintf(os.Stderr, "Error: -url is required\n")
+		fs.Usage()
+		os.Exit(1)
+	}
+
+	if *verbose {
+		log.Printf("Sending request to: %s", *targetURL)
+		log.Printf("Using source port: %d", *sourcePort)
+		log.Printf("Timeout: %v", *timeout)
+	}
+
+	client := createRapidClient(*sourcePort, *timeout)
+
+	// Send a single request.
+	resp, err := client.Get(*targetURL)
+	if err != nil {
+		return fmt.Errorf("request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read response: %w", err)
+	}
+
+	if *verbose {
+		fmt.Printf("Status: %s\n", resp.Status)
+		fmt.Printf("Response: %s", string(body))
+	} else {
+		// Just print the raw response body.
+		fmt.Print(string(body))
+	}
+	return nil
+}
+
+// createRapidClient creates an HTTP client configured for rapid connections with
+// source port reuse.
+func createRapidClient(sourcePort int, timeout time.Duration) *http.Client {
+	// 1. Create a custom dialer function.
+	dialer := &net.Dialer{
+		Timeout:   timeout,
+		KeepAlive: 0, // Disable keep-alive to force new connections.
+		// Control function to set socket options before connection.
+		Control: func(network, address string, c syscall.RawConn) error {
+			return c.Control(func(fd uintptr) {
+				// Set SO_REUSEADDR to allow reusing the port more quickly.
+				err := syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, syscall.SO_REUSEADDR, 1)
+				if err != nil {
+					log.Printf("Warning: Failed to set SO_REUSEADDR: %v", err)
+				}
+			})
+		},
+	}
+
+	// 2. Define the local address and port to use for every outgoing connection.
+	localAddr := &net.TCPAddr{
+		IP:   net.IPv4zero, // Bind to all local IPv4 addresses.
+		Port: sourcePort,   // Use the specified source port.
+	}
+	dialer.LocalAddr = localAddr
+
+	// 3. Create an HTTP client that uses the custom dialer.
+	client := &http.Client{
+		Timeout: timeout,
+		Transport: &http.Transport{
+			DialContext:           dialer.DialContext,
+			DisableKeepAlives:     true,             // Force new connections.
+			MaxIdleConnsPerHost:   0,                // No connection pooling.
+			IdleConnTimeout:       1 * time.Second,  // Short idle timeout.
+			TLSHandshakeTimeout:   10 * time.Second, // TLS timeout.
+			ExpectContinueTimeout: 1 * time.Second,  // Expect 100-continue timeout.
+		},
+	}
+
+	return client
+}

--- a/e2e/images/rapidclient/client.go
+++ b/e2e/images/rapidclient/client.go
@@ -23,7 +23,6 @@ import (
 	"log"
 	"net"
 	"net/http"
-	"os"
 	"syscall"
 	"time"
 )
@@ -39,9 +38,11 @@ type clientMode struct{}
 func (clientMode) Name() string { return "client" }
 
 func (clientMode) Run(args []string) error {
-	// ExitOnError mirrors the original behaviour: a bad flag prints usage to
-	// stderr and exits non-zero.
-	fs := flag.NewFlagSet("client", flag.ExitOnError)
+	// ContinueOnError so a parse error or missing required flag is returned to
+	// main (which maps it to a non-zero exit) rather than calling os.Exit here.
+	// This honours the Mode.Run contract, matches server mode, and keeps the
+	// mode unit-testable.
+	fs := flag.NewFlagSet("client", flag.ContinueOnError)
 	var (
 		targetURL  = fs.String("url", "", "Target URL to send request to (required)")
 		sourcePort = fs.Int("port", 12345, "Source port to use for connection")
@@ -53,9 +54,7 @@ func (clientMode) Run(args []string) error {
 	}
 
 	if *targetURL == "" {
-		fmt.Fprintf(os.Stderr, "Error: -url is required\n")
-		fs.Usage()
-		os.Exit(1)
+		return fmt.Errorf("-url is required")
 	}
 
 	if *verbose {

--- a/e2e/images/rapidclient/client.go
+++ b/e2e/images/rapidclient/client.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2025 Tigera, Inc. All rights reserved.
+Copyright (c) 2026 Tigera, Inc. All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/e2e/images/rapidclient/main.go
+++ b/e2e/images/rapidclient/main.go
@@ -14,103 +14,33 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Command rapidclient is a multi-mode e2e test utility. The mode is selected by
+// the MODE environment variable; an unset MODE defaults to "client", preserving
+// the original client behaviour (and its flag interface) for existing callers.
+// See DESIGN.md for the mode contracts.
 package main
 
 import (
-	"flag"
-	"fmt"
-	"io"
 	"log"
-	"net"
-	"net/http"
 	"os"
-	"syscall"
-	"time"
 )
 
+// defaultMode is used when MODE is unset, preserving the original rapidclient
+// (client) behaviour for existing callers such as the maglev e2e test.
+const defaultMode = "client"
+
 func main() {
-	// Command line flags
-	var (
-		targetURL  = flag.String("url", "", "Target URL to send request to (required)")
-		sourcePort = flag.Int("port", 12345, "Source port to use for connection")
-		timeout    = flag.Duration("timeout", 30*time.Second, "Request timeout")
-		verbose    = flag.Bool("v", false, "Verbose logging")
-	)
-	flag.Parse()
-
-	if *targetURL == "" {
-		fmt.Fprintf(os.Stderr, "Error: -url is required\n")
-		flag.Usage()
-		os.Exit(1)
+	modeName := os.Getenv("MODE")
+	if modeName == "" {
+		modeName = defaultMode
 	}
 
-	if *verbose {
-		log.Printf("Sending request to: %s", *targetURL)
-		log.Printf("Using source port: %d", *sourcePort)
-		log.Printf("Timeout: %v", *timeout)
+	mode, ok := lookupMode(modeName)
+	if !ok {
+		log.Fatalf("unknown MODE %q; known modes: %v", modeName, modeNames())
 	}
 
-	client := createRapidClient(*sourcePort, *timeout)
-
-	// Send a single request
-	resp, err := client.Get(*targetURL)
-	if err != nil {
-		log.Fatalf("Request failed: %v", err)
+	if err := mode.Run(os.Args[1:]); err != nil {
+		log.Fatalf("%s: %v", modeName, err)
 	}
-	defer func() { _ = resp.Body.Close() }()
-
-	// Read and print the response
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		log.Fatalf("Failed to read response: %v", err)
-	}
-
-	if *verbose {
-		fmt.Printf("Status: %s\n", resp.Status)
-		fmt.Printf("Response: %s", string(body))
-	} else {
-		// Just print the raw response body
-		fmt.Print(string(body))
-	}
-}
-
-// createRapidClient creates an HTTP client configured for rapid connections with source port reuse
-func createRapidClient(sourcePort int, timeout time.Duration) *http.Client {
-	// 1. Create a custom dialer function
-	dialer := &net.Dialer{
-		Timeout:   timeout,
-		KeepAlive: 0, // Disable keep-alive to force new connections
-		// Control function to set socket options before connection
-		Control: func(network, address string, c syscall.RawConn) error {
-			return c.Control(func(fd uintptr) {
-				// Set SO_REUSEADDR to allow reusing the port more quickly
-				err := syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, syscall.SO_REUSEADDR, 1)
-				if err != nil {
-					log.Printf("Warning: Failed to set SO_REUSEADDR: %v", err)
-				}
-			})
-		},
-	}
-
-	// 2. Define the local address and port to use for every outgoing connection
-	localAddr := &net.TCPAddr{
-		IP:   net.IPv4zero, // Bind to all local IPv4 addresses
-		Port: sourcePort,   // Use the specified source port
-	}
-	dialer.LocalAddr = localAddr
-
-	// 3. Create an HTTP client that uses the custom dialer
-	client := &http.Client{
-		Timeout: timeout,
-		Transport: &http.Transport{
-			DialContext:           dialer.DialContext,
-			DisableKeepAlives:     true,             // Force new connections
-			MaxIdleConnsPerHost:   0,                // No connection pooling
-			IdleConnTimeout:       1 * time.Second,  // Short idle timeout
-			TLSHandshakeTimeout:   10 * time.Second, // TLS timeout
-			ExpectContinueTimeout: 1 * time.Second,  // Expect 100-continue timeout
-		},
-	}
-
-	return client
 }

--- a/e2e/images/rapidclient/main.go
+++ b/e2e/images/rapidclient/main.go
@@ -29,13 +29,20 @@ import (
 // (client) behaviour for existing callers such as the maglev e2e test.
 const defaultMode = "client"
 
-func main() {
-	modeName := os.Getenv("MODE")
-	if modeName == "" {
-		modeName = defaultMode
+// resolveMode maps a MODE env value to a registered mode. An empty value selects
+// defaultMode, preserving the original client behaviour for callers that set no
+// MODE. ok is false for a non-empty but unregistered mode.
+func resolveMode(env string) (mode Mode, name string, ok bool) {
+	name = env
+	if name == "" {
+		name = defaultMode
 	}
+	m, ok := lookupMode(name)
+	return m, name, ok
+}
 
-	mode, ok := lookupMode(modeName)
+func main() {
+	mode, modeName, ok := resolveMode(os.Getenv("MODE"))
 	if !ok {
 		log.Fatalf("unknown MODE %q; known modes: %v", modeName, modeNames())
 	}

--- a/e2e/images/rapidclient/mode.go
+++ b/e2e/images/rapidclient/mode.go
@@ -1,0 +1,55 @@
+/*
+Copyright (c) 2026 Tigera, Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import "sort"
+
+// Mode is one behaviour of the multi-mode rapidclient binary, selected at
+// runtime by the MODE env var. Each mode parses its own flags from the args it
+// is handed, so modes have independent flag surfaces. Add a mode by calling
+// registerMode from an init().
+type Mode interface {
+	// Name is the MODE value that selects this mode.
+	Name() string
+	// Run parses flags from args and executes the mode. A non-nil error is
+	// surfaced by main as a non-zero exit.
+	Run(args []string) error
+}
+
+// modes is the registry of available modes, keyed by Name.
+var modes = map[string]Mode{}
+
+// registerMode adds m to the registry. Intended to be called from init().
+func registerMode(m Mode) {
+	modes[m.Name()] = m
+}
+
+// lookupMode returns the registered mode for name, if any.
+func lookupMode(name string) (Mode, bool) {
+	m, ok := modes[name]
+	return m, ok
+}
+
+// modeNames returns the registered mode names, sorted, for error messages.
+func modeNames() []string {
+	names := make([]string, 0, len(modes))
+	for n := range modes {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	return names
+}

--- a/e2e/images/rapidclient/server.go
+++ b/e2e/images/rapidclient/server.go
@@ -1,0 +1,175 @@
+/*
+Copyright (c) 2026 Tigera, Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+)
+
+func init() { registerMode(serverMode{}) }
+
+const (
+	// defaultServerPort matches the port the packet-size e2e test expects.
+	defaultServerPort = 5000
+
+	// udpReadBuffer is the UDP datagram read size. Test payloads are < MTU, so
+	// they are never truncated; datagrams larger than this would be truncated by
+	// the kernel (out of range for the test).
+	udpReadBuffer = 65535
+
+	// lengthAlphabet is the whitespace-free filler used for /length responses.
+	// It MUST contain no whitespace: the packet-size test asserts
+	// len(strings.TrimSpace(body)) == N, so any whitespace would shorten the
+	// trimmed length and fail the check. Content is otherwise irrelevant.
+	lengthAlphabet = "abcdefghijklmnopqrstuvwxyz0123456789"
+
+	postHelp = "This URL is meant for testing POSTs. It returns the number of bytes received."
+)
+
+// serverMode is the HTTP + UDP "dataplane server" used by the packet-size e2e
+// test. It replaces the former Flask + socat image. See DESIGN.md for the
+// endpoint contract.
+type serverMode struct{}
+
+func (serverMode) Name() string { return "server" }
+
+func (serverMode) Run(args []string) error {
+	// Server config comes from the PORT env var only. Stray args are tolerated
+	// (ignored) for parity with the old runme.sh wrapper; the --port CLI override
+	// it accepted is intentionally not replicated.
+	fs := flag.NewFlagSet("server", flag.ContinueOnError)
+	_ = fs.Parse(args)
+
+	port := defaultServerPort
+	if v := os.Getenv("PORT"); v != "" {
+		p, err := strconv.Atoi(v)
+		if err != nil || p < 1 || p > 65535 {
+			return fmt.Errorf("invalid PORT %q", v)
+		}
+		port = p
+	}
+	addr := ":" + strconv.Itoa(port)
+
+	// UDP echo on the same port. Bind the unspecified address so Linux serves
+	// both IPv4 and v4-mapped IPv6 from one socket (matching the old host="::").
+	pc, err := net.ListenPacket("udp", addr)
+	if err != nil {
+		return fmt.Errorf("udp listen on %s: %w", addr, err)
+	}
+	go serveUDP(pc)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", handleRoot)
+	mux.HandleFunc("/length/", handleLength)
+	mux.HandleFunc("/post", handlePost)
+
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		return fmt.Errorf("tcp listen on %s: %w", addr, err)
+	}
+	log.Printf("rapidclient server listening on %s (tcp+udp)", addr)
+	return http.Serve(ln, mux)
+}
+
+// handleRoot serves a static string at "/" and 404s every other unmatched path
+// (the "/" pattern is ServeMux's catch-all).
+func handleRoot(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != "/" {
+		http.NotFound(w, r)
+		return
+	}
+	_, _ = io.WriteString(w, "rapidclient dataplane server")
+}
+
+// handleLength serves exactly N whitespace-free bytes at /length/{N}.
+func handleLength(w http.ResponseWriter, r *http.Request) {
+	n, err := strconv.Atoi(strings.TrimPrefix(r.URL.Path, "/length/"))
+	if err != nil || n < 0 {
+		http.Error(w, "length must be a non-negative integer", http.StatusBadRequest)
+		return
+	}
+	w.Header().Set("Content-Type", "text/plain")
+	// Write the whole body in one call so net/http sets Content-Length and does
+	// not chunk-frame the response.
+	_, _ = w.Write(lengthBody(n))
+}
+
+// lengthBody returns n bytes drawn from lengthAlphabet (whitespace-free).
+func lengthBody(n int) []byte {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = lengthAlphabet[i%len(lengthAlphabet)]
+	}
+	return b
+}
+
+// handlePost returns the number of bytes in a POST body; any other method gets
+// the help string (parity with the former Flask handler, which accepted GET).
+func handlePost(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		_, _ = io.WriteString(w, postHelp)
+		return
+	}
+	// Count without buffering the (up to ~10000-byte) body.
+	n, err := io.Copy(io.Discard, r.Body)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	_, _ = io.WriteString(w, strconv.FormatInt(n, 10))
+}
+
+// serveUDP echoes each received datagram back to its sender, verbatim.
+//
+// This is a single read→write loop, which is correct for any number of peers:
+// each datagram is echoed to its own source addr, and the shared buf is safe to
+// reuse precisely because one goroutine reads and writes it sequentially.
+//
+// CAVEAT — if you ever parallelise the UDP echo (e.g. to keep up with a
+// concurrent packet-size test that fires probes in parallel rather than
+// serially), you MUST copy buf[:n] before handing it to a goroutine, or the next
+// ReadFrom will overwrite it mid-flight (data race / corrupted echo):
+//
+//	n, addr, _ := pc.ReadFrom(buf)
+//	d := append([]byte(nil), buf[:n]...) // copy first
+//	go pc.WriteTo(d, addr)
+//
+// You'd also want pc.(*net.UDPConn).SetReadBuffer(...) so bursts don't overflow
+// SO_RCVBUF and silently drop datagrams. Neither is needed today: the test
+// sends serially and wraps the UDP check in Eventually(), which retries any
+// transient loss. See DESIGN.md ("UDP echo").
+func serveUDP(pc net.PacketConn) {
+	buf := make([]byte, udpReadBuffer)
+	for {
+		n, addr, err := pc.ReadFrom(buf)
+		if err != nil {
+			log.Printf("udp read error: %v", err)
+			continue
+		}
+		if _, err := pc.WriteTo(buf[:n], addr); err != nil {
+			log.Printf("udp write error: %v", err)
+		}
+	}
+}

--- a/e2e/images/rapidclient/server.go
+++ b/e2e/images/rapidclient/server.go
@@ -73,8 +73,11 @@ func resolveServerPort(env string) (int, error) {
 func (serverMode) Run(args []string) error {
 	// Server config comes from the PORT env var only. Stray args are tolerated
 	// (ignored) for parity with the old runme.sh wrapper; the --port CLI override
-	// it accepted is intentionally not replicated.
+	// it accepted is intentionally not replicated. Discard the FlagSet's output
+	// so an unknown arg (e.g. the old --port) is ignored quietly rather than
+	// printing a "flag provided but not defined" error + usage to stderr.
 	fs := flag.NewFlagSet("server", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
 	_ = fs.Parse(args)
 
 	port, err := resolveServerPort(os.Getenv("PORT"))

--- a/e2e/images/rapidclient/server.go
+++ b/e2e/images/rapidclient/server.go
@@ -56,6 +56,20 @@ type serverMode struct{}
 
 func (serverMode) Name() string { return "server" }
 
+// resolveServerPort maps the PORT env value to a listen port. An empty value
+// selects defaultServerPort; a non-empty value must parse as a valid TCP/UDP
+// port (1-65535), otherwise an error is returned.
+func resolveServerPort(env string) (int, error) {
+	if env == "" {
+		return defaultServerPort, nil
+	}
+	p, err := strconv.Atoi(env)
+	if err != nil || p < 1 || p > 65535 {
+		return 0, fmt.Errorf("invalid PORT %q", env)
+	}
+	return p, nil
+}
+
 func (serverMode) Run(args []string) error {
 	// Server config comes from the PORT env var only. Stray args are tolerated
 	// (ignored) for parity with the old runme.sh wrapper; the --port CLI override
@@ -63,13 +77,9 @@ func (serverMode) Run(args []string) error {
 	fs := flag.NewFlagSet("server", flag.ContinueOnError)
 	_ = fs.Parse(args)
 
-	port := defaultServerPort
-	if v := os.Getenv("PORT"); v != "" {
-		p, err := strconv.Atoi(v)
-		if err != nil || p < 1 || p > 65535 {
-			return fmt.Errorf("invalid PORT %q", v)
-		}
-		port = p
+	port, err := resolveServerPort(os.Getenv("PORT"))
+	if err != nil {
+		return err
 	}
 	addr := ":" + strconv.Itoa(port)
 

--- a/e2e/images/rapidclient/server.go
+++ b/e2e/images/rapidclient/server.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -111,9 +112,14 @@ func handleLength(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.Header().Set("Content-Type", "text/plain")
-	// Write the whole body in one call so net/http sets Content-Length and does
-	// not chunk-frame the response.
-	_, _ = w.Write(lengthBody(n))
+	// Set Content-Length explicitly and write the body in one call so the response
+	// is never chunk-framed, regardless of N. (net/http only auto-sets
+	// Content-Length when the whole body fits its internal buffer (~2KB) before the
+	// handler returns; larger bodies would otherwise fall back to chunked.) Keeping
+	// the framing deterministic matches the contract DESIGN.md describes.
+	body := lengthBody(n)
+	w.Header().Set("Content-Length", strconv.Itoa(len(body)))
+	_, _ = w.Write(body)
 }
 
 // lengthBody returns n bytes drawn from lengthAlphabet (whitespace-free).
@@ -165,6 +171,11 @@ func serveUDP(pc net.PacketConn) {
 	for {
 		n, addr, err := pc.ReadFrom(buf)
 		if err != nil {
+			// A closed conn is terminal — returning avoids a hot spin loop
+			// (and lets the test's deferred Close stop this goroutine).
+			if errors.Is(err, net.ErrClosed) {
+				return
+			}
 			log.Printf("udp read error: %v", err)
 			continue
 		}

--- a/e2e/images/rapidclient/server_test.go
+++ b/e2e/images/rapidclient/server_test.go
@@ -159,3 +159,50 @@ func TestDispatch(t *testing.T) {
 		t.Error("unknown mode unexpectedly resolved")
 	}
 }
+
+// TestResolveServerPort covers PORT env parsing: empty falls back to the
+// default, valid ports pass through, and out-of-range / non-numeric values are
+// rejected. This is the logic serverMode.Run relies on but never exercises in
+// its own tests (it binds real sockets), so guard it directly.
+func TestResolveServerPort(t *testing.T) {
+	valid := []struct {
+		in   string
+		want int
+	}{
+		{"", defaultServerPort},
+		{"1", 1},
+		{"5000", 5000},
+		{"65535", 65535},
+	}
+	for _, tc := range valid {
+		got, err := resolveServerPort(tc.in)
+		if err != nil {
+			t.Errorf("resolveServerPort(%q) unexpected error: %v", tc.in, err)
+			continue
+		}
+		if got != tc.want {
+			t.Errorf("resolveServerPort(%q) = %d, want %d", tc.in, got, tc.want)
+		}
+	}
+	for _, in := range []string{"0", "-1", "65536", "70000", "abc", "5000x"} {
+		if _, err := resolveServerPort(in); err == nil {
+			t.Errorf("resolveServerPort(%q) = nil error, want error", in)
+		}
+	}
+}
+
+// TestResolveMode locks in the MODE dispatch contract the PR rests on: an empty
+// MODE must resolve to the client mode (backward compatibility for callers that
+// set no MODE, e.g. the maglev test), "server" selects the server mode, and an
+// unknown value is reported as unresolved.
+func TestResolveMode(t *testing.T) {
+	if m, name, ok := resolveMode(""); !ok || name != defaultMode || m.Name() != defaultMode {
+		t.Errorf("resolveMode(\"\") = (%v, %q, %v), want the %q mode", m, name, ok, defaultMode)
+	}
+	if m, name, ok := resolveMode("server"); !ok || name != "server" || m.Name() != "server" {
+		t.Errorf("resolveMode(\"server\") = (%v, %q, %v), want the server mode", m, name, ok)
+	}
+	if _, name, ok := resolveMode("bogus"); ok {
+		t.Errorf("resolveMode(%q) resolved unexpectedly", name)
+	}
+}

--- a/e2e/images/rapidclient/server_test.go
+++ b/e2e/images/rapidclient/server_test.go
@@ -206,3 +206,12 @@ func TestResolveMode(t *testing.T) {
 		t.Errorf("resolveMode(%q) resolved unexpectedly", name)
 	}
 }
+
+// TestClientModeRequiresURL locks in the Mode.Run error contract for client
+// mode: a missing required -url returns an error (which main maps to a non-zero
+// exit) rather than calling os.Exit — so the mode is composable and testable.
+func TestClientModeRequiresURL(t *testing.T) {
+	if err := (clientMode{}).Run([]string{}); err == nil {
+		t.Error("clientMode.Run with no -url = nil error, want error")
+	}
+}

--- a/e2e/images/rapidclient/server_test.go
+++ b/e2e/images/rapidclient/server_test.go
@@ -1,0 +1,161 @@
+/*
+Copyright (c) 2026 Tigera, Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestLengthEndpoint covers the core packet-size contract: GET /length/{N}
+// returns a body whose length, after TrimSpace, is exactly N.
+func TestLengthEndpoint(t *testing.T) {
+	for _, n := range []int{1, 10, 1400, 10000} {
+		req := httptest.NewRequest(http.MethodGet, "/length/"+strconv.Itoa(n), nil)
+		rec := httptest.NewRecorder()
+		handleLength(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Errorf("N=%d: status = %d, want 200", n, rec.Code)
+			continue
+		}
+		got := len(strings.TrimSpace(rec.Body.String()))
+		if got != n {
+			t.Errorf("N=%d: trimmed body length = %d, want %d", n, got, n)
+		}
+	}
+}
+
+func TestLengthZero(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/length/0", nil)
+	rec := httptest.NewRecorder()
+	handleLength(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if rec.Body.Len() != 0 {
+		t.Errorf("body length = %d, want 0", rec.Body.Len())
+	}
+}
+
+func TestLengthBadInput(t *testing.T) {
+	for _, path := range []string{"/length/abc", "/length/-5", "/length/"} {
+		req := httptest.NewRequest(http.MethodGet, path, nil)
+		rec := httptest.NewRecorder()
+		handleLength(rec, req)
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("%s: status = %d, want 400", path, rec.Code)
+		}
+	}
+}
+
+func TestPostReturnsByteCount(t *testing.T) {
+	const length = 1234
+	body := strings.Repeat("X", length)
+	req := httptest.NewRequest(http.MethodPost, "/post", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	handlePost(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	got, err := strconv.Atoi(strings.TrimSpace(rec.Body.String()))
+	if err != nil {
+		t.Fatalf("could not parse response %q: %v", rec.Body.String(), err)
+	}
+	if got != length {
+		t.Errorf("reported byte count = %d, want %d", got, length)
+	}
+}
+
+func TestPostGetReturnsHelp(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/post", nil)
+	rec := httptest.NewRecorder()
+	handlePost(rec, req)
+	if rec.Code != http.StatusOK || rec.Body.Len() == 0 {
+		t.Errorf("GET /post: status=%d bodyLen=%d, want 200 with help text", rec.Code, rec.Body.Len())
+	}
+}
+
+func TestRootAndNotFound(t *testing.T) {
+	root := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	handleRoot(rec, root)
+	if rec.Code != http.StatusOK || rec.Body.Len() == 0 {
+		t.Errorf("GET /: status=%d bodyLen=%d, want 200 non-empty", rec.Code, rec.Body.Len())
+	}
+
+	other := httptest.NewRequest(http.MethodGet, "/nope", nil)
+	rec = httptest.NewRecorder()
+	handleRoot(rec, other)
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("GET /nope: status=%d, want 404", rec.Code)
+	}
+}
+
+// TestUDPEcho verifies the UDP listener echoes a datagram back verbatim.
+func TestUDPEcho(t *testing.T) {
+	pc, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer func() { _ = pc.Close() }()
+	go serveUDP(pc)
+
+	conn, err := net.Dial("udp", pc.LocalAddr().String())
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	payload := strings.Repeat("0123456789", 100) // 1000 bytes, no whitespace
+	if _, err := conn.Write([]byte(payload)); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	_ = conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+	buf := make([]byte, len(payload)+16)
+	n, err := conn.Read(buf)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if got := string(buf[:n]); got != payload {
+		t.Errorf("echo mismatch: got %d bytes, want %d", len(got), len(payload))
+	}
+}
+
+// TestDispatch checks the registry: client and server are registered and the
+// default selection (empty MODE) resolves to client.
+func TestDispatch(t *testing.T) {
+	if _, ok := lookupMode("client"); !ok {
+		t.Error("client mode not registered")
+	}
+	if _, ok := lookupMode("server"); !ok {
+		t.Error("server mode not registered")
+	}
+	if _, ok := lookupMode(defaultMode); !ok {
+		t.Errorf("default mode %q not registered", defaultMode)
+	}
+	if _, ok := lookupMode("nope"); ok {
+		t.Error("unknown mode unexpectedly resolved")
+	}
+}

--- a/e2e/pkg/tests/networking/maglev.go
+++ b/e2e/pkg/tests/networking/maglev.go
@@ -588,12 +588,17 @@ func (m *MaglevTests) sendRequestsAndGatherStats(extNode *externalnode.Client, u
 	uniqueBackends := make(map[string]int)
 	totalRequests := m.maglevConfig.NumberOfRequests
 
+	// The external node runs this image via plain `docker run`; on gcp-kubeadm PR
+	// CI it was side-loaded into the external node's docker (RAPIDCLIENT_TAG),
+	// otherwise docker pulls the published :latest.
+	rapidClient, _ := images.RapidClientImage()
+
 	for i := range totalRequests {
 		// Use external node to run rapidclient with netexec endpoint to get hostname
 		// Use configured source port for consistent testing
 		ep := net.JoinHostPort(clusterIP, fmt.Sprint(m.maglevConfig.ServicePort))
 		cmd := fmt.Sprintf("sudo docker run --rm --net=host %s -url http://%s/shell?cmd=hostname -port %d",
-			images.RapidClient, ep, m.maglevConfig.SourcePort)
+			rapidClient, ep, m.maglevConfig.SourcePort)
 		output, err := extNode.Exec("sh", "-c", cmd)
 		Expect(err).NotTo(HaveOccurred(), "Request %d (%s) to %s failed", i+1, ipVersion, ep)
 

--- a/e2e/pkg/tests/networking/packet_size.go
+++ b/e2e/pkg/tests/networking/packet_size.go
@@ -90,14 +90,22 @@ func generatePacketLengths(mtu int) (getLengths, postLengths, udpLengths []int) 
 }
 
 // withPacketSizeServer is a conncheck server pod customizer that replaces the
-// default image with the PacketSizeServer. See images.PacketSizeServer for the
-// endpoints the server exposes.
+// default image with the multi-mode rapidclient image run as the packet-size
+// server. See images.RapidClientImage for the endpoints the server exposes and
+// the side-load/pull-policy contract.
 func withPacketSizeServer(pod *v1.Pod) {
+	image, preloaded := images.RapidClientImage()
 	for i := range pod.Spec.Containers {
-		pod.Spec.Containers[i].Image = images.PacketSizeServer
+		pod.Spec.Containers[i].Image = image
 		pod.Spec.Containers[i].Args = nil
-		// PacketSizeServer is the multi-mode rapidclient image; MODE=server
-		// selects the HTTP/UDP dataplane server.
+		// When the image was side-loaded into the nodes' containerd (PR CI on
+		// gcp-kubeadm), it is not in any registry — pin to the loaded copy and
+		// fail loudly if it is somehow absent rather than pulling a stale one.
+		if preloaded {
+			pod.Spec.Containers[i].ImagePullPolicy = v1.PullNever
+		}
+		// The rapidclient image is multi-mode; MODE=server selects the HTTP/UDP
+		// dataplane server.
 		pod.Spec.Containers[i].Env = append(pod.Spec.Containers[i].Env,
 			v1.EnvVar{Name: "MODE", Value: "server"})
 		if pod.Spec.Containers[i].ReadinessProbe != nil && pod.Spec.Containers[i].ReadinessProbe.HTTPGet != nil {

--- a/e2e/pkg/tests/networking/packet_size.go
+++ b/e2e/pkg/tests/networking/packet_size.go
@@ -96,6 +96,10 @@ func withPacketSizeServer(pod *v1.Pod) {
 	for i := range pod.Spec.Containers {
 		pod.Spec.Containers[i].Image = images.PacketSizeServer
 		pod.Spec.Containers[i].Args = nil
+		// PacketSizeServer is the multi-mode rapidclient image; MODE=server
+		// selects the HTTP/UDP dataplane server.
+		pod.Spec.Containers[i].Env = append(pod.Spec.Containers[i].Env,
+			v1.EnvVar{Name: "MODE", Value: "server"})
 		if pod.Spec.Containers[i].ReadinessProbe != nil && pod.Spec.Containers[i].ReadinessProbe.HTTPGet != nil {
 			pod.Spec.Containers[i].ReadinessProbe.HTTPGet.Path = "/length/1"
 		}

--- a/e2e/pkg/utils/images/images.go
+++ b/e2e/pkg/utils/images/images.go
@@ -40,12 +40,6 @@ const (
 	// subcommands for common test helpers. Version is pinned; bump deliberately.
 	Agnhost = "registry.k8s.io/e2e-test-images/agnhost:2.47"
 
-	// RapidClient is a Tigera-built HTTP client that reuses a fixed source port
-	// across rapid sequential connections. Needed for Maglev tests where the
-	// load-balancer hash depends on source port staying the same; curl, wget,
-	// and agnhost don't expose source-port control.
-	RapidClient = "quay.io/tigeradev/rapidclient"
-
 	// Iperf3 is a TCP/UDP bandwidth generator, used by iperfcheck for throughput
 	// tests. No upstream K8s test image provides iperf3.
 	Iperf3 = "docker.io/networkstatic/iperf3:latest"
@@ -65,23 +59,46 @@ const (
 	// Use with `netexec --http-port=PORT` args. Hit /clientip for source IP.
 	EchoServer = Agnhost
 
-	// PacketSizeServer is an HTTP/UDP server for tests that need controlled
-	// payload sizes (e.g. MTU boundary, fragmentation, encap overhead). It is the
-	// multi-mode rapidclient image (same as RapidClient) run with MODE=server,
-	// set by the packet-size pod customizer. Endpoints, all on the same port
-	// (default 5000):
-	//   - GET /length/<N>: response body is exactly N bytes.
-	//   - POST /post: returns the number of bytes received.
-	//   - UDP: echoes received datagrams.
-	// Source: e2e/images/rapidclient/server.go (see that dir's DESIGN.md).
-	PacketSizeServer = "quay.io/tigeradev/rapidclient"
-
 	// KubeVirtUbuntu: Ubuntu 20.04 containerDisk for KubeVirt VM e2e tests.
 	KubeVirtUbuntu = "mcas/kubevirt-ubuntu-20.04@sha256:35158058769932812d8ec3ba76985b6f3b02ba288e33a22c77445a7b7f8b3e30"
 
 	// CalicoBIRD: Calico BIRD 1.x. Keep in sync with BIRD_VERSION in metadata.mk.
 	CalicoBIRD = "calico/bird:v0.3.3-211-g9111ec3c"
 )
+
+// rapidClientRepo is the multi-mode rapidclient image (client mode by default;
+// MODE=server runs the packet-size HTTP/UDP dataplane server). Both the Maglev
+// client and the packet-size server use this single image; the mode is selected
+// at pod-creation time. See e2e/images/rapidclient/ (and its DESIGN.md).
+//
+// Client mode (default): a Tigera-built HTTP client that reuses a fixed source
+// port across rapid sequential connections — needed for Maglev tests where the
+// load-balancer hash depends on the source port staying the same (curl, wget and
+// agnhost don't expose source-port control).
+//
+// Server mode (MODE=server): an HTTP/UDP server for tests that need controlled
+// payload sizes (MTU boundary, fragmentation, encap overhead). Endpoints, all on
+// the same port (default 5000): GET /length/<N> returns exactly N bytes; POST
+// /post returns the number of bytes received; UDP echoes received datagrams.
+const rapidClientRepo = "quay.io/tigeradev/rapidclient"
+
+// RapidClientImage returns the rapidclient image reference and whether it was
+// side-loaded onto the e2e nodes.
+//
+// PR CI cannot push images to a registry (fork PRs get no push credential), so on
+// gcp-kubeadm the phases/load_images.sh e2e phase builds rapidclient from the PR
+// source and imports it directly into each node's containerd, then exports
+// RAPIDCLIENT_TAG (e.g. "pr-13105"). When that env is set we return the pinned tag
+// and preloaded=true; callers creating pods MUST then set ImagePullPolicy: Never
+// so a missing/failed load fails loudly instead of silently pulling a stale
+// published image. When it is unset (other providers, local dev) we fall back to
+// the published :latest and default pull behaviour — preserving prior behaviour.
+func RapidClientImage() (ref string, preloaded bool) {
+	if tag := os.Getenv("RAPIDCLIENT_TAG"); tag != "" {
+		return rapidClientRepo + ":" + tag, true
+	}
+	return rapidClientRepo + ":latest", false
+}
 
 // Get client image and powershell command based on windows OS version
 func WindowsClientImage() string {

--- a/e2e/pkg/utils/images/images.go
+++ b/e2e/pkg/utils/images/images.go
@@ -66,13 +66,15 @@ const (
 	EchoServer = Agnhost
 
 	// PacketSizeServer is an HTTP/UDP server for tests that need controlled
-	// payload sizes (e.g. MTU boundary, fragmentation, encap overhead).
-	// Endpoints, all on the same port (default 5000):
+	// payload sizes (e.g. MTU boundary, fragmentation, encap overhead). It is the
+	// multi-mode rapidclient image (same as RapidClient) run with MODE=server,
+	// set by the packet-size pod customizer. Endpoints, all on the same port
+	// (default 5000):
 	//   - GET /length/<N>: response body is exactly N bytes.
-	//   - POST /post: echoes the request body.
-	//   - UDP: echoes received datagrams (socat-backed, 10KB buffer).
-	// Source: tigera/k8s-e2e/images/flask.
-	PacketSizeServer = "calico/k8s-e2e-dataplane-server:stable"
+	//   - POST /post: returns the number of bytes received.
+	//   - UDP: echoes received datagrams.
+	// Source: e2e/images/rapidclient/server.go (see that dir's DESIGN.md).
+	PacketSizeServer = "quay.io/tigeradev/rapidclient"
 
 	// KubeVirtUbuntu: Ubuntu 20.04 containerDisk for KubeVirt VM e2e tests.
 	KubeVirtUbuntu = "mcas/kubevirt-ubuntu-20.04@sha256:35158058769932812d8ec3ba76985b6f3b02ba288e33a22c77445a7b7f8b3e30"


### PR DESCRIPTION
## Description

The packet-size e2e tests (`Feature:Datapath` "Packet Size Verification") use a server image — `calico/k8s-e2e-dataplane-server` — built from `tigera/k8s-e2e/images/flask` and published **amd64-only**. On arm64 clusters (e.g. the azr-aks ARM lane) the amd64 binary crashes immediately on startup (container exit 255), so the server pod never reaches `Running` and every packet-size spec fails. This has been red on arm64 for 6+ weeks. The image is also external to the monorepo and pinned to a floating `:stable` tag, which is how the gap went unnoticed.

This change ports that server into the in-repo `rapidclient` image as a new mode and builds it multi-arch.

**What changed**
- `rapidclient` becomes a **multi-mode** binary dispatched by the `MODE` env var. Unset `MODE` defaults to `client` — today's behaviour and flag interface are unchanged (the maglev test invocation is untouched).
- New `server` mode ports the flask + socat server in pure Go:
  - `GET /length/{N}` → exactly N whitespace-free bytes
  - `POST /post` → number of bytes received (`GET` returns help text)
  - `GET /` → static sanity string
  - UDP echo on the same port, dual-stack
- The image is now built **multi-arch (amd64 + arm64)** with a manifest-list guard so it can't silently regress to single-arch (the original bug).
- `images.PacketSizeServer` repointed to `quay.io/tigeradev/rapidclient`; the packet-size pod customizer sets `MODE=server`.

See `e2e/images/rapidclient/DESIGN.md` for the full contract, the one deliberate difference from the python version (the `--port=` CLI override is dropped in favour of `PORT` env), and the concurrency caveat for any future parallelisation of the packet-size probes.

**Testing**
- Unit tests for the server contract (length/zero/bad-input/post/help/root-404/UDP echo) and mode dispatch — `go test ./e2e/images/rapidclient/` passes.
- Follow-up validation once the image is published: run "Packet Size Verification" on an arm64 (azr-aks) cluster to confirm it goes green, plus an amd64 run to confirm no regression.

**Follow-ups (not in this PR)**
- Pin the e2e utility image to an immutable tag/digest (floating tags were part of why this rotted).
- Retire `images/flask` from `tigera/k8s-e2e` once this lands.

**Release note:**
```release-note
None
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)