### PR TITLE
node k8st: run each test in a randomly-suffixed namespace

### DIFF
--- a/node/tests/k8st/tests/bgp_advert_test.go
+++ b/node/tests/k8st/tests/bgp_advert_test.go
@@ -48,8 +48,6 @@ import (
 )
 
 const (
-	// bgpTestNS is the namespace each advertisement subtest deploys into.
-	bgpTestNS = "bgp-test"
 	// extPeerName is the BGPPeer from the cluster nodes to the external router.
 	extPeerName = "node-extra.peer"
 	// rrPeerName is the BGPPeer created by the route-reflector tests.
@@ -147,6 +145,11 @@ type bgpAdvertEnv struct {
 	nodes          []string
 	ips            []string
 	externalNodeIP string
+
+	// ns is the namespace the current subtest deploys into. startTest assigns
+	// it a fresh random name per subtest so concurrent or repeated runs against
+	// the same cluster do not collide.
+	ns string
 }
 
 // TestBGPAdvert exercises service-IP advertisement under the full node-to-node
@@ -232,12 +235,13 @@ func TestBGPAdvertRR(t *testing.T) {
 // run before it (matching the Python tearDown ordering, where add_cleanup
 // callbacks run before the namespace deletion and config restore).
 func (e *bgpAdvertEnv) startTest(t *testing.T) {
+	e.ns = utils.RandomSuffix("bgp-test")
 	t.Cleanup(func() { e.teardownTest(t) })
-	utils.CreateNamespace(t, bgpTestNS)
+	utils.CreateNamespace(t, e.ns)
 }
 
 func (e *bgpAdvertEnv) teardownTest(t *testing.T) {
-	utils.DeleteAndConfirm(t, bgpTestNS, "ns", "")
+	utils.DeleteAndConfirm(t, e.ns, "ns", "")
 
 	// Delete the RR-specific BGPPeer (created by some tests), ignoring absence.
 	deleteBGPPeer(e.cli, rrPeerName)
@@ -274,16 +278,16 @@ func (e *bgpAdvertEnv) testClusterIPAdvertisement(t *testing.T) {
 
 	// Create both a Local and a Cluster type NodePort service with one replica.
 	localSvc, clusterSvc := "nginx-local", "nginx-cluster"
-	utils.Deploy(t, utils.NginxImage, localSvc, bgpTestNS, 80, utils.DeployOptions{})
-	utils.Deploy(t, utils.NginxImage, clusterSvc, bgpTestNS, 80, utils.DeployOptions{TrafficPolicy: corev1.ServiceExternalTrafficPolicyCluster})
-	utils.WaitUntilExists(t, localSvc, "svc", bgpTestNS)
-	utils.WaitUntilExists(t, clusterSvc, "svc", bgpTestNS)
+	utils.Deploy(t, utils.NginxImage, localSvc, e.ns, 80, utils.DeployOptions{})
+	utils.Deploy(t, utils.NginxImage, clusterSvc, e.ns, 80, utils.DeployOptions{TrafficPolicy: corev1.ServiceExternalTrafficPolicyCluster})
+	utils.WaitUntilExists(t, localSvc, "svc", e.ns)
+	utils.WaitUntilExists(t, clusterSvc, "svc", e.ns)
 
-	localSvcIP := utils.GetSvcClusterIP(t, localSvc, bgpTestNS)
-	clusterSvcIP := utils.GetSvcClusterIP(t, clusterSvc, bgpTestNS)
+	localSvcIP := utils.GetSvcClusterIP(t, localSvc, e.ns)
+	clusterSvcIP := utils.GetSvcClusterIP(t, clusterSvc, e.ns)
 
-	utils.WaitForDeployment(t, localSvc, bgpTestNS)
-	utils.WaitForDeployment(t, clusterSvc, bgpTestNS)
+	utils.WaitForDeployment(t, localSvc, e.ns)
+	utils.WaitForDeployment(t, clusterSvc, e.ns)
 
 	// Both services should be reachable from the external node.
 	curlRetry(t, localSvcIP)
@@ -294,14 +298,14 @@ func (e *bgpAdvertEnv) testClusterIPAdvertisement(t *testing.T) {
 	assertRouteNotContains(t, clusterSvcIP)
 
 	// Scale the local service to 4 replicas and assert ECMP routing.
-	utils.ScaleDeployment(t, localSvc, bgpTestNS, 4)
-	utils.WaitForDeployment(t, localSvc, bgpTestNS)
+	utils.ScaleDeployment(t, localSvc, e.ns, 4)
+	utils.WaitForDeployment(t, localSvc, e.ns)
 	assertEcmpRoutes(t, localSvcIP, []string{e.ips[1], e.ips[2], e.ips[3]})
 	curlRetry(t, localSvcIP)
 
 	// Delete both services; the clusterIP is no longer advertised.
-	utils.DeleteAndConfirm(t, localSvc, "svc", bgpTestNS)
-	utils.DeleteAndConfirm(t, clusterSvc, "svc", bgpTestNS)
+	utils.DeleteAndConfirm(t, localSvc, "svc", e.ns)
+	utils.DeleteAndConfirm(t, clusterSvc, "svc", e.ns)
 	assertRouteNotContains(t, localSvcIP)
 }
 
@@ -318,16 +322,16 @@ func (e *bgpAdvertEnv) testNodeExclusion(t *testing.T) {
 	assertRouteContains(t, clusterCIDR)
 
 	localSvc, clusterSvc := "nginx-local", "nginx-cluster"
-	utils.Deploy(t, utils.NginxImage, localSvc, bgpTestNS, 80, utils.DeployOptions{})
-	utils.Deploy(t, utils.NginxImage, clusterSvc, bgpTestNS, 80, utils.DeployOptions{TrafficPolicy: corev1.ServiceExternalTrafficPolicyCluster})
-	utils.WaitUntilExists(t, localSvc, "svc", bgpTestNS)
-	utils.WaitUntilExists(t, clusterSvc, "svc", bgpTestNS)
+	utils.Deploy(t, utils.NginxImage, localSvc, e.ns, 80, utils.DeployOptions{})
+	utils.Deploy(t, utils.NginxImage, clusterSvc, e.ns, 80, utils.DeployOptions{TrafficPolicy: corev1.ServiceExternalTrafficPolicyCluster})
+	utils.WaitUntilExists(t, localSvc, "svc", e.ns)
+	utils.WaitUntilExists(t, clusterSvc, "svc", e.ns)
 
-	localSvcIP := utils.GetSvcClusterIP(t, localSvc, bgpTestNS)
-	clusterSvcIP := utils.GetSvcClusterIP(t, clusterSvc, bgpTestNS)
+	localSvcIP := utils.GetSvcClusterIP(t, localSvc, e.ns)
+	clusterSvcIP := utils.GetSvcClusterIP(t, clusterSvc, e.ns)
 
-	utils.WaitForDeployment(t, localSvc, bgpTestNS)
-	utils.WaitForDeployment(t, clusterSvc, bgpTestNS)
+	utils.WaitForDeployment(t, localSvc, e.ns)
+	utils.WaitForDeployment(t, clusterSvc, e.ns)
 
 	curlRetry(t, localSvcIP)
 	curlRetry(t, clusterSvcIP)
@@ -339,8 +343,8 @@ func (e *bgpAdvertEnv) testNodeExclusion(t *testing.T) {
 	curlRetry(t, clusterSvcIP)
 
 	// Scale local service to 4 replicas.
-	utils.ScaleDeployment(t, localSvc, bgpTestNS, 4)
-	utils.WaitForDeployment(t, localSvc, bgpTestNS)
+	utils.ScaleDeployment(t, localSvc, e.ns, 4)
+	utils.WaitForDeployment(t, localSvc, e.ns)
 
 	// Local service is advertised only from nodes that can run pods; the
 	// cluster CIDR is advertised from all nodes.
@@ -363,19 +367,19 @@ func (e *bgpAdvertEnv) testNodeExclusion(t *testing.T) {
 	curlRetry(t, clusterSvcIP)
 
 	// Delete the local service; it is no longer advertised.
-	utils.DeleteAndConfirm(t, localSvc, "svc", bgpTestNS)
+	utils.DeleteAndConfirm(t, localSvc, "svc", e.ns)
 	assertRouteNotContains(t, localSvcIP)
 
 	// Re-create the local service; advertised from the correct nodes only.
-	utils.CreateService(t, localSvc, localSvc, bgpTestNS, 80, utils.DeployOptions{})
-	utils.WaitUntilExists(t, localSvc, "svc", bgpTestNS)
-	localSvcIP = utils.GetSvcClusterIP(t, localSvc, bgpTestNS)
+	utils.CreateService(t, localSvc, localSvc, e.ns, 80, utils.DeployOptions{})
+	utils.WaitUntilExists(t, localSvc, "svc", e.ns)
+	localSvcIP = utils.GetSvcClusterIP(t, localSvc, e.ns)
 	assertEcmpRoutes(t, localSvcIP, []string{e.ips[2], e.ips[3]})
 	curlRetry(t, localSvcIP)
 
 	// Add an external IP and assert it follows the same advertisement rules.
 	localSvcExternalIP := "175.200.1.1"
-	utils.AddSvcExternalIPs(t, localSvc, bgpTestNS, []string{localSvcExternalIP})
+	utils.AddSvcExternalIPs(t, localSvc, e.ns, []string{localSvcExternalIP})
 	assertEcmpRoutes(t, localSvcExternalIP, []string{e.ips[2], e.ips[3]})
 
 	// Re-enable the excluded node; it advertises service routes again.
@@ -386,8 +390,8 @@ func (e *bgpAdvertEnv) testNodeExclusion(t *testing.T) {
 	curlRetry(t, localSvcIP)
 
 	// Delete both services; the clusterIP is no longer advertised.
-	utils.DeleteAndConfirm(t, localSvc, "svc", bgpTestNS)
-	utils.DeleteAndConfirm(t, clusterSvc, "svc", bgpTestNS)
+	utils.DeleteAndConfirm(t, localSvc, "svc", e.ns)
+	utils.DeleteAndConfirm(t, clusterSvc, "svc", e.ns)
 	assertRouteNotContains(t, localSvcIP)
 }
 
@@ -404,33 +408,33 @@ func (e *bgpAdvertEnv) testExternalIPAdvertisement(t *testing.T) {
 	})
 
 	localSvc, clusterSvc := "nginx-local", "nginx-cluster"
-	utils.Deploy(t, utils.NginxImage, localSvc, bgpTestNS, 80, utils.DeployOptions{})
-	utils.Deploy(t, utils.NginxImage, clusterSvc, bgpTestNS, 80, utils.DeployOptions{TrafficPolicy: corev1.ServiceExternalTrafficPolicyCluster})
-	utils.WaitUntilExists(t, localSvc, "svc", bgpTestNS)
-	utils.WaitUntilExists(t, clusterSvc, "svc", bgpTestNS)
+	utils.Deploy(t, utils.NginxImage, localSvc, e.ns, 80, utils.DeployOptions{})
+	utils.Deploy(t, utils.NginxImage, clusterSvc, e.ns, 80, utils.DeployOptions{TrafficPolicy: corev1.ServiceExternalTrafficPolicyCluster})
+	utils.WaitUntilExists(t, localSvc, "svc", e.ns)
+	utils.WaitUntilExists(t, clusterSvc, "svc", e.ns)
 
-	localSvcIP := utils.GetSvcClusterIP(t, localSvc, bgpTestNS)
-	clusterSvcIP := utils.GetSvcClusterIP(t, clusterSvc, bgpTestNS)
+	localSvcIP := utils.GetSvcClusterIP(t, localSvc, e.ns)
+	clusterSvcIP := utils.GetSvcClusterIP(t, clusterSvc, e.ns)
 
-	utils.WaitForDeployment(t, localSvc, bgpTestNS)
-	utils.WaitForDeployment(t, clusterSvc, bgpTestNS)
+	utils.WaitForDeployment(t, localSvc, e.ns)
+	utils.WaitForDeployment(t, clusterSvc, e.ns)
 
 	// clusterIPs are not advertised (no serviceClusterIPs configured).
 	assertRouteNotContains(t, localSvcIP)
 	assertRouteNotContains(t, clusterSvcIP)
 
 	// Network policy that only accepts traffic from the external node.
-	createExternalNodeIngressPolicy(t, e.externalNodeIP)
+	createExternalNodeIngressPolicy(t, e.ns, e.externalNodeIP)
 
-	localSvcHostIP := utils.GetSvcHostIP(t, localSvc, bgpTestNS)
-	clusterSvcHostIP := utils.GetSvcHostIP(t, clusterSvc, bgpTestNS)
+	localSvcHostIP := utils.GetSvcHostIP(t, localSvc, e.ns)
+	clusterSvcHostIP := utils.GetSvcHostIP(t, clusterSvc, e.ns)
 
 	// Select an IP from each external IP CIDR.
 	localSvcExternalIP := "175.200.1.1"
 	clusterSvcExternalIP := "200.255.255.1"
 
-	utils.AddSvcExternalIPs(t, localSvc, bgpTestNS, []string{localSvcExternalIP})
-	utils.AddSvcExternalIPs(t, clusterSvc, bgpTestNS, []string{clusterSvcExternalIP})
+	utils.AddSvcExternalIPs(t, localSvc, e.ns, []string{localSvcExternalIP})
+	utils.AddSvcExternalIPs(t, clusterSvc, e.ns, []string{clusterSvcExternalIP})
 
 	// The external IP of the local service is advertised but not the cluster one.
 	localSvcExternalIPsRoute := fmt.Sprintf("%s via %s", localSvcExternalIP, localSvcHostIP)
@@ -439,13 +443,13 @@ func (e *bgpAdvertEnv) testExternalIPAdvertisement(t *testing.T) {
 	assertRouteNotContains(t, clusterSvcExternalIPsRoute)
 
 	// Scale the local service to 4 replicas; expect ECMP routes for its ext IP.
-	utils.ScaleDeployment(t, localSvc, bgpTestNS, 4)
-	utils.WaitForDeployment(t, localSvc, bgpTestNS)
+	utils.ScaleDeployment(t, localSvc, e.ns, 4)
+	utils.WaitForDeployment(t, localSvc, e.ns)
 	assertEcmpRoutes(t, localSvcExternalIP, []string{e.ips[1], e.ips[2], e.ips[3]})
 
 	// Delete both services; the external IP is no longer advertised.
-	utils.DeleteAndConfirm(t, localSvc, "svc", bgpTestNS)
-	utils.DeleteAndConfirm(t, clusterSvc, "svc", bgpTestNS)
+	utils.DeleteAndConfirm(t, localSvc, "svc", e.ns)
+	utils.DeleteAndConfirm(t, clusterSvc, "svc", e.ns)
 	assertRouteNotContains(t, localSvcExternalIPsRoute)
 }
 
@@ -462,13 +466,13 @@ func (e *bgpAdvertEnv) testFullyQualifiedServiceIPs(t *testing.T) {
 	// externalTrafficPolicy=Cluster, triggering advertisement from all nodes.
 	svcName := "nginx-svc"
 	extIP := "90.15.0.1"
-	utils.Deploy(t, utils.NginxImage, svcName, bgpTestNS, 80, utils.DeployOptions{
+	utils.Deploy(t, utils.NginxImage, svcName, e.ns, 80, utils.DeployOptions{
 		TrafficPolicy: corev1.ServiceExternalTrafficPolicyCluster,
 		SvcType:       corev1.ServiceTypeClusterIP,
 		ExtIP:         extIP,
 	})
-	utils.WaitUntilExists(t, svcName, "svc", bgpTestNS)
-	utils.WaitForDeployment(t, svcName, bgpTestNS)
+	utils.WaitUntilExists(t, svcName, "svc", e.ns)
+	utils.WaitForDeployment(t, svcName, e.ns)
 
 	assertEcmpRoutes(t, extIP, []string{e.ips[0], e.ips[1], e.ips[2], e.ips[3]})
 }
@@ -483,25 +487,25 @@ func (e *bgpAdvertEnv) testLoadBalancerIPAdvertisement(t *testing.T) {
 
 	// Create a dummy service to occupy the first LB IP, so the IP we test with
 	// below isn't the zero address of the range.
-	utils.CreateService(t, "dummy-service", "dummy-service", bgpTestNS, 80, utils.DeployOptions{SvcType: corev1.ServiceTypeLoadBalancer})
+	utils.CreateService(t, "dummy-service", "dummy-service", e.ns, 80, utils.DeployOptions{SvcType: corev1.ServiceTypeLoadBalancer})
 
 	localSvc, clusterSvc := "nginx-local", "nginx-cluster"
-	utils.Deploy(t, utils.NginxImage, clusterSvc, bgpTestNS, 80, utils.DeployOptions{
+	utils.Deploy(t, utils.NginxImage, clusterSvc, e.ns, 80, utils.DeployOptions{
 		TrafficPolicy: corev1.ServiceExternalTrafficPolicyCluster,
 		SvcType:       corev1.ServiceTypeLoadBalancer,
 	})
-	utils.Deploy(t, utils.NginxImage, localSvc, bgpTestNS, 80, utils.DeployOptions{SvcType: corev1.ServiceTypeLoadBalancer})
-	utils.WaitUntilExists(t, localSvc, "svc", bgpTestNS)
-	utils.WaitUntilExists(t, clusterSvc, "svc", bgpTestNS)
+	utils.Deploy(t, utils.NginxImage, localSvc, e.ns, 80, utils.DeployOptions{SvcType: corev1.ServiceTypeLoadBalancer})
+	utils.WaitUntilExists(t, localSvc, "svc", e.ns)
+	utils.WaitUntilExists(t, clusterSvc, "svc", e.ns)
 
-	localLBIP := utils.GetSvcLoadBalancerIP(t, localSvc, bgpTestNS)
-	clusterLBIP := utils.GetSvcLoadBalancerIP(t, clusterSvc, bgpTestNS)
+	localLBIP := utils.GetSvcLoadBalancerIP(t, localSvc, e.ns)
+	clusterLBIP := utils.GetSvcLoadBalancerIP(t, clusterSvc, e.ns)
 
-	utils.WaitForDeployment(t, localSvc, bgpTestNS)
-	utils.WaitForDeployment(t, clusterSvc, bgpTestNS)
+	utils.WaitForDeployment(t, localSvc, e.ns)
+	utils.WaitForDeployment(t, clusterSvc, e.ns)
 
-	localSvcHostIP := utils.GetSvcHostIP(t, localSvc, bgpTestNS)
-	clusterSvcHostIP := utils.GetSvcHostIP(t, clusterSvc, bgpTestNS)
+	localSvcHostIP := utils.GetSvcHostIP(t, localSvc, e.ns)
+	clusterSvcHostIP := utils.GetSvcHostIP(t, clusterSvc, e.ns)
 
 	// LB IP of the local service is advertised but not the cluster service's.
 	localSvcLBRoute := fmt.Sprintf("%s via %s", localLBIP, localSvcHostIP)
@@ -514,8 +518,8 @@ func (e *bgpAdvertEnv) testLoadBalancerIPAdvertisement(t *testing.T) {
 	assertEcmpRoutes(t, lbCIDR, []string{e.ips[0], e.ips[1], e.ips[2], e.ips[3]})
 
 	// Scale the local service to 4 replicas; expect ECMP for its LB IP.
-	utils.ScaleDeployment(t, localSvc, bgpTestNS, 4)
-	utils.WaitForDeployment(t, localSvc, bgpTestNS)
+	utils.ScaleDeployment(t, localSvc, e.ns, 4)
+	utils.WaitForDeployment(t, localSvc, e.ns)
 	assertEcmpRoutes(t, localLBIP, []string{e.ips[1], e.ips[2], e.ips[3]})
 
 	// Disable LoadBalancer advertisement; routes are withdrawn.
@@ -543,8 +547,8 @@ func (e *bgpAdvertEnv) testLoadBalancerIPAdvertisement(t *testing.T) {
 	curlRetry(t, clusterLBIP)
 
 	// Delete both services; the LB IP is no longer advertised.
-	utils.DeleteAndConfirm(t, localSvc, "svc", bgpTestNS)
-	utils.DeleteAndConfirm(t, clusterSvc, "svc", bgpTestNS)
+	utils.DeleteAndConfirm(t, localSvc, "svc", e.ns)
+	utils.DeleteAndConfirm(t, clusterSvc, "svc", e.ns)
 	assertRouteNotContains(t, localLBIP)
 }
 
@@ -559,18 +563,18 @@ func (e *bgpAdvertEnv) testManyServices(t *testing.T) {
 
 	// Create a local service and deployment.
 	localSvc := "nginx-local"
-	utils.Deploy(t, utils.NginxImage, localSvc, bgpTestNS, 80, utils.DeployOptions{})
-	utils.WaitForDeployment(t, localSvc, bgpTestNS)
+	utils.Deploy(t, utils.NginxImage, localSvc, e.ns, 80, utils.DeployOptions{})
+	utils.WaitForDeployment(t, localSvc, e.ns)
 
-	clusterIPs := []string{utils.GetSvcClusterIP(t, localSvc, bgpTestNS)}
+	clusterIPs := []string{utils.GetSvcClusterIP(t, localSvc, e.ns)}
 
 	// Create many more services selecting the same deployment.
 	const numSvc = 50
 	for i := range numSvc {
-		utils.CreateService(t, fmt.Sprintf("nginx-svc-%d", i), localSvc, bgpTestNS, 80, utils.DeployOptions{})
+		utils.CreateService(t, fmt.Sprintf("nginx-svc-%d", i), localSvc, e.ns, 80, utils.DeployOptions{})
 	}
 	for i := range numSvc {
-		clusterIPs = append(clusterIPs, utils.GetSvcClusterIP(t, fmt.Sprintf("nginx-svc-%d", i), bgpTestNS))
+		clusterIPs = append(clusterIPs, utils.GetSvcClusterIP(t, fmt.Sprintf("nginx-svc-%d", i), e.ns))
 	}
 
 	// Assert all are advertised to the other node. This should happen quickly
@@ -589,8 +593,8 @@ func (e *bgpAdvertEnv) testManyServices(t *testing.T) {
 	}
 
 	// Scale to 0 replicas; all routes are removed.
-	utils.ScaleDeployment(t, localSvc, bgpTestNS, 0)
-	utils.WaitForDeployment(t, localSvc, bgpTestNS)
+	utils.ScaleDeployment(t, localSvc, e.ns, 0)
+	utils.WaitForDeployment(t, localSvc, e.ns)
 	err = utils.RetryUntilSuccess(t, 60*time.Second, func() error {
 		routes := utils.ExternalNodeRoutes(t)
 		for _, cip := range clusterIPs {
@@ -617,11 +621,11 @@ func (e *bgpAdvertEnv) testBGPFilterIPAdvertisement(t *testing.T) {
 
 	// Create a Local type NodePort service with a single replica.
 	localSvc := "nginx-local"
-	utils.Deploy(t, utils.NginxImage, localSvc, bgpTestNS, 80, utils.DeployOptions{})
-	utils.WaitUntilExists(t, localSvc, "svc", bgpTestNS)
+	utils.Deploy(t, utils.NginxImage, localSvc, e.ns, 80, utils.DeployOptions{})
+	utils.WaitUntilExists(t, localSvc, "svc", e.ns)
 
-	localSvcIP := utils.GetSvcClusterIP(t, localSvc, bgpTestNS)
-	utils.WaitForDeployment(t, localSvc, bgpTestNS)
+	localSvcIP := utils.GetSvcClusterIP(t, localSvc, e.ns)
+	utils.WaitForDeployment(t, localSvc, e.ns)
 
 	curlRetry(t, localSvcIP)
 	assertRouteContains(t, localSvcIP)
@@ -732,7 +736,7 @@ func (e *bgpAdvertEnv) createRRWorkload(t *testing.T, mutate func(*corev1.Servic
 
 	labels := map[string]string{"app": "nginx", "run": "nginx-rr"}
 	dep := &appsv1.Deployment{
-		ObjectMeta: metav1.ObjectMeta{Name: "nginx-rr", Namespace: bgpTestNS, Labels: map[string]string{"app": "nginx"}},
+		ObjectMeta: metav1.ObjectMeta{Name: "nginx-rr", Namespace: e.ns, Labels: map[string]string{"app": "nginx"}},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: new(int32(1)),
 			Selector: &metav1.LabelSelector{MatchLabels: labels},
@@ -752,13 +756,13 @@ func (e *bgpAdvertEnv) createRRWorkload(t *testing.T, mutate func(*corev1.Servic
 			},
 		},
 	}
-	_, err := cs.AppsV1().Deployments(bgpTestNS).Create(ctx, dep, metav1.CreateOptions{})
+	_, err := cs.AppsV1().Deployments(e.ns).Create(ctx, dep, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("creating nginx-rr deployment: %v", err)
 	}
 
 	svc := &corev1.Service{
-		ObjectMeta: metav1.ObjectMeta{Name: "nginx-rr", Namespace: bgpTestNS, Labels: labels},
+		ObjectMeta: metav1.ObjectMeta{Name: "nginx-rr", Namespace: e.ns, Labels: labels},
 		Spec: corev1.ServiceSpec{
 			Ports:    []corev1.ServicePort{{Port: 80, TargetPort: intstr.FromInt32(80)}},
 			Selector: labels,
@@ -769,7 +773,7 @@ func (e *bgpAdvertEnv) createRRWorkload(t *testing.T, mutate func(*corev1.Servic
 	// back the spec we set (including loadBalancerIP / externalIPs), so the
 	// returned object carries everything the caller asserts on — matching the
 	// Python, which reads spec.clusterIP / spec.loadBalancerIP directly.
-	created, err := cs.CoreV1().Services(bgpTestNS).Create(ctx, svc, metav1.CreateOptions{})
+	created, err := cs.CoreV1().Services(e.ns).Create(ctx, svc, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("creating nginx-rr service: %v", err)
 	}
@@ -892,12 +896,12 @@ func labelNode(t *testing.T, node, key, value string) {
 
 // createExternalNodeIngressPolicy creates a NetworkPolicy in the test namespace
 // that only admits TCP/80 ingress from the external node's IP.
-func createExternalNodeIngressPolicy(t *testing.T, externalIP string) {
+func createExternalNodeIngressPolicy(t *testing.T, nsName, externalIP string) {
 	t.Helper()
 	tcp := corev1.ProtocolTCP
 	port80 := intstr.FromInt32(80)
 	policy := &networkingv1.NetworkPolicy{
-		ObjectMeta: metav1.ObjectMeta{Name: "allow-tcp-80-ex", Namespace: bgpTestNS},
+		ObjectMeta: metav1.ObjectMeta{Name: "allow-tcp-80-ex", Namespace: nsName},
 		Spec: networkingv1.NetworkPolicySpec{
 			PodSelector: metav1.LabelSelector{},
 			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
@@ -909,7 +913,7 @@ func createExternalNodeIngressPolicy(t *testing.T, externalIP string) {
 			}},
 		},
 	}
-	_, err := utils.K8sClient(t).NetworkingV1().NetworkPolicies(bgpTestNS).Create(
+	_, err := utils.K8sClient(t).NetworkingV1().NetworkPolicies(nsName).Create(
 		context.Background(), policy, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("creating NetworkPolicy: %v", err)

--- a/node/tests/k8st/tests/bgp_advert_test.go
+++ b/node/tests/k8st/tests/bgp_advert_test.go
@@ -44,6 +44,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
+	e2eutils "github.com/projectcalico/calico/e2e/pkg/utils"
 	"github.com/projectcalico/calico/node/tests/k8st/utils"
 )
 
@@ -235,7 +236,7 @@ func TestBGPAdvertRR(t *testing.T) {
 // run before it (matching the Python tearDown ordering, where add_cleanup
 // callbacks run before the namespace deletion and config restore).
 func (e *bgpAdvertEnv) startTest(t *testing.T) {
-	e.ns = utils.RandomSuffix("bgp-test")
+	e.ns = e2eutils.GenerateRandomName("bgp-test")
 	t.Cleanup(func() { e.teardownTest(t) })
 	utils.CreateNamespace(t, e.ns)
 }

--- a/node/tests/k8st/tests/bgp_filter_test.go
+++ b/node/tests/k8st/tests/bgp_filter_test.go
@@ -74,10 +74,6 @@ const (
 	externalNodeV4 = "kube-node-extra"
 	externalNodeV6 = "kube-node-extra-v6"
 
-	// anchorNamespace holds the idle pod that pins an IPAM block to the egress
-	// node so it has something to advertise to the external routers.
-	anchorNamespace = "bgp-filter-anchor"
-
 	peerNameV4 = "node-extra.peer"
 	peerNameV6 = "node-extra-v6.peer"
 
@@ -177,7 +173,11 @@ func setupBGPFilterEnv(t *testing.T, ctx context.Context, g *WithT) *bgpFilterEn
 	// Mark the egress node so the node-selected BGPPeers attach to it.
 	labelNode(t, env.egressNode, "egress", "true")
 
-	ensureEgressNodeOwnsBlock(t, ctx, g, cli, env.egressNode)
+	// anchorNS pins an idle pod to the egress node so it owns an IPAM block to
+	// advertise. The random suffix keeps it unique per test so concurrent or
+	// repeated runs against the same cluster do not collide.
+	anchorNS := utils.RandomSuffix("bgp-filter-anchor")
+	ensureEgressNodeOwnsBlock(t, ctx, g, cli, env.egressNode, anchorNS)
 
 	// Establish BGPPeers from the egress node to each external router.
 	createBGPPeer(t, ctx, g, cli, peerNameV4, env.externalNodeIP)
@@ -191,15 +191,15 @@ func setupBGPFilterEnv(t *testing.T, ctx context.Context, g *WithT) *bgpFilterEn
 // that may host no pods (and thus no block, especially for IPv6). The pod uses
 // the default pools so its block CIDRs match clusterRouteRegexV4/V6; waiting for
 // both IPs claims a block in each family before any assertion runs.
-func ensureEgressNodeOwnsBlock(t *testing.T, ctx context.Context, g *WithT, cli ctrlclient.Client, node string) {
+func ensureEgressNodeOwnsBlock(t *testing.T, ctx context.Context, g *WithT, cli ctrlclient.Client, node, nsName string) {
 	t.Helper()
 
-	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: anchorNamespace}}
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: nsName}}
 	g.Expect(cli.Create(ctx, ns)).To(Succeed(), "creating anchor namespace")
 	t.Cleanup(func() { _ = cli.Delete(context.Background(), ns) })
 
 	pod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{Name: "block-anchor", Namespace: anchorNamespace},
+		ObjectMeta: metav1.ObjectMeta{Name: "block-anchor", Namespace: nsName},
 		Spec: corev1.PodSpec{
 			NodeName:   node,
 			Containers: []corev1.Container{{Name: "anchor", Image: utils.Agnhost, Args: []string{"pause"}}},

--- a/node/tests/k8st/tests/bgp_filter_test.go
+++ b/node/tests/k8st/tests/bgp_filter_test.go
@@ -38,6 +38,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
+	e2eutils "github.com/projectcalico/calico/e2e/pkg/utils"
 	"github.com/projectcalico/calico/node/tests/k8st/utils"
 )
 
@@ -176,7 +177,7 @@ func setupBGPFilterEnv(t *testing.T, ctx context.Context, g *WithT) *bgpFilterEn
 	// anchorNS pins an idle pod to the egress node so it owns an IPAM block to
 	// advertise. The random suffix keeps it unique per test so concurrent or
 	// repeated runs against the same cluster do not collide.
-	anchorNS := utils.RandomSuffix("bgp-filter-anchor")
+	anchorNS := e2eutils.GenerateRandomName("bgp-filter-anchor")
 	ensureEgressNodeOwnsBlock(t, ctx, g, cli, env.egressNode, anchorNS)
 
 	// Establish BGPPeers from the egress node to each external router.

--- a/node/tests/k8st/tests/cluster_routes_test.go
+++ b/node/tests/k8st/tests/cluster_routes_test.go
@@ -84,7 +84,7 @@ func TestClusterRouteOwnership(t *testing.T) {
 	g.Expect(cli.Create(ctx, pool)).To(Succeed(), "creating IPPool")
 	t.Cleanup(func() { deletePool(t, cli, pool.Name) })
 
-	nsName := "cluster-routes"
+	nsName := utils.RandomSuffix("cluster-routes")
 	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: nsName}}
 	g.Expect(cli.Create(ctx, ns)).To(Succeed(), "creating namespace")
 	t.Cleanup(func() { _ = cli.Delete(context.Background(), ns) })

--- a/node/tests/k8st/tests/cluster_routes_test.go
+++ b/node/tests/k8st/tests/cluster_routes_test.go
@@ -32,6 +32,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
+	e2eutils "github.com/projectcalico/calico/e2e/pkg/utils"
 	"github.com/projectcalico/calico/node/tests/k8st/utils"
 )
 
@@ -84,7 +85,7 @@ func TestClusterRouteOwnership(t *testing.T) {
 	g.Expect(cli.Create(ctx, pool)).To(Succeed(), "creating IPPool")
 	t.Cleanup(func() { deletePool(t, cli, pool.Name) })
 
-	nsName := utils.RandomSuffix("cluster-routes")
+	nsName := e2eutils.GenerateRandomName("cluster-routes")
 	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: nsName}}
 	g.Expect(cli.Create(ctx, ns)).To(Succeed(), "creating namespace")
 	t.Cleanup(func() { _ = cli.Delete(context.Background(), ns) })

--- a/node/tests/k8st/tests/encap_spoofing_test.go
+++ b/node/tests/k8st/tests/encap_spoofing_test.go
@@ -37,9 +37,6 @@ import (
 )
 
 const (
-	// spoofNamespace holds the access/scapy pod pair shared by both subtests.
-	spoofNamespace = "ipip-spoofing"
-
 	// spoofedNodeIP is the (arbitrary, in-pod-CIDR) address used as the outer
 	// destination of forged encapsulated packets. Matches the Python original.
 	spoofedNodeIP = "10.192.0.3"
@@ -57,6 +54,11 @@ const (
 func TestSpoof(t *testing.T) {
 	defer utils.CollectDiagsOnFailure(t)()
 
+	// nsName holds the access/scapy pod pair shared by both scenarios. The
+	// random suffix keeps it unique per test so concurrent or repeated runs
+	// against the same cluster do not collide.
+	nsName := utils.RandomSuffix("ipip-spoofing")
+
 	g := NewWithT(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
 	t.Cleanup(cancel)
@@ -68,7 +70,7 @@ func TestSpoof(t *testing.T) {
 		"spoofing test needs a control-plane node and at least two workers")
 
 	// Namespace + pods, created once for both scenarios.
-	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: spoofNamespace}}
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: nsName}}
 	g.Expect(cli.Create(ctx, ns)).To(Succeed(), "creating namespace")
 	t.Cleanup(func() { _ = cli.Delete(context.Background(), ns) })
 
@@ -79,7 +81,7 @@ func TestSpoof(t *testing.T) {
 	// access listens for UDP on 5000 and appends what it receives to snoop.txt;
 	// the grep against that file is how we detect delivery.
 	access := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{Name: "access", Namespace: spoofNamespace},
+		ObjectMeta: metav1.ObjectMeta{Name: "access", Namespace: nsName},
 		Spec: corev1.PodSpec{
 			NodeName: nodes[1],
 			Containers: []corev1.Container{{
@@ -94,7 +96,7 @@ func TestSpoof(t *testing.T) {
 
 	// scapy forges the (normal and spoofed) packets.
 	scapy := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{Name: "scapy", Namespace: spoofNamespace},
+		ObjectMeta: metav1.ObjectMeta{Name: "scapy", Namespace: nsName},
 		Spec: corev1.PodSpec{
 			NodeName: nodes[2],
 			Containers: []corev1.Container{{
@@ -107,14 +109,14 @@ func TestSpoof(t *testing.T) {
 	g.Expect(cli.Create(ctx, scapy)).To(Succeed(), "creating scapy pod")
 	t.Cleanup(func() { _ = cli.Delete(context.Background(), scapy) })
 
-	utils.WaitForPodReady(t, spoofNamespace, "scapy", 2*time.Minute)
-	utils.WaitForPodReady(t, spoofNamespace, "access", 2*time.Minute)
+	utils.WaitForPodReady(t, nsName, "scapy", 2*time.Minute)
+	utils.WaitForPodReady(t, nsName, "access", 2*time.Minute)
 
 	// IPIP: a packet of the form IP(node)/IP(pod)/UDP is IPIP encapsulation.
 	t.Run("ipip", func(t *testing.T) {
 		defer utils.CollectDiagsOnFailure(t)()
-		runSpoofScenario(t, cli, ctx, "IPIP", "ipip", func(g *WithT, podIP, message string) {
-			sendScapy(t, fmt.Sprintf(
+		runSpoofScenario(t, cli, ctx, nsName, "IPIP", "ipip", func(g *WithT, podIP, message string) {
+			sendScapy(t, nsName, fmt.Sprintf(
 				"send(IP(dst='%s')/IP(dst='%s')/UDP(dport=5000, sport=5000)/Raw(load='%s'))",
 				spoofedNodeIP, podIP, message))
 		})
@@ -123,8 +125,8 @@ func TestSpoof(t *testing.T) {
 	// VXLAN: IP(node)/UDP(4789)/VXLAN/Ether()/IP(pod)/UDP is VXLAN encapsulation.
 	t.Run("vxlan", func(t *testing.T) {
 		defer utils.CollectDiagsOnFailure(t)()
-		runSpoofScenario(t, cli, ctx, "VXLAN", "vxlan", func(g *WithT, podIP, message string) {
-			sendScapy(t, fmt.Sprintf(
+		runSpoofScenario(t, cli, ctx, nsName, "VXLAN", "vxlan", func(g *WithT, podIP, message string) {
+			sendScapy(t, nsName, fmt.Sprintf(
 				"send(IP(dst='%s')/UDP(dport=4789)/VXLAN(vni=4096)/Ether()/IP(dst='%s')/UDP(dport=5000, sport=5000)/Raw(load='%s'))",
 				spoofedNodeIP, podIP, message))
 		})
@@ -135,14 +137,14 @@ func TestSpoof(t *testing.T) {
 // is delivered, then confirms a spoofed (encapsulated, forged-inner-source)
 // packet is not. sendSpoofed forges the encapsulated packet for the mode under
 // test (its shape is the only thing that differs between IPIP and VXLAN).
-func runSpoofScenario(t *testing.T, cli ctrlclient.Client, ctx context.Context, encap, prefix string, sendSpoofed func(g *WithT, podIP, message string)) {
+func runSpoofScenario(t *testing.T, cli ctrlclient.Client, ctx context.Context, nsName, encap, prefix string, sendSpoofed func(g *WithT, podIP, message string)) {
 	g := NewWithT(t)
 
 	setEncapsulation(t, g, cli, ctx, encap)
 
 	// The access pod's IP is the inner destination of every packet we forge.
 	remotePodIP := waitForPodIP(ctx, g, cli, &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{Name: "access", Namespace: spoofNamespace},
+		ObjectMeta: metav1.ObjectMeta{Name: "access", Namespace: nsName},
 	}, corev1.IPv4Protocol)
 	t.Logf("access pod IP: %s", remotePodIP)
 
@@ -150,9 +152,9 @@ func runSpoofScenario(t *testing.T, cli ctrlclient.Client, ctx context.Context, 
 	clearConntrack(t, ctx)
 	normalMsg := prefix + "-normal"
 	g.Eventually(func() error {
-		sendScapy(t, fmt.Sprintf(
+		sendScapy(t, nsName, fmt.Sprintf(
 			"send(IP(dst='%s')/UDP(dport=5000, sport=5000)/Raw(load='%s'))", remotePodIP, normalMsg))
-		return grepSnoop(t, normalMsg)
+		return grepSnoop(t, nsName, normalMsg)
 	}, "60s", "2s").Should(Succeed(), "normal %s packet was never delivered", encap)
 
 	// A spoofed (encapsulated) packet must NOT be delivered: we keep forging it
@@ -161,7 +163,7 @@ func runSpoofScenario(t *testing.T, cli ctrlclient.Client, ctx context.Context, 
 	spoofedMsg := prefix + "-spoofed"
 	g.Eventually(func() error {
 		sendSpoofed(g, remotePodIP, spoofedMsg)
-		if err := grepSnoop(t, spoofedMsg); err == nil {
+		if err := grepSnoop(t, nsName, spoofedMsg); err == nil {
 			return fmt.Errorf("ERROR - succeeded in sending spoofed %s packet", encap)
 		}
 		return nil
@@ -171,17 +173,17 @@ func runSpoofScenario(t *testing.T, cli ctrlclient.Client, ctx context.Context, 
 // sendScapy feeds a single scapy send() statement to the scapy pod on stdin.
 // scapy send failures are non-fatal (the Python original swallowed them): the
 // assertion is made by grepping the access pod, not by scapy's exit code.
-func sendScapy(t *testing.T, script string) {
+func sendScapy(t *testing.T, nsName, script string) {
 	t.Helper()
-	_, _ = utils.ExecInPodStdin(t, spoofNamespace, "scapy", script+"\n", []string{"scapy"},
+	_, _ = utils.ExecInPodStdin(t, nsName, "scapy", script+"\n", []string{"scapy"},
 		utils.RunOptions{AllowFail: true, SuppressErrLog: true})
 }
 
 // grepSnoop greps the access pod's capture file for message. A non-nil error
 // means the message was not found (i.e. the packet was not delivered).
-func grepSnoop(t *testing.T, message string) error {
+func grepSnoop(t *testing.T, nsName, message string) error {
 	t.Helper()
-	_, err := utils.ExecInPod(t, spoofNamespace, "access", "grep "+message+" /root/snoop.txt",
+	_, err := utils.ExecInPod(t, nsName, "access", "grep "+message+" /root/snoop.txt",
 		utils.RunOptions{AllowFail: true, SuppressErrLog: true})
 	return err
 }

--- a/node/tests/k8st/tests/encap_spoofing_test.go
+++ b/node/tests/k8st/tests/encap_spoofing_test.go
@@ -54,9 +54,7 @@ const (
 func TestSpoof(t *testing.T) {
 	defer utils.CollectDiagsOnFailure(t)()
 
-	// nsName holds the access/scapy pod pair shared by both scenarios. The
-	// random suffix keeps it unique per test so concurrent or repeated runs
-	// against the same cluster do not collide.
+	// nsName holds the access/scapy pod pair shared by both scenarios.
 	nsName := utils.RandomSuffix("ipip-spoofing")
 
 	g := NewWithT(t)

--- a/node/tests/k8st/tests/encap_spoofing_test.go
+++ b/node/tests/k8st/tests/encap_spoofing_test.go
@@ -33,6 +33,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
+	e2eutils "github.com/projectcalico/calico/e2e/pkg/utils"
 	"github.com/projectcalico/calico/node/tests/k8st/utils"
 )
 
@@ -55,7 +56,7 @@ func TestSpoof(t *testing.T) {
 	defer utils.CollectDiagsOnFailure(t)()
 
 	// nsName holds the access/scapy pod pair shared by both scenarios.
-	nsName := utils.RandomSuffix("ipip-spoofing")
+	nsName := e2eutils.GenerateRandomName("ipip-spoofing")
 
 	g := NewWithT(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)

--- a/node/tests/k8st/tests/proxy_neigh_test.go
+++ b/node/tests/k8st/tests/proxy_neigh_test.go
@@ -50,6 +50,7 @@ import (
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlconfig "sigs.k8s.io/controller-runtime/pkg/client/config"
 
+	e2eutils "github.com/projectcalico/calico/e2e/pkg/utils"
 	"github.com/projectcalico/calico/node/tests/k8st/utils"
 )
 
@@ -113,7 +114,7 @@ func runFamily(t *testing.T, family corev1.IPFamily) {
 	t.Logf("Test pool CIDRs (%s): workload=%s LB=%s", family, workloadCIDR, lbCIDR)
 
 	suffix := strings.ToLower(string(family))
-	nsName := utils.RandomSuffix("proxy-neigh-" + suffix)
+	nsName := e2eutils.GenerateRandomName("proxy-neigh-" + suffix)
 
 	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: nsName}}
 	g.Expect(cli.Create(ctx, ns)).To(Succeed(), "creating namespace")

--- a/node/tests/k8st/tests/proxy_neigh_test.go
+++ b/node/tests/k8st/tests/proxy_neigh_test.go
@@ -113,7 +113,7 @@ func runFamily(t *testing.T, family corev1.IPFamily) {
 	t.Logf("Test pool CIDRs (%s): workload=%s LB=%s", family, workloadCIDR, lbCIDR)
 
 	suffix := strings.ToLower(string(family))
-	nsName := "proxy-neigh-" + suffix
+	nsName := utils.RandomSuffix("proxy-neigh-" + suffix)
 
 	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: nsName}}
 	g.Expect(cli.Create(ctx, ns)).To(Succeed(), "creating namespace")

--- a/node/tests/k8st/utils/utils.go
+++ b/node/tests/k8st/utils/utils.go
@@ -20,6 +20,7 @@ package utils
 
 import (
 	"context"
+	"crypto/rand"
 	"errors"
 	"fmt"
 	"os"
@@ -58,6 +59,29 @@ var ipv6Map = map[string]string{
 	"kind-worker":        "2001:20::1",
 	"kind-worker2":       "2001:20::2",
 	"kind-worker3":       "2001:20::3",
+}
+
+// randSuffixChars are the characters RandomSuffix draws from. Lowercase
+// alphanumerics keep the result a valid DNS-1123 label, the format Kubernetes
+// requires for namespace names.
+const randSuffixChars = "abcdefghijklmnopqrstuvwxyz0123456789"
+
+// RandomSuffix appends a short random suffix to name, separated by a hyphen.
+// Tests use it to derive a unique namespace name per run so that concurrent or
+// repeated runs against the same cluster do not collide. The result remains a
+// valid DNS-1123 label.
+func RandomSuffix(name string) string {
+	const n = 5
+	b := make([]byte, n)
+	if _, err := rand.Read(b); err != nil {
+		// crypto/rand should never fail; fall back to a fixed suffix rather
+		// than panicking in a test helper.
+		return name + "-rand"
+	}
+	for i := range b {
+		b[i] = randSuffixChars[int(b[i])%len(randSuffixChars)]
+	}
+	return name + "-" + string(b)
 }
 
 func envOr(key, fallback string) string {

--- a/node/tests/k8st/utils/utils.go
+++ b/node/tests/k8st/utils/utils.go
@@ -20,7 +20,6 @@ package utils
 
 import (
 	"context"
-	"crypto/rand"
 	"errors"
 	"fmt"
 	"os"
@@ -59,25 +58,6 @@ var ipv6Map = map[string]string{
 	"kind-worker":        "2001:20::1",
 	"kind-worker2":       "2001:20::2",
 	"kind-worker3":       "2001:20::3",
-}
-
-// RandomSuffix appends a short random suffix to name, separated by a hyphen.
-// Tests use it to derive a unique namespace name per run so that concurrent or
-// repeated runs against the same cluster do not collide. The result remains a
-// valid DNS-1123 label.
-func RandomSuffix(name string) string {
-	const randSuffixChars = "abcdefghijklmnopqrstuvwxyz0123456789"
-	const n = 5
-	b := make([]byte, n)
-	if _, err := rand.Read(b); err != nil {
-		// crypto/rand should never fail; fall back to a fixed suffix rather
-		// than panicking in a test helper.
-		return name + "-rand"
-	}
-	for i := range b {
-		b[i] = randSuffixChars[int(b[i])%len(randSuffixChars)]
-	}
-	return name + "-" + string(b)
 }
 
 func envOr(key, fallback string) string {

--- a/node/tests/k8st/utils/utils.go
+++ b/node/tests/k8st/utils/utils.go
@@ -61,16 +61,12 @@ var ipv6Map = map[string]string{
 	"kind-worker3":       "2001:20::3",
 }
 
-// randSuffixChars are the characters RandomSuffix draws from. Lowercase
-// alphanumerics keep the result a valid DNS-1123 label, the format Kubernetes
-// requires for namespace names.
-const randSuffixChars = "abcdefghijklmnopqrstuvwxyz0123456789"
-
 // RandomSuffix appends a short random suffix to name, separated by a hyphen.
 // Tests use it to derive a unique namespace name per run so that concurrent or
 // repeated runs against the same cluster do not collide. The result remains a
 // valid DNS-1123 label.
 func RandomSuffix(name string) string {
+	const randSuffixChars = "abcdefghijklmnopqrstuvwxyz0123456789"
 	const n = 5
 	b := make([]byte, n)
 	if _, err := rand.Read(b); err != nil {


### PR DESCRIPTION
## Description

k8st node tests previously deployed into fixed-name namespaces (`bgp-test`, `ipip-spoofing`, `bgp-filter-anchor`, `cluster-routes`, `proxy-neigh-*`). A fixed name means two runs against the same cluster — concurrent CI jobs, a retry overlapping a not-yet-torn-down run — collide on namespace creation.

This change derives every test namespace name through a new `utils.RandomSuffix` helper, which appends a short random suffix (lowercase alphanumeric, so the result stays a valid DNS-1123 label) via `crypto/rand`.

The suffixed name is held in **per-test state** rather than a mutable package-level global:

- `cluster_routes_test.go`, `proxy_neigh_test.go` — already used a stack local; just wrapped with `RandomSuffix`.
- `encap_spoofing_test.go` — namespace is now a local in `TestSpoof`, threaded into `runSpoofScenario`/`sendScapy`/`grepSnoop`.
- `bgp_filter_test.go` — namespace is now a local in `setupBGPFilterEnv`, passed into `ensureEgressNodeOwnsBlock`.
- `bgp_advert_test.go` — namespace is now an `ns` field on `bgpAdvertEnv`, assigned per subtest in `startTest`; the one standalone helper (`createExternalNodeIngressPolicy`) takes it as a parameter.

Eliminating the shared mutable global also removes the data race that would otherwise appear if these tests are parallelized in future.

## Release Note

```release-note
None
```