### PR TITLE
felix/fv: drain neighbours before device teardown to avoid kernel panic

### DIFF
--- a/felix/fv/infrastructure/felix.go
+++ b/felix/fv/infrastructure/felix.go
@@ -341,6 +341,24 @@ func (f *Felix) Stop() {
 		_ = f.ExecMayFail("rmdir", path.Join("/run/calico/cgroup/", f.Name))
 	}
 	f.FlowServerStop()
+
+	// Quiesce the neighbour tables before we free this container's network
+	// devices.  This works around a kernel use-after-free panic (observed on
+	// 6.17.0-1020-gcp) that reboots the test VM during teardown and flakes the
+	// FV suite.  When an unresolved ARP/ND neighbour times out, the kernel's
+	// neigh_invalidate() generates an ICMP "destination unreachable" for every
+	// packet still queued behind that neighbour
+	// (neigh_timer_handler -> arp_error_report -> ipv4_link_failure ->
+	// __icmp_send).  If the input device of a queued packet has already been
+	// torn down, __icmp_send -> icmp_route_lookup -> l3mdev_master_ifindex_rcu
+	// -> netdev_master_upper_dev_get_rcu dereferences the freed netdevice and
+	// panics in interrupt context.  Removing this container frees its veth (the
+	// docker0-bridged host side and the in-container side), so flushing the
+	// neighbour entries first drops any queued packets and cancels the
+	// retransmit timers, ensuring no timer can fire against a device we are
+	// about to free.  Best effort: teardown must not fail if these don't run.
+	f.drainNeighbours()
+
 	f.Container.Stop()
 
 	if ginkgo.CurrentSpecReport().Failed() {
@@ -348,6 +366,26 @@ func (f *Felix) Stop() {
 	} else {
 		Expect(f.DataRaces()).To(BeEmpty(), "Test PASSED but data races were detected in the logs at teardown.")
 	}
+}
+
+// drainNeighbours flushes neighbour (ARP/ND) state that could otherwise
+// outlive this container's network devices.  See the call site in Stop() for
+// the kernel panic this avoids.
+//
+// On the host we flush only the entries for this container's own addresses
+// (rather than the whole table) so that batches running in parallel on the
+// same host - as `make fv` does locally - are not disturbed.  Inside the
+// container, which is about to be destroyed, we flush everything.  All calls
+// are best effort.
+func (f *Felix) drainNeighbours() {
+	if f.IP != "" {
+		_ = utils.RunMayFail("ip", "neigh", "flush", "to", f.IP)
+	}
+	if f.IPv6 != "" {
+		_ = utils.RunMayFail("ip", "-6", "neigh", "flush", "to", f.IPv6)
+	}
+	f.ExecBestEffort("ip", "neigh", "flush", "all")
+	f.ExecBestEffort("ip", "-6", "neigh", "flush", "all")
 }
 
 func (f *Felix) Restart() {

--- a/felix/fv/workload/workload.go
+++ b/felix/fv/workload/workload.go
@@ -108,9 +108,33 @@ func (w *Workload) Stop() {
 		return
 	}
 
-	cleanupCmds := []string{
-		fmt.Sprintf("kill -9 %s", w.pid),
+	// Flush the neighbour state that references the devices we are about to
+	// delete before deleting them.  This avoids a kernel use-after-free panic
+	// on device teardown (see felix/fv/infrastructure/felix.go Felix.Stop for
+	// the full explanation): if an unresolved-neighbour timer fires after the
+	// queued packet's device has been freed, the kernel panics in interrupt
+	// context (arp_error_report -> ipv4_link_failure -> __icmp_send ->
+	// netdev_master_upper_dev_get_rcu on a freed netdevice).  Flushing drops the
+	// queued packets and cancels the timers.
+	var cleanupCmds []string
+	if w.NamespaceID() != "" {
+		cleanupCmds = append(cleanupCmds,
+			fmt.Sprintf("ip netns exec %s ip neigh flush all", w.NamespaceID()),
+			fmt.Sprintf("ip netns exec %s ip -6 neigh flush all", w.NamespaceID()),
+		)
 	}
+	if w.IP != "" {
+		cleanupCmds = append(cleanupCmds, fmt.Sprintf("ip neigh flush to %s", w.IP))
+	}
+	if w.IP6 != "" {
+		cleanupCmds = append(cleanupCmds, fmt.Sprintf("ip -6 neigh flush to %s", w.IP6))
+	}
+
+	// Then tear the workload down in order.  These used to run concurrently
+	// (joined with " & "), but deleting an in-use device and its namespace at
+	// the same time as killing the process that uses them is exactly the race
+	// that triggers the kernel panic above, so run them sequentially instead.
+	cleanupCmds = append(cleanupCmds, fmt.Sprintf("kill -9 %s", w.pid))
 	if w.InterfaceName != "" {
 		// Only try to delete the veth if we created one.
 		cleanupCmds = append(cleanupCmds, fmt.Sprintf("ip link del %s", w.InterfaceName))
@@ -118,9 +142,8 @@ func (w *Workload) Stop() {
 	if w.NamespaceID() != "" {
 		cleanupCmds = append(cleanupCmds, fmt.Sprintf("ip netns del %s", w.NamespaceID()))
 	}
-	cleanupCmds = append(cleanupCmds, "wait")
 
-	_ = w.C.ExecMayFail("sh", "-c", strings.Join(cleanupCmds, " & "))
+	_ = w.C.ExecMayFail("sh", "-c", strings.Join(cleanupCmds, "; "))
 	// Killing the process inside the container should cause our long-running
 	// docker exec command to exit.  Do the Wait on a background goroutine,
 	// so we can time it out, just in case.


### PR DESCRIPTION
Felix FV jobs intermittently **panic and reboot their GCE test VM during teardown**, flaking the suite. The watchdog-captured serial console (job `f347a9ad`, kernel `6.17.0-1020-gcp`, Ubuntu 24.04 BPF-iptables FV) shows a kernel **use-after-free**:

```
BUG: unable to handle page fault for address: fffffffffffffff0
RIP: netdev_master_upper_dev_get_rcu+0x2d          ← walks a freed netdevice's adj_list.upper
 l3mdev_master_ifindex_rcu / icmp_route_lookup / __icmp_send
 ipv4_send_dest_unreach / ipv4_link_failure / arp_error_report
 neigh_invalidate / neigh_timer_handler / run_timer_softirq
Kernel panic - not syncing: Fatal exception in interrupt   → reboot
```

### Root cause

An **in-use device being torn down**, exactly as suspected:

1. A packet is queued behind an **unresolved ARP/ND neighbour**.
2. The packet's **device is freed** (container/veth teardown).
3. The neighbour's retransmit **timer then fires**, declares failure, and tries to send an ICMP "destination unreachable" for the queued packet — walking the **already-freed netdevice** and faulting in **interrupt context**, which is always fatal.

`Comm: docker` is incidental (the timer interrupted docker's teardown). The crashing device has a `docker0` master, i.e. the host-side veth of a Calico FV "node" container. This is a kernel bug on the GCP 6.17 kernel that we cannot fix from Calico, so we work around it by not triggering the path.

> Note: `net.ipv4.neigh.default.unres_qlen_bytes=0` is **not** sufficient — the kernel still queues one skb unconditionally (`__skb_queue_tail` after the drop loop in `__neigh_event_send`), and one queued skb is enough to panic.

### Change

Drain neighbour state (which drops queued packets **and** cancels the timers) before the devices are freed, and stop racing the teardown:

- **`felix/fv/infrastructure/felix.go` `Felix.Stop()`** — new `drainNeighbours()`: flush the host neighbour entries for the container's own IPs (scoped with `ip neigh flush to <ip>` so parallel local `make fv` batches are undisturbed) and all neighbours inside the container, before `Container.Stop()`.
- **`felix/fv/workload/workload.go` `Workload.Stop()`** — flush the workload's neighbour state, then tear the workload down **sequentially** instead of deleting the veth and its namespace concurrently with killing the process that uses them — that concurrency (`kill & ip link del & ip netns del & wait`) was itself the race.

Both are best-effort (cannot fail a test).