### PR TITLE
fix(fv): widen connlimit drain timeouts to 90s to fix contention flake

### DIFF
--- a/felix/fv/qos_controls_test.go
+++ b/felix/fv/qos_controls_test.go
@@ -943,7 +943,7 @@ var _ = infrastructure.DatastoreDescribe(
 							}
 
 							By("Waiting for ingress counter to drop to 0 via BPF fast-path")
-							Eventually(getBPFCurrentCount(0, 0, "ingress"), "30s", "1s").Should(Equal(uint32(0)))
+							Eventually(getBPFCurrentCount(0, 0, "ingress"), "90s", "1s").Should(Equal(uint32(0)))
 
 							By("Removing limits from workload 0")
 							w[0].WorkloadEndpoint.Spec.QoSControls = nil
@@ -996,7 +996,7 @@ var _ = infrastructure.DatastoreDescribe(
 							}
 
 							By("Waiting for ingress counter to drop to 0 via BPF fast-path")
-							Eventually(getBPFCurrentCount(0, 0, "ingress"), "30s", "1s").Should(Equal(uint32(0)))
+							Eventually(getBPFCurrentCount(0, 0, "ingress"), "90s", "1s").Should(Equal(uint32(0)))
 
 							By("Tearing down the workload netns (final cleanup)")
 							w[1].Stop()
@@ -1130,8 +1130,13 @@ var _ = infrastructure.DatastoreDescribe(
 								}
 
 								By("Waiting for cleanup-time decrement after TCPFinsSeen expiry")
-								// 5s TCPFinsSeen + ~10s scan period + margin.
-								Eventually(getBPFCurrentCount(0, 0, "ingress"), "30s", "1s").Should(Equal(uint32(0)))
+								// Half-closed TCPFinsSeen (5s) then cleaner/scanner cadence
+								// (~10s/~30s) drains the counter. Unloaded this is ~12s,
+								// but under CI batch contention the cleaner/scanner Go
+								// loops are CPU-starved and the drain stretches well past
+								// 30s, so use a generous 90s window (verified on a loaded
+								// 6.8 VM: 30s flakes, 90s is stable).
+								Eventually(getBPFCurrentCount(0, 0, "ingress"), "90s", "1s").Should(Equal(uint32(0)))
 
 								By("Removing limits from workload 0")
 								w[0].WorkloadEndpoint.Spec.QoSControls = nil
@@ -1167,8 +1172,13 @@ var _ = infrastructure.DatastoreDescribe(
 								}
 
 								By("Waiting for cleanup-time decrement after TCPEstablished expiry")
-								// 5s TCPEstablished + ~10s scan period + margin.
-								Eventually(getBPFCurrentCount(0, 0, "ingress"), "30s", "1s").Should(Equal(uint32(0)))
+								// Idle TCPEstablished (5s) then cleaner/scanner cadence
+								// (~10s/~30s) drains the counter. Unloaded this is ~12s,
+								// but under CI batch contention the cleaner/scanner Go
+								// loops are CPU-starved and the drain stretches well past
+								// 30s, so use a generous 90s window (verified on a loaded
+								// 6.8 VM: 30s flakes, 90s is stable).
+								Eventually(getBPFCurrentCount(0, 0, "ingress"), "90s", "1s").Should(Equal(uint32(0)))
 
 								By("Removing limits from workload 0")
 								w[0].WorkloadEndpoint.Spec.QoSControls = nil
@@ -1215,8 +1225,13 @@ var _ = infrastructure.DatastoreDescribe(
 								}()
 
 								By("Waiting for CT entries to age out and cleanup-time decrement to fire")
-								// 5s TCPEstablished + ~10s scan period + margin.
-								Eventually(getBPFCurrentCount(0, 0, "ingress"), "30s", "1s").Should(Equal(uint32(0)))
+								// Idle TCPEstablished (5s) then cleaner/scanner cadence
+								// (~10s/~30s) drains the counter. Unloaded this is ~12s,
+								// but under CI batch contention the cleaner/scanner Go
+								// loops are CPU-starved and the drain stretches well past
+								// 30s, so use a generous 90s window (verified on a loaded
+								// 6.8 VM: 30s flakes, 90s is stable).
+								Eventually(getBPFCurrentCount(0, 0, "ingress"), "90s", "1s").Should(Equal(uint32(0)))
 
 								By("Removing limits from workload 0")
 								w[0].WorkloadEndpoint.Spec.QoSControls = nil


### PR DESCRIPTION
The QoS connection-limit FV tests wait for the per-pod connlimit counter to drain back to 0 after the connections go away. That drain is driven by the Felix conntrack cleaner and connlimit scanner: a CT entry idles out (TCPEstablished/TCPFinsSeen, 5s in these tests), the cleaner purges it on its next cycle (~10s), and the cleanup-time decrement / scanner recount (~30s) brings the counter down. Unloaded this completes in ~12s.

Under CI batch contention the cleaner and scanner Go loops get CPU-starved and the drain stretches well past the 30s Eventually budget, so the wait times out with the counter still non-zero (e.g. "Expected 2 to equal 0"). This is purely a test timing issue — the counter does drain correctly, just slowly under load; it is not a dataplane bug.

Widen all five connlimit drain-to-0 waits (egress recycle, half-close, idle TCPEstablished, and network partition) from 30s to 90s.

Reproduced and verified on a loaded kernel-6.8 GCP VM (stress-ng, loadavg ~25 on 4 cores) matching CI: with a 30s window the network- partition spec fails on the first loaded run; with 90s it passes 8/8. In isolation it never reproduces (6.8 VM 15/15, local 6.12 20/20), confirming the trigger is contention, not the kernel or the logic.

<!-- Describe your changes, including the type of change (bug fix, feature, etc.),
why it should be merged, testing done, and links to related issues. -->

<!-- For any user-visible change, replace TBD with a one-line description. -->
**Release note:**
```release-note
TBD
```
