### PR TITLE
watchersyncer: add NewMultiClient + ResourceType.ClientID

### DIFF
--- a/libcalico-go/lib/backend/watchersyncer/watchersyncer.go
+++ b/libcalico-go/lib/backend/watchersyncer/watchersyncer.go
@@ -90,7 +90,7 @@ func WithWatchRetryTimeout(t time.Duration) Option {
 
 // New creates a new multiple Watcher-backed api.Syncer.
 func New(client api.Client, resourceTypes []ResourceType, callbacks api.SyncerCallbacks, options ...Option) api.Syncer {
-	return NewMultiClient(map[string]api.Client{"": client}, resourceTypes, callbacks)
+	return NewMultiClient(map[string]api.Client{"": client}, resourceTypes, callbacks, options...)
 }
 
 // NewMultiClient creates a new multiple Watcher-backed api.Syncer with multiple backing clients.

--- a/libcalico-go/lib/backend/watchersyncer/watchersyncer.go
+++ b/libcalico-go/lib/backend/watchersyncer/watchersyncer.go
@@ -43,6 +43,12 @@ type ResourceType struct {
 	// SendDeletesOnConnFail will send deletes for all resources (and therefore do a full resync) if
 	// the connection fails at any point.
 	SendDeletesOnConnFail bool
+
+	// Client identifier. If using a single client syncer, this should be blank. Otherwise this refers
+	// to the named client in the supplied map of clients. If a client is not in the supplied map, then
+	// the corresponding watcher will not be created (i.e. there will be no updates from that resource
+	// type).
+	ClientID string
 }
 
 // Error indicating a problem with a watcher communicating with the backend.
@@ -82,12 +88,15 @@ func WithWatchRetryTimeout(t time.Duration) Option {
 	}
 }
 
-var _ = WithWatchRetryTimeout
-
 // New creates a new multiple Watcher-backed api.Syncer.
 func New(client api.Client, resourceTypes []ResourceType, callbacks api.SyncerCallbacks, options ...Option) api.Syncer {
+	return NewMultiClient(map[string]api.Client{"": client}, resourceTypes, callbacks)
+}
+
+// NewMultiClient creates a new multiple Watcher-backed api.Syncer with multiple backing clients.
+func NewMultiClient(clients map[string]api.Client, resourceTypes []ResourceType, callbacks api.SyncerCallbacks, options ...Option) api.Syncer {
 	rs := &watcherSyncer{
-		watcherCaches:     make([]*watcherCache, len(resourceTypes)),
+		watcherCaches:     make([]*watcherCache, 0, len(resourceTypes)),
 		results:           make(chan any, 2000),
 		callbacks:         callbacks,
 		watchRetryTimeout: DefaultWatchRetryTimeout,
@@ -95,8 +104,15 @@ func New(client api.Client, resourceTypes []ResourceType, callbacks api.SyncerCa
 	for _, o := range options {
 		o(rs)
 	}
-	for i, r := range resourceTypes {
-		rs.watcherCaches[i] = newWatcherCache(client, r, rs.results, rs.watchRetryTimeout)
+	for _, r := range resourceTypes {
+		if client, ok := clients[r.ClientID]; ok {
+			rs.watcherCaches = append(rs.watcherCaches, newWatcherCache(client, r, rs.results, rs.watchRetryTimeout))
+		} else {
+			log.WithFields(log.Fields{
+				"ClientID":      r.ClientID,
+				"ListInterface": r.ListInterface,
+			}).Debug("Skipping syncer resource because no client has been specified that matches the associated clientID")
+		}
 	}
 	return rs
 }

--- a/libcalico-go/lib/backend/watchersyncer/watchersyncer_test.go
+++ b/libcalico-go/lib/backend/watchersyncer/watchersyncer_test.go
@@ -869,6 +869,80 @@ var _ = Describe("Test the backend datastore multi-watch syncer", func() {
 		})
 		rs.ExpectParseError("zzzzz", "xxxxx")
 	})
+
+	It("should forward New()'s Option arguments so WithWatchRetryTimeout takes effect", func() {
+		// Regression coverage: New() delegates to NewMultiClient, and the options
+		// variadic must be forwarded — otherwise a caller of New() who passes
+		// WithWatchRetryTimeout silently gets the default (10-minute) timeout and
+		// the syncer never signals SyncFailed on sustained connectivity loss.
+		defer setWatchIntervals(watchersyncer.MinResyncInterval, watchersyncer.ListRetryInterval, watchersyncer.WatchPollInterval)
+		setWatchIntervals(50*time.Millisecond, 500*time.Millisecond, 500*time.Millisecond)
+
+		rs := newStartedWatcherSyncerTester(
+			[]watchersyncer.ResourceType{r1},
+			watchersyncer.WithWatchRetryTimeout(50*time.Millisecond),
+		)
+		rs.ExpectStatusUpdate(api.WaitForDatastore)
+
+		// Age lastSuccessfulConnTime past the (short) retry timeout so the next
+		// List failure hits the sustained-disconnect branch rather than being
+		// absorbed as a transient hiccup.
+		time.Sleep(100 * time.Millisecond)
+		rs.clientListResponse(r1, genError)
+
+		// With options forwarded, watchRetryTimeout is 50ms and SyncFailed fires
+		// on the first List failure (time.Since already > 50ms). Without
+		// forwarding, watchRetryTimeout stays at the 10-minute default and this
+		// ExpectConnErrors would time out.
+		rs.ExpectConnErrors([]error{genError})
+	})
+
+	It("should dispatch each resource to the client named by its ClientID", func() {
+		// Two backend clients, each responsible for a distinct resource type via
+		// ClientID. Reaching InSync proves NewMultiClient wired each resource's
+		// watcherCache to the correct client: if either client had received a
+		// resource it wasn't set up for, fakeClient.List / fakeClient.Watch would
+		// have panicked.
+		rc1 := r1
+		rc1.ClientID = "clientA"
+		rc2 := r2
+		rc2.ClientID = "clientB"
+
+		rs := newStartedMultiClientTester([]string{"clientA", "clientB"}, []watchersyncer.ResourceType{rc1, rc2})
+		rs.ExpectStatusUpdate(api.WaitForDatastore)
+		rs.clientListResponse(rc1, emptyList)
+		rs.ExpectStatusUpdate(api.ResyncInProgress)
+		rs.clientListResponse(rc2, emptyList)
+		rs.ExpectStatusUpdate(api.InSync)
+
+		// Unblock the two Watch calls so subsequent tests aren't racing with
+		// leftover goroutines from this one. fakeClient.Watch has no context
+		// select, so watcherSyncer.Stop() would hang here.
+		rs.clientWatchResponse(rc1, notSupported)
+		rs.clientWatchResponse(rc2, notSupported)
+	})
+
+	It("should skip resources whose ClientID has no matching client", func() {
+		// rMissing's ClientID is not in the client map. NewMultiClient must skip
+		// it entirely: no watcherCache should be created, and InSync depends only
+		// on rMatch completing its List. If a phantom cache for rMissing were
+		// created (e.g. against the wrong client), InSync would never fire
+		// because that cache would sit forever waiting on a List response.
+		rMatch := r1
+		rMatch.ClientID = "clientA"
+		rMissing := r2
+		rMissing.ClientID = "clientB" // no matching client below
+
+		rs := newStartedMultiClientTester([]string{"clientA"}, []watchersyncer.ResourceType{rMatch, rMissing})
+		rs.ExpectStatusUpdate(api.WaitForDatastore)
+		rs.clientListResponse(rMatch, emptyList)
+		rs.ExpectStatusUpdate(api.ResyncInProgress)
+		rs.ExpectStatusUpdate(api.InSync)
+
+		// Unblock the Watch call so subsequent tests aren't racing with a
+		// leftover goroutine from this one.
+		rs.clientWatchResponse(rMatch, notSupported)
+	})
 })
 
 var (
@@ -1012,19 +1086,68 @@ func modifiedEvent(key model.Key) api.WatchEvent {
 
 // Create a new watcherSyncerTester - this creates and starts a WatcherSyncer with
 // client and sync consumer interfaces implemented and controlled by the test.
-func newStartedWatcherSyncerTester(l []watchersyncer.ResourceType) *watcherSyncerTester {
-	rst := newWatcherSyncerTester(l)
+func newStartedWatcherSyncerTester(l []watchersyncer.ResourceType, opts ...watchersyncer.Option) *watcherSyncerTester {
+	rst := newWatcherSyncerTester(l, opts...)
 	rst.watcherSyncer.Start()
 	return rst
 }
 
-func newWatcherSyncerTester(l []watchersyncer.ResourceType) *watcherSyncerTester {
-	// Create the required watchers.  This hs methods that we use to drive
-	// responses.
+func newWatcherSyncerTester(l []watchersyncer.ResourceType, opts ...watchersyncer.Option) *watcherSyncerTester {
+	// Single-client case: one fakeClient serving every resource, ClientID left
+	// at the zero value on every ResourceType.
+	fc := newFakeClientFor(l)
+	st := testutils.NewSyncerTester()
+	return &watcherSyncerTester{
+		SyncerTester:  st,
+		fc:            fc,
+		fcs:           map[string]*fakeClient{"": fc},
+		watcherSyncer: watchersyncer.New(fc, l, st, opts...),
+	}
+}
+
+// newStartedMultiClientTester constructs a tester backed by multiple fakeClients,
+// one per entry in clientIDs. Each entry in resources is dispatched by its
+// ClientID field to the matching fakeClient; resources whose ClientID has no
+// matching entry in clientIDs are still passed to NewMultiClient (which skips
+// them, exercising the skip-when-missing-client path).
+func newStartedMultiClientTester(clientIDs []string, resources []watchersyncer.ResourceType, opts ...watchersyncer.Option) *watcherSyncerTester {
+	rst := newMultiClientTester(clientIDs, resources, opts...)
+	rst.watcherSyncer.Start()
+	return rst
+}
+
+func newMultiClientTester(clientIDs []string, resources []watchersyncer.ResourceType, opts ...watchersyncer.Option) *watcherSyncerTester {
+	// Group resources by ClientID and build a fakeClient per requested ID that
+	// serves only the resources dispatched to it. Resources whose ClientID has
+	// no matching entry in clientIDs get no fakeClient — the syncer will skip
+	// them.
+	resourcesByID := map[string][]watchersyncer.ResourceType{}
+	for _, r := range resources {
+		resourcesByID[r.ClientID] = append(resourcesByID[r.ClientID], r)
+	}
+	fcs := map[string]*fakeClient{}
+	clients := map[string]api.Client{}
+	for _, id := range clientIDs {
+		fc := newFakeClientFor(resourcesByID[id])
+		fcs[id] = fc
+		clients[id] = fc
+	}
+	st := testutils.NewSyncerTester()
+	return &watcherSyncerTester{
+		SyncerTester:  st,
+		fcs:           fcs,
+		watcherSyncer: watchersyncer.NewMultiClient(clients, resources, st, opts...),
+	}
+}
+
+// newFakeClientFor returns a fakeClient prepared to serve the given resource
+// types and only those. If the syncer accidentally routes a request to a
+// client that wasn't prepared for that resource, fakeClient.List /
+// fakeClient.Watch will panic on the missing map entry — the test fails
+// loudly rather than silently mis-dispatching.
+func newFakeClientFor(resources []watchersyncer.ResourceType) *fakeClient {
 	lws := map[string]*listWatchSource{}
-	for _, r := range l {
-		// We create a watcher for each resource type.  We'll store these off the
-		// default enumeration path for that resource.
+	for _, r := range resources {
 		name := model.ListOptionsToDefaultPathRoot(r.ListInterface)
 		lws[name] = &listWatchSource{
 			name:            name,
@@ -1034,31 +1157,29 @@ func newWatcherSyncerTester(l []watchersyncer.ResourceType) *watcherSyncerTester
 			results:         make(chan api.WatchEvent, 200),
 		}
 	}
-
-	fc := &fakeClient{
-		lws: lws,
-	}
-
-	// Create the syncer tester.
-	st := testutils.NewSyncerTester()
-	rst := &watcherSyncerTester{
-		SyncerTester:  st,
-		fc:            fc,
-		watcherSyncer: watchersyncer.New(fc, l, st),
-		lws:           lws,
-	}
-	return rst
+	return &fakeClient{lws: lws}
 }
 
 // watcherSyncerTester is used to create, start and validate a watcherSyncer.  It
 // contains a number of useful methods used for asserting current state.
 //
-// This helper extends the function of the testutils SyncerTester.
+// This helper extends the function of the testutils SyncerTester and supports
+// both single-client and multi-client syncers. In the single-client case,
+// fcs[""] and fc point at the same fakeClient. In the multi-client case,
+// fcs is keyed by ClientID and fc is nil.
 type watcherSyncerTester struct {
 	*testutils.SyncerTester
 	fc            *fakeClient
-	lws           map[string]*listWatchSource
+	fcs           map[string]*fakeClient
 	watcherSyncer api.Syncer
+}
+
+// lwsFor returns the listWatchSource that answers for r on its dispatched
+// fakeClient. Panics if there is no fakeClient for r.ClientID, which for
+// tests means the caller forgot to include that ID in clientIDs.
+func (rst *watcherSyncerTester) lwsFor(r watchersyncer.ResourceType) *listWatchSource {
+	name := model.ListOptionsToDefaultPathRoot(r.ListInterface)
+	return rst.fcs[r.ClientID].lws[name]
 }
 
 // Call to test that all of the client and watcher events have been processed.
@@ -1066,10 +1187,12 @@ type watcherSyncerTester struct {
 // than the watcherSyncer.
 func (rst *watcherSyncerTester) expectAllEventsHandled() {
 	log.Infof("Expecting all events to have been handled")
-	for _, l := range rst.lws {
-		ExpectWithOffset(1, l.listCallResults).To(HaveLen(0), "pending list results to be processed")
-		ExpectWithOffset(1, l.stopEvents).To(HaveLen(0), "pending stop events to be processed")
-		ExpectWithOffset(1, l.results).To(HaveLen(0), "pending watch results to be processed")
+	for _, fc := range rst.fcs {
+		for _, l := range fc.lws {
+			ExpectWithOffset(1, l.listCallResults).To(HaveLen(0), "pending list results to be processed")
+			ExpectWithOffset(1, l.stopEvents).To(HaveLen(0), "pending stop events to be processed")
+			ExpectWithOffset(1, l.results).To(HaveLen(0), "pending watch results to be processed")
+		}
 	}
 }
 
@@ -1078,11 +1201,13 @@ func (rst *watcherSyncerTester) expectAllEventsHandled() {
 // are better.
 func (rst *watcherSyncerTester) allEventsHandled() bool {
 	eventsHandled := true
-	for _, l := range rst.lws {
-		eventsHandled = eventsHandled && (len(l.listCallResults) == 0)
-		eventsHandled = eventsHandled && (len(l.watchCallError) == 0)
-		eventsHandled = eventsHandled && (len(l.stopEvents) == 0)
-		eventsHandled = eventsHandled && (len(l.results) == 0)
+	for _, fc := range rst.fcs {
+		for _, l := range fc.lws {
+			eventsHandled = eventsHandled && (len(l.listCallResults) == 0)
+			eventsHandled = eventsHandled && (len(l.watchCallError) == 0)
+			eventsHandled = eventsHandled && (len(l.stopEvents) == 0)
+			eventsHandled = eventsHandled && (len(l.results) == 0)
+		}
 	}
 	return eventsHandled
 }
@@ -1090,6 +1215,7 @@ func (rst *watcherSyncerTester) allEventsHandled() bool {
 // Call to send an event via a particular watcher.
 func (rst *watcherSyncerTester) sendEvent(r watchersyncer.ResourceType, event api.WatchEvent) {
 	name := model.ListOptionsToDefaultPathRoot(r.ListInterface)
+	lws := rst.lwsFor(r)
 	log.WithField("Name", name).Infof("Sending event")
 
 	// The test framework uses a single results channel for each resource, so to send the
@@ -1097,7 +1223,7 @@ func (rst *watcherSyncerTester) sendEvent(r watchersyncer.ResourceType, event ap
 	// terminating (so we know exactly which mock watcher invocation the result will be sent
 	// from).
 	log.Info("Waiting for previous watcher to terminate (if any)")
-	rst.lws[name].termWg.Wait()
+	lws.termWg.Wait()
 	log.Info("Previous watcher terminated (if any)")
 
 	if event.Type == api.WatchError {
@@ -1105,14 +1231,14 @@ func (rst *watcherSyncerTester) sendEvent(r watchersyncer.ResourceType, event ap
 		// watcher as part of the creation of the new one.  Increment the init wait group
 		// in the watcher which will be decremented once the old one has fully terminated.
 		log.WithField("Name", name).Info("Watcher error will trigger restart - increment termination count")
-		rst.lws[name].termWg.Add(1)
+		lws.termWg.Add(1)
 	}
 
 	log.WithFields(log.Fields{
 		"name":  name,
 		"event": event,
 	}).Info("Sending event")
-	rst.lws[name].results <- event
+	lws.results <- event
 
 	if event.Type == api.WatchError {
 		// Finally, since this is a terminating event then we expect a corresponding Stop()
@@ -1126,13 +1252,14 @@ func (rst *watcherSyncerTester) sendEvent(r watchersyncer.ResourceType, event ap
 // Call to verify that stop has been invoked on the watcher.
 func (rst *watcherSyncerTester) expectStop(r watchersyncer.ResourceType) {
 	name := model.ListOptionsToDefaultPathRoot(r.ListInterface)
+	lws := rst.lwsFor(r)
 	log.WithField("Name", name).Infof("Expecting Stop")
 	EventuallyWithOffset(1, func() bool {
-		return len(rst.lws[name].stopEvents) > 0
+		return len(lws.stopEvents) > 0
 	}).Should(BeTrue())
 
 	// Pull the stop event to acknowledge it.
-	<-rst.lws[name].stopEvents
+	<-lws.stopEvents
 }
 
 // Call to specify the response of the client List invocation.  The List call will block
@@ -1146,7 +1273,7 @@ func (rst *watcherSyncerTester) clientListResponse(r watchersyncer.ResourceType,
 	}).Info("Setting client List response")
 	switch response.(type) {
 	case error, *model.KVPairList:
-		rst.lws[name].listCallResults <- response
+		rst.lwsFor(r).listCallResults <- response
 	default:
 		panic("Error in test, wrong type specified")
 	}
@@ -1163,7 +1290,7 @@ func (rst *watcherSyncerTester) clientWatchResponse(r watchersyncer.ResourceType
 	}).Info("Setting client Watch response")
 
 	// Send the required response.
-	rst.lws[name].watchCallError <- err
+	rst.lwsFor(r).watchCallError <- err
 }
 
 // fakeClient implements the api.Client interface.  We mock this out so that we can control


### PR DESCRIPTION
## Description

Port the multi-client constructor and per-resource `ClientID` field from Enterprise into OSS. Pure infrastructure: the mechanism allows a single watcherSyncer to draw events from multiple backend clients, with each `ResourceType` naming which client it uses via the new `ClientID` field.

The existing single-client API is preserved by making `New()` a thin wrapper that calls `NewMultiClient(map[string]api.Client{"": client}, ...)`. `ResourceType` values with no explicit `ClientID` get the empty-string default, which matches the map key. Existing callers are unaffected.

No OSS consumer currently uses the multi-client form. Bringing the plumbing into OSS removes the structural divergence between the trees.
