### PR TITLE
lib/std/time: add Resolve for the RFC3339-or-now-relative query format

### DIFF
--- a/felix/deps.txt
+++ b/felix/deps.txt
@@ -313,6 +313,7 @@ local:goldmane/pkg/types
 local:goldmane/proto
 local:lib/datastructures/hashring
 local:lib/std/chanutil
+local:lib/std/log
 local:lib/std/time
 local:lib/std/uniquelabels
 local:lib/std/uniquestr

--- a/goldmane/deps.txt
+++ b/goldmane/deps.txt
@@ -101,6 +101,7 @@ local:goldmane/pkg/stream
 local:goldmane/pkg/types
 local:goldmane/proto
 local:lib/std/chanutil
+local:lib/std/log
 local:lib/std/time
 local:lib/std/uniquelabels
 local:lib/std/uniquestr

--- a/kube-controllers/deps.txt
+++ b/kube-controllers/deps.txt
@@ -196,6 +196,7 @@ local:kube-controllers/pkg/discovery
 local:kube-controllers/pkg/kubecontrollers
 local:kube-controllers/pkg/status
 local:lib/std/chanutil
+local:lib/std/log
 local:lib/std/time
 local:lib/std/uniquelabels
 local:lib/std/uniquestr

--- a/lib/std/time/time.go
+++ b/lib/std/time/time.go
@@ -1,8 +1,13 @@
 package time
 
 import (
+	"errors"
+	"strconv"
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/projectcalico/calico/lib/std/log"
 )
 
 func init() {
@@ -164,6 +169,78 @@ func Unix(sec int64, nsec int64) Time {
 
 func Parse(layout, value string) (Time, error) {
 	return time.Parse(layout, value)
+}
+
+// Resolve parses a user-supplied time string in either RFC3339
+// absolute form or the "now - <duration>" relative form Calico uses
+// across its query APIs. Supported relative units: s (seconds),
+// m (minutes), h (hours), d (24-hour days; no DST adjustment). "now"
+// alone returns now; "now - 0" likewise. The now argument anchors
+// relative inputs — pass time.Now() in production, a fixed instant
+// in tests.
+//
+// Different from Parse, which is the stdlib time.Parse re-export
+// and only handles an explicit layout string. Resolve is for
+// query/filter values where the caller hasn't pre-detected which
+// form the user supplied.
+//
+// Returns (nil, nil, nil) when tstr is nil or empty. On success,
+// returns the resolved time and an "echo" value: the original
+// string for relative inputs, or Unix seconds for absolute inputs
+// (handy for round-tripping back through caches/UIs that want to
+// preserve the user's original phrasing).
+func Resolve(now Time, tstr *string) (*Time, any, error) {
+	if tstr == nil || *tstr == "" {
+		return nil, nil, nil
+	}
+	// "now - X" relative form: try this first; fall through to
+	// RFC3339 if the head isn't "now".
+	parts := strings.SplitN(*tstr, "-", 2)
+	if strings.TrimSpace(parts[0]) == "now" {
+		log.Debug("resolving relative time", "input", *tstr)
+		now = now.UTC()
+		if len(parts) == 1 {
+			return &now, *tstr, nil
+		}
+		dur := strings.TrimSpace(parts[1])
+		if dur == "0" {
+			return &now, *tstr, nil
+		}
+		if len(dur) < 2 {
+			log.Debug("relative duration too short", "duration", dur)
+			return nil, nil, errors.New("error parsing time in query - not a supported format")
+		}
+		var mul time.Duration
+		switch dur[len(dur)-1] {
+		case 's':
+			mul = time.Second
+		case 'm':
+			mul = time.Minute
+		case 'h':
+			mul = time.Hour
+		case 'd':
+			mul = 24 * time.Hour
+		default:
+			log.Debug("unsupported relative duration unit", "duration", dur)
+			return nil, nil, errors.New("error parsing time in query - not a supported format")
+		}
+		val, err := strconv.ParseUint(strings.TrimSpace(dur[:len(dur)-1]), 10, 64)
+		if err != nil {
+			log.Debug("failed to parse relative duration value", "duration", dur, "err", err)
+			return nil, nil, err
+		}
+		t := now.Add(-(time.Duration(val) * mul))
+		return &t, *tstr, nil
+	}
+
+	// Absolute form: RFC3339.
+	t, err := time.Parse(time.RFC3339, *tstr)
+	if err != nil {
+		log.Debug("failed to parse as RFC3339", "input", *tstr, "err", err)
+		return nil, nil, err
+	}
+	t = t.UTC()
+	return &t, t.Unix(), nil
 }
 
 func Date(year int, month Month, day, hour, min, sec, nsec int, loc *Location) Time {

--- a/lib/std/time/time_test.go
+++ b/lib/std/time/time_test.go
@@ -1,0 +1,111 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+
+package time_test
+
+import (
+	"testing"
+
+	"github.com/projectcalico/calico/lib/std/time"
+)
+
+func TestResolve(t *testing.T) {
+	now := time.Now()
+
+	t.Run("relative", func(t *testing.T) {
+		cases := []struct {
+			name      string
+			input     string
+			wantDelta time.Duration
+		}{
+			{"now", "now", 0},
+			{"now - 0", "now - 0", 0},
+			{"now - 15m", "now - 15m", 15 * time.Minute},
+			{"no-space now-10m", "now-10m", 10 * time.Minute},
+			{"now-100h", "now-100h", 100 * time.Hour},
+			{"now-3d", "now-3d", 3 * 24 * time.Hour},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				s := tc.input
+				got, echo, err := time.Resolve(now, &s)
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if got == nil {
+					t.Fatal("expected resolved time, got nil")
+				}
+				if delta := now.Sub(*got); delta != tc.wantDelta {
+					t.Errorf("delta = %v, want %v", delta, tc.wantDelta)
+				}
+				if echo != tc.input {
+					t.Errorf("echo = %v, want %v", echo, tc.input)
+				}
+			})
+		}
+	})
+
+	t.Run("relative errors", func(t *testing.T) {
+		cases := []struct {
+			name  string
+			input string
+		}{
+			{"missing unit (now-32)", "now-32"},
+			{"bad unit (now-xxx)", "now-xxx"},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				s := tc.input
+				got, echo, err := time.Resolve(now, &s)
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				if got != nil {
+					t.Errorf("expected nil time, got %v", got)
+				}
+				if echo != nil {
+					t.Errorf("expected nil echo, got %v", echo)
+				}
+			})
+		}
+	})
+
+	t.Run("RFC3339", func(t *testing.T) {
+		nowUTC := time.Now().UTC()
+		s := nowUTC.Add(-5 * time.Second).UTC().Format(time.RFC3339)
+		got, echo, err := time.Resolve(nowUTC, &s)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got == nil {
+			t.Fatal("expected resolved time, got nil")
+		}
+		// Compare in whole seconds — nowUTC keeps sub-second precision
+		// that the RFC3339-formatted string dropped.
+		if delta := nowUTC.Sub(*got) / time.Second; delta != 5 {
+			t.Errorf("delta seconds = %v, want 5", delta)
+		}
+		if echo != got.Unix() {
+			t.Errorf("echo = %v, want %v", echo, got.Unix())
+		}
+	})
+
+	t.Run("nil or empty", func(t *testing.T) {
+		cases := []struct {
+			name  string
+			input *string
+		}{
+			{"nil", nil},
+			{"empty", ptr("")},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				got, echo, err := time.Resolve(now, tc.input)
+				if err != nil || got != nil || echo != nil {
+					t.Errorf("expected all-nil for %s input, got (%v, %v, %v)", tc.name, got, echo, err)
+				}
+			})
+		}
+	})
+}
+
+func ptr(s string) *string { return &s }


### PR DESCRIPTION
Many Calico query APIs accept time as either an RFC3339 absolute or a `"now - <duration>"` relative form (units: `s` / `m` / `h` / `d`). Today that parsing lives in `lma/pkg/timeutils.ParseTime`, which means anything that wants to share the convention has to take an `lma` dependency even when it has no other reason to. This promotes the function to `lib/std/time` as `Resolve`.

## Why

- `lma/pkg/timeutils/time.go` is one function in one file behind an otherwise heavy module. Seven non-test consumers across the monorepo already import it (`ui-apis/`, `queryserver/`, `policy-recommendation/`, `compliance/`, plus internal lma callers); none structurally depend on lma for any other reason.
- Future modules (e.g. an extracted linseed client) that need the same parsing shouldn't have to drag lma in.
- The parsing convention itself is a cross-cutting Calico idiom that belongs in a neutral library, not buried in a specific component.

## Why a new function instead of overloading `Parse`

`Parse` already exists in this package as the `time.Parse(layout, value)` re-export — caller supplies the layout. `Resolve` is for *user-supplied* query/filter values where the caller hasn't pre-detected which form they were given. Different contracts → different names.

## Implementation notes

- Same RFC3339-or-`now-X` semantics as `lma/pkg/timeutils.ParseTime`. Signature is `Resolve(now Time, tstr *string) (*Time, any, error)` — preserves the original's "echo" return (original string for relative inputs, Unix seconds for absolute) for callers that want to round-trip the user's input form.
- Debug logging is routed through `lib/std/log` (slog-shaped) instead of taking a direct logrus dependency. Matches the rest of `lib/std`; no-op until a process registers a backend via `log.SetDefaultLogger`.
- Doc comment doesn't reference Elasticsearch (the original called this "a loose elasticsearch format"); the convention is described on its own terms.

## Follow-ups (not in this PR)

- Point `lma/pkg/timeutils.ParseTime` at `time.Resolve` as a back-compat re-export, then migrate the seven callers off `lma/pkg/timeutils` and delete the file. Separate PR so the migration can land at each consumer's own pace.

## Tests

- 9 cases from `lma/pkg/timeutils/time_test.go` ported, plus 2 new ones covering the nil/empty-input contract.
- Reshaped from Ginkgo into a single `TestResolve` with table-driven subtests, matching the raw-testing style other `lib/std` packages use.
- `go test ./time/...` — passing.
