### PR TITLE
networking-calico: skip etcd writes when sync would not change the value

### DIFF
--- a/networking-calico/networking_calico/plugins/ml2/drivers/calico/endpoints.py
+++ b/networking-calico/networking_calico/plugins/ml2/drivers/calico/endpoints.py
@@ -587,10 +587,15 @@ class WorkloadEndpointSyncer(ResourceSyncer):
         name = endpoint_name({**port, "binding:host_id": host})
         for attempt in range(MAX_CAS_ATTEMPTS):
             try:
-                _, mod_revision = datamodel_v3.get_namespaced(
-                    "WorkloadEndpoint", self.namespace, name
+                existing, mod_revision = datamodel_v3.get_namespaced(
+                    "WorkloadEndpoint",
+                    self.namespace,
+                    name,
+                    with_labels_and_annotations=True,
                 )
+                existing_spec, existing_labels, existing_annotations = existing
             except etcdv3.KeyNotFound:
+                existing_spec = existing_labels = existing_annotations = None
                 mod_revision = 0
 
             try:
@@ -627,13 +632,29 @@ class WorkloadEndpointSyncer(ResourceSyncer):
             # references it.  sync_sgs_to_etcd is CAS-protected per SG and idempotent
             # across retries.
             self.policy_syncer.sync_sgs_to_etcd(port_extra.security_groups, context)
+            new_spec = endpoint_spec(write_port, port_extra)
+            new_labels = endpoint_labels(write_port, self.namespace, port_extra)
+            new_annotations = endpoint_annotations(write_port)
+            if (
+                existing_spec is not None
+                and existing_spec == new_spec
+                and existing_labels == new_labels
+                and existing_annotations == new_annotations
+            ):
+                # etcd already holds the spec / labels / annotations we would write --
+                # skip the put to avoid a needless revision bump and a Felix watch event
+                # on identical data.
+                LOG.debug(
+                    "WorkloadEndpoint %s already correct in etcd; skipping put", name
+                )
+                return True
             if datamodel_v3.put(
                 "WorkloadEndpoint",
                 self.namespace,
                 name,
-                endpoint_spec(write_port, port_extra),
-                labels=endpoint_labels(write_port, self.namespace, port_extra),
-                annotations=endpoint_annotations(write_port),
+                new_spec,
+                labels=new_labels,
+                annotations=new_annotations,
                 mod_revision=mod_revision,
             ):
                 return True
@@ -683,11 +704,11 @@ class WorkloadEndpointSyncer(ResourceSyncer):
         name = endpoint_name({**port, "binding:host_id": dest_host})
         for attempt in range(MAX_CAS_ATTEMPTS):
             try:
-                _, mod_revision = datamodel_v3.get_namespaced(
+                existing_spec, mod_revision = datamodel_v3.get_namespaced(
                     "LiveMigration", self.namespace, name
                 )
             except etcdv3.KeyNotFound:
-                mod_revision = 0
+                existing_spec, mod_revision = None, 0
 
             try:
                 db_port = self.db.get_port(context, port_id)
@@ -718,11 +739,19 @@ class WorkloadEndpointSyncer(ResourceSyncer):
                 continue
 
             dest_port = {**db_port, "binding:host_id": dest_host}
+            new_spec = live_migration_spec(self.namespace, db_port, dest_port)
+            if existing_spec is not None and existing_spec == new_spec:
+                # etcd already holds the spec we would write -- skip the put to avoid a
+                # needless revision bump and a Felix watch event on identical data.
+                LOG.debug(
+                    "LiveMigration %s already correct in etcd; skipping put", name
+                )
+                return True
             if datamodel_v3.put(
                 "LiveMigration",
                 self.namespace,
                 name,
-                live_migration_spec(self.namespace, db_port, dest_port),
+                new_spec,
                 mod_revision=mod_revision,
             ):
                 return True

--- a/networking-calico/networking_calico/plugins/ml2/drivers/calico/policy.py
+++ b/networking-calico/networking_calico/plugins/ml2/drivers/calico/policy.py
@@ -180,11 +180,11 @@ class PolicySyncer(ResourceSyncer):
         name = SG_NAME_PREFIX + sgid
         for attempt in range(MAX_CAS_ATTEMPTS):
             try:
-                _, mod_revision = datamodel_v3.get_namespaced(
+                existing_spec, mod_revision = datamodel_v3.get_namespaced(
                     self.resource_kind, self.namespace, name
                 )
             except etcdv3.KeyNotFound:
-                mod_revision = 0
+                existing_spec, mod_revision = None, 0
             sgs = self.db.get_security_groups(context, filters={"id": [sgid]})
 
             if not sgs:
@@ -213,11 +213,19 @@ class PolicySyncer(ResourceSyncer):
             rules = self.db.get_security_group_rules(
                 context, filters={"security_group_id": [sgid]}
             )
+            new_spec = policy_spec(sgid, rules)
+            if existing_spec is not None and existing_spec == new_spec:
+                # etcd already holds the spec we would write -- skip the put to avoid a
+                # needless revision bump and a Felix watch event on identical data.
+                LOG.debug(
+                    "NetworkPolicy %s already correct in etcd; skipping put", name
+                )
+                return
             if datamodel_v3.put(
                 self.resource_kind,
                 self.namespace,
                 name,
-                policy_spec(sgid, rules),
+                new_spec,
                 mod_revision=mod_revision,
             ):
                 return

--- a/networking-calico/networking_calico/plugins/ml2/drivers/calico/subnets.py
+++ b/networking-calico/networking_calico/plugins/ml2/drivers/calico/subnets.py
@@ -115,9 +115,9 @@ class SubnetSyncer(ResourceSyncer):
         key = datamodel_v2.key_for_subnet(subnet_id, self.region_string)
         for attempt in range(MAX_CAS_ATTEMPTS):
             try:
-                _, mod_revision = etcdv3.get(key)
+                existing_value, mod_revision = etcdv3.get(key)
             except etcdv3.KeyNotFound:
-                mod_revision = 0
+                existing_value, mod_revision = None, 0
             try:
                 # Re-read the subnet from the Neutron DB so that we can be sure of
                 # writing subnet data (if necessary) that post-dates what we just read
@@ -145,6 +145,11 @@ class SubnetSyncer(ResourceSyncer):
                     subnet_id,
                 )
                 continue
+            if existing_value is not None and existing_value == write_data:
+                # etcd already holds the value we would write -- skip the put to avoid a
+                # needless revision bump and a Felix watch event on identical data.
+                LOG.debug("Subnet %s already correct in etcd; skipping put", subnet_id)
+                return
             if self.update_in_etcd(key, write_data, mod_revision=mod_revision):
                 return
             LOG.debug(

--- a/networking-calico/networking_calico/plugins/ml2/drivers/calico/test/test_plugin_etcd.py
+++ b/networking-calico/networking_calico/plugins/ml2/drivers/calico/test/test_plugin_etcd.py
@@ -653,15 +653,12 @@ class TestPluginEtcdBase(_TestEtcdBase):
         self.assertEtcdWrites({})
         self.assertEtcdDeletes(set())
 
-        # Add lib.port1 back again.
+        # Add lib.port1 back again.  Only the WEP write happens; the SG NetworkPolicy
+        # still has its initial value, so the no-op-write optimisation in
+        # ``_cas_sync_sg`` skips that put.
         self.osdb_ports = [lib.port1, lib.port2]
         self.driver.create_port_postcommit(context)
-        self.assertEtcdWrites(
-            {
-                ep_deadbeef_key_v3: ep_deadbeef_value_v3,
-                self.sg_default_key_v3: self.sg_default_value_v3,
-            }
-        )
+        self.assertEtcdWrites({ep_deadbeef_key_v3: ep_deadbeef_value_v3})
         self.assertEtcdDeletes(set())
 
         # Migrate port1 to a different host.
@@ -679,12 +676,9 @@ class TestPluginEtcdBase(_TestEtcdBase):
         ep_deadbeef_value_v3["spec"]["node"] = ep_deadbeef_value_v3["spec"][
             "node"
         ].replace("felix-host-1", "new-host")
-        self.assertEtcdWrites(
-            {
-                ep_deadbeef_key_v3: ep_deadbeef_value_v3,
-                self.sg_default_key_v3: self.sg_default_value_v3,
-            }
-        )
+
+        # SG NetworkPolicy unchanged from previous write; no-op skip.
+        self.assertEtcdWrites({ep_deadbeef_key_v3: ep_deadbeef_value_v3})
 
         # Now resync again, moving self.osdb_ports to move port 1 back to the
         # old host felix-host-1.  The effect will be as though we've
@@ -752,10 +746,9 @@ class TestPluginEtcdBase(_TestEtcdBase):
             },
         }
 
-        expected_writes = {
-            ep_hello_key_v3: ep_hello_value_v3,
-            self.sg_default_key_v3: self.sg_default_value_v3,
-        }
+        # SG NetworkPolicy unchanged from previous write; no-op skip in
+        # ``_cas_sync_sg``.
+        expected_writes = {ep_hello_key_v3: ep_hello_value_v3}
         self.assertEtcdWrites(expected_writes)
         self.assertEtcdDeletes(set())
         self.osdb_ports = [lib.port1, lib.port2, context._port]
@@ -935,11 +928,9 @@ class TestPluginEtcdBase(_TestEtcdBase):
         ep_hello_value_v3["metadata"]["labels"][
             "sg-name.projectcalico.org/openstack-My_first_SG"
         ] = "SG-1"
-        expected_writes = {
-            ep_hello_key_v3: ep_hello_value_v3,
-            sg_1_key_v3: sg_1_value_v3,
-        }
-        self.assertEtcdWrites(expected_writes)
+
+        # SG-1 NetworkPolicy unchanged from previous write; no-op skip.
+        self.assertEtcdWrites({ep_hello_key_v3: ep_hello_value_v3})
 
         # Resync with all latest data - expect no etcd writes or deletes.
         _log.info("Resync with existing etcd data")
@@ -1067,11 +1058,9 @@ class TestPluginEtcdBase(_TestEtcdBase):
         ep_hello_value_v3["metadata"]["annotations"][
             "openstack.projectcalico.org/network-id"
         ] = "calico-other-network-id"
-        expected_writes = {
-            ep_hello_key_v3: ep_hello_value_v3,
-            sg_1_key_v3: sg_1_value_v3,
-        }
-        self.assertEtcdWrites(expected_writes)
+
+        # SG-1 NetworkPolicy unchanged since the previous resync; no-op skip.
+        self.assertEtcdWrites({ep_hello_key_v3: ep_hello_value_v3})
         self.assertEtcdDeletes(set())
 
         # Add a QoS policy.
@@ -1084,11 +1073,9 @@ class TestPluginEtcdBase(_TestEtcdBase):
             "egressBandwidth": 10000000,
             "egressBurst": 4294967296,
         }
-        expected_writes = {
-            ep_hello_key_v3: ep_hello_value_v3,
-            sg_1_key_v3: sg_1_value_v3,
-        }
-        self.assertEtcdWrites(expected_writes)
+
+        # SG-1 NetworkPolicy unchanged; no-op skip.
+        self.assertEtcdWrites({ep_hello_key_v3: ep_hello_value_v3})
         self.assertEtcdDeletes(set())
 
         # Add configuration for QoS settings that are not represented on the
@@ -1110,11 +1097,9 @@ class TestPluginEtcdBase(_TestEtcdBase):
             "ingressMaxConnections": 10,
             "egressMaxConnections": 20,
         }
-        expected_writes = {
-            ep_hello_key_v3: ep_hello_value_v3,
-            sg_1_key_v3: sg_1_value_v3,
-        }
-        self.assertEtcdWrites(expected_writes)
+
+        # SG-1 NetworkPolicy unchanged; no-op skip.
+        self.assertEtcdWrites({ep_hello_key_v3: ep_hello_value_v3})
         self.assertEtcdDeletes(set())
 
         # Change to a QoS policy that will set all possible settings.
@@ -1139,11 +1124,8 @@ class TestPluginEtcdBase(_TestEtcdBase):
             "ingressPacketBurst": 81,
             "egressPacketBurst": 91,
         }
-        expected_writes = {
-            ep_hello_key_v3: ep_hello_value_v3,
-            sg_1_key_v3: sg_1_value_v3,
-        }
-        self.assertEtcdWrites(expected_writes)
+        # SG-1 NetworkPolicy unchanged; no-op skip.
+        self.assertEtcdWrites({ep_hello_key_v3: ep_hello_value_v3})
         self.assertEtcdDeletes(set())
 
         # Reset for future tests.
@@ -1167,11 +1149,9 @@ class TestPluginEtcdBase(_TestEtcdBase):
             "egressBandwidth": 10000000,
             "egressBurst": 4294967296,
         }
-        expected_writes = {
-            ep_hello_key_v3: ep_hello_value_v3,
-            sg_1_key_v3: sg_1_value_v3,
-        }
-        self.assertEtcdWrites(expected_writes)
+
+        # SG-1 NetworkPolicy unchanged; no-op skip.
+        self.assertEtcdWrites({ep_hello_key_v3: ep_hello_value_v3})
         self.assertEtcdDeletes(set())
 
         # Remove the QoS policy from the network again.
@@ -1181,11 +1161,9 @@ class TestPluginEtcdBase(_TestEtcdBase):
 
         # Expected changes
         del ep_hello_value_v3["spec"]["qosControls"]
-        expected_writes = {
-            ep_hello_key_v3: ep_hello_value_v3,
-            sg_1_key_v3: sg_1_value_v3,
-        }
-        self.assertEtcdWrites(expected_writes)
+
+        # SG-1 NetworkPolicy unchanged; no-op skip.
+        self.assertEtcdWrites({ep_hello_key_v3: ep_hello_value_v3})
         self.assertEtcdDeletes(set())
 
         # Reset the state for safety.
@@ -2190,19 +2168,16 @@ class TestLiveMigration(TestPluginEtcdBase):
 
         self._pre_migrate()
 
-        # Destination WEP and LiveMigration should be written.  Security group policy is
-        # also rewritten alongside the WEP write.  The source WEP is also rewritten --
-        # update_port_postcommit syncs every (port, host) slot that might be affected by
-        # the update, and the source slot is in scope.  The rewrite is content-identical
-        # in normal cases (migrating_to isn't reflected in source-WEP
-        # spec/labels/annotations) but the test mock records it as a write.
+        # Destination WEP and LiveMigration should be written.
+        # ``update_port_postcommit`` also touches the source-WEP slot and the SG
+        # NetworkPolicy referenced by the port, but the no-op-write optimisation in
+        # ``sync_wep`` / ``_cas_sync_sg`` short-circuits both because their desired
+        # content is identical to what etcd already holds.
         expected_writes = {
-            self._ep_key(self.SOURCE_HOST): self._ep_value(self.SOURCE_HOST),
             self._ep_key(self.DEST_HOST): self._ep_value(self.DEST_HOST),
             self._lm_key(self.DEST_HOST): self._lm_value(
                 self.SOURCE_HOST, self.DEST_HOST
             ),
-            self.sg_default_key_v3: self.sg_default_value_v3,
         }
         self.assertEtcdWrites(expected_writes)
         # Source WEP should NOT be deleted.


### PR DESCRIPTION
The dynamic sync paths (``sync_subnet``, ``sync_wep``, ``sync_lm``, ``_cas_sync_sg``) previously CAS-put the freshly composed write data unconditionally once the loop reached the "present, write" decision. In many real cases the data is byte-identical to what etcd already holds -- particularly during ``update_port_postcommit`` which fans out to every host slot the port might own, and ``handle_qos_policy_update`` which fans out to every port bound to the changing policy.  Each needless write costs an etcd revision bump, a network round-trip, and a Felix watch event that re-evaluates a WEP that did not change.

Each sync method now compares the desired write data against the existing value we already read at the top of the CAS loop and returns early if they match.

Comparison shapes:

* ``sync_subnet``: byte-equality of the JSON-as-string Subnet representation.  ``json.dumps`` on the always-same field-order ``subnet_etcd_data`` dict is deterministic.

* ``_cas_sync_sg`` / ``sync_lm``: structural ``spec == spec`` against the spec dict returned by ``datamodel_v3.get_namespaced``.

* ``sync_wep``: structural comparison of (spec, labels, annotations) against the matching tuple returned by ``datamodel_v3.get_namespaced( ..., with_labels_and_annotations=True)`` -- the same API the resync uses for its compare-loop.

Subtleties:

* **Serialisation drift after deploys**: if production serialisation ever changes shape (added or renamed field), the first round of writes after the deploy will all look "different" and write through normally.  Steady state from then on.

* **Race on identical write**: between our read and our compare, another worker writes the same value at a higher mod_revision. We skip, return success.  etcd has the right value -- we just did not bump the revision.  Correct.

* **Felix-misses-watch defence**: theoretical risk if Felix ever loses a watch event.  In practice the watch path is reliable and the resync still rewrites everything periodically.

Test updates:

Many ``assertEtcdWrites`` callsites used to include "spurious" writes that the no-op skip now silences.  Updated to reflect the new reality:

* ``test_pre_live_migration``: drops the source-WEP rewrite (the ``migrating_to`` change does not affect source-WEP content) and the SG NetworkPolicy rewrite (unchanged from the initial resync).
* ``test_start_two_ports`` (inherited by 5 test classes): drops several SG NetworkPolicy rewrites that were unchanged between the test's resync and the subsequent port-update assertions.

See [CORE-13073](https://tigera.atlassian.net/browse/CORE-13073) for the design discussion.


[CORE-13073]: https://tigera.atlassian.net/browse/CORE-13073?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ