### PR TITLE
k8st: fix BGPFilter test IPv6 export route assertion

### DIFF
--- a/node/tests/k8st/tests/bgp_filter_test.go
+++ b/node/tests/k8st/tests/bgp_filter_test.go
@@ -568,16 +568,31 @@ func assertExternalRoute(t *testing.T, container, proto, routeRegex, peerIPRegex
 	if ipv6 {
 		birdCmd = "birdcl6"
 	}
-	// IPv6 routes are advertised with a connected link-local next-hop, so the
-	// peer's global address appears in BIRD's "from" field (inside the protocol
-	// brackets) rather than in "via"; IPv4 routes have no "from" and use the
-	// global address as the next-hop.
+	// IPv4 routes use the peer's global address as the next-hop, with no "from"
+	// field:
 	//   v4: <route> via <peerIP> on eth0 [<proto> <time>] ...
-	//   v6: <route> via fe80::... on eth0 [<proto> <time> from <peerIP>] ...
+	//
+	// IPv6 depends on how the peer is configured in bird6.cfg.template:
+	//   - OSS pins "gateway recursive" on every peer, so the route is advertised
+	//     with the peer's global address as the next-hop (same shape as v4).
+	//   - Enterprise emits "direct" for a directly-connected peer (the external
+	//     router shares the egress node's segment), so BIRD uses a link-local
+	//     next-hop and carries the peer's global address in the "from" field:
+	//       v6: <route> via fe80::... on eth0 [<proto> <time> from <peerIP>] ...
+	//
+	// Accept either form so the assertion holds in both repos regardless of
+	// which next-hop BIRD emits. The query is already scoped with
+	// "show route protocol <proto>", so the link-local branch needn't re-verify
+	// the peer IP.
 	pattern := routeRegex + ` *via ` + peerIPRegex + ` on .* \[` + proto
 	if ipv6 {
-		pattern = routeRegex + ` *via fe80:[0-9a-f:]+ on .* \[` + proto + `.*from ` + peerIPRegex
+		pattern = `(?:` +
+			routeRegex + ` *via ` + peerIPRegex + ` on .* \[` + proto +
+			`|` +
+			routeRegex + ` *via fe80:[0-9a-f:]+ on .* \[` + proto +
+			`)`
 	}
+
 	re := regexp.MustCompile(pattern)
 
 	err := utils.RetryUntilSuccess(t, time.Minute, func() error {

--- a/node/tests/k8st/tests/bgp_filter_test.go
+++ b/node/tests/k8st/tests/bgp_filter_test.go
@@ -568,7 +568,17 @@ func assertExternalRoute(t *testing.T, container, proto, routeRegex, peerIPRegex
 	if ipv6 {
 		birdCmd = "birdcl6"
 	}
-	re := regexp.MustCompile(routeRegex + ` *via ` + peerIPRegex + ` on .* \[` + proto)
+	// IPv6 routes are advertised with a connected link-local next-hop, so the
+	// peer's global address appears in BIRD's "from" field (inside the protocol
+	// brackets) rather than in "via"; IPv4 routes have no "from" and use the
+	// global address as the next-hop.
+	//   v4: <route> via <peerIP> on eth0 [<proto> <time>] ...
+	//   v6: <route> via fe80::... on eth0 [<proto> <time> from <peerIP>] ...
+	pattern := routeRegex + ` *via ` + peerIPRegex + ` on .* \[` + proto
+	if ipv6 {
+		pattern = routeRegex + ` *via fe80:[0-9a-f:]+ on .* \[` + proto + `.*from ` + peerIPRegex
+	}
+	re := regexp.MustCompile(pattern)
 
 	err := utils.RetryUntilSuccess(t, time.Minute, func() error {
 		out, err := utils.Run(t, fmt.Sprintf("docker exec %s %s show route protocol %s", container, birdCmd, proto),


### PR DESCRIPTION
### Description

The `basic` BGPFilter k8st test's IPv6 **export** check (`assertExternalRoute`) never matched, causing `TestBGPFilter/basic_v6` and `TestBGPFilter/basic_v4v6` to fail (time out) on a route that was actually present.

`assertExternalRoute` looked for the cluster's exported IPAM-block route on the external router with next-hop `via <egress node global IPv6>`. But IPv6 BGP over the shared L2 segment advertises a **connected link-local next-hop** (`via fe80::...`); the egress node's global address shows up in BIRD's `from` field instead. Observed BIRD output on the external v6 router:

```
fd00:10:244:0:586d:4461:e980:a280/122 via fe80::42:acff:fe12:5 on eth0 [Mesh_with_node_1 ... from 2001:20::1] ...
```

The route was being exported correctly the whole time. The IPv4 case passed only because the node's data-plane IP doubles as both the BGP peer address and the connected next-hop.

This change matches a link-local next-hop plus the peer's global address in the `from` field for IPv6, and keeps the existing global-next-hop match for IPv4. It also repairs the v6 export-*reject* assertion, which previously passed vacuously because its regex could never match the real route line — so it couldn't have caught a regression either way.

Only the `basic` scenario exercises `assertExternalRoute` (export direction); `ordering` and `global_peer` only check `assertClusterRoute` (import direction), where the next-hop is the external router's own global address, which is why they were unaffected.

### Testing done

Validated the updated regexes against the exact BIRD route output captured from a failing run:
- v4 route present → matches ✅
- v6 route present (link-local next-hop, global in `from`) → matches ✅
- v6 route absent → no match ✅
- v6 route from a different peer → no match ✅

`go vet ./node/tests/k8st/tests/` is clean.

**Release note:**
```release-note
NONE
```