### PR TITLE
networking-calico: keep source WEP during live-migration setup

### DIFF
--- a/networking-calico/networking_calico/plugins/ml2/drivers/calico/endpoints.py
+++ b/networking-calico/networking_calico/plugins/ml2/drivers/calico/endpoints.py
@@ -747,15 +747,16 @@ class WorkloadEndpointSyncer(ResourceSyncer):
         if db_port is None:
             return False
         migrating_to = db_port.get("binding:profile", {}).get("migrating_to")
+
         # Source role: port is bound at this host.  Consider it bound if either
-        # ``vif_type != "unbound"``, or the port is undergoing live migration --
-        # setting ``binding:profile.migrating_to`` triggers Neutron to rebind the
-        # port for the destination, and during that rebind ``vif_type`` flips
-        # transiently to "unbound" while ``binding:host_id`` stays at the source.
-        # The VM is still running at the source throughout this window, so the
-        # source WEP must stay in place.  Without the ``or migrating_to`` clause
-        # we'd delete the source WEP mid-migration and drop traffic to the VM
-        # until Nova's actual cutover completes.
+        # ``vif_type != "unbound"``, or the port is undergoing live migration -- setting
+        # ``binding:profile.migrating_to`` triggers Neutron to rebind the port for the
+        # destination, and during that rebind ``vif_type`` flips transiently to
+        # "unbound" while ``binding:host_id`` stays at the source.  The VM is still
+        # running at the source throughout this window, so the source WEP must stay in
+        # place.  Without the ``or migrating_to`` clause we'd delete the source WEP
+        # mid-migration and drop traffic to the VM until Nova's actual cutover
+        # completes.
         if db_port["binding:host_id"] == host and (
             db_port.get("binding:vif_type") != "unbound" or migrating_to
         ):

--- a/networking-calico/networking_calico/plugins/ml2/drivers/calico/endpoints.py
+++ b/networking-calico/networking_calico/plugins/ml2/drivers/calico/endpoints.py
@@ -755,7 +755,7 @@ class WorkloadEndpointSyncer(ResourceSyncer):
         # The VM is still running at the source throughout this window, so the
         # source WEP must stay in place.  Without the ``or migrating_to`` clause
         # we'd delete the source WEP mid-migration and drop traffic to the VM
-        # until Nova's actual cutover completes (see the CORE-13xxx post-mortem).
+        # until Nova's actual cutover completes.
         if db_port["binding:host_id"] == host and (
             db_port.get("binding:vif_type") != "unbound" or migrating_to
         ):

--- a/networking-calico/networking_calico/plugins/ml2/drivers/calico/endpoints.py
+++ b/networking-calico/networking_calico/plugins/ml2/drivers/calico/endpoints.py
@@ -746,14 +746,22 @@ class WorkloadEndpointSyncer(ResourceSyncer):
         """Decide whether a WEP slot at ``host`` should exist for ``db_port``."""
         if db_port is None:
             return False
-        # Source role: port is bound at this host.
-        if (
-            db_port.get("binding:vif_type") != "unbound"
-            and db_port["binding:host_id"] == host
+        migrating_to = db_port.get("binding:profile", {}).get("migrating_to")
+        # Source role: port is bound at this host.  Consider it bound if either
+        # ``vif_type != "unbound"``, or the port is undergoing live migration --
+        # setting ``binding:profile.migrating_to`` triggers Neutron to rebind the
+        # port for the destination, and during that rebind ``vif_type`` flips
+        # transiently to "unbound" while ``binding:host_id`` stays at the source.
+        # The VM is still running at the source throughout this window, so the
+        # source WEP must stay in place.  Without the ``or migrating_to`` clause
+        # we'd delete the source WEP mid-migration and drop traffic to the VM
+        # until Nova's actual cutover completes (see the CORE-13xxx post-mortem).
+        if db_port["binding:host_id"] == host and (
+            db_port.get("binding:vif_type") != "unbound" or migrating_to
         ):
             return True
         # Dest role: port is migrating to this host.
-        if db_port.get("binding:profile", {}).get("migrating_to") == host:
+        if migrating_to == host:
             return True
         return False
 

--- a/networking-calico/networking_calico/plugins/ml2/drivers/calico/test/test_plugin_etcd.py
+++ b/networking-calico/networking_calico/plugins/ml2/drivers/calico/test/test_plugin_etcd.py
@@ -2209,18 +2209,18 @@ class TestLiveMigration(TestPluginEtcdBase):
         self.assertEtcdDeletes(set())
 
     def test_pre_live_migration_transient_vif_unbound(self):
-        """Source WEP must survive the transient ``vif_type=unbound`` at migration start.
+        """Source WEP must survive the transient ``vif_type=unbound`` at migration
+        start.
 
         In a real deployment, setting ``binding:profile.migrating_to`` on a port
-        triggers Neutron to rebind the port for the destination host.  During
-        that rebind ``binding:vif_type`` transiently flips from ``tap`` to
-        ``unbound`` while ``binding:host_id`` stays at the source.  If the
-        driver's ``_wep_desired_present`` treats ``vif_type == "unbound"`` as
-        "port not bound at this host" without considering the concurrent
-        ``migrating_to`` state, ``update_port_postcommit`` would delete the
-        source-host WEP even though the VM is still running there -- Felix at
-        the source would then tear down its programming and traffic would drop
-        until Nova's actual cutover completed.
+        triggers Neutron to rebind the port for the destination host.  During that
+        rebind ``binding:vif_type`` transiently flips from ``tap`` to ``unbound`` while
+        ``binding:host_id`` stays at the source.  If the driver's
+        ``_wep_desired_present`` treats ``vif_type == "unbound"`` as "port not bound at
+        this host" without considering the concurrent ``migrating_to`` state,
+        ``update_port_postcommit`` would delete the source-host WEP even though the VM
+        is still running there -- Felix at the source would then tear down its
+        programming and traffic would drop until Nova's actual cutover completed.
 
         This case did not fire in ``test_pre_live_migration`` above because
         ``_pre_migrate`` only sets ``migrating_to`` without touching
@@ -2229,14 +2229,17 @@ class TestLiveMigration(TestPluginEtcdBase):
         self._do_initial_resync()
 
         context = self._make_port_context()
+
         # Pre-migration state: fully bound at the source.
         context.original = copy.deepcopy(self.port)
+
         # Post-migration-start state as Neutron actually produces it: host_id
         # stays at the source, vif_type flips to "unbound" during the rebind,
         # migrating_to points at the destination.
         context._port = copy.deepcopy(self.port)
         context._port["binding:profile"] = {"migrating_to": self.DEST_HOST}
         context._port["binding:vif_type"] = "unbound"
+
         # The DB re-read inside sync_wep must return the same shape.
         self.osdb_ports[0]["binding:profile"] = {"migrating_to": self.DEST_HOST}
         self.osdb_ports[0]["binding:vif_type"] = "unbound"

--- a/networking-calico/networking_calico/plugins/ml2/drivers/calico/test/test_plugin_etcd.py
+++ b/networking-calico/networking_calico/plugins/ml2/drivers/calico/test/test_plugin_etcd.py
@@ -2209,7 +2209,7 @@ class TestLiveMigration(TestPluginEtcdBase):
         self.assertEtcdDeletes(set())
 
     def test_pre_live_migration_transient_vif_unbound(self):
-        """Regression test for the ms-mregion-carajammy ST hang.
+        """Source WEP must survive the transient ``vif_type=unbound`` at migration start.
 
         In a real deployment, setting ``binding:profile.migrating_to`` on a port
         triggers Neutron to rebind the port for the destination host.  During

--- a/networking-calico/networking_calico/plugins/ml2/drivers/calico/test/test_plugin_etcd.py
+++ b/networking-calico/networking_calico/plugins/ml2/drivers/calico/test/test_plugin_etcd.py
@@ -2208,6 +2208,47 @@ class TestLiveMigration(TestPluginEtcdBase):
         # Source WEP should NOT be deleted.
         self.assertEtcdDeletes(set())
 
+    def test_pre_live_migration_transient_vif_unbound(self):
+        """Regression test for the ms-mregion-carajammy ST hang.
+
+        In a real deployment, setting ``binding:profile.migrating_to`` on a port
+        triggers Neutron to rebind the port for the destination host.  During
+        that rebind ``binding:vif_type`` transiently flips from ``tap`` to
+        ``unbound`` while ``binding:host_id`` stays at the source.  If the
+        driver's ``_wep_desired_present`` treats ``vif_type == "unbound"`` as
+        "port not bound at this host" without considering the concurrent
+        ``migrating_to`` state, ``update_port_postcommit`` would delete the
+        source-host WEP even though the VM is still running there -- Felix at
+        the source would then tear down its programming and traffic would drop
+        until Nova's actual cutover completed.
+
+        This case did not fire in ``test_pre_live_migration`` above because
+        ``_pre_migrate`` only sets ``migrating_to`` without touching
+        ``binding:vif_type``.
+        """
+        self._do_initial_resync()
+
+        context = self._make_port_context()
+        # Pre-migration state: fully bound at the source.
+        context.original = copy.deepcopy(self.port)
+        # Post-migration-start state as Neutron actually produces it: host_id
+        # stays at the source, vif_type flips to "unbound" during the rebind,
+        # migrating_to points at the destination.
+        context._port = copy.deepcopy(self.port)
+        context._port["binding:profile"] = {"migrating_to": self.DEST_HOST}
+        context._port["binding:vif_type"] = "unbound"
+        # The DB re-read inside sync_wep must return the same shape.
+        self.osdb_ports[0]["binding:profile"] = {"migrating_to": self.DEST_HOST}
+        self.osdb_ports[0]["binding:vif_type"] = "unbound"
+
+        self.driver.update_port_postcommit(context)
+
+        # The source WEP must NOT be deleted.  The dest WEP and LiveMigration
+        # get written as usual.
+        self.assertEtcdDeletes(set())
+        self.assertIn(self._ep_key(self.DEST_HOST), self.recent_writes)
+        self.assertIn(self._lm_key(self.DEST_HOST), self.recent_writes)
+
     def test_live_migration_succeeded(self):
         """After migration succeeds, source WEP deleted, dest WEP kept."""
         self._do_initial_resync()


### PR DESCRIPTION
Setting ``binding:profile.migrating_to`` on a port causes Neutron to rebind the port for the destination host.  During that rebind ``binding:vif_type`` transiently flips from ``tap`` to ``unbound`` while ``binding:host_id`` stays at the source host (the VM is still running there; Nova's cutover happens later).

``_wep_desired_present`` was treating ``vif_type == "unbound"`` as "port not bound at this host" unconditionally.  In the transient window above, ``update_port_postcommit``'s per-host sync loop then called ``sync_wep(port, source_host, ctx)``, ``_wep_desired_present`` returned False, and ``sync_wep`` CAS-deleted the source WEP.  Felix at the source noticed the WEP disappear and tore down its iptables / BPF programming, and traffic to the VM broke until Nova's actual cutover repopulated a WEP at the destination -- which for long-running SSH sessions the test opens to the migrating VM meant the connection hung.

Observed against the ms-mregion-carajammy OpenStack ST following the PR #13113 merge.  Etcd op timeline for the failing port during migration setup:

    09:27:24.528  put LM at compute3         <-- sync_lm
    09:27:24.539  get WEP at compute2        <-- sync_wep(port, compute2)
    09:27:24.566  DELETE WEP at compute2     <-- this is the bug
    09:27:24.815  put WEP at compute3        <-- sync_wep(port, compute3)

The OLD (pre-PR-13113) code did not hit this because its "delete source WEP" branch was gated on
``original.binding:host_id != port.binding:host_id`` -- both were ``compute2`` during migration setup, so no delete.

Fix: in ``_wep_desired_present``, treat ``vif_type == "unbound"`` as transient when the port is undergoing live migration:

    if db_port["binding:host_id"] == host and (
        db_port.get("binding:vif_type") != "unbound" or migrating_to
    ):
        return True

Walking the four canonical migration phases:

  1. Pre-migration:  host=C2, vif=tap,     migr=None  -> C2 kept.
  2. Migration setup: host=C2, vif=unbound, migr=C3   -> C2 kept
     (via the new ``or migrating_to`` clause).
  3. Migration success: host=C3, vif=tap,  migr=None  -> C2 deleted
     (correct source cleanup); C3 kept.
  4. Migration failure: host=C2, vif=tap,  migr=None  -> C2 kept;
     C3 deleted (correct dest cleanup).

Regression test: ``test_pre_live_migration_transient_vif_unbound`` in ``TestLiveMigration`` reproduces Neutron's actual post-migration- start port shape (``vif_type=unbound``, ``host_id=source``, ``migrating_to=dest``) and asserts no source-WEP delete happens. Without the ``_wep_desired_present`` fix this test fails; with the fix it passes.  The existing ``test_pre_live_migration`` did not catch the regression because ``_pre_migrate`` only sets ``migrating_to`` and does not touch ``binding:vif_type``.