### PR TITLE
typha: fix flake in "grace period after reading snapshot" FV test

### DIFF
--- a/typha/fv-tests/server_test.go
+++ b/typha/fv-tests/server_test.go
@@ -896,8 +896,12 @@ var _ = Describe("With an in-process Server with short grace period", func() {
 		h.Config.PingInterval = 10000 * time.Second
 		h.Config.PongTimeout = 50000 * time.Second
 
-		// Short timeouts so we can hit them quickly.
-		h.Config.MaxFallBehind = time.Second
+		// Short timeouts so we can hit them quickly.  MaxFallBehind is kept
+		// comfortably below the 1s spacing the tests use between breadcrumbs:
+		// the "grace used" check fires on crumbAge > MaxFallBehind, and a
+		// crumbAge manufactured to equal MaxFallBehind is a boundary coin-flip
+		// (a breadcrumb gap measured at 999.95ms once flaked the grace test).
+		h.Config.MaxFallBehind = 500 * time.Millisecond
 		h.Config.NewClientFallBehindGracePeriod = time.Second
 
 		// The snapshot is >10MB; set the write buffer to something much less than that since these
@@ -957,10 +961,11 @@ var _ = Describe("With an in-process Server with short grace period", func() {
 			origGaugeValue, err := getPerSyncerCounter(syncproto.SyncerTypeFelix, "typha_connections_grace_used")
 			Expect(err).NotTo(HaveOccurred())
 
-			// Make the client block after it reads the first update.  This means the server will have started
-			// streaming the snapshot but it shouldn't be able to finish streaming the snapshot.  Blocking for
-			// >1s wastes the MaxFallBehind timeout so this client will need to rely on the
-			// NewClientFallBehindGracePeriod, which should kick in only once we've finished reading the snapshot.
+			// Make the client block after it reads the first update, so it can't promptly finish reading
+			// the snapshot.  By the time it does and the server starts streaming deltas, the breadcrumb the
+			// client is on is more than MaxFallBehind old (the server's crumbAge > MaxFallBehind check).
+			// Rather than being cut off immediately, the client then relies on the
+			// NewClientFallBehindGracePeriod to catch up.
 			recorder.BlockAfterNUpdates(1, 2500*time.Millisecond)
 
 			client := syncclient.New(


### PR DESCRIPTION
The grace-period FV test set MaxFallBehind to exactly 1s and manufactured the client's "fall behind" gap with time.Sleep(time.Second) between breadcrumbs. The server only counts a grace period when it observes crumbAge > MaxFallBehind, so with crumbAge == MaxFallBehind the check was a boundary coin-flip. A run where the measured breadcrumb gap came out at 999.95ms left typha_connections_grace_used at 0 and failed the assertion.

Drop MaxFallBehind to 500ms so the ~1s breadcrumb spacing reliably clears the threshold, keeping the 1s grace window unchanged.