### PR TITLE
fix(helm): Use semver-compliant helm chart versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -152,6 +152,10 @@ bin/send-perf-results: $(shell find ./hack/perf -name '*.go')
 
 CHART_DESTINATION ?= ./bin
 
+chart-test:
+	$(info $(GIT_VERSION))
+	$(info $(GIT_VERSION:v%=%))
+
 # Build helm charts.
 chart: $(CHART_DESTINATION)/tigera-operator-$(GIT_VERSION).tgz \
 			 $(CHART_DESTINATION)/projectcalico.org.v3-$(GIT_VERSION).tgz \
@@ -161,21 +165,21 @@ $(CHART_DESTINATION)/tigera-operator-$(GIT_VERSION).tgz: bin/helm $(shell find .
 	mkdir -p $(CHART_DESTINATION)
 	bin/helm package ./charts/tigera-operator \
 	--destination $(CHART_DESTINATION)/ \
-	--version $(GIT_VERSION) \
+	--version $(GIT_VERSION:v%=%) \
 	--app-version $(GIT_VERSION)
 
 $(CHART_DESTINATION)/crd.projectcalico.org.v1-$(GIT_VERSION).tgz: bin/helm $(shell find ./charts/crd.projectcalico.org.v1/ -type f)
 	mkdir -p $(CHART_DESTINATION)
 	bin/helm package ./charts/crd.projectcalico.org.v1/ \
 	--destination $(CHART_DESTINATION)/ \
-	--version $(GIT_VERSION) \
+	--version $(GIT_VERSION:v%=%) \
 	--app-version $(GIT_VERSION)
 
 $(CHART_DESTINATION)/projectcalico.org.v3-$(GIT_VERSION).tgz: bin/helm $(shell find ./charts/projectcalico.org.v3/ -type f)
 	mkdir -p $(CHART_DESTINATION)
 	bin/helm package ./charts/projectcalico.org.v3/ \
 	--destination $(CHART_DESTINATION)/ \
-	--version $(GIT_VERSION) \
+	--version $(GIT_VERSION:v%=%) \
 	--app-version $(GIT_VERSION)
 
 ###############################################################################


### PR DESCRIPTION
When generating our helm charts, we've always filled the `version` field with the version string we use in all other parts of Calico, e.g. `v3.32.1`. Unfortunately, the `version` field is intended to be a semver-compliant version string, and technically the leading `v` makes this an invalid field value (and therefore an invalid chart).

This hasn't been an issue in the past, since no available tooling seems to have an issue with this, but now that we're pushing charts to OCI registries such as quay.io, we've discovered that, when listing tags in an OCI registry, `helm` only considers semver-compliant tags in its list; this means that any non-semver-compliant tags are filtered out, and therefore that `helm` cannot find any versions. This was first reported by a user in #12826.

While I've re-tagged the v3.32.x charts in quay.io, this will continue to be an issue as long as we're publishing invalid semver versions in our helm charts.

This change simply removes the leading `v` from the `version` field when generating the helm chart. It will need to be tested further to ensure that this doesn't break assumptions elsewhere.

<!-- For any user-visible change, replace TBD with a one-line description. -->
**Release note:**
```release-note
Adjust helm charts to use semver-compliant version strings. Helm charts which previously had a trailing `v` in their version field now have this version removed. This results in a helm chart that is fully compliant with the spec. While existing tooling hasn't had an issue with these invalid version fields, pushing these charts to an OCI registry resulted in non-compliant registry tags which helm then ignored when listing versions. The tags should now be compliant and behave correctly in all known circumstances. Users who rely on parsing or sorting these version fields should ensure that their tooling correctly handles this transition.
```

