### PR TITLE
node k8st: run namespace-isolated tests in parallel

### DIFF
--- a/node/tests/k8st/tests/cluster_routes_test.go
+++ b/node/tests/k8st/tests/cluster_routes_test.go
@@ -56,6 +56,12 @@ const (
 // traverse the IPIP tunnel), then asserts that the client node's route to the
 // server's block is owned by the configured cluster-route owner via tunl0.
 func TestClusterRouteOwnership(t *testing.T) {
+	// Safe to parallelise: this test confines its mutations to its own
+	// dedicated IPPool and randomly-suffixed namespace, and only reads
+	// cluster-global config (the default FelixConfiguration). Go defers
+	// parallel tests until all serial tests have finished, so the
+	// cluster-disruptive k8st tests never overlap with this one.
+	t.Parallel()
 	defer utils.CollectDiagsOnFailure(t)()
 
 	g := NewWithT(t)

--- a/node/tests/k8st/tests/simple_test.go
+++ b/node/tests/k8st/tests/simple_test.go
@@ -151,6 +151,7 @@ func runRestartChurnTest(t *testing.T, numRepeats int, restartFn func(*restartCh
 //
 // Port of test_simple.py:TestAllRunning.test_calicosystem_pods_running.
 func TestCalicoSystemPodsRunning(t *testing.T) {
+	t.Parallel()
 	defer utils.CollectDiagsOnFailure(t)()
 	utils.CheckPodStatus(t, "calico-system")
 }
@@ -160,6 +161,7 @@ func TestCalicoSystemPodsRunning(t *testing.T) {
 //
 // Port of test_simple.py:TestAllRunning.test_default_pods_running.
 func TestDefaultPodsRunning(t *testing.T) {
+	t.Parallel()
 	defer utils.CollectDiagsOnFailure(t)()
 	utils.CheckPodStatus(t, "default")
 }
@@ -169,6 +171,7 @@ func TestDefaultPodsRunning(t *testing.T) {
 //
 // Port of test_simple.py:TestAllRunning.test_calico_monitoring_pods_running.
 func TestCalicoMonitoringPodsRunning(t *testing.T) {
+	t.Parallel()
 	defer utils.CollectDiagsOnFailure(t)()
 	utils.CheckPodStatus(t, "calico-monitoring")
 }


### PR DESCRIPTION
## Description

Marks the four k8st tests that touch no shared mutable cluster state with `t.Parallel()`, so they run concurrently instead of serially:

- `TestCalicoSystemPodsRunning`, `TestDefaultPodsRunning`, `TestCalicoMonitoringPodsRunning` — pure read-only pod-status checks (`simple_test.go`).
- `TestClusterRouteOwnership` — confines its writes to a dedicated IPPool and a randomly-suffixed namespace, and only reads the default FelixConfiguration (`cluster_routes_test.go`).

### Why this is safe

The rest of the k8st suite is left serial on purpose, because those tests perturb shared dataplane / global-singleton state:

- **Cluster-disruptive:** `TestSpoof` (flips Installation encapsulation + restarts all calico-node pods), `TestGracefulRestart*` (kills BIRD / restarts node pods), `TestReadiness*`/`TestFelixDown` (kill bird/confd/felix on a node).
- **Global-singleton mutators:** `TestBGPAdvert`/`TestBGPAdvertRR` (default `BGPConfiguration`), `TestProxyNeigh` (default `FelixConfiguration`), `TestBGPFilter` (BGPPeers + shared external routers).

Go's testing model defers parallel tests until **every serial test (including its cleanups) has completed**, then runs the parallel batch together. So the disruptive/global tests never overlap with the parallel batch, and the parallel batch only contains tests that are mutually independent (the three read-only checks plus one test isolated to its own namespace + pool). The shared helpers they use (`newClient`, `CollectDiagsOnFailure`) are stateless.

This builds on the recent random-namespace work (#13120), which removed the package-level data races that were the prerequisite for any parallelism here.

## Release Note

```release-note
None
```
