### PR TITLE
node k8st: use Gomega assertions and Eventually for retries

### DIFF
--- a/node/tests/k8st/tests/bgp_advert_test.go
+++ b/node/tests/k8st/tests/bgp_advert_test.go
@@ -254,13 +254,12 @@ func (e *bgpAdvertEnv) teardownTest(t *testing.T) {
 	})
 
 	// Remove node-2's route-reflector config, retrying to absorb transient
-	// update conflicts.
-	err := utils.RetryUntilSuccess(t, 90*time.Second, func() error {
+	// update conflicts. This is cleanup, so a failure is reported but not fatal
+	// (a fatal here would skip sibling cleanups) — use a non-failing Gomega.
+	g := NewGomega(func(message string, _ ...int) { t.Errorf("%s", message) })
+	g.Eventually(func() error {
 		return clearRRConfig(t, e.nodes[2])
-	})
-	if err != nil {
-		t.Errorf("failed to clear route-reflector config on %s: %v", e.nodes[2], err)
-	}
+	}, 90*time.Second, time.Second).Should(Succeed(), "failed to clear route-reflector config on %s", e.nodes[2])
 }
 
 // ----------------------------------------------------------------------------
@@ -580,7 +579,8 @@ func (e *bgpAdvertEnv) testManyServices(t *testing.T) {
 
 	// Assert all are advertised to the other node. This should happen quickly
 	// enough that they're programmed by the time we've queried them all.
-	err := utils.RetryUntilSuccess(t, 20*time.Second, func() error {
+	g := NewWithT(t)
+	g.Eventually(func() error {
 		routes := utils.ExternalNodeRoutes(t)
 		for _, cip := range clusterIPs {
 			if !strings.Contains(routes, cip) {
@@ -588,15 +588,12 @@ func (e *bgpAdvertEnv) testManyServices(t *testing.T) {
 			}
 		}
 		return nil
-	})
-	if err != nil {
-		t.Fatalf("not all service routes advertised: %v", err)
-	}
+	}, 20*time.Second, time.Second).Should(Succeed(), "not all service routes advertised")
 
 	// Scale to 0 replicas; all routes are removed.
 	utils.ScaleDeployment(t, localSvc, e.ns, 0)
 	utils.WaitForDeployment(t, localSvc, e.ns)
-	err = utils.RetryUntilSuccess(t, 60*time.Second, func() error {
+	g.Eventually(func() error {
 		routes := utils.ExternalNodeRoutes(t)
 		for _, cip := range clusterIPs {
 			if strings.Contains(routes, cip) {
@@ -604,10 +601,7 @@ func (e *bgpAdvertEnv) testManyServices(t *testing.T) {
 			}
 		}
 		return nil
-	})
-	if err != nil {
-		t.Fatalf("service routes were not withdrawn: %v", err)
-	}
+	}, 60*time.Second, time.Second).Should(Succeed(), "service routes were not withdrawn")
 }
 
 func (e *bgpAdvertEnv) testBGPFilterIPAdvertisement(t *testing.T) {
@@ -674,9 +668,9 @@ func (e *bgpAdvertEnv) testRR(t *testing.T) {
 
 	// Make node-2 a route reflector, retrying to absorb update conflicts.
 	g := NewWithT(t)
-	g.Expect(utils.RetryUntilSuccess(t, 90*time.Second, func() error {
+	g.Eventually(func() error {
 		return setRRConfig(t, e.nodes[2])
-	})).To(Succeed(), "setting route-reflector config on %s", e.nodes[2])
+	}, 90*time.Second, time.Second).Should(Succeed(), "setting route-reflector config on %s", e.nodes[2])
 
 	// Disable the mesh, advertise the cluster/external CIDRs, and peer the
 	// cluster nodes with the RR.
@@ -710,9 +704,9 @@ func (e *bgpAdvertEnv) testSingleIPLBRR(t *testing.T) {
 	})
 
 	g := NewWithT(t)
-	g.Expect(utils.RetryUntilSuccess(t, 90*time.Second, func() error {
+	g.Eventually(func() error {
 		return setRRConfig(t, e.nodes[2])
-	})).To(Succeed(), "setting route-reflector config on %s", e.nodes[2])
+	}, 90*time.Second, time.Second).Should(Succeed(), "setting route-reflector config on %s", e.nodes[2])
 
 	e.setBGPConfig(t, v3.BGPConfigurationSpec{
 		NodeToNodeMeshEnabled:  new(false),
@@ -732,6 +726,7 @@ func (e *bgpAdvertEnv) testSingleIPLBRR(t *testing.T) {
 // matching Service customised by mutate, then returns the created Service.
 func (e *bgpAdvertEnv) createRRWorkload(t *testing.T, mutate func(*corev1.Service)) *corev1.Service {
 	t.Helper()
+	g := NewWithT(t)
 	cs := utils.K8sClient(t)
 	ctx := context.Background()
 
@@ -758,9 +753,7 @@ func (e *bgpAdvertEnv) createRRWorkload(t *testing.T, mutate func(*corev1.Servic
 		},
 	}
 	_, err := cs.AppsV1().Deployments(e.ns).Create(ctx, dep, metav1.CreateOptions{})
-	if err != nil {
-		t.Fatalf("creating nginx-rr deployment: %v", err)
-	}
+	g.Expect(err).NotTo(HaveOccurred(), "creating nginx-rr deployment")
 
 	svc := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{Name: "nginx-rr", Namespace: e.ns, Labels: labels},
@@ -775,9 +768,7 @@ func (e *bgpAdvertEnv) createRRWorkload(t *testing.T, mutate func(*corev1.Servic
 	// returned object carries everything the caller asserts on — matching the
 	// Python, which reads spec.clusterIP / spec.loadBalancerIP directly.
 	created, err := cs.CoreV1().Services(e.ns).Create(ctx, svc, metav1.CreateOptions{})
-	if err != nil {
-		t.Fatalf("creating nginx-rr service: %v", err)
-	}
+	g.Expect(err).NotTo(HaveOccurred(), "creating nginx-rr service")
 	return created
 }
 
@@ -821,15 +812,15 @@ func (e *bgpAdvertEnv) setBGPConfig(t *testing.T, spec v3.BGPConfigurationSpec) 
 // one (it survives across the two test classes).
 func createBGPSecret(t *testing.T, cli ctrlclient.Client) {
 	t.Helper()
+	g := NewWithT(t)
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{Name: bgpSecretName, Namespace: bgpSecretNS},
 		Type:       corev1.SecretTypeOpaque,
 		StringData: map[string]string{bgpSecretKey: bgpSecretVal},
 	}
-	err := cli.Create(context.Background(), secret)
-	if err != nil && !apierrors.IsAlreadyExists(err) {
-		t.Fatalf("creating BGP secret: %v", err)
-	}
+	// The Secret survives across the two test classes, so an existing one is fine.
+	g.Expect(ctrlclient.IgnoreAlreadyExists(cli.Create(context.Background(), secret))).
+		To(Succeed(), "creating BGP secret")
 }
 
 // upsertBGPPeer creates the peer, or replaces its spec if it already exists.
@@ -871,14 +862,15 @@ func setPeerFilters(t *testing.T, cli ctrlclient.Client, name string, filters []
 		}
 		peer.Spec.Filters = filters
 		return cli.Update(ctx, peer)
-	}, "20s", "2s").Should(Succeed(), "setting filters %v on BGPPeer %s", filters, name)
+	}, "20s", "1s").Should(Succeed(), "setting filters %v on BGPPeer %s", filters, name)
 }
 
 // labelNode sets a label on a node (overwriting any existing value).
 func labelNode(t *testing.T, node, key, value string) {
 	t.Helper()
+	g := NewWithT(t)
 	cs := utils.K8sClient(t)
-	err := utils.RetryUntilSuccess(t, 30*time.Second, func() error {
+	g.Eventually(func() error {
 		n, err := cs.CoreV1().Nodes().Get(context.Background(), node, metav1.GetOptions{})
 		if err != nil {
 			return err
@@ -889,16 +881,14 @@ func labelNode(t *testing.T, node, key, value string) {
 		n.Labels[key] = value
 		_, err = cs.CoreV1().Nodes().Update(context.Background(), n, metav1.UpdateOptions{})
 		return err
-	})
-	if err != nil {
-		t.Fatalf("labelling node %s %s=%s: %v", node, key, value, err)
-	}
+	}, 30*time.Second, time.Second).Should(Succeed(), "labelling node %s %s=%s", node, key, value)
 }
 
 // createExternalNodeIngressPolicy creates a NetworkPolicy in the test namespace
 // that only admits TCP/80 ingress from the external node's IP.
 func createExternalNodeIngressPolicy(t *testing.T, nsName, externalIP string) {
 	t.Helper()
+	g := NewWithT(t)
 	tcp := corev1.ProtocolTCP
 	port80 := intstr.FromInt32(80)
 	policy := &networkingv1.NetworkPolicy{
@@ -916,9 +906,7 @@ func createExternalNodeIngressPolicy(t *testing.T, nsName, externalIP string) {
 	}
 	_, err := utils.K8sClient(t).NetworkingV1().NetworkPolicies(nsName).Create(
 		context.Background(), policy, metav1.CreateOptions{})
-	if err != nil {
-		t.Fatalf("creating NetworkPolicy: %v", err)
-	}
+	g.Expect(err).NotTo(HaveOccurred(), "creating NetworkPolicy")
 }
 
 // setRRConfig labels the node as a route reflector and sets its cluster ID,
@@ -993,30 +981,26 @@ func mapField(m map[string]any, key string) map[string]any {
 // substr.
 func assertRouteContains(t *testing.T, substr string) {
 	t.Helper()
-	err := utils.RetryUntilSuccess(t, 90*time.Second, func() error {
+	g := NewWithT(t)
+	g.Eventually(func() error {
 		if routes := utils.ExternalNodeRoutes(t); !strings.Contains(routes, substr) {
 			return fmt.Errorf("route table does not contain %q:\n%s", substr, routes)
 		}
 		return nil
-	})
-	if err != nil {
-		t.Fatalf("expected route %q: %v", substr, err)
-	}
+	}, 90*time.Second, time.Second).Should(Succeed(), "expected route %q", substr)
 }
 
 // assertRouteNotContains retries until the external node's route table no longer
 // contains substr.
 func assertRouteNotContains(t *testing.T, substr string) {
 	t.Helper()
-	err := utils.RetryUntilSuccess(t, 90*time.Second, func() error {
+	g := NewWithT(t)
+	g.Eventually(func() error {
 		if routes := utils.ExternalNodeRoutes(t); strings.Contains(routes, substr) {
 			return fmt.Errorf("route table still contains %q:\n%s", substr, routes)
 		}
 		return nil
-	})
-	if err != nil {
-		t.Fatalf("expected route %q to be withdrawn: %v", substr, err)
-	}
+	}, 90*time.Second, time.Second).Should(Succeed(), "expected route %q to be withdrawn", substr)
 }
 
 // assertEcmpRoutes retries until the external node's route table contains the
@@ -1030,25 +1014,21 @@ func assertEcmpRoutes(t *testing.T, dst string, via []string) {
 	for _, ip := range sorted {
 		match += fmt.Sprintf("\n\tnexthop via %s dev eth0 weight 1 ", ip)
 	}
-	err := utils.RetryUntilSuccess(t, 90*time.Second, func() error {
+	g := NewWithT(t)
+	g.Eventually(func() error {
 		if routes := utils.ExternalNodeRoutes(t); !strings.Contains(routes, match) {
 			return fmt.Errorf("ECMP route block not found:\n%s\nin:\n%s", match, routes)
 		}
 		return nil
-	})
-	if err != nil {
-		t.Fatalf("expected ECMP routes for %s via %v: %v", dst, sorted, err)
-	}
+	}, 90*time.Second, time.Second).Should(Succeed(), "expected ECMP routes for %s via %v", dst, sorted)
 }
 
 // curlRetry retries a curl from the external node to host until it succeeds.
 func curlRetry(t *testing.T, host string) {
 	t.Helper()
-	err := utils.RetryUntilSuccess(t, 90*time.Second, func() error {
+	g := NewWithT(t)
+	g.Eventually(func() error {
 		_, err := utils.Curl(t, host)
 		return err
-	})
-	if err != nil {
-		t.Fatalf("could not curl %s from external node: %v", host, err)
-	}
+	}, 90*time.Second, time.Second).Should(Succeed(), "could not curl %s from external node", host)
 }

--- a/node/tests/k8st/tests/bgp_filter_test.go
+++ b/node/tests/k8st/tests/bgp_filter_test.go
@@ -535,17 +535,15 @@ func (e *bgpFilterEnv) assertClusterRoute(t *testing.T, route, peerIP string, ip
 	pattern := regexp.QuoteMeta(route) + ` *via ` + regexp.QuoteMeta(peerIP) + ` on .* \[` + proto
 	re := regexp.MustCompile(pattern)
 
-	err := utils.RetryUntilSuccess(t, time.Minute, func() error {
+	g := NewWithT(t)
+	g.Eventually(func() error {
 		out, err := utils.ExecInCalicoNode(t, e.egressNode, birdCmd+" show route protocol "+proto,
 			utils.RunOptions{AllowFail: true, SuppressErrLog: true})
 		if err != nil {
 			return err
 		}
 		return checkRoutePresence(re, out, route, present)
-	})
-	if err != nil {
-		t.Fatalf("cluster route check failed for %s on %s: %v", route, e.egressNode, err)
-	}
+	}, time.Minute, time.Second).Should(Succeed(), "cluster route check failed for %s on %s", route, e.egressNode)
 }
 
 // assertExternalRoute polls an external router's BIRD until a route matching
@@ -583,17 +581,15 @@ func assertExternalRoute(t *testing.T, container, proto, routeRegex, peerIPRegex
 
 	re := regexp.MustCompile(pattern)
 
-	err := utils.RetryUntilSuccess(t, time.Minute, func() error {
+	g := NewWithT(t)
+	g.Eventually(func() error {
 		out, err := utils.Run(t, fmt.Sprintf("docker exec %s %s show route protocol %s", container, birdCmd, proto),
 			utils.RunOptions{AllowFail: true, SuppressErrLog: true})
 		if err != nil {
 			return err
 		}
 		return checkRoutePresence(re, out, routeRegex, present)
-	})
-	if err != nil {
-		t.Fatalf("external route check failed for %s on %s: %v", routeRegex, container, err)
-	}
+	}, time.Minute, time.Second).Should(Succeed(), "external route check failed for %s on %s", routeRegex, container)
 }
 
 // checkRoutePresence returns nil when re's match of out agrees with the

--- a/node/tests/k8st/tests/cluster_routes_test.go
+++ b/node/tests/k8st/tests/cluster_routes_test.go
@@ -109,7 +109,7 @@ func TestClusterRouteOwnership(t *testing.T) {
 			fmt.Sprintf("curl --silent --show-error --max-time 5 http://%s/clientip", serverIP+":80"),
 			utils.RunOptions{AllowFail: true, SuppressErrLog: true})
 		return err
-	}, "120s", "5s").Should(Succeed(),
+	}, "120s", "1s").Should(Succeed(),
 		"client pod could not reach server pod %s across the IPIP tunnel", serverIP)
 
 	// The client node's route to the server's block must be programmed by the

--- a/node/tests/k8st/tests/encap_spoofing_test.go
+++ b/node/tests/k8st/tests/encap_spoofing_test.go
@@ -154,7 +154,7 @@ func runSpoofScenario(t *testing.T, cli ctrlclient.Client, ctx context.Context, 
 		sendScapy(t, nsName, fmt.Sprintf(
 			"send(IP(dst='%s')/UDP(dport=5000, sport=5000)/Raw(load='%s'))", remotePodIP, normalMsg))
 		return grepSnoop(t, nsName, normalMsg)
-	}, "60s", "2s").Should(Succeed(), "normal %s packet was never delivered", encap)
+	}, "60s", "1s").Should(Succeed(), "normal %s packet was never delivered", encap)
 
 	// A spoofed (encapsulated) packet must NOT be delivered: we keep forging it
 	// and require that the grep for its payload keeps failing.
@@ -166,7 +166,7 @@ func runSpoofScenario(t *testing.T, cli ctrlclient.Client, ctx context.Context, 
 			return fmt.Errorf("ERROR - succeeded in sending spoofed %s packet", encap)
 		}
 		return nil
-	}, "60s", "2s").Should(Succeed(), "spoofed %s packet was delivered — anti-spoofing failed", encap)
+	}, "60s", "1s").Should(Succeed(), "spoofed %s packet was delivered — anti-spoofing failed", encap)
 }
 
 // sendScapy feeds a single scapy send() statement to the scapy pod on stdin.
@@ -191,13 +191,12 @@ func grepSnoop(t *testing.T, nsName, message string) error {
 // previous delivery can't mask the next test via an established flow.
 func clearConntrack(t *testing.T, ctx context.Context) {
 	t.Helper()
+	g := NewWithT(t)
 	cs := utils.K8sClient(t)
 	pods, err := cs.CoreV1().Pods("calico-system").List(ctx, metav1.ListOptions{
 		LabelSelector: "k8s-app=calico-node",
 	})
-	if err != nil {
-		t.Fatalf("listing calico-node pods: %v", err)
-	}
+	g.Expect(err).NotTo(HaveOccurred(), "listing calico-node pods")
 	for _, p := range pods.Items {
 		utils.MustExecInCalicoNode(t, p.Spec.NodeName, "conntrack -F")
 	}
@@ -257,7 +256,7 @@ func setEncapsulation(t *testing.T, g *WithT, cli ctrlclient.Client, ctx context
 				p.Spec.IPIPMode, p.Spec.VXLANMode)
 		}
 		return nil
-	}, "60s", "2s").Should(Succeed(), "operator did not reconcile %s to %s", defaultV4Pool, encap)
+	}, "60s", "1s").Should(Succeed(), "operator did not reconcile %s to %s", defaultV4Pool, encap)
 
 	// Restart calico-node to cleanly apply the new encapsulation.
 	cs := utils.K8sClient(t)
@@ -273,9 +272,10 @@ func setEncapsulation(t *testing.T, g *WithT, cli ctrlclient.Client, ctx context
 // Ready, so we additionally require no pod carries a deletion timestamp.
 func waitForCalicoNodeRestart(t *testing.T, ctx context.Context) {
 	t.Helper()
+	g := NewWithT(t)
 
 	cs := utils.K8sClient(t)
-	err := utils.RetryUntilSuccess(t, 2*time.Minute, func() error {
+	g.Eventually(func() error {
 		pods, err := cs.CoreV1().Pods("calico-system").List(ctx, metav1.ListOptions{
 			LabelSelector: "k8s-app=calico-node",
 		})
@@ -300,8 +300,5 @@ func waitForCalicoNodeRestart(t *testing.T, ctx context.Context) {
 			}
 		}
 		return nil
-	})
-	if err != nil {
-		t.Fatalf("calico-node pods did not restart cleanly: %v", err)
-	}
+	}, 2*time.Minute, time.Second).Should(Succeed(), "calico-node pods did not restart cleanly")
 }

--- a/node/tests/k8st/tests/node_status_test.go
+++ b/node/tests/k8st/tests/node_status_test.go
@@ -90,7 +90,7 @@ func TestNodeMeshStatus(t *testing.T) {
 				st.BGP.NumberEstablishedV4, st.BGP.NumberEstablishedV6)
 		}
 		return nil
-	}, "60s", "2s").Should(Succeed(), "CalicoNodeStatus %s never reported a fully-established mesh", statusName)
+	}, "60s", "1s").Should(Succeed(), "CalicoNodeStatus %s never reported a fully-established mesh", statusName)
 
 	// Agent (BIRD) status: both daemons Ready, router ID equal to the node IP.
 	g.Expect(st.Agent.BIRDV4.RouterID).To(Equal(testNodeIP), "birdV4 router ID")

--- a/node/tests/k8st/tests/proxy_neigh_test.go
+++ b/node/tests/k8st/tests/proxy_neigh_test.go
@@ -230,7 +230,7 @@ func probe(g *WithT, peer *extL2Peer, ip string) {
 	g.Eventually(func() error {
 		_, err := peer.Curl(httpURL(ip))
 		return err
-	}, "60s", "2s").Should(Succeed(), "HTTP request to %s never succeeded — Felix did not answer ARP/NDP for it", ip)
+	}, "60s", "1s").Should(Succeed(), "HTTP request to %s never succeeded — Felix did not answer ARP/NDP for it", ip)
 }
 
 func httpURL(ip string) string {
@@ -299,7 +299,7 @@ func setLocalSubnetL2Reachability(ctx context.Context, g *WithT, cli ctrlclient.
 			}
 			cur.Spec.LocalSubnetL2Reachability = original
 			return cli.Update(rctx, cur)
-		}, "20s", "2s").Should(Succeed(), "restoring original LocalSubnetL2Reachability")
+		}, "20s", "1s").Should(Succeed(), "restoring original LocalSubnetL2Reachability")
 	}
 }
 
@@ -323,7 +323,7 @@ func waitForPodIP(ctx context.Context, g *WithT, cli ctrlclient.Client, pod *cor
 			}
 		}
 		return fmt.Errorf("pod %s has no %s IP yet", pod.Name, family)
-	}, "120s", "2s").Should(Succeed(), "server pod never got a %s IP", family)
+	}, "120s", "1s").Should(Succeed(), "server pod never got a %s IP", family)
 	return ip
 }
 
@@ -342,7 +342,7 @@ func waitForLBVIP(ctx context.Context, g *WithT, cli ctrlclient.Client, svc *cor
 		}
 		vip = ingress[0].IP
 		return nil
-	}, "120s", "2s").Should(Succeed(), "Calico did not allocate a VIP for service %s", svc.Name)
+	}, "120s", "1s").Should(Succeed(), "Calico did not allocate a VIP for service %s", svc.Name)
 	return vip
 }
 

--- a/node/tests/k8st/tests/simple_test.go
+++ b/node/tests/k8st/tests/simple_test.go
@@ -40,12 +40,11 @@ func TestGracefulRestartMethodology(t *testing.T) {
 
 	restart := func(state *restartChurnState) {
 		utils.MustRun(t, "docker exec "+state.restartNode+" pkill bird")
-		err := utils.RetryUntilSuccess(t, 15*time.Second, func() error {
+		NewWithT(t).Eventually(func() error {
 			_, err := utils.Run(t, "docker exec "+state.restartNode+" pgrep bird",
 				utils.RunOptions{AllowFail: true, SuppressErrLog: true})
 			return err
-		})
-		NewWithT(t).Expect(err).NotTo(HaveOccurred(), "BIRD did not restart within 15s")
+		}, 15*time.Second, time.Second).Should(Succeed(), "BIRD did not restart within 15s")
 		time.Sleep(5 * time.Second)
 	}
 
@@ -64,10 +63,9 @@ func TestGracefulRestart(t *testing.T) {
 		utils.DeletePodAndWait(t, "calico-system", state.restartPodName, 2*time.Minute)
 
 		// Wait until a replacement calico-node pod has been created.
-		err := utils.RetryUntilSuccess(t, 15*time.Second, func() error {
+		NewWithT(t).Eventually(func() error {
 			return state.refreshRestartPodName(t)
-		})
-		NewWithT(t).Expect(err).NotTo(HaveOccurred(), "replacement calico-node pod did not appear within 15s")
+		}, 15*time.Second, time.Second).Should(Succeed(), "replacement calico-node pod did not appear within 15s")
 
 		// Wait until it is ready, before returning.
 		utils.WaitForPodReady(t, "calico-system", state.restartPodName, 2*time.Minute)

--- a/node/tests/k8st/utils/external_node.go
+++ b/node/tests/k8st/utils/external_node.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 	"time"
 
+	//nolint:staticcheck // Ignore ST1001: should not use dot imports
 	. "github.com/onsi/gomega"
 )
 

--- a/node/tests/k8st/utils/external_node.go
+++ b/node/tests/k8st/utils/external_node.go
@@ -19,6 +19,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	. "github.com/onsi/gomega"
 )
 
 // ----------------------------------------------------------------------------
@@ -48,12 +50,10 @@ func StartExternalNodeWithBGP(t testing.TB, name, birdPeerConfig, bird6PeerConfi
 	MustRun(t, fmt.Sprintf("docker run -d --privileged --net=kind --name %s %s", name, RouterImage))
 
 	// The image may still be downloading; retry until the container responds.
-	if err := RetryUntilSuccess(t, time.Minute, func() error {
+	NewWithT(t).Eventually(func() error {
 		_, err := Run(t, fmt.Sprintf("docker exec %s df -h", name), RunOptions{AllowFail: true, SuppressErrLog: true})
 		return err
-	}); err != nil {
-		t.Fatalf("external node %s did not come up: %v", name, err)
-	}
+	}, time.Minute, time.Second).Should(Succeed(), "external node %s did not come up", name)
 
 	// Install curl and iproute2.
 	MustRun(t, fmt.Sprintf("docker exec %s apk add --no-cache curl iproute2", name))

--- a/node/tests/k8st/utils/routes.go
+++ b/node/tests/k8st/utils/routes.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	//nolint:staticcheck // Ignore ST1001: should not use dot imports
 	. "github.com/onsi/gomega"
 )
 

--- a/node/tests/k8st/utils/routes.go
+++ b/node/tests/k8st/utils/routes.go
@@ -21,6 +21,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	. "github.com/onsi/gomega"
 )
 
 // RouteProto identifies the netlink protocol that owns a kernel route. The
@@ -121,7 +123,7 @@ func AssertRouteOwnership(t testing.TB, nodeName, dstSubstring, expectedDev stri
 	t.Helper()
 	t.Logf("Asserting routes for %q on node %s use dev=%q proto=%s",
 		dstSubstring, nodeName, expectedDev, expectedProto)
-	err := RetryUntilSuccess(t, 60*time.Second, func() error {
+	NewWithT(t).Eventually(func() error {
 		routes, err := GetNodeRoutes(t, nodeName, dstSubstring)
 		if err != nil {
 			return err
@@ -139,8 +141,5 @@ func AssertRouteOwnership(t testing.TB, nodeName, dstSubstring, expectedDev stri
 		}
 		return fmt.Errorf("no route on node %s with dev=%q proto=%s found among %v",
 			nodeName, expectedDev, expectedProto, routes)
-	})
-	if err != nil {
-		t.Fatalf("route ownership assertion failed: %v", err)
-	}
+	}, 60*time.Second, time.Second).Should(Succeed(), "route ownership assertion failed")
 }

--- a/node/tests/k8st/utils/services.go
+++ b/node/tests/k8st/utils/services.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 	"time"
 
+	//nolint:staticcheck // Ignore ST1001: should not use dot imports
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"

--- a/node/tests/k8st/utils/services.go
+++ b/node/tests/k8st/utils/services.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 	"time"
 
+	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -171,7 +172,7 @@ func CreateService(t testing.TB, name, app, ns string, port int32, opts DeployOp
 func WaitForDeployment(t testing.TB, name, ns string) {
 	t.Helper()
 	cs := K8sClient(t)
-	err := RetryUntilSuccess(t, 2*time.Minute, func() error {
+	NewWithT(t).Eventually(func() error {
 		d, err := cs.AppsV1().Deployments(ns).Get(context.Background(), name, metav1.GetOptions{})
 		if err != nil {
 			return err
@@ -191,17 +192,14 @@ func WaitForDeployment(t testing.TB, name, ns string) {
 				ns, name, d.Status.UpdatedReplicas, d.Status.Replicas, d.Status.AvailableReplicas, desired)
 		}
 		return nil
-	})
-	if err != nil {
-		t.Fatalf("deployment %s/%s did not roll out: %v", ns, name, err)
-	}
+	}, 2*time.Minute, time.Second).Should(Succeed(), "deployment %s/%s did not roll out", ns, name)
 }
 
 // ScaleDeployment sets the deployment's replica count.
 func ScaleDeployment(t testing.TB, name, ns string, replicas int32) {
 	t.Helper()
 	cs := K8sClient(t)
-	err := RetryUntilSuccess(t, 30*time.Second, func() error {
+	NewWithT(t).Eventually(func() error {
 		d, err := cs.AppsV1().Deployments(ns).Get(context.Background(), name, metav1.GetOptions{})
 		if err != nil {
 			return err
@@ -209,10 +207,7 @@ func ScaleDeployment(t testing.TB, name, ns string, replicas int32) {
 		d.Spec.Replicas = new(replicas)
 		_, err = cs.AppsV1().Deployments(ns).Update(context.Background(), d, metav1.UpdateOptions{})
 		return err
-	})
-	if err != nil {
-		t.Fatalf("scaling deployment %s/%s to %d: %v", ns, name, replicas, err)
-	}
+	}, 30*time.Second, time.Second).Should(Succeed(), "scaling deployment %s/%s to %d", ns, name, replicas)
 }
 
 // WaitUntilExists blocks until the named resource exists, fatally failing on
@@ -220,7 +215,7 @@ func ScaleDeployment(t testing.TB, name, ns string, replicas int32) {
 func WaitUntilExists(t testing.TB, name, resourceType, ns string) {
 	t.Helper()
 	cs := K8sClient(t)
-	err := RetryUntilSuccess(t, 90*time.Second, func() error {
+	NewWithT(t).Eventually(func() error {
 		switch resourceType {
 		case "svc":
 			_, err := cs.CoreV1().Services(ns).Get(context.Background(), name, metav1.GetOptions{})
@@ -229,10 +224,7 @@ func WaitUntilExists(t testing.TB, name, resourceType, ns string) {
 			t.Fatalf("WaitUntilExists: unsupported resource type %q", resourceType)
 			return nil
 		}
-	})
-	if err != nil {
-		t.Fatalf("%s %s/%s never appeared: %v", resourceType, ns, name, err)
-	}
+	}, 90*time.Second, time.Second).Should(Succeed(), "%s %s/%s never appeared", resourceType, ns, name)
 }
 
 // DeleteAndConfirm deletes the named resource and blocks until it is gone from
@@ -272,9 +264,8 @@ func DeleteAndConfirm(t testing.TB, name, resourceType, ns string) {
 		}
 		return fmt.Errorf("%s %s/%s still exists", resourceType, ns, name)
 	}
-	if err := RetryUntilSuccess(t, 120*time.Second, gone); err != nil {
-		t.Fatalf("%s %s/%s was not deleted: %v", resourceType, ns, name, err)
-	}
+	NewWithT(t).Eventually(gone, 120*time.Second, time.Second).
+		Should(Succeed(), "%s %s/%s was not deleted", resourceType, ns, name)
 }
 
 func GetSvcClusterIP(t testing.TB, svc, ns string) string {
@@ -291,7 +282,7 @@ func GetSvcLoadBalancerIP(t testing.TB, svc, ns string) string {
 	t.Helper()
 	cs := K8sClient(t)
 	var lbIP string
-	err := RetryUntilSuccess(t, 10*time.Second, func() error {
+	NewWithT(t).Eventually(func() error {
 		s, err := cs.CoreV1().Services(ns).Get(context.Background(), svc, metav1.GetOptions{})
 		if err != nil {
 			return err
@@ -301,10 +292,7 @@ func GetSvcLoadBalancerIP(t testing.TB, svc, ns string) string {
 		}
 		lbIP = s.Status.LoadBalancer.Ingress[0].IP
 		return nil
-	})
-	if err != nil {
-		t.Fatalf("waiting for LoadBalancer IP on %s/%s: %v", ns, svc, err)
-	}
+	}, 10*time.Second, time.Second).Should(Succeed(), "waiting for LoadBalancer IP on %s/%s", ns, svc)
 	return lbIP
 }
 
@@ -328,7 +316,7 @@ func GetSvcHostIP(t testing.TB, app, ns string) string {
 func AddSvcExternalIPs(t testing.TB, svc, ns string, ips []string) {
 	t.Helper()
 	cs := K8sClient(t)
-	err := RetryUntilSuccess(t, 30*time.Second, func() error {
+	NewWithT(t).Eventually(func() error {
 		s, err := cs.CoreV1().Services(ns).Get(context.Background(), svc, metav1.GetOptions{})
 		if err != nil {
 			return err
@@ -336,8 +324,5 @@ func AddSvcExternalIPs(t testing.TB, svc, ns string, ips []string) {
 		s.Spec.ExternalIPs = ips
 		_, err = cs.CoreV1().Services(ns).Update(context.Background(), s, metav1.UpdateOptions{})
 		return err
-	})
-	if err != nil {
-		t.Fatalf("adding external IPs %v to %s/%s: %v", ips, ns, svc, err)
-	}
+	}, 30*time.Second, time.Second).Should(Succeed(), "adding external IPs %v to %s/%s", ips, ns, svc)
 }

--- a/node/tests/k8st/utils/utils.go
+++ b/node/tests/k8st/utils/utils.go
@@ -20,7 +20,6 @@ package utils
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -29,6 +28,7 @@ import (
 	"testing"
 	"time"
 
+	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -160,59 +160,6 @@ func mergeRunOptions(opts []RunOptions) RunOptions {
 		return RunOptions{}
 	}
 	return opts[0]
-}
-
-// ----------------------------------------------------------------------------
-// Retry.
-
-// RetryUntilSuccess invokes fn until it returns nil or the timeout
-// elapses. It uses exponential backoff starting at 0.5s and capped at 10s.
-// The time taken by fn counts toward the wall-clock deadline
-// so the overall budget is predictable.
-//
-// Returns the last error from fn on timeout, or nil on success.
-func RetryUntilSuccess(t testing.TB, timeout time.Duration, fn func() error) error {
-	t.Helper()
-	if timeout <= 0 {
-		timeout = 90 * time.Second
-	}
-	start := time.Now()
-	deadline := start.Add(timeout)
-	backoff := 500 * time.Millisecond
-	const maxBackoff = 10 * time.Second
-	attempts := 0
-
-	var lastErr error
-	for {
-		attempts++
-		err := fn()
-		if err == nil {
-			elapsed := time.Since(start)
-			if elapsed > timeout/2 {
-				t.Logf("retry succeeded but used %s of %s budget (%d attempts)", elapsed, timeout, attempts)
-			}
-			return nil
-		}
-		lastErr = err
-		now := time.Now()
-		if !now.Before(deadline) {
-			return fmt.Errorf("retry did not succeed within %s (%d attempts): %w", timeout, attempts, lastErr)
-		}
-		remaining := deadline.Sub(now)
-		sleep := backoff
-		if sleep > remaining {
-			sleep = remaining
-		}
-		if sleep > maxBackoff {
-			sleep = maxBackoff
-		}
-		t.Logf("retry attempt %d hit error, sleeping %s (%s remaining): %v", attempts, sleep, remaining, err)
-		time.Sleep(sleep)
-		backoff = time.Duration(float64(backoff) * 1.5)
-		if backoff > maxBackoff {
-			backoff = maxBackoff
-		}
-	}
 }
 
 // ----------------------------------------------------------------------------
@@ -706,7 +653,7 @@ func PodNames(t testing.TB, namespace, labelSelector, fieldSelector string) ([]s
 func WaitForPodsReady(t testing.TB, namespace, labelSelector string, timeout time.Duration) {
 	t.Helper()
 	cs := K8sClient(t)
-	err := RetryUntilSuccess(t, timeout, func() error {
+	NewWithT(t).Eventually(func() error {
 		ctx, cancel := context.WithTimeout(context.Background(), timeout)
 		defer cancel()
 
@@ -725,10 +672,7 @@ func WaitForPodsReady(t testing.TB, namespace, labelSelector string, timeout tim
 			}
 		}
 		return nil
-	})
-	if err != nil {
-		t.Fatalf("pods in %s did not become ready within %s: %v", namespace, timeout, err)
-	}
+	}, timeout, time.Second).Should(Succeed(), "pods in %s did not become ready within %s", namespace, timeout)
 }
 
 // WaitForPodReady blocks until the named pod has a Ready condition of
@@ -736,7 +680,7 @@ func WaitForPodsReady(t testing.TB, namespace, labelSelector string, timeout tim
 func WaitForPodReady(t testing.TB, namespace, name string, timeout time.Duration) {
 	t.Helper()
 	cs := K8sClient(t)
-	err := RetryUntilSuccess(t, timeout, func() error {
+	NewWithT(t).Eventually(func() error {
 		pod, err := cs.CoreV1().Pods(namespace).Get(context.Background(), name, metav1.GetOptions{})
 		if err != nil {
 			return err
@@ -745,10 +689,7 @@ func WaitForPodReady(t testing.TB, namespace, name string, timeout time.Duration
 			return fmt.Errorf("pod %s/%s is not ready", namespace, name)
 		}
 		return nil
-	})
-	if err != nil {
-		t.Fatalf("pod %s/%s did not become ready within %s: %v", namespace, name, timeout, err)
-	}
+	}, timeout, time.Second).Should(Succeed(), "pod %s/%s did not become ready within %s", namespace, name, timeout)
 }
 
 func podIsReady(pod *corev1.Pod) bool {
@@ -772,7 +713,7 @@ func DeletePodAndWait(t testing.TB, namespace, name string, timeout time.Duratio
 	if err != nil && !apierrors.IsNotFound(err) {
 		t.Fatalf("deleting pod %s/%s: %v", namespace, name, err)
 	}
-	err = RetryUntilSuccess(t, timeout, func() error {
+	NewWithT(t).Eventually(func() error {
 		_, err := cs.CoreV1().Pods(namespace).Get(context.Background(), name, metav1.GetOptions{})
 		if apierrors.IsNotFound(err) {
 			return nil
@@ -781,16 +722,5 @@ func DeletePodAndWait(t testing.TB, namespace, name string, timeout time.Duratio
 			return err
 		}
 		return fmt.Errorf("pod %s/%s still exists", namespace, name)
-	})
-	if err != nil {
-		t.Fatalf("pod %s/%s was not deleted within %s: %v", namespace, name, timeout, err)
-	}
+	}, timeout, time.Second).Should(Succeed(), "pod %s/%s was not deleted within %s", namespace, name, timeout)
 }
-
-// ----------------------------------------------------------------------------
-// Errors.
-
-// ErrTimeout is returned by RetryUntilSuccess on deadline expiry. It's a
-// convenience for callers that want to distinguish timeouts from other
-// errors; RetryUntilSuccess wraps it via fmt.Errorf.
-var ErrTimeout = errors.New("retry timeout")

--- a/node/tests/k8st/utils/utils.go
+++ b/node/tests/k8st/utils/utils.go
@@ -28,6 +28,7 @@ import (
 	"testing"
 	"time"
 
+	//nolint:staticcheck // Ignore ST1001: should not use dot imports
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"


### PR DESCRIPTION
Test-only refactor of the Go k8st system tests (`node/tests/k8st/`) to standardize on Gomega, matching the pattern the BGP advertisement tests already established.

**What changed**
- Replaced the remaining raw `t.Fatalf`/`t.Errorf` assertions with Gomega `Expect`/`Eventually`.
- Replaced the bespoke `utils.RetryUntilSuccess` retry helper with Gomega's `Eventually` (1s polling) at every call site, and removed the now-unused helper along with the dead `ErrTimeout` var.
- Dot-imported Gomega in all k8st files so matchers are used unqualified.

One deliberate exception: `bgp_advert_test.go`'s `teardownTest` keeps non-fatal cleanup semantics by using a `NewGomega` handler that reports via `t.Errorf` rather than failing the test (a fatal there would skip sibling cleanups).

**Testing**
- `go vet ./node/tests/k8st/...` passes.
- `gofmt -l` clean.
- No production code or behaviour changes; these are system tests that run against a live kind cluster.

**Release note:**
```release-note
NONE
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)