### PR TITLE
node/windows: install calico binary as calico-ipam too

### DIFF
--- a/node/windows-packaging/CalicoWindows/libs/calico/calico.psm1
+++ b/node/windows-packaging/CalicoWindows/libs/calico/calico.psm1
@@ -121,6 +121,11 @@ function Install-CNIPlugin()
     Write-Host "Copying CNI binaries to $env:CNI_BIN_DIR"
     cp "$baseDir\cni\*.exe" "$env:CNI_BIN_DIR"
 
+    # calico.exe is a monobinary that also acts as the IPAM plugin when invoked as
+    # calico-ipam, so install it under that name too (as cni-plugin's install-cni
+    # does) to satisfy the conf's calico-ipam ipam type.
+    cp "$env:CNI_BIN_DIR\calico.exe" "$env:CNI_BIN_DIR\calico-ipam.exe" -Force -ErrorAction Stop
+
     $cniConfFile = $env:CNI_CONF_DIR + "\" + $env:CNI_CONF_FILENAME
     Write-Host "Writing CNI configuration to $cniConfFile."
     $nodeNameFile = "$baseDir\nodename".replace('\', '\\')


### PR DESCRIPTION
The Windows CNI plugin is a monobinary that also serves as the IPAM plugin when invoked as calico-ipam, mirroring cni-plugin's install-cni which installs the binary under both "calico" and "calico-ipam" names. The Windows archive only ships calico.exe, but Install-CNIPlugin writes a CNI conf with ipam type "calico-ipam", so Windows pod sandbox creation fails with "failed to find plugin calico-ipam" until the calico-node DaemonSet's install-cni runs. Install the binary as calico-ipam.exe as well so the archive-based install is self-sufficient.

**Release note:**
```release-note
Fix Windows archive-based CNI install so the calico-ipam plugin is present, preventing pod sandbox creation failures ("failed to find plugin calico-ipam").
```