### PR TITLE
argoci: add e2e crons for the remaining OSS pipelines

### DIFF
--- a/.argoci/cron/e2e-benchmarking.yaml
+++ b/.argoci/cron/e2e-benchmarking.yaml
@@ -1,0 +1,88 @@
+# Condensed ArgoCI e2e workflow; cc-argoci-handler expands it into a CronWorkflow at runtime.
+# Migrated from the Semaphore e2e pipeline of the same name — maintained here by hand.
+version: condensed
+generateName: e2e-benchmarking-
+schedule: 0 21 * * 0
+globalPrologue: |
+  cd "${CI_HOME}/${CI_GIT_DIR}"
+  export ARGO_WORKFLOW_NAME="{{workflow.name}}"
+  export ARGO_WORKFLOW_UID="{{workflow.uid}}"
+  export BENCHMARKER_IMAGE="${BENCHMARKER_IMAGE:-gcr.io/unique-caldron-775/banzai-tests/benchmark:master}"
+  export FUNCTIONAL_AREA="${FUNCTIONAL_AREA:-benchmarking.yml}"
+  export GOOGLE_NETWORK="${GOOGLE_NETWORK:-semaphore-autotest}"
+  export GOOGLE_PROJECT="${GOOGLE_PROJECT:-unique-caldron-775}"
+  export KOPS_AWS_DNS_ZONE="${KOPS_AWS_DNS_ZONE:-kops.ci.aws.eng.tigera.net}"
+  export KOPS_STATE_STORE_NAME="${KOPS_STATE_STORE_NAME:-kops-tigera-dev-ci}"
+  export OPENSHIFT_BASE_DOMAIN="${OPENSHIFT_BASE_DOMAIN:-openshift.ci.aws.eng.tigera.net}"
+  export PRIVATE_REGISTRY="${PRIVATE_REGISTRY:-quay.io/}"
+  export PRODUCT="${PRODUCT:-calico}"
+  export RANCHER_DNS_NAME="${RANCHER_DNS_NAME:-rancher.ci.gcp.eng.tigera.net}"
+  export SEMAPHORE_ARTIFACT_EXPIRY="${SEMAPHORE_ARTIFACT_EXPIRY:-1w}"
+  export STO_RELEASE="${STO_RELEASE:-v0.16.0}"
+  export USE_PRIVATE_REGISTRY="${USE_PRIVATE_REGISTRY:-true}"
+  source .argoci/scripts/global_prologue.sh
+globalEpilogue: |
+  source "${CI_HOME}/${CI_GIT_DIR}/.argoci/scripts/global_epilogue.sh"
+defaults:
+  secretBundles:
+    - banzai-secrets
+steps:
+  - name: benchmarks
+    services:
+      - docker
+    env:
+      - name: AWS_NODE_INSTANCE_TYPE
+        value: m5.large
+      - name: BENCHMARKER_TEST_CONFIGS
+        value: |
+          '[{"testtype":"sto","numpolicies":[10,100,1000,10000],"encap":"none","dataplane":"iptables"},{"testtype":"qperf","numpolicies":[10,100,1000,10000],"encap":"none","dataplane":"iptables"},{"testtype":"iperf","numpolicies":[10,100,1000,10000],"encap":"none","dataplane":"iptables"},{"testtype":"sto","numpolicies":[10,100,1000,10000],"encap":"vxlan","dataplane":"iptables"},{"testtype":"qperf","numpolicies":[10,100,1000,10000],"encap":"vxlan","dataplane":"iptables"},{"testtype":"iperf","numpolicies":[10,100,1000,10000],"encap":"vxlan","dataplane":"iptables"},{"testtype":"sto","numpolicies":[10,100,1000,10000],"encap":"none","dataplane":"bpf"},{"testtype":"qperf","numpolicies":[10,100,1000,10000],"encap":"none","dataplane":"bpf"},{"testtype":"iperf","numpolicies":[10,100,1000,10000],"encap":"none","dataplane":"bpf"},{"testtype":"sto","numpolicies":[10,100,1000,10000],"encap":"vxlan","dataplane":"bpf"},{"testtype":"qperf","numpolicies":[10,100,1000,10000],"encap":"vxlan","dataplane":"bpf"},{"testtype":"iperf","numpolicies":[10,100,1000,10000],"encap":"vxlan","dataplane":"bpf"}]'
+      - name: BENCHMARKS
+        value: benchmarker
+      - name: DATAPLANE
+        value: CalicoIptables
+      - name: INSTALLER
+        value: operator
+      - name: K8S_VERSION
+        value: stable
+      - name: NUM_ADDON_PODS
+        value: "300"
+      - name: NUM_INFRA_NODES
+        value: "3"
+      - name: PROVISIONER
+        value: aws-kubeadm
+      - name: TEST_TYPE
+        value: benchmark
+      - name: USE_HASH_RELEASE
+        value: "true"
+      - name: VPC_SUBNETS
+        value: '["172.16.101.0/24"]'
+    matrix:
+      - name: calico
+        env:
+          - name: PRODUCT
+            value: calico
+    commands: |
+      .argoci/scripts/body_standard.sh
+  - name: tiger-bench
+    services:
+      - docker
+    env:
+      - name: INSTALLER
+        value: operator
+      - name: K8S_VERSION
+        value: stable
+      - name: PROVISIONER
+        value: aws-kubeadm
+      - name: TEST_TYPE
+        value: tiger-bench
+      - name: TIGER_BENCH_VERSION
+        value: main
+      - name: USE_HASH_RELEASE
+        value: "true"
+    matrix:
+      - name: calico
+        env:
+          - name: PRODUCT
+            value: calico
+    commands: |
+      .argoci/scripts/body_standard.sh

--- a/.argoci/cron/e2e-bpf.yaml
+++ b/.argoci/cron/e2e-bpf.yaml
@@ -1,0 +1,755 @@
+# Condensed ArgoCI e2e workflow; cc-argoci-handler expands it into a CronWorkflow at runtime.
+# Migrated from the Semaphore e2e pipeline of the same name — maintained here by hand.
+version: condensed
+generateName: e2e-bpf-
+schedule: 10 21 * * 2
+globalPrologue: |
+  cd "${CI_HOME}/${CI_GIT_DIR}"
+  export ARGO_WORKFLOW_NAME="{{workflow.name}}"
+  export ARGO_WORKFLOW_UID="{{workflow.uid}}"
+  export DATAPLANE="${DATAPLANE:-CalicoBPF}"
+  export FUNCTIONAL_AREA="${FUNCTIONAL_AREA:-bpf.yml}"
+  export INSTALLER="${INSTALLER:-operator}"
+  export K8S_E2E_FLAGS="${K8S_E2E_FLAGS:---ginkgo.focus=(\[sig-calico\]|\[Conformance\]|Host-Protection) --ginkgo.skip=(\[Slow\]|\[Disruptive\]|Feature:SCTP|Feature:Maglev)}"
+  export PRIVATE_REGISTRY="${PRIVATE_REGISTRY:-quay.io/}"
+  export USE_PRIVATE_REGISTRY="${USE_PRIVATE_REGISTRY:-true}"
+  source .argoci/scripts/global_prologue.sh
+globalEpilogue: |
+  source "${CI_HOME}/${CI_GIT_DIR}/.argoci/scripts/global_epilogue.sh"
+defaults:
+  secretBundles:
+    - banzai-secrets
+steps:
+  - name: arm64-smoke-tests-kubeadm-arm64
+    services:
+      - docker
+    env:
+      - name: ENABLE_WIREGUARD
+        value: "true"
+      - name: GOOGLE_MACHINE_TYPE
+        value: t2a-standard-2
+      - name: INSTALLER
+        value: operator
+      - name: K8S_VERSION
+        value: stable-1
+      - name: PROVISIONER
+        value: gcp-kubeadm
+      - name: STERN_CHECK
+        value: DISABLED
+    matrix:
+      - name: ubuntu-2204-lts-arm64
+        env:
+          - name: CLUSTER_IMAGE
+            value: ubuntu-2204-lts-arm64
+      - name: rocky-linux-9-arm64
+        env:
+          - name: CLUSTER_IMAGE
+            value: rocky-linux-9-arm64
+    commands: |
+      .argoci/scripts/body_standard.sh
+  - name: arm64-smoke-tests-aks-arm64
+    services:
+      - docker
+    env:
+      - name: AZ_VM_SIZE
+        value: Standard_D4plds_v5
+      - name: INSTALLER
+        value: operator
+      - name: PROVISIONER
+        value: azr-aks
+      - name: STERN_CHECK
+        value: DISABLED
+    matrix:
+      - name: stable-1-azure-
+        env:
+          - name: K8S_VERSION
+            value: stable-1
+          - name: AZ_NETWORK_PLUGIN
+            value: azure
+          - name: CLUSTER_MODE
+            value: ""
+      - name: stable-1-none-
+        env:
+          - name: K8S_VERSION
+            value: stable-1
+          - name: AZ_NETWORK_PLUGIN
+            value: none
+          - name: CLUSTER_MODE
+            value: ""
+    commands: |
+      .argoci/scripts/body_standard.sh
+  - name: bpf-run-matrix-aws-encap
+    services:
+      - docker
+    env:
+      - name: CLUSTER_NODES
+        value: "3"
+      - name: ENABLE_EXTERNAL_NODE
+        value: "true"
+      - name: IPAM_TEST_POOL_SUBNET
+        value: 10.0.0.0/29
+      - name: K8S_E2E_DOCKER_EXTRA_FLAGS
+        value: --env EKS_CNI
+      - name: K8S_E2E_FLAGS
+        value: --ginkgo.focus=(\[sig-calico\]|Conformance|Dataplane:BPF|Feature:NetworkPolicy) --ginkgo.skip=(Slow|Disruptive|calient|allow.ingress.access.from.updated.pod|Dataplane:LB|Feature:SCTP|Feature:Maglev)
+      - name: K8S_VERSION
+        value: stable-3
+      - name: PROVISIONER
+        value: aws-kubeadm
+      - name: USE_API_SERVER
+        value: "false"
+    matrix:
+      - name: "true"
+        env:
+          - name: USE_VXLAN
+            value: "true"
+      - name: "false"
+        env:
+          - name: USE_VXLAN
+            value: "false"
+    commands: |
+      .argoci/scripts/body_standard.sh
+  - name: bpf-run-matrix-aws-single-subnet-dual-ip-family
+    services:
+      - docker
+    env:
+      - name: BGP_STATUS
+        value: Enabled
+      - name: BPF_NETWORK_BOOTSTRAP
+        value: Enabled
+      - name: CLUSTER_NODES
+        value: "3"
+      - name: CLUSTER_ROUTING_MODE
+        value: Felix
+      - name: ENABLE_EXTERNAL_NODE
+        value: "true"
+      - name: ENCAPSULATION_TYPE
+        value: None
+      - name: IPAM_TEST_POOL_SUBNET
+        value: 10.0.0.0/29
+      - name: IP_FAMILY
+        value: dual
+      - name: K8S_E2E_DOCKER_EXTRA_FLAGS
+        value: --env EKS_CNI
+      - name: K8S_E2E_FLAGS
+        value: --ginkgo.focus=(\[sig-calico\]|Conformance|Dataplane:BPF|Feature:NetworkPolicy) --ginkgo.skip=(Slow|Disruptive|calient|allow.ingress.access.from.updated.pod|Dataplane:LB|Feature:SCTP)
+      - name: KUBE_PROXY_MANAGEMENT
+        value: Enabled
+      - name: PROVISIONER
+        value: aws-kubeadm
+      - name: VPC_SUBNETS
+        value: '["172.16.101.0/24"]'
+    matrix:
+      - name: "true"
+        env:
+          - name: ENABLE_WIREGUARD
+            value: "true"
+      - name: "false"
+        env:
+          - name: ENABLE_WIREGUARD
+            value: "false"
+    commands: |
+      .argoci/scripts/body_standard.sh
+  - name: bpf-run-matrix-aws-talos-no-encap-dsr
+    services:
+      - docker
+    env:
+      - name: BGP_STATUS
+        value: Enabled
+      - name: CLUSTER_NODES
+        value: "3"
+      - name: ENABLE_BPF_DSR
+        value: "true"
+      - name: ENABLE_EXTERNAL_NODE
+        value: "false"
+      - name: ENCAPSULATION_TYPE
+        value: None
+      - name: IPAM_TEST_POOL_SUBNET
+        value: 10.0.0.0/29
+      - name: K8S_E2E_DOCKER_EXTRA_FLAGS
+        value: --env EKS_CNI
+      - name: K8S_E2E_FLAGS
+        value: --ginkgo.focus=(\[sig-calico\]|Conformance|Dataplane:BPF|Feature:NetworkPolicy) --ginkgo.skip=(Slow|Disruptive|calient|allow.ingress.access.from.updated.pod|Dataplane:LB|Feature:SCTP|Feature:Maglev)
+      - name: PROVISIONER
+        value: aws-talos
+      - name: VPC_SUBNETS
+        value: '["172.16.101.0/24"]'
+    commands: |
+      .argoci/scripts/body_standard.sh
+  - name: bpf-run-matrix-gcp-bpf-dp-dsr
+    services:
+      - docker
+    env:
+      - name: BPF_NETWORK_BOOTSTRAP
+        value: Enabled
+      - name: CLUSTER_NODES
+        value: "3"
+      - name: ENABLE_BPF_DSR
+        value: "true"
+      - name: ENABLE_EXTERNAL_NODE
+        value: "true"
+      - name: ENABLE_IP_FORWARDING
+        value: "true"
+      - name: K8S_E2E_DOCKER_EXTRA_FLAGS
+        value: --env EKS_CNI
+      - name: K8S_E2E_FLAGS
+        value: --ginkgo.focus=(\[sig-calico\]|Conformance|Dataplane:BPF|Feature:NetworkPolicy) --ginkgo.skip=(Slow|Disruptive|calient|allow.ingress.access.from.updated.pod|Dataplane:LB|Feature:SCTP|Feature:Maglev)
+      - name: KUBE_PROXY_MANAGEMENT
+        value: Enabled
+      - name: PROVISIONER
+        value: gcp-kubeadm
+      - name: USE_API_SERVER
+        value: "false"
+    commands: |
+      .argoci/scripts/body_standard.sh
+  - name: bpf-run-matrix-gcp-bpf-dp-encap-w-nodelocal-dnscache
+    services:
+      - docker
+    env:
+      - name: CLUSTER_IMAGE
+        value: ubuntu-2204-lts
+      - name: CLUSTER_NODES
+        value: "3"
+      - name: ENABLE_EXTERNAL_NODE
+        value: "true"
+      - name: ENABLE_NODE_LOCAL_DNS_CACHE
+        value: "true"
+      - name: K8S_E2E_DOCKER_EXTRA_FLAGS
+        value: --env EKS_CNI
+      - name: K8S_E2E_FLAGS
+        value: --ginkgo.focus=(\[sig-calico\]|Conformance|Dataplane:BPF|Feature:NetworkPolicy) --ginkgo.skip=(Slow|Disruptive|calient|allow.ingress.access.from.updated.pod|Dataplane:LB|Feature:SCTP|Feature:Maglev)
+      - name: PROVISIONER
+        value: gcp-kubeadm
+    matrix:
+      - name: "true"
+        env:
+          - name: USE_VXLAN
+            value: "true"
+      - name: "false"
+        env:
+          - name: USE_VXLAN
+            value: "false"
+    commands: |
+      .argoci/scripts/body_standard.sh
+  - name: bpf-run-matrix-aks-w-aks-cni
+    services:
+      - docker
+    env:
+      - name: CLUSTER_NODES
+        value: "3"
+      - name: ENABLE_EXTERNAL_NODE
+        value: "false"
+      - name: INSTALLER
+        value: operator
+      - name: K8S_E2E_DOCKER_EXTRA_FLAGS
+        value: --env EKS_CNI
+      - name: K8S_E2E_FLAGS
+        value: --ginkgo.focus=(\[sig-calico\]|Conformance|Dataplane:BPF|Feature:NetworkPolicy) --ginkgo.skip=(Slow|Disruptive|calient|allow.ingress.access.from.updated.pod|Dataplane:LB|outside.the.cluster|external.to.nodeport|StrictAffinity|Feature:SCTP|Feature:Maglev)
+    matrix:
+      - name: azr-aks
+        env:
+          - name: PROVISIONER
+            value: azr-aks
+    commands: |
+      .argoci/scripts/body_standard.sh
+  - name: bpf-run-matrix-aks-w-calico-cni
+    services:
+      - docker
+    env:
+      - name: AZ_CREATE_MODE
+        value: AKS
+      - name: AZ_NETWORK_PLUGIN
+        value: none
+      - name: CLUSTER_NODES
+        value: "3"
+      - name: CNI_PLUGIN
+        value: Calico
+      - name: ENABLE_EXTERNAL_NODE
+        value: "false"
+      - name: INSTALLER
+        value: operator
+      - name: K8S_E2E_DOCKER_EXTRA_FLAGS
+        value: --env EKS_CNI
+      - name: K8S_E2E_FLAGS
+        value: --ginkgo.focus=(\[sig-calico\]|Conformance|Dataplane:BPF|Feature:NetworkPolicy) --ginkgo.skip=(Slow|Disruptive|calient|allow.ingress.access.from.updated.pod|Dataplane:LB|outside.the.cluster|external.to.nodeport|StrictAffinity|Feature:SCTP|Feature:Maglev)
+      - name: PROVISIONER
+        value: azr-aks
+    commands: |
+      .argoci/scripts/body_standard.sh
+  - name: bpf-run-matrix-bpf-aks-w-aks-cni-overlay
+    services:
+      - docker
+    env:
+      - name: AZ_CREATE_MODE
+        value: AKS
+      - name: AZ_NETWORK_PLUGIN
+        value: azure
+      - name: CLUSTER_NODES
+        value: "3"
+      - name: ENABLE_EXTERNAL_NODE
+        value: "false"
+      - name: INSTALLER
+        value: operator
+      - name: IPV4_POD_CIDR
+        value: 10.244.0.0/16
+      - name: K8S_E2E_DOCKER_EXTRA_FLAGS
+        value: --env EKS_CNI
+      - name: K8S_E2E_FLAGS
+        value: --ginkgo.focus=(\[sig-calico\]|\[Conformance\]|Feature:NetworkPolicy) --ginkgo.skip=(Slow|Disruptive|calient|allow.ingress.access.from.updated.pod|Dataplane:LB|outside.the.cluster|MTU|ExternalNode|external.to.nodeport|StrictAffinity|Feature:SCTP|Feature:Maglev)
+      - name: NETWORK_PLUGIN_MODE
+        value: overlay
+      - name: PROVISIONER
+        value: azr-aks
+    commands: |
+      .argoci/scripts/body_standard.sh
+  - name: bpf-run-matrix-aws-kops-rhel8-2
+    services:
+      - docker
+    env:
+      - name: CLUSTER_IMAGE
+        value: ami-02f147dfb8be58a10
+      - name: CLUSTER_NODES
+        value: "3"
+      - name: ENABLE_EXTERNAL_NODE
+        value: "true"
+      - name: K8S_E2E_DOCKER_EXTRA_FLAGS
+        value: --env EKS_CNI
+      - name: K8S_E2E_FLAGS
+        value: --ginkgo.focus=(\[sig-calico\]|Conformance|Dataplane:BPF|Feature:NetworkPolicy) --ginkgo.skip=(Slow|Disruptive|calient|allow.ingress.access.from.updated.pod|EndpointSlice|Services\sshould|Ingress.API|IngressClass.API|Feature:SCTP|Feature:Maglev)
+      - name: K8S_VERSION
+        value: stable-3
+      - name: PROVISIONER
+        value: aws-kops
+      - name: USE_VENDORED_CNI
+        value: "false"
+    commands: |
+      .argoci/scripts/body_standard.sh
+  - name: bpf-run-matrix-aws-lb-bpf
+    services:
+      - docker
+    env:
+      - name: BGP_STATUS
+        value: Enabled
+      - name: CLUSTER_NODES
+        value: "3"
+      - name: EKS_CNI
+        value: calico
+      - name: ENABLE_EXTERNAL_NODE
+        value: "true"
+      - name: IPAM_TEST_POOL_SUBNET
+        value: 10.0.0.0/29
+      - name: IPV4_POD_CIDR
+        value: 172.16.0.0/16
+      - name: K8S_E2E_DOCKER_EXTRA_FLAGS
+        value: --env EKS_CNI
+      - name: K8S_E2E_FLAGS
+        value: --ginkgo.focus=(\[calico\]|\[Conformance\]|Host-Protection) --ginkgo.skip=(\[Slow\]|\[Disruptive\]|Feature:SCTP|Feature:Maglev|both.pod.and.service.Proxy\b|proxy.through.a.service.and.a.pod|replica.with.a.public.image|DNS.for.ExternalName.services|DNS.for.pods.for.Hostname|DNS.for.pods.for.Subdomain|DNS.for.services|DNS.for.the.cluster|DNS.qualified.names.for.services)
+      - name: PROVISIONER
+        value: aws-eks
+    matrix:
+      - name: ipip
+        env:
+          - name: ENCAPSULATION_TYPE
+            value: IPIP
+      - name: vxlan
+        env:
+          - name: ENCAPSULATION_TYPE
+            value: VXLAN
+    commands: |
+      .argoci/scripts/body_standard.sh
+  - name: bpf-run-matrix-aws-lb-iptables
+    services:
+      - docker
+    env:
+      - name: BGP_STATUS
+        value: Enabled
+      - name: CLUSTER_NODES
+        value: "3"
+      - name: DATAPLANE
+        value: CalicoIptables
+      - name: EKS_CNI
+        value: calico
+      - name: ENABLE_EXTERNAL_NODE
+        value: "true"
+      - name: IPAM_TEST_POOL_SUBNET
+        value: 10.0.0.0/29
+      - name: IPV4_POD_CIDR
+        value: 172.16.0.0/16
+      - name: K8S_E2E_DOCKER_EXTRA_FLAGS
+        value: --env EKS_CNI
+      - name: K8S_E2E_FLAGS
+        value: --ginkgo.focus=(\[calico\]|\[Conformance\]|Host-Protection) --ginkgo.skip=(\[Slow\]|\[Disruptive\]|Feature:SCTP|Feature:Maglev|both.pod.and.service.Proxy\b|proxy.through.a.service.and.a.pod|replica.with.a.public.image|DNS.for.ExternalName.services|DNS.for.pods.for.Hostname|DNS.for.pods.for.Subdomain|DNS.for.services|DNS.for.the.cluster|DNS.qualified.names.for.services)
+      - name: PROVISIONER
+        value: aws-eks
+    matrix:
+      - name: ipip
+        env:
+          - name: ENCAPSULATION_TYPE
+            value: IPIP
+      - name: vxlan
+        env:
+          - name: ENCAPSULATION_TYPE
+            value: VXLAN
+    commands: |
+      .argoci/scripts/body_standard.sh
+  - name: bpf-run-matrix-eks-w-aws-cni
+    services:
+      - docker
+    env:
+      - name: AWS_K8S_CNI_VERSION
+        value: NA
+      - name: CLUSTER_NODES
+        value: "3"
+      - name: ENABLE_EXTERNAL_NODE
+        value: "true"
+      - name: INSTALLER
+        value: operator
+      - name: K8S_E2E_DOCKER_EXTRA_FLAGS
+        value: --env EKS_CNI
+      - name: K8S_E2E_FLAGS
+        value: --ginkgo.focus=(\[sig-calico\]|Conformance|Dataplane:BPF|Feature:NetworkPolicy) --ginkgo.skip=(Slow|Disruptive|calient|allow.ingress.access.from.updated.pod|Dataplane:LB|Feature:SCTP|Feature:Maglev)
+      - name: NUM_ADDON_PODS
+        value: "45"
+      - name: PROVISIONER
+        value: aws-eks
+    matrix:
+      - name: aws
+        env:
+          - name: EKS_CNI
+            value: aws
+    commands: |
+      .argoci/scripts/body_standard.sh
+  - name: bpf-run-matrix-eks-w-calico-cni
+    services:
+      - docker
+    env:
+      - name: CLUSTER_NODES
+        value: "3"
+      - name: ENABLE_EXTERNAL_NODE
+        value: "true"
+      - name: ENCAPSULATION_TYPE
+        value: VXLAN
+      - name: INSTALLER
+        value: operator
+      - name: IPAM_TEST_POOL_SUBNET
+        value: 10.0.0.0/29
+      - name: IPV4_POD_CIDR
+        value: 172.16.0.0/16
+      - name: K8S_E2E_DOCKER_EXTRA_FLAGS
+        value: --env EKS_CNI
+      - name: K8S_E2E_FLAGS
+        value: --ginkgo.focus=(\[sig-calico\]|\[Conformance\]|\[Dataplane:BPF\]) --ginkgo.skip=(\[Slow\]|\[Disruptive\]|v1.should.proxy.through.a.service|DNS.should.resolve|DNS.should.provide|IPAM.StrictAffinity|Feature:SCTP|Feature:Maglev|both.pod.and.service.Proxy\b|proxy.through.a.service.and.a.pod|replica.with.a.public.image|DNS.for.ExternalName.services|DNS.for.pods.for.Hostname|DNS.for.pods.for.Subdomain|DNS.for.services|DNS.for.the.cluster|DNS.qualified.names.for.services)
+      - name: PROVISIONER
+        value: aws-eks
+    matrix:
+      - name: calico
+        env:
+          - name: EKS_CNI
+            value: calico
+    commands: |
+      .argoci/scripts/body_standard.sh
+  - name: bpf-run-matrix-bpf-eks-aws-cni-lb
+    services:
+      - docker
+    env:
+      - name: CLUSTER_NODES
+        value: "3"
+      - name: ENABLE_EXTERNAL_NODE
+        value: "true"
+      - name: INSTALLER
+        value: operator
+      - name: K8S_E2E_DOCKER_EXTRA_FLAGS
+        value: --env EKS_CNI
+      - name: K8S_E2E_FLAGS
+        value: --ginkgo.focus=(Dataplane:LB) --ginkgo.skip=(Feature:Maglev)
+      - name: NUM_ADDON_PODS
+        value: "45"
+      - name: PROVISIONER
+        value: aws-eks
+    matrix:
+      - name: aws
+        env:
+          - name: EKS_CNI
+            value: aws
+    commands: |
+      .argoci/scripts/body_standard.sh
+  - name: bpf-run-matrix-aws-kubeadm-dual-stack
+    services:
+      - docker
+    env:
+      - name: CLUSTER_NODES
+        value: "3"
+      - name: ENABLE_EXTERNAL_NODE
+        value: "true"
+      - name: ENCAPSULATION_TYPE
+        value: VXLAN
+      - name: ENCAPSULATION_TYPE_V6
+        value: VXLAN
+      - name: INSTALLER
+        value: operator
+      - name: IPV4_POD_CIDR
+        value: 192.168.0.0/16
+      - name: IPV6_POD_CIDR
+        value: fd00:10:244::/64
+      - name: K8S_E2E_DOCKER_EXTRA_FLAGS
+        value: --env IP_FAMILY
+      - name: K8S_E2E_FLAGS
+        value: --ginkgo.focus=(\[Conformance\]|\[Dataplane:BPF\]) --ginkgo.skip=(\[Slow\]|\[Disruptive\]|v1.should.proxy.through.a.service|DNS.should.resolve|DNS.should.provide|IPAM.StrictAffinity|Feature:SCTP|Feature:Maglev|DataPath|HostPorts|WireGuard|HostPort|EndpointSlices.pointing.to.API.Server|sig-calico-enterprise)
+      - name: NAT_OUTGOING
+        value: Enabled
+      - name: NAT_OUTGOING_V6
+        value: Enabled
+      - name: PROVISIONER
+        value: aws-kubeadm
+    matrix:
+      - name: dual-calicobpf
+        env:
+          - name: IP_FAMILY
+            value: dual
+          - name: DATAPLANE
+            value: CalicoBPF
+      - name: dual-calicoiptables
+        env:
+          - name: IP_FAMILY
+            value: dual
+          - name: DATAPLANE
+            value: CalicoIptables
+    commands: |
+      .argoci/scripts/body_standard.sh
+  - name: bpf-run-matrix-kops-w-calico-cni-ipv6
+    services:
+      - docker
+    env:
+      - name: BGP_STATUS
+        value: Disabled
+      - name: CLUSTER_NODES
+        value: "3"
+      - name: CNI_PLUGIN
+        value: Calico
+      - name: ENABLE_EXTERNAL_NODE
+        value: "true"
+      - name: ENCAPSULATION_TYPE_V6
+        value: VXLAN
+      - name: INSTALLER
+        value: operator
+      - name: IPV4_POD_CIDR
+        value: ""
+      - name: IPV6_POD_CIDR
+        value: fd00:10:244::/64
+      - name: K8S_E2E_DOCKER_EXTRA_FLAGS
+        value: --env EKS_CNI
+      - name: K8S_E2E_FLAGS
+        value: --ginkgo.focus=(\[sig-calico\]|\[Conformance\]|\[Dataplane:BPF\]) --ginkgo.skip=(\[Slow\]|\[Disruptive\]|v1.should.proxy.through.a.service|DNS.should.resolve|DNS.should.provide|IPAM.StrictAffinity|Feature:SCTP|DataPath|HostPorts|WireGuard|HostPort|EndpointSlices.pointing.to.API.Server|Feature:Maglev)
+      - name: K8S_VERSION
+        value: stable-1
+      - name: NAT_OUTGOING_V6
+        value: Enabled
+      - name: PROVISIONER
+        value: aws-kops
+      - name: USE_VENDORED_CNI
+        value: "false"
+    matrix:
+      - name: calicobpf-ipv6
+        env:
+          - name: DATAPLANE
+            value: CalicoBPF
+          - name: IP_FAMILY
+            value: ipv6
+      - name: calicoiptables-ipv6
+        env:
+          - name: DATAPLANE
+            value: CalicoIptables
+          - name: IP_FAMILY
+            value: ipv6
+    commands: |
+      .argoci/scripts/body_standard.sh
+  - name: bpf-run-matrix-kops-w-calico-cni-ipv4
+    services:
+      - docker
+    env:
+      - name: BGP_STATUS
+        value: Disabled
+      - name: CLUSTER_NODES
+        value: "3"
+      - name: CNI_PLUGIN
+        value: Calico
+      - name: ENABLE_EXTERNAL_NODE
+        value: "true"
+      - name: ENCAPSULATION_TYPE
+        value: VXLAN
+      - name: INSTALLER
+        value: operator
+      - name: K8S_E2E_DOCKER_EXTRA_FLAGS
+        value: --env EKS_CNI
+      - name: K8S_E2E_FLAGS
+        value: --ginkgo.focus=(\[sig-calico\]|\[Conformance\]|\[Dataplane:BPF\]) --ginkgo.skip=(\[Slow\]|\[Disruptive\]|v1.should.proxy.through.a.service|DNS.should.resolve|DNS.should.provide|IPAM.StrictAffinity|Feature:SCTP|Feature:Maglev|DataPath|HostPorts|WireGuard|HostPort|EndpointSlices.pointing.to.API.Server)
+      - name: NAT_OUTGOING
+        value: Enabled
+      - name: PROVISIONER
+        value: aws-kops
+      - name: USE_VENDORED_CNI
+        value: "false"
+    matrix:
+      - name: calicobpf-ipv4
+        env:
+          - name: DATAPLANE
+            value: CalicoBPF
+          - name: IP_FAMILY
+            value: ipv4
+      - name: calicoiptables-ipv4
+        env:
+          - name: DATAPLANE
+            value: CalicoIptables
+          - name: IP_FAMILY
+            value: ipv4
+    commands: |
+      .argoci/scripts/body_standard.sh
+  - name: bpf-mini-scale-runs
+    services:
+      - docker
+    env:
+      - name: NUM_INFRA_NODES
+        value: "3"
+      - name: PROVISIONER
+        value: gcp-kubeadm
+      - name: SCALE_TEST_TTFP50_THRESHOLD
+        value: "0.006"
+      - name: SCALE_TEST_TTFP99_THRESHOLD
+        value: "0.6"
+      - name: TEST_TYPE
+        value: scale-test
+    commands: |
+      .argoci/scripts/body_standard.sh
+  - name: 9k-mtu-runs-aws-bpf-9k-mtu
+    services:
+      - docker
+    env:
+      - name: CLUSTER_NODES
+        value: "3"
+      - name: ENABLE_EXTERNAL_NODE
+        value: "true"
+      - name: IPAM_TEST_POOL_SUBNET
+        value: 10.0.0.0/29
+      - name: K8S_E2E_DOCKER_EXTRA_FLAGS
+        value: --env NETWORK_MTU
+      - name: K8S_E2E_FLAGS
+        value: --ginkgo.focus=(\[sig-calico\]|Conformance|Dataplane:BPF|Feature:NetworkPolicy) --ginkgo.skip=(Slow|Disruptive|calient|allow.ingress.access.from.updated.pod|Dataplane:LB|Feature:SCTP|Feature:Maglev)
+      - name: NETWORK_MTU
+        value: "9001"
+      - name: PROVISIONER
+        value: aws-kubeadm
+      - name: VPC_SUBNETS
+        value: '["172.16.101.0/24"]'
+    matrix:
+      - name: none
+        env:
+          - name: ENCAPSULATION_TYPE
+            value: None
+    commands: |
+      .argoci/scripts/body_standard.sh
+  - name: 9k-mtu-runs-aws-iptables-9k-mtu
+    services:
+      - docker
+    env:
+      - name: CLUSTER_NODES
+        value: "3"
+      - name: DATAPLANE
+        value: CalicoIptables
+      - name: ENABLE_EXTERNAL_NODE
+        value: "true"
+      - name: IPAM_TEST_POOL_SUBNET
+        value: 10.0.0.0/29
+      - name: K8S_E2E_DOCKER_EXTRA_FLAGS
+        value: --env NETWORK_MTU
+      - name: K8S_E2E_FLAGS
+        value: --ginkgo.focus=(\[sig-calico\]|\[Conformance\]) --ginkgo.skip=(\[Slow\]|\[Disruptive\]|\[DataPath\]|WireGuard|Feature:SCTP|Feature:Maglev)
+      - name: NETWORK_MTU
+        value: "9001"
+      - name: PROVISIONER
+        value: aws-kubeadm
+      - name: VPC_SUBNETS
+        value: '["172.16.101.0/24"]'
+    matrix:
+      - name: none
+        env:
+          - name: ENCAPSULATION_TYPE
+            value: None
+    commands: |
+      .argoci/scripts/body_standard.sh
+  - name: bpf-mode-switch
+    services:
+      - docker
+    env:
+      - name: DATAPLANE
+        value: CalicoIptables
+      - name: ENABLE_EXTERNAL_NODE
+        value: "true"
+      - name: INSTALLER
+        value: operator
+      - name: K8S_E2E_FLAGS
+        value: --ginkgo.focus=(Dataplane:BPF.*ModeSwitch.*external-node-to-nodePort) --ginkgo.skip=(Feature:Maglev)
+      - name: PROVISIONER
+        value: gcp-kubeadm
+    commands: |
+      .argoci/scripts/body_standard.sh
+  - name: wireguard
+    services:
+      - docker
+    env:
+      - name: AZ_CREATE_MODE
+        value: AKS
+      - name: AZ_NETWORK_PLUGIN
+        value: azure
+      - name: ENABLE_EXTERNAL_NODE
+        value: "false"
+      - name: INSTALLER
+        value: operator
+      - name: IPV4_POD_CIDR
+        value: 10.244.0.0/16
+      - name: K8S_E2E_FLAGS
+        value: --ginkgo.focus=(\[sig-calico\]|\[Conformance\]|Feature:NetworkPolicy) --ginkgo.skip=(Slow|Disruptive|calient|allow.ingress.access.from.updated.pod|Dataplane:LB|outside.the.cluster|MTU|ExternalNode|external.to.nodeport|StrictAffinity|Feature:SCTP|Feature:Maglev)
+      - name: NETWORK_PLUGIN_MODE
+        value: overlay
+      - name: PROVISIONER
+        value: azr-aks
+    commands: |
+      .argoci/scripts/body_standard.sh
+  - name: usage-reporting-with-bpf
+    services:
+      - docker
+    env:
+      - name: CLUSTER_NODES
+        value: "1"
+      - name: ENABLE_EXTERNAL_NODE
+        value: "true"
+      - name: ENABLE_USAGE
+        value: "true"
+      - name: PROVISIONER
+        value: aws-kubeadm
+      - name: TEST_TYPE
+        value: usage-reporting
+      - name: USAGE_REPORTING_COUNTRY
+        value: US
+      - name: USE_HASH_RELEASE
+        value: "false"
+    matrix:
+      - name: stable
+        env:
+          - name: K8S_VERSION
+            value: stable
+    commands: |
+      .argoci/scripts/body_standard.sh
+  - name: kubevirt-e2e-tests
+    services:
+      - docker
+    env:
+      - name: E2E_TEST_CONFIG
+        value: e2e/config/gcp-kubevirt.yaml
+      - name: K8S_VERSION
+        value: stable-1.35
+      - name: NUM_KUBEVIRT_VMS
+        value: "2"
+      - name: PROVISIONER
+        value: gcp-kubeadm
+    commands: |
+      .argoci/scripts/body_standard.sh

--- a/.argoci/cron/e2e-certification.yaml
+++ b/.argoci/cron/e2e-certification.yaml
@@ -1,0 +1,106 @@
+# Condensed ArgoCI e2e workflow; cc-argoci-handler expands it into a CronWorkflow at runtime.
+# Migrated from the Semaphore e2e pipeline of the same name — maintained here by hand.
+version: condensed
+generateName: e2e-certification-
+schedule: 10 21 * * 1
+globalPrologue: |
+  cd "${CI_HOME}/${CI_GIT_DIR}"
+  export ARGO_WORKFLOW_NAME="{{workflow.name}}"
+  export ARGO_WORKFLOW_UID="{{workflow.uid}}"
+  export DATAPLANE="${DATAPLANE:-CalicoIptables}"
+  export FUNCTIONAL_AREA="${FUNCTIONAL_AREA:-certification.yml}"
+  export INSTALLER="${INSTALLER:-operator}"
+  export PROVISIONER="${PROVISIONER:-aws-openshift}"
+  export STERN_CHECK="${STERN_CHECK:-DISABLED}"
+  export TEST_TYPE="${TEST_TYPE:-ocp-cert}"
+  source .argoci/scripts/global_prologue.sh
+globalEpilogue: |
+  source "${CI_HOME}/${CI_GIT_DIR}/.argoci/scripts/global_epilogue.sh"
+defaults:
+  secretBundles:
+    - banzai-secrets
+steps:
+  - name: standalone-cluster-tests
+    services:
+      - docker
+    env:
+      - name: ENABLE_OCP_VIRT
+        value: "true"
+      - name: OPENSHIFT_CLUSTER_TYPE
+        value: Standalone
+      - name: TEST_TYPE
+        value: ocp-cert
+    matrix:
+      - name: 4-20-1
+        env:
+          - name: OPENSHIFT_VERSION
+            value: 4.20.1
+      - name: 4-19-17
+        env:
+          - name: OPENSHIFT_VERSION
+            value: 4.19.17
+      - name: 4-18-27
+        env:
+          - name: OPENSHIFT_VERSION
+            value: 4.18.27
+    commands: |
+      .argoci/scripts/body_standard.sh
+  - name: hcp-setup-hosting
+    services:
+      - docker
+    env:
+      - name: HCP_STAGE
+        value: setup-hosting
+      - name: HOSTING_CLUSTER
+        value: hcp-shared-hosting
+      - name: OPENSHIFT_CLUSTER_TYPE
+        value: HCP-hosting
+      - name: OPENSHIFT_VERSION
+        value: 4.20.1
+    commands: |
+      .argoci/scripts/body_standard.sh
+  - name: hcp-hosted-setup-and-tests
+    services:
+      - docker
+    depends:
+      - hcp-setup-hosting
+    env:
+      - name: HCP_STAGE
+        value: hosted
+      - name: HOSTING_CLUSTER
+        value: hcp-shared-hosting
+      - name: OPENSHIFT_CLUSTER_TYPE
+        value: HCP-hosted
+      - name: TEST_TYPE
+        value: ocp-cert
+    matrix:
+      - name: 4-20-1
+        env:
+          - name: OPENSHIFT_VERSION
+            value: 4.20.1
+      - name: 4-19-17
+        env:
+          - name: OPENSHIFT_VERSION
+            value: 4.19.17
+      - name: 4-18-27
+        env:
+          - name: OPENSHIFT_VERSION
+            value: 4.18.27
+    commands: |
+      .argoci/scripts/body_standard.sh
+onExit:
+  # Tear down the shared hosting cluster after the whole workflow, regardless of
+  # how the hosted matrix cells finished (onExit always runs). It gets the full
+  # globalPrologue/globalEpilogue: the prologue restores the hosting BZ_HOME and
+  # the epilogue runs bz destroy + removes the GCS handoff blob. See
+  # .argoci/design/hcp.md.
+  - name: hcp-destroy-hosting
+    services:
+      - docker
+    env:
+      - name: HCP_STAGE
+        value: destroy-hosting
+      - name: HOSTING_CLUSTER
+        value: hcp-shared-hosting
+    commands: |
+      .argoci/scripts/body_standard.sh

--- a/.argoci/cron/e2e-iptables.yaml
+++ b/.argoci/cron/e2e-iptables.yaml
@@ -620,7 +620,7 @@ steps:
       - name: AWS_K8S_CNI_VERSION
         value: NA
       - name: CNI_PLUGIN
-        value: aws
+        value: AmazonVPC
       - name: ENABLE_WIREGUARD
         value: "true"
       - name: INSTALLER
@@ -642,7 +642,7 @@ steps:
       - name: AWS_K8S_CNI_VERSION
         value: NA
       - name: CNI_PLUGIN
-        value: calico
+        value: Calico
       - name: ENABLE_WIREGUARD
         value: "true"
       - name: INSTALLER

--- a/.argoci/cron/e2e-iptables.yaml
+++ b/.argoci/cron/e2e-iptables.yaml
@@ -1,0 +1,829 @@
+# Condensed ArgoCI e2e workflow; cc-argoci-handler expands it into a CronWorkflow at runtime.
+# Migrated from the Semaphore e2e pipeline of the same name — maintained here by hand.
+version: condensed
+generateName: e2e-iptables-
+schedule: 10 21 * * 4
+globalPrologue: |
+  cd "${CI_HOME}/${CI_GIT_DIR}"
+  export ARGO_WORKFLOW_NAME="{{workflow.name}}"
+  export ARGO_WORKFLOW_UID="{{workflow.uid}}"
+  export DATAPLANE="${DATAPLANE:-CalicoIptables}"
+  export FUNCTIONAL_AREA="${FUNCTIONAL_AREA:-iptables.yml}"
+  export IPV4_POD_CIDR="${IPV4_POD_CIDR:-192.168.0.0/16}"
+  export K8S_E2E_FLAGS="${K8S_E2E_FLAGS:---ginkgo.focus=(\[sig-calico\]|\[Conformance\]) --ginkgo.skip=(\[Slow\]|\[Disruptive\]|\[DataPath\]|Proxy.version.v1.should.proxy.through.a.service.and.a.pod|WireGuard)}"
+  export PRIVATE_REGISTRY="${PRIVATE_REGISTRY:-quay.io/}"
+  export USE_PRIVATE_REGISTRY="${USE_PRIVATE_REGISTRY:-true}"
+  source .argoci/scripts/global_prologue.sh
+globalEpilogue: |
+  source "${CI_HOME}/${CI_GIT_DIR}/.argoci/scripts/global_epilogue.sh"
+defaults:
+  secretBundles:
+    - banzai-secrets
+steps:
+  - name: openshift-ocp
+    services:
+      - docker
+    env:
+      - name: INSTALLER
+        value: operator
+      - name: PROVISIONER
+        value: aws-openshift
+    matrix:
+      - name: 4-18-29
+        env:
+          - name: OPENSHIFT_VERSION
+            value: 4.18.29
+      - name: 4-19-20
+        env:
+          - name: OPENSHIFT_VERSION
+            value: 4.19.20
+      - name: 4-20-6
+        env:
+          - name: OPENSHIFT_VERSION
+            value: 4.20.6
+    commands: |
+      .argoci/scripts/body_standard.sh
+  - name: arm64-smoke-tests-aks-arm64
+    services:
+      - docker
+    env:
+      - name: AZ_VM_SIZE
+        value: Standard_D4plds_v5
+      - name: INSTALLER
+        value: operator
+      - name: PROVISIONER
+        value: azr-aks
+      - name: STERN_CHECK
+        value: DISABLED
+    matrix:
+      - name: stable-1-azure-
+        env:
+          - name: K8S_VERSION
+            value: stable-1
+          - name: AZ_NETWORK_PLUGIN
+            value: azure
+          - name: CLUSTER_MODE
+            value: ""
+      - name: stable-1-none-
+        env:
+          - name: K8S_VERSION
+            value: stable-1
+          - name: AZ_NETWORK_PLUGIN
+            value: none
+          - name: CLUSTER_MODE
+            value: ""
+    commands: |
+      .argoci/scripts/body_standard.sh
+  - name: arm64-smoke-tests-eks-arm64-calico-cni
+    services:
+      - docker
+    env:
+      - name: AWS_NODE_INSTANCE_TYPE
+        value: t4g.large
+      - name: EKS_CNI
+        value: calico
+      - name: INSTALLER
+        value: operator
+      - name: IPV4_POD_CIDR
+        value: 172.16.0.0/16
+      - name: K8S_E2E_FLAGS
+        value: --ginkgo.focus=(\[calico\]|\[Conformance\]) --ginkgo.skip=(\[Slow\]|\[Disruptive\]|\[DataPath\]|both.pod.and.service.Proxy\b|proxy.through.a.service.and.a.pod|replica.with.a.public.image|DNS.for.ExternalName.services|DNS.for.pods.for.Hostname|DNS.for.pods.for.Subdomain|DNS.for.services|DNS.for.the.cluster|DNS.qualified.names.for.services)
+      - name: PROVISIONER
+        value: aws-eks
+      - name: STERN_CHECK
+        value: DISABLED
+    matrix:
+      - name: stable-1
+        env:
+          - name: K8S_VERSION
+            value: stable-1
+    commands: |
+      .argoci/scripts/body_standard.sh
+  - name: aks-aks-w-calico-cni
+    services:
+      - docker
+    env:
+      - name: AZ_CREATE_MODE
+        value: AKS
+      - name: CNI_POD_SETUP_TIMEOUT_SECONDS
+        value: "15"
+      - name: ENCAPSULATION_TYPE
+        value: VXLAN
+      - name: INSTALLER
+        value: helmerator
+      - name: K8S_E2E_FLAGS
+        value: --ginkgo.focus=(\[sig-calico\]|\[Conformance\]) --ginkgo.skip=(\[Slow\]|\[Disruptive\])
+      - name: K8S_VERSION
+        value: stable-1
+      - name: PROVISIONER
+        value: azr-aks
+    matrix:
+      - name: calico
+        env:
+          - name: CNI_PLUGIN
+            value: Calico
+    commands: |
+      .argoci/scripts/body_standard.sh
+  - name: aks-aks-w-aks-cni
+    services:
+      - docker
+    env:
+      - name: AZ_CREATE_MODE
+        value: AKS
+      - name: AZ_NETWORK_PLUGIN
+        value: azure
+      - name: ENCAPSULATION_TYPE
+        value: None
+      - name: INSTALLER
+        value: operator
+      - name: IPV4_POD_CIDR
+        value: 10.244.0.0/16
+      - name: K8S_E2E_FLAGS
+        value: --ginkgo.focus=(\[sig-calico\]|\[Conformance\]) --ginkgo.skip=(\[Slow\]|\[Disruptive\]|IPAM.StrictAffinity)
+      - name: K8S_VERSION
+        value: stable-1
+      - name: PROVISIONER
+        value: azr-aks
+    commands: |
+      .argoci/scripts/body_standard.sh
+  - name: aks-aks-private-w-aks-cni-overlay
+    services:
+      - docker
+    env:
+      - name: AZ_CREATE_MODE
+        value: AKS
+      - name: AZ_NETWORK_PLUGIN
+        value: azure
+      - name: CLUSTER_MODE
+        value: private
+      - name: INSTALLER
+        value: operator
+      - name: IPV4_POD_CIDR
+        value: 10.244.0.0/16
+      - name: K8S_E2E_FLAGS
+        value: --ginkgo.focus=(\[sig-calico\]|\[Conformance\]|Feature:NetworkPolicy) --ginkgo.skip=(Slow|Disruptive|calient|allow.ingress.access.from.updated.pod|Dataplane:LB|outside.the.cluster|MTU|ExternalNode|external.to.nodeport|StrictAffinity|Feature:SCTP)
+      - name: K8S_VERSION
+        value: stable-1
+      - name: NETWORK_PLUGIN_MODE
+        value: overlay
+      - name: PROVISIONER
+        value: azr-aks
+    commands: |
+      .argoci/scripts/body_standard.sh
+  - name: aks-aks-migrate-from-vendored-calico-cni-to-calico-cni
+    services:
+      - docker
+    env:
+      - name: AZ_CREATE_MODE
+        value: AKS
+      - name: CNI_PLUGIN
+        value: Calico
+      - name: DESIRED_POLICY
+        value: Calico
+      - name: INSTALLER
+        value: operator
+      - name: K8S_E2E_FLAGS
+        value: --ginkgo.focus=(\[sig-calico\]|\[Conformance\]) --ginkgo.skip=(\[Slow\]|\[Disruptive\])
+      - name: K8S_VERSION
+        value: stable-1
+      - name: PROVISIONER
+        value: azr-aks
+      - name: USE_VENDORED_CNI
+        value: "true"
+    commands: |
+      .argoci/scripts/body_standard.sh
+  - name: dual-stack-k8s-e2e-kdd
+    jobSize: large
+    services:
+      - docker
+    env:
+      - name: ENABLE_CALICOCTL_APISERVER
+        value: "true"
+      - name: ENABLE_DUAL_STACK
+        value: "true"
+      - name: K8S_E2E_EXTRA_FLAGS
+        value: --feature-gates=dualstack=true
+      - name: K8S_E2E_FLAGS
+        value: --ginkgo.focus=(\[sig-calico\]|\[Conformance\]) --ginkgo.skip=(\[Slow\]|\[Disruptive\]|\[DataPath\]|WireGuard)
+      - name: K8S_VERSION
+        value: stable-1
+      - name: KIND_CONFIG
+        value: |
+          kind: Cluster
+          apiVersion: kind.x-k8s.io/v1alpha4
+          networking:
+            disableDefaultCNI: true
+            ipFamily: dual
+            podSubnet: "192.168.0.0/16,fd00:10:244::/64"
+          nodes:
+          # the control plane node
+          - role: control-plane
+          - role: worker
+          - role: worker
+          - role: worker
+      - name: PROVISIONER
+        value: local-kind
+    matrix:
+      - name: calico-yaml
+        env:
+          - name: MANIFEST_FILE
+            value: calico.yaml
+      - name: calico-typha-yaml
+        env:
+          - name: MANIFEST_FILE
+            value: calico-typha.yaml
+    commands: |
+      .argoci/scripts/body_standard.sh
+  - name: dual-stack-k8s-e2e-etcd
+    jobSize: large
+    services:
+      - docker
+    env:
+      - name: ENABLE_DUAL_STACK
+        value: "true"
+      - name: INSTALL_ETCD_POD
+        value: "true"
+      - name: K8S_E2E_EXTRA_FLAGS
+        value: --feature-gates=dualstack=true
+      - name: K8S_E2E_FLAGS
+        value: --ginkgo.focus=(\[sig-calico\]|\[Conformance\]) --ginkgo.skip=(\[Slow\]|\[Disruptive\]|\[DataPath\]|WireGuard|EndpointSlice|Tiered RBAC)
+      - name: K8S_VERSION
+        value: stable-1
+      - name: KIND_CONFIG
+        value: |
+          kind: Cluster
+          apiVersion: kind.x-k8s.io/v1alpha4
+          networking:
+            disableDefaultCNI: true
+            ipFamily: dual
+            podSubnet: "192.168.0.0/16,fd00:10:244::/64"
+          nodes:
+          # the control plane node
+          - role: control-plane
+          - role: worker
+          - role: worker
+          - role: worker
+      - name: MANIFEST_FILE
+        value: calico-etcd.yaml
+      - name: PROVISIONER
+        value: local-kind
+    commands: |
+      .argoci/scripts/body_standard.sh
+  - name: autohep-test
+    jobSize: large
+    services:
+      - docker
+    env:
+      - name: ENABLE_AUTOHEP
+        value: "true"
+      - name: PROVISIONER
+        value: local-kind
+    commands: |
+      .argoci/scripts/body_standard.sh
+  - name: ipvs
+    services:
+      - docker
+    env:
+      - name: KUBE_PROXY_MODE
+        value: ipvs
+      - name: PROVISIONER
+        value: gcp-kubeadm
+      - name: USE_API_SERVER
+        value: "false"
+    matrix:
+      - name: stable
+        env:
+          - name: K8S_VERSION
+            value: stable
+    commands: |
+      .argoci/scripts/body_standard.sh
+  - name: usage-reporting
+    jobSize: large
+    services:
+      - docker
+    env:
+      - name: ENABLE_USAGE
+        value: "true"
+      - name: MANIFEST_FILE
+        value: calico.yaml
+      - name: PROVISIONER
+        value: local-kind
+      - name: TEST_TYPE
+        value: usage-reporting
+    matrix:
+      - name: stable
+        env:
+          - name: K8S_VERSION
+            value: stable
+    commands: |
+      .argoci/scripts/body_standard.sh
+  - name: k8s-beta-runs
+    services:
+      - docker
+    env:
+      - name: ENABLE_CALICOCTL_APISERVER
+        value: "true"
+      - name: PROVISIONER
+        value: gcp-kubeadm
+      - name: USE_HASH_RELEASE
+        value: "true"
+    matrix:
+      - name: beta-calico-yaml-iptables
+        env:
+          - name: K8S_VERSION
+            value: beta
+          - name: MANIFEST_FILE
+            value: calico.yaml
+          - name: KUBE_PROXY_MODE
+            value: iptables
+    commands: |
+      .argoci/scripts/body_standard.sh
+  - name: k8s-distros
+    services:
+      - docker
+    env:
+      - name: K8S_VERSION
+        value: v1.31.3
+      - name: RKE_VERSION
+        value: v1.7.1
+    matrix:
+      - name: gcp-rancher
+        env:
+          - name: PROVISIONER
+            value: gcp-rancher
+    commands: |
+      .argoci/scripts/body_standard.sh
+  - name: wireguard-vxlan-k8s-e2e
+    services:
+      - docker
+    env:
+      - name: ENABLE_EXTERNAL_NODE
+        value: "true"
+      - name: ENABLE_WIREGUARD
+        value: "true"
+      - name: IPAM_TEST_POOL_SUBNET
+        value: 10.0.0.0/29
+      - name: K8S_E2E_FLAGS
+        value: --ginkgo.focus=(WireGuard)
+      - name: PROVISIONER
+        value: aws-kubeadm
+      - name: USE_HASH_RELEASE
+        value: "true"
+      - name: USE_VXLAN
+        value: "true"
+      - name: VPC_SUBNETS
+        value: '["172.16.101.0/24"]'
+    matrix:
+      - name: stable
+        env:
+          - name: K8S_VERSION
+            value: stable
+    commands: |
+      .argoci/scripts/body_standard.sh
+  - name: wireguard-k8s-e2e
+    services:
+      - docker
+    env:
+      - name: ENABLE_EXTERNAL_NODE
+        value: "true"
+      - name: ENABLE_WIREGUARD
+        value: "true"
+      - name: IPAM_TEST_POOL_SUBNET
+        value: 10.0.0.0/29
+      - name: K8S_E2E_FLAGS
+        value: --ginkgo.focus=(WireGuard)
+      - name: PROVISIONER
+        value: aws-kubeadm
+      - name: USE_HASH_RELEASE
+        value: "true"
+      - name: VPC_SUBNETS
+        value: '["172.16.101.0/24"]'
+    matrix:
+      - name: stable-true
+        env:
+          - name: K8S_VERSION
+            value: stable
+          - name: DISABLE_IPIP
+            value: "true"
+      - name: stable-false
+        env:
+          - name: K8S_VERSION
+            value: stable
+          - name: DISABLE_IPIP
+            value: "false"
+    commands: |
+      .argoci/scripts/body_standard.sh
+  - name: operator-migration-kind-dual-stack
+    jobSize: large
+    services:
+      - docker
+    env:
+      - name: INSTALLER
+        value: manual
+      - name: IPV6_POD_CIDR
+        value: fd00:10:244::/64
+      - name: IP_FAMILY
+        value: dual
+      - name: OPERATOR_MIGRATE
+        value: "true"
+      - name: PRODUCT
+        value: calico
+      - name: PROVISIONER
+        value: local-kind
+      - name: USE_HASH_RELEASE
+        value: "true"
+    matrix:
+      - name: stable-1
+        env:
+          - name: K8S_VERSION
+            value: stable-1
+    commands: |
+      .argoci/scripts/body_standard.sh
+  - name: operator-migration-kind-ipv6
+    jobSize: large
+    services:
+      - docker
+    env:
+      - name: INSTALLER
+        value: manual
+      - name: IPV4_POD_CIDR
+        value: ""
+      - name: IPV6_POD_CIDR
+        value: fd00:10:244::/64
+      - name: IP_FAMILY
+        value: ipv6
+      - name: OPERATOR_MIGRATE
+        value: "true"
+      - name: PRODUCT
+        value: calico
+      - name: PROVISIONER
+        value: local-kind
+      - name: USE_HASH_RELEASE
+        value: "true"
+    matrix:
+      - name: stable-1
+        env:
+          - name: K8S_VERSION
+            value: stable-1
+    commands: |
+      .argoci/scripts/body_standard.sh
+  - name: wireguard-regression-k8s-e2e-kdd-new
+    services:
+      - docker
+    env:
+      - name: DISABLE_IPIP
+        value: "true"
+      - name: ENABLE_WIREGUARD
+        value: "true"
+      - name: IPAM_TEST_POOL_SUBNET
+        value: 10.0.0.0/29
+      - name: K8S_E2E_FLAGS
+        value: --ginkgo.focus=(\[sig-calico\]|\[Conformance\]) --ginkgo.skip=(\[Slow\]|\[Disruptive\]|\[DataPath\])
+      - name: PROVISIONER
+        value: aws-kubeadm
+      - name: USE_HASH_RELEASE
+        value: "true"
+      - name: VPC_SUBNETS
+        value: '["172.16.101.0/24"]'
+    matrix:
+      - name: stable
+        env:
+          - name: K8S_VERSION
+            value: stable
+    commands: |
+      .argoci/scripts/body_standard.sh
+  - name: wireguard-regression-k8s-e2e-kdd-old
+    services:
+      - docker
+    env:
+      - name: DISABLE_IPIP
+        value: "true"
+      - name: ENABLE_WIREGUARD
+        value: "true"
+      - name: IPAM_TEST_POOL_SUBNET
+        value: 10.0.0.0/29
+      - name: K8S_E2E_FLAGS
+        value: --ginkgo.focus=(\[sig-calico\]|\[Conformance\]) --ginkgo.skip=(\[Slow\]|\[Disruptive\]|\[DataPath\]|EndpointSlice|Services\sshould|Ingress.API|IngressClass.API|Proxy.version.v1.*pod.and.service.Proxy.\[)
+      - name: PROVISIONER
+        value: aws-kubeadm
+      - name: USE_API_SERVER
+        value: "false"
+      - name: USE_HASH_RELEASE
+        value: "true"
+      - name: VPC_SUBNETS
+        value: '["172.16.101.0/24"]'
+    matrix:
+      - name: stable-3
+        env:
+          - name: K8S_VERSION
+            value: stable-3
+    commands: |
+      .argoci/scripts/body_standard.sh
+  - name: wireguard-regression-k8s-e2e-aks-w-aks-cni-overlay
+    services:
+      - docker
+    env:
+      - name: AZ_CREATE_MODE
+        value: AKS
+      - name: AZ_NETWORK_PLUGIN
+        value: azure
+      - name: ENABLE_EXTERNAL_NODE
+        value: "false"
+      - name: ENABLE_WIREGUARD
+        value: "true"
+      - name: INSTALLER
+        value: operator
+      - name: IPV4_POD_CIDR
+        value: 10.244.0.0/16
+      - name: K8S_E2E_FLAGS
+        value: --ginkgo.focus=(\[sig-calico\]|\[Conformance\]|Feature:NetworkPolicy) --ginkgo.skip=(Slow|Disruptive|calient|allow.ingress.access.from.updated.pod|Dataplane:LB|outside.the.cluster|MTU|ExternalNode|external.to.nodeport|StrictAffinity|Feature:SCTP)
+      - name: NETWORK_PLUGIN_MODE
+        value: overlay
+      - name: PROVISIONER
+        value: azr-aks
+      - name: USE_HASH_RELEASE
+        value: "true"
+    commands: |
+      .argoci/scripts/body_standard.sh
+  - name: focused-wireguard-e2e-aks-w-azure-cni
+    services:
+      - docker
+    env:
+      - name: ENABLE_WIREGUARD
+        value: "true"
+      - name: ENCAPSULATION_TYPE
+        value: None
+      - name: INSTALLER
+        value: helmerator
+      - name: K8S_E2E_FLAGS
+        value: --ginkgo.focus=WireGuard --ginkgo.skip=(\[Slow\]|\[Disruptive\]|\[DataPath\])
+      - name: USE_HASH_RELEASE
+        value: "true"
+    matrix:
+      - name: azr-aks-stable-3-azurevnet
+        env:
+          - name: PROVISIONER
+            value: azr-aks
+          - name: K8S_VERSION
+            value: stable-3
+          - name: CNI_PLUGIN
+            value: AzureVNET
+      - name: azr-aks-stable-azurevnet
+        env:
+          - name: PROVISIONER
+            value: azr-aks
+          - name: K8S_VERSION
+            value: stable
+          - name: CNI_PLUGIN
+            value: AzureVNET
+    commands: |
+      .argoci/scripts/body_standard.sh
+  - name: focused-wireguard-e2e-aks-with-calico-cni
+    services:
+      - docker
+    env:
+      - name: AKS_CNI
+        value: calico
+      - name: ENABLE_WIREGUARD
+        value: "true"
+      - name: ENCAPSULATION_TYPE
+        value: VXLAN
+      - name: INSTALLER
+        value: helmerator
+      - name: K8S_E2E_FLAGS
+        value: --ginkgo.focus=WireGuard --ginkgo.skip=(\[Slow\]|\[Disruptive\]|\[DataPath\])
+      - name: USE_HASH_RELEASE
+        value: "true"
+    matrix:
+      - name: azr-aks-stable-3-calico
+        env:
+          - name: PROVISIONER
+            value: azr-aks
+          - name: K8S_VERSION
+            value: stable-3
+          - name: CNI_PLUGIN
+            value: Calico
+      - name: azr-aks-stable-calico
+        env:
+          - name: PROVISIONER
+            value: azr-aks
+          - name: K8S_VERSION
+            value: stable
+          - name: CNI_PLUGIN
+            value: Calico
+    commands: |
+      .argoci/scripts/body_standard.sh
+  - name: focused-wireguard-e2e-eks-kdd-aws-cni
+    services:
+      - docker
+    env:
+      - name: AWS_K8S_CNI_VERSION
+        value: NA
+      - name: CNI_PLUGIN
+        value: aws
+      - name: ENABLE_WIREGUARD
+        value: "true"
+      - name: INSTALLER
+        value: helmerator
+      - name: K8S_E2E_FLAGS
+        value: --ginkgo.focus=WireGuard --ginkgo.skip=(\[Slow\]|\[Disruptive\]|\[DataPath\])
+      - name: K8S_VERSION
+        value: stable-1
+      - name: PROVISIONER
+        value: aws-eks
+      - name: USE_HASH_RELEASE
+        value: "true"
+    commands: |
+      .argoci/scripts/body_standard.sh
+  - name: focused-wireguard-e2e-eks-kdd-calico-cni
+    services:
+      - docker
+    env:
+      - name: AWS_K8S_CNI_VERSION
+        value: NA
+      - name: CNI_PLUGIN
+        value: calico
+      - name: ENABLE_WIREGUARD
+        value: "true"
+      - name: INSTALLER
+        value: helmerator
+      - name: K8S_E2E_FLAGS
+        value: --ginkgo.focus=WireGuard --ginkgo.skip=(\[Slow\]|\[Disruptive\]|\[DataPath\]|both.pod.and.service.Proxy\b|proxy.through.a.service.and.a.pod|replica.with.a.public.image|DNS.for.ExternalName.services|DNS.for.pods.for.Hostname|DNS.for.pods.for.Subdomain|DNS.for.services|DNS.for.the.cluster|DNS.qualified.names.for.services)
+      - name: K8S_VERSION
+        value: stable-1
+      - name: PROVISIONER
+        value: aws-eks
+      - name: USE_HASH_RELEASE
+        value: "true"
+    commands: |
+      .argoci/scripts/body_standard.sh
+  - name: distro-support
+    services:
+      - docker
+    env:
+      - name: CLUSTER_ROUTING_MODE
+        value: Felix
+    matrix:
+      - name: ubuntu-2404-lts-gcp-kubeadm
+        env:
+          - name: CLUSTER_IMAGE
+            value: ubuntu-2404-lts
+          - name: PROVISIONER
+            value: gcp-kubeadm
+      - name: ubuntu-2204-lts-gcp-kubeadm
+        env:
+          - name: CLUSTER_IMAGE
+            value: ubuntu-2204-lts
+          - name: PROVISIONER
+            value: gcp-kubeadm
+      - name: rhel-10-gcp-kubeadm
+        env:
+          - name: CLUSTER_IMAGE
+            value: rhel-10
+          - name: PROVISIONER
+            value: gcp-kubeadm
+      - name: centos-stream-8-gcp-kubeadm
+        env:
+          - name: CLUSTER_IMAGE
+            value: centos-stream-8
+          - name: PROVISIONER
+            value: gcp-kubeadm
+      - name: rhel-9-gcp-kubeadm
+        env:
+          - name: CLUSTER_IMAGE
+            value: rhel-9
+          - name: PROVISIONER
+            value: gcp-kubeadm
+      - name: rocky-linux-8-gcp-kubeadm
+        env:
+          - name: CLUSTER_IMAGE
+            value: rocky-linux-8
+          - name: PROVISIONER
+            value: gcp-kubeadm
+    commands: |
+      .argoci/scripts/body_standard.sh
+  - name: datastore-k8s-e2e-kdd-old
+    services:
+      - docker
+    env:
+      - name: ENABLE_CALICOCTL_APISERVER
+        value: "true"
+      - name: PROVISIONER
+        value: gcp-kubeadm
+    matrix:
+      - name: stable-3-calico-yaml
+        env:
+          - name: K8S_VERSION
+            value: stable-3
+          - name: MANIFEST_FILE
+            value: calico.yaml
+      - name: stable-3-calico-typha-yaml
+        env:
+          - name: K8S_VERSION
+            value: stable-3
+          - name: MANIFEST_FILE
+            value: calico-typha.yaml
+      - name: stable-3-canal-yaml
+        env:
+          - name: K8S_VERSION
+            value: stable-3
+          - name: MANIFEST_FILE
+            value: canal.yaml
+    commands: |
+      .argoci/scripts/body_standard.sh
+  - name: datastore-k8s-e2e-kdd-new
+    services:
+      - docker
+    env:
+      - name: ENABLE_CALICOCTL_APISERVER
+        value: "true"
+      - name: K8S_E2E_FLAGS
+        value: --ginkgo.focus=(\[sig-calico\]|\[Conformance\]) --ginkgo.skip=(\[Slow\]|\[Disruptive\]|\[DataPath\]|WireGuard)
+      - name: PROVISIONER
+        value: gcp-kubeadm
+    matrix:
+      - name: stable-calico-yaml
+        env:
+          - name: K8S_VERSION
+            value: stable
+          - name: MANIFEST_FILE
+            value: calico.yaml
+      - name: stable-calico-typha-yaml
+        env:
+          - name: K8S_VERSION
+            value: stable
+          - name: MANIFEST_FILE
+            value: calico-typha.yaml
+      - name: stable-canal-yaml
+        env:
+          - name: K8S_VERSION
+            value: stable
+          - name: MANIFEST_FILE
+            value: canal.yaml
+    commands: |
+      .argoci/scripts/body_standard.sh
+  - name: datastore-k8s-e2e-etcd
+    services:
+      - docker
+    env:
+      - name: INSTALL_ETCD_POD
+        value: "true"
+      - name: K8S_E2E_FLAGS
+        value: --ginkgo.skip=(Tiered RBAC)
+      - name: MANIFEST_FILE
+        value: calico-etcd.yaml
+      - name: PROVISIONER
+        value: gcp-kubeadm
+    matrix:
+      - name: stable-3
+        env:
+          - name: K8S_VERSION
+            value: stable-3
+    commands: |
+      .argoci/scripts/body_standard.sh
+  - name: migration
+    jobSize: large
+    services:
+      - docker
+    env:
+      - name: CALICO_MANIFEST
+        value: manifests/flannel-migration/calico.yaml
+      - name: INSTALLER
+        value: manual
+      - name: K8S_E2E_FLAGS
+        value: --ginkgo.focus=(\[sig-calico\]|\[Conformance\]) --ginkgo.skip=(\[Slow\]|\[Disruptive\]|\[DataPath\]|WireGuard)
+      - name: K8S_VERSION
+        value: stable-1
+      - name: MIGRATION_MANIFEST
+        value: manifests/flannel-migration/migration-job.yaml
+      - name: PROVISIONER
+        value: local-kind
+      - name: USE_HASH_RELEASE
+        value: "true"
+    matrix:
+      - name: https-raw-githubusercontent-com-projectcalico-calico-v3-28-2-manifests-canal-yaml
+        env:
+          - name: DOWNLEVEL_MANIFEST
+            value: https://raw.githubusercontent.com/projectcalico/calico/v3.28.2/manifests/canal.yaml
+      - name: https-raw-githubusercontent-com-coreos-flannel-master-documentation-kube-flannel-yml
+        env:
+          - name: DOWNLEVEL_MANIFEST
+            value: https://raw.githubusercontent.com/coreos/flannel/master/Documentation/kube-flannel.yml
+    commands: |
+      .argoci/scripts/body_flannel-migration.sh
+  - name: kubevirt-e2e-tests
+    services:
+      - docker
+    env:
+      - name: E2E_TEST_CONFIG
+        value: e2e/config/gcp-kubevirt.yaml
+      - name: INSTALLER
+        value: operator
+      - name: K8S_VERSION
+        value: stable-1.35
+      - name: NUM_KUBEVIRT_VMS
+        value: "2"
+      - name: PROVISIONER
+        value: gcp-kubeadm
+    commands: |
+      .argoci/scripts/body_standard.sh

--- a/.argoci/cron/e2e-patch-verification.yaml
+++ b/.argoci/cron/e2e-patch-verification.yaml
@@ -1,0 +1,395 @@
+# Condensed ArgoCI e2e workflow; cc-argoci-handler expands it into a CronWorkflow at runtime.
+# Migrated from the Semaphore e2e pipeline of the same name — maintained here by hand.
+version: condensed
+generateName: e2e-patch-verification-
+schedule: 10 21 * * 3
+globalPrologue: |
+  cd "${CI_HOME}/${CI_GIT_DIR}"
+  export ARGO_WORKFLOW_NAME="{{workflow.name}}"
+  export ARGO_WORKFLOW_UID="{{workflow.uid}}"
+  export FUNCTIONAL_AREA="${FUNCTIONAL_AREA:-patch-verification.yml}"
+  export IPV4_POD_CIDR="${IPV4_POD_CIDR:-192.168.0.0/16}"
+  export K8S_E2E_FLAGS="${K8S_E2E_FLAGS:---ginkgo.focus=(\[Conformance\]|Observe|RBAC) --ginkgo.skip=(\[Slow\]|\[Disruptive\]|sig-node|sig-apps|sig-storage|sig-scheduling|sig-calico-enterprise)}"
+  export K8S_VERSION="${K8S_VERSION:-stable-3}"
+  export PRIVATE_REGISTRY="${PRIVATE_REGISTRY:-quay.io/}"
+  export USE_PRIVATE_REGISTRY="${USE_PRIVATE_REGISTRY:-true}"
+  source .argoci/scripts/global_prologue.sh
+globalEpilogue: |
+  source "${CI_HOME}/${CI_GIT_DIR}/.argoci/scripts/global_epilogue.sh"
+defaults:
+  secretBundles:
+    - banzai-secrets
+steps:
+  - name: kind-tests
+    jobSize: large
+    services:
+      - docker
+    env:
+      - name: CNI_PLUGIN
+        value: Calico
+      - name: DATAPLANE
+        value: CalicoIptables
+      - name: ENABLE_AUTO_HEP
+        value: "true"
+      - name: INSTALLER
+        value: helmerator
+      - name: IPV4_POD_CIDR
+        value: ""
+      - name: IPV6_POD_CIDR
+        value: fd00:10:244::/56
+      - name: IP_FAMILY
+        value: ipv6
+      - name: K8S_E2E_DOCKER_EXTRA_FLAGS
+        value: --env IP_FAMILY
+      - name: K8S_VERSION
+        value: stable-1
+      - name: PROVISIONER
+        value: local-kind
+    commands: |
+      .argoci/scripts/body_standard.sh
+  - name: manifests-flannel-migration
+    services:
+      - docker
+    env:
+      - name: AWS_NODE_INSTANCE_TYPE
+        value: t3.large
+      - name: CALICO_MANIFEST
+        value: manifests/flannel-migration/calico.yaml
+      - name: CLUSTER_IMAGE
+        value: jammy-22.04
+      - name: DATAPLANE
+        value: CalicoIptables
+      - name: DOWNLEVEL_MANIFEST
+        value: https://raw.githubusercontent.com/coreos/flannel/master/Documentation/kube-flannel.yml
+      - name: ENCAPSULATION_TYPE
+        value: VXLAN
+      - name: INSTALLER
+        value: manual
+      - name: IPV4_POD_CIDR
+        value: 192.168.0.0/16
+      - name: IP_FAMILY
+        value: ipv4
+      - name: K8S_E2E_DOCKER_EXTRA_FLAGS
+        value: --env IP_FAMILY
+      - name: K8S_VERSION
+        value: stable
+      - name: MIGRATION_MANIFEST
+        value: manifests/flannel-migration/migration-job.yaml
+      - name: NAT_OUTGOING
+        value: Enabled
+      - name: PROVISIONER
+        value: aws-kubeadm
+    commands: |
+      .argoci/scripts/body_flannel-migration.sh
+  - name: manifests-canal
+    services:
+      - docker
+    env:
+      - name: CLUSTER_IMAGE
+        value: ubuntu-2204-lts
+      - name: DATAPLANE
+        value: CalicoIptables
+      - name: GOOGLE_MACHINE_TYPE
+        value: e2-standard-2
+      - name: INSTALLER
+        value: manual
+      - name: IP_FAMILY
+        value: ipv4
+      - name: K8S_E2E_DOCKER_EXTRA_FLAGS
+        value: --env IP_FAMILY
+      - name: K8S_VERSION
+        value: stable
+      - name: MANIFEST_FILE
+        value: canal.yaml
+      - name: NAT_OUTGOING
+        value: Enabled
+      - name: PROVISIONER
+        value: gcp-kubeadm
+    commands: |
+      .argoci/scripts/body_standard.sh
+  - name: manifests-canal-migration
+    services:
+      - docker
+    env:
+      - name: CALICO_MANIFEST
+        value: manifests/flannel-migration/calico.yaml
+      - name: CLUSTER_IMAGE
+        value: ubuntu-2204-lts
+      - name: DATAPLANE
+        value: CalicoIptables
+      - name: DOWNLEVEL_MANIFEST
+        value: https://raw.githubusercontent.com/projectcalico/calico/v3.28.2/manifests/canal.yaml
+      - name: GOOGLE_MACHINE_TYPE
+        value: e2-standard-2
+      - name: INSTALLER
+        value: manual
+      - name: IP_FAMILY
+        value: ipv4
+      - name: K8S_E2E_DOCKER_EXTRA_FLAGS
+        value: --env IP_FAMILY
+      - name: K8S_VERSION
+        value: stable
+      - name: MIGRATION_MANIFEST
+        value: manifests/flannel-migration/migration-job.yaml
+      - name: PROVISIONER
+        value: gcp-kubeadm
+    commands: |
+      .argoci/scripts/body_flannel-migration.sh
+  - name: manifests-calico-etcd
+    services:
+      - docker
+    env:
+      - name: CLUSTER_IMAGE
+        value: ubuntu-2404-lts-amd64
+      - name: DATAPLANE
+        value: CalicoIptables
+      - name: ENCAPSULATION_TYPE
+        value: IPIP
+      - name: GOOGLE_MACHINE_TYPE
+        value: e2-standard-2
+      - name: INSTALLER
+        value: manual
+      - name: INSTALL_ETCD_POD
+        value: "true"
+      - name: IP_FAMILY
+        value: ipv4
+      - name: K8S_E2E_DOCKER_EXTRA_FLAGS
+        value: --env IP_FAMILY
+      - name: K8S_VERSION
+        value: stable
+      - name: KUBE_PROXY_MODE
+        value: ipvs
+      - name: MANIFEST_FILE
+        value: calico-etcd.yaml
+      - name: NAT_OUTGOING
+        value: Enabled
+      - name: PROVISIONER
+        value: gcp-kubeadm
+    commands: |
+      .argoci/scripts/body_standard.sh
+  - name: manifests-operator-migration
+    services:
+      - docker
+    env:
+      - name: CLUSTER_IMAGE
+        value: ubuntu-2404-lts-amd64
+      - name: DATAPLANE
+        value: CalicoNftables
+      - name: ENCAPSULATION_TYPE
+        value: IPIP
+      - name: GOOGLE_MACHINE_TYPE
+        value: e2-standard-2
+      - name: INSTALLER
+        value: manual
+      - name: IP_FAMILY
+        value: ipv4
+      - name: K8S_E2E_DOCKER_EXTRA_FLAGS
+        value: --env IP_FAMILY
+      - name: K8S_VERSION
+        value: stable
+      - name: KUBE_PROXY_MODE
+        value: nftables
+      - name: MANIFEST_FILE
+        value: calico.yaml
+      - name: NAT_OUTGOING
+        value: Enabled
+      - name: OPERATOR_MIGRATE
+        value: "true"
+      - name: PROVISIONER
+        value: gcp-kubeadm
+    commands: |
+      .argoci/scripts/body_standard.sh
+  - name: operator-helmerator-aks-w-aks-cni-overlay
+    services:
+      - docker
+    env:
+      - name: AZ_CREATE_MODE
+        value: AKS
+      - name: CNI_PLUGIN
+        value: AzureVNET
+      - name: INSTALLER
+        value: operator
+      - name: IPV4_POD_CIDR
+        value: 10.244.0.0/16
+      - name: IP_FAMILY
+        value: ipv4
+      - name: K8S_VERSION
+        value: stable-1
+      - name: NETWORK_PLUGIN_MODE
+        value: overlay
+      - name: PROVISIONER
+        value: azr-aks
+    commands: |
+      .argoci/scripts/body_standard.sh
+  - name: operator-helmerator-eks-w-calico-cni
+    services:
+      - docker
+    env:
+      - name: AWS_NODE_INSTANCE_TYPE
+        value: t3.large
+      - name: CNI_PLUGIN
+        value: Calico
+      - name: DATAPLANE
+        value: CalicoBPF
+      - name: EKS_AMI_FAMILY
+        value: AmazonLinux2023
+      - name: ENABLE_NODE_LOCAL_DNS_CACHE
+        value: "true"
+      - name: ENABLE_WIREGUARD
+        value: "true"
+      - name: ENCAPSULATION_TYPE
+        value: VXLAN
+      - name: INSTALLER
+        value: helmerator
+      - name: IPAM_TEST_POOL_SUBNET
+        value: 10.0.0.0/29
+      - name: IPV4_POD_CIDR
+        value: 172.16.0.0/16
+      - name: IP_FAMILY
+        value: ipv4
+      - name: K8S_E2E_FLAGS
+        value: --ginkgo.focus=(\[Conformance\]|Observe|RBAC) --ginkgo.skip=(\[Slow\]|\[Disruptive\]|sig-node|sig-apps|sig-storage|sig-scheduling|sig-calico-enterprise|DNS.should.........DNS)
+      - name: K8S_VERSION
+        value: stable-3
+      - name: PROVISIONER
+        value: aws-eks
+    commands: |
+      .argoci/scripts/body_standard.sh
+  - name: operator-helmerator-eks-w-aws-cni
+    services:
+      - docker
+    env:
+      - name: AWS_K8S_CNI_VERSION
+        value: NA
+      - name: AWS_NODE_INSTANCE_TYPE
+        value: t3.large
+      - name: CNI_PLUGIN
+        value: AmazonVPC
+      - name: DATAPLANE
+        value: CalicoBPF
+      - name: INSTALLER
+        value: operator
+      - name: IPAM_TEST_POOL_SUBNET
+        value: 10.0.0.0/29
+      - name: IPV4_POD_CIDR
+        value: 172.16.0.0/16
+      - name: IP_FAMILY
+        value: ipv4
+      - name: K8S_VERSION
+        value: stable-1
+      - name: PROVISIONER
+        value: aws-eks
+    commands: |
+      .argoci/scripts/body_standard.sh
+  - name: operator-helmerator-windows-aws-kubeadm-containerd
+    services:
+      - docker
+    env:
+      - name: CNI_PLUGIN
+        value: Calico
+      - name: DATAPLANE
+        value: CalicoBPF
+      - name: ENABLE_AUTO_HEP
+        value: "true"
+      - name: ENCAPSULATION_TYPE
+        value: VXLAN
+      - name: INSTALLER
+        value: helmerator
+      - name: IP_FAMILY
+        value: ipv4
+      - name: K8S_VERSION
+        value: stable
+      - name: PROVISIONER
+        value: aws-kubeadm
+      - name: WINDOWS_CONTAINER_RUNTIME
+        value: containerd:2.1.1
+      - name: WINDOWS_OS_VERSION
+        value: "2022"
+    commands: |
+      .argoci/scripts/body_standard.sh
+  - name: operator-helmerator-windows-aws-kubeadm-docker
+    services:
+      - docker
+    env:
+      - name: CLUSTER_IMAGE
+        value: jammy-22.04
+      - name: CNI_PLUGIN
+        value: Calico
+      - name: DATAPLANE
+        value: CalicoNftables
+      - name: ENABLE_AUTO_HEP
+        value: "true"
+      - name: ENCAPSULATION_TYPE
+        value: None
+      - name: INSTALLER
+        value: helmerator
+      - name: IP_FAMILY
+        value: ipv4
+      - name: K8S_VERSION
+        value: stable-3
+      - name: KUBE_PROXY_MODE
+        value: nftables
+      - name: PROVISIONER
+        value: aws-kubeadm
+      - name: VPC_SUBNETS
+        value: '["172.16.101.0/24"]'
+      - name: WINDOWS_OS_VERSION
+        value: "1809"
+    commands: |
+      .argoci/scripts/body_standard.sh
+  - name: operator-helmerator-rke2
+    services:
+      - docker
+    env:
+      - name: CLUSTER_IMAGE
+        value: ubuntu-2204-lts
+      - name: CNI_PLUGIN
+        value: Calico
+      - name: DATAPLANE
+        value: CalicoBPF
+      - name: ENABLE_AUTO_HEP
+        value: "true"
+      - name: ENCAPSULATION_TYPE
+        value: VXLAN
+      - name: INSTALLER
+        value: operator
+      - name: IP_FAMILY
+        value: ipv4
+      - name: K8S_VERSION
+        value: stable-1
+      - name: PROVISIONER
+        value: gcp-rke2
+    commands: |
+      .argoci/scripts/body_standard.sh
+  - name: kubevirt-e2e-tests
+    services:
+      - docker
+    env:
+      - name: E2E_TEST_CONFIG
+        value: e2e/config/gcp-kubevirt.yaml
+      - name: INSTALLER
+        value: operator
+      - name: K8S_VERSION
+        value: stable-1.35
+      - name: NUM_KUBEVIRT_VMS
+        value: "2"
+      - name: PROVISIONER
+        value: gcp-kubeadm
+    commands: |
+      .argoci/scripts/body_standard.sh
+  - name: openshift
+    services:
+      - docker
+    env:
+      - name: DATAPLANE
+        value: CalicoBPF
+      - name: INSTALLER
+        value: operator
+      - name: IP_FAMILY
+        value: ipv4
+      - name: OPENSHIFT_VERSION
+        value: 4.18.17
+      - name: PROVISIONER
+        value: aws-openshift
+    commands: |
+      .argoci/scripts/body_standard.sh

--- a/.argoci/cron/e2e-test.yaml
+++ b/.argoci/cron/e2e-test.yaml
@@ -1,0 +1,38 @@
+# Condensed ArgoCI e2e workflow; cc-argoci-handler expands it into a CronWorkflow at runtime.
+# Migrated from the Semaphore e2e pipeline of the same name — maintained here by hand.
+version: condensed
+generateName: e2e-test-
+schedule: 0 0 31 2 *
+globalPrologue: |
+  cd "${CI_HOME}/${CI_GIT_DIR}"
+  export ARGO_WORKFLOW_NAME="{{workflow.name}}"
+  export ARGO_WORKFLOW_UID="{{workflow.uid}}"
+  export FUNCTIONAL_AREA="${FUNCTIONAL_AREA:-test.yml}"
+  export K8S_E2E_FLAGS="${K8S_E2E_FLAGS:---ginkgo.focus=(\[sig-calico\].*\[Conformance\]) --ginkgo.skip=(\[Slow\]|\[Disruptive\]|\[DataPath\])}"
+  export PRIVATE_REGISTRY="${PRIVATE_REGISTRY:-quay.io/}"
+  export PRODUCT="${PRODUCT:-calico}"
+  export TEST_TYPE="${TEST_TYPE:-k8s-e2e}"
+  export USE_PRIVATE_REGISTRY="${USE_PRIVATE_REGISTRY:-true}"
+  source .argoci/scripts/global_prologue.sh
+globalEpilogue: |
+  source "${CI_HOME}/${CI_GIT_DIR}/.argoci/scripts/global_epilogue.sh"
+defaults:
+  secretBundles:
+    - banzai-secrets
+steps:
+  - name: calico-tests
+    services:
+      - docker
+    matrix:
+      - name: gcp-kubeadm-stable-operator-calicobpf
+        env:
+          - name: PROVISIONER
+            value: gcp-kubeadm
+          - name: K8S_VERSION
+            value: stable
+          - name: INSTALLER
+            value: operator
+          - name: DATAPLANE
+            value: CalicoBPF
+    commands: |
+      .argoci/scripts/body_standard.sh

--- a/.argoci/cron/e2e-upgrade.yaml
+++ b/.argoci/cron/e2e-upgrade.yaml
@@ -1,0 +1,137 @@
+# Condensed ArgoCI e2e workflow; cc-argoci-handler expands it into a CronWorkflow at runtime.
+# Migrated from the Semaphore e2e pipeline of the same name — maintained here by hand.
+version: condensed
+generateName: e2e-upgrade-
+schedule: 10 21 * * 3
+globalPrologue: |
+  cd "${CI_HOME}/${CI_GIT_DIR}"
+  export ARGO_WORKFLOW_NAME="{{workflow.name}}"
+  export ARGO_WORKFLOW_UID="{{workflow.uid}}"
+  export CALICOCTL_INSTALL_TYPE="${CALICOCTL_INSTALL_TYPE:-container}"
+  export FUNCTIONAL_AREA="${FUNCTIONAL_AREA:-upgrade.yml}"
+  export K8S_E2E_FLAGS="${K8S_E2E_FLAGS:---ginkgo.focus=(\[Conformance\]|Observe|RBAC) --ginkgo.skip=(\[Slow\]|\[Disruptive\]|\[DataPath\]|sig-node|sig-apps|sig-storage|sig-scheduling|sig-calico-enterprise)}"
+  export PRIVATE_REGISTRY="${PRIVATE_REGISTRY:-quay.io/}"
+  export PRODUCT="${PRODUCT:-calico}"
+  export RELEASE_STREAM="${RELEASE_STREAM:-v3.29}"
+  export TEST_TYPE="${TEST_TYPE:-k8s-e2e}"
+  export UPLEVEL_PRE_RELEASE="${UPLEVEL_PRE_RELEASE:-true}"
+  export UPLEVEL_PRODUCT="${UPLEVEL_PRODUCT:-calico}"
+  export USE_HASH_RELEASE="${USE_HASH_RELEASE:-false}"
+  export USE_PRIVATE_REGISTRY="${USE_PRIVATE_REGISTRY:-true}"
+  source .argoci/scripts/global_prologue.sh
+globalEpilogue: |
+  source "${CI_HOME}/${CI_GIT_DIR}/.argoci/scripts/global_epilogue.sh"
+defaults:
+  secretBundles:
+    - banzai-secrets
+steps:
+  - name: calico-tests-aks-byo-cni-w-azurelinux
+    services:
+      - docker
+    env:
+      - name: AZ_NETWORK_PLUGIN
+        value: none
+      - name: CLUSTER_IMAGE
+        value: AzureLinux
+      - name: PROVISIONER
+        value: azr-aks
+    matrix:
+      - name: stable-2-operator-calicoiptables
+        env:
+          - name: K8S_VERSION
+            value: stable-2
+          - name: INSTALLER
+            value: operator
+          - name: DATAPLANE
+            value: CalicoIptables
+    commands: |
+      .argoci/scripts/body_standard.sh
+  - name: calico-tests-eks
+    services:
+      - docker
+    env:
+      - name: K8S_E2E_FLAGS
+        value: --ginkgo.focus=(\[Conformance\]|Observe|RBAC) --ginkgo.skip=(\[Slow\]|\[Disruptive\]|\[DataPath\]|sig-node|sig-apps|sig-storage|sig-scheduling|sig-calico-enterprise|DNS.should.provide.DNS|DNS.should.resolve.DNS|DNS.should.provide./etc|IP.address.is.not.reallocated|Proxy.version.v1)
+      - name: PROVISIONER
+        value: aws-eks
+    matrix:
+      - name: stable-1-calico-manual-calicobpf
+        env:
+          - name: K8S_VERSION
+            value: stable-1
+          - name: EKS_CNI
+            value: calico
+          - name: INSTALLER
+            value: manual
+          - name: DATAPLANE
+            value: CalicoBPF
+    commands: |
+      .argoci/scripts/body_standard.sh
+  - name: calico-tests-kubeadm-iptables
+    services:
+      - docker
+    matrix:
+      - name: aws-kubeadm-stable-3-operator-calicoiptables
+        env:
+          - name: PROVISIONER
+            value: aws-kubeadm
+          - name: K8S_VERSION
+            value: stable-3
+          - name: INSTALLER
+            value: operator
+          - name: DATAPLANE
+            value: CalicoIptables
+    commands: |
+      .argoci/scripts/body_standard.sh
+  - name: calico-tests-kubeadm-bpf
+    services:
+      - docker
+    matrix:
+      - name: gcp-kubeadm-stable-operator-calicobpf
+        env:
+          - name: PROVISIONER
+            value: gcp-kubeadm
+          - name: K8S_VERSION
+            value: stable
+          - name: INSTALLER
+            value: operator
+          - name: DATAPLANE
+            value: CalicoBPF
+    commands: |
+      .argoci/scripts/body_standard.sh
+  - name: calico-tests-rke2
+    services:
+      - docker
+    env:
+      - name: PROVISIONER
+        value: gcp-rke2
+    matrix:
+      - name: -stable-2-operator-calicoiptables
+        env:
+          - name: RKE_NETWORKING
+            value: ""
+          - name: K8S_VERSION
+            value: stable-2
+          - name: INSTALLER
+            value: operator
+          - name: DATAPLANE
+            value: CalicoIptables
+    commands: |
+      .argoci/scripts/body_standard.sh
+  - name: calico-tests-openshift
+    services:
+      - docker
+    env:
+      - name: PROVISIONER
+        value: aws-openshift
+    matrix:
+      - name: 4-19-20-calicoiptables-operator
+        env:
+          - name: OPENSHIFT_VERSION
+            value: 4.19.20
+          - name: DATAPLANE
+            value: CalicoIptables
+          - name: INSTALLER
+            value: operator
+    commands: |
+      .argoci/scripts/body_standard.sh

--- a/.argoci/cron/e2e-vpp.yaml
+++ b/.argoci/cron/e2e-vpp.yaml
@@ -1,0 +1,214 @@
+# Condensed ArgoCI e2e workflow; cc-argoci-handler expands it into a CronWorkflow at runtime.
+# Migrated from the Semaphore e2e pipeline of the same name — maintained here by hand.
+version: condensed
+generateName: e2e-vpp-
+schedule: 0 16 * * 1,3,5
+globalPrologue: |
+  cd "${CI_HOME}/${CI_GIT_DIR}"
+  export ARGO_WORKFLOW_NAME="{{workflow.name}}"
+  export ARGO_WORKFLOW_UID="{{workflow.uid}}"
+  export BGP_STATUS="${BGP_STATUS:-Enabled}"
+  export CNI_PLUGIN="${CNI_PLUGIN:-Calico}"
+  export DATAPLANE="${DATAPLANE:-CalicoVPP}"
+  export ENABLE_CLOUD_PROVIDER="${ENABLE_CLOUD_PROVIDER:-false}"
+  export ENABLE_EXTERNAL_NODE="${ENABLE_EXTERNAL_NODE:-true}"
+  export ENCAPSULATION_TYPE="${ENCAPSULATION_TYPE:-IPIP}"
+  export FUNCTIONAL_AREA="${FUNCTIONAL_AREA:-vpp.yml}"
+  export GS_BUCKET="${GS_BUCKET:-vpp-results}"
+  export INSTALLER="${INSTALLER:-operator}"
+  export IPV4_POD_CIDR="${IPV4_POD_CIDR:-192.168.0.0/16}"
+  export K8S_E2E_DOCKER_EXTRA_FLAGS="${K8S_E2E_DOCKER_EXTRA_FLAGS:--e CLIENT_TYPE=k8s}"
+  export K8S_E2E_FLAGS="${K8S_E2E_FLAGS:---ginkgo.focus=(\[sig-calico\]|Dataplane:BPF) --ginkgo.skip=(\[Slow\]|\[Disruptive\]|wireguard|Wireguard|WireGuard|calient|doNotTrack|performanceHints|Tiered-Policy|Feature:Maglev)}"
+  export K8S_VERSION="${K8S_VERSION:-stable-1}"
+  export PRIVATE_REGISTRY="${PRIVATE_REGISTRY:-quay.io/}"
+  export RELEASE_STREAM="${RELEASE_STREAM:-master}"
+  export USE_LATEST_RELEASE="${USE_LATEST_RELEASE:-false}"
+  export USE_PRIVATE_REGISTRY="${USE_PRIVATE_REGISTRY:-true}"
+  export VPP_VERSION="${VPP_VERSION:-master}"
+  source .argoci/scripts/global_prologue.sh
+globalEpilogue: |
+  source "${CI_HOME}/${CI_GIT_DIR}/.argoci/scripts/global_epilogue.sh"
+defaults:
+  secretBundles:
+    - banzai-secrets
+steps:
+  - name: k8s-e2e-st-v3-28-regression-test
+    services:
+      - docker
+    matrix:
+      - name: gcp-kubeadm-calico-vpp-nohuge-yaml-v3-28-v3-28-0
+        env:
+          - name: PROVISIONER
+            value: gcp-kubeadm
+          - name: VPP_MANIFEST_FILE
+            value: calico-vpp-nohuge.yaml
+          - name: RELEASE_STREAM
+            value: v3.28
+          - name: VPP_VERSION
+            value: v3.28.0
+    commands: |
+      .argoci/scripts/body_standard.sh
+  - name: k8s-e2e-st-vpp-kadm
+    services:
+      - docker
+    matrix:
+      - name: gcp-kubeadm-calico-vpp-nohuge-yaml
+        env:
+          - name: PROVISIONER
+            value: gcp-kubeadm
+          - name: VPP_MANIFEST_FILE
+            value: calico-vpp-nohuge.yaml
+      - name: aws-kubeadm-calico-vpp-nohuge-yaml
+        env:
+          - name: PROVISIONER
+            value: aws-kubeadm
+          - name: VPP_MANIFEST_FILE
+            value: calico-vpp-nohuge.yaml
+    commands: |
+      .argoci/scripts/body_standard.sh
+  - name: k8s-e2e-st-vpp-kadm-huge
+    services:
+      - docker
+    env:
+      - name: ENABLE_HUGEPAGES
+        value: "true"
+    matrix:
+      - name: gcp-kubeadm-calico-vpp-dpdk-yaml
+        env:
+          - name: PROVISIONER
+            value: gcp-kubeadm
+          - name: VPP_MANIFEST_FILE
+            value: calico-vpp-dpdk.yaml
+      - name: aws-kubeadm-calico-vpp-dpdk-yaml
+        env:
+          - name: PROVISIONER
+            value: aws-kubeadm
+          - name: VPP_MANIFEST_FILE
+            value: calico-vpp-dpdk.yaml
+    commands: |
+      .argoci/scripts/body_standard.sh
+  - name: k8s-e2e-st-vpp-kadm-vx-huge
+    services:
+      - docker
+    env:
+      - name: BGP_STATUS
+        value: Enabled
+      - name: ENABLE_HUGEPAGES
+        value: "true"
+      - name: ENCAPSULATION_TYPE
+        value: VXLAN
+    matrix:
+      - name: gcp-kubeadm-calico-vpp-dpdk-yaml
+        env:
+          - name: PROVISIONER
+            value: gcp-kubeadm
+          - name: VPP_MANIFEST_FILE
+            value: calico-vpp-dpdk.yaml
+    commands: |
+      .argoci/scripts/body_standard.sh
+  - name: k8s-e2e-st-vpp-kadm-wg-huge
+    services:
+      - docker
+    env:
+      - name: ENABLE_HUGEPAGES
+        value: "true"
+      - name: ENABLE_WIREGUARD
+        value: "true"
+    matrix:
+      - name: gcp-kubeadm-calico-vpp-dpdk-yaml
+        env:
+          - name: PROVISIONER
+            value: gcp-kubeadm
+          - name: VPP_MANIFEST_FILE
+            value: calico-vpp-dpdk.yaml
+    commands: |
+      .argoci/scripts/body_standard.sh
+  - name: k8s-e2e-st-vpp-eks
+    services:
+      - docker
+    env:
+      - name: FAILSAFE_443
+        value: "true"
+      - name: IPV4_POD_CIDR
+        value: 172.16.0.0/16
+      - name: K8S_E2E_FLAGS
+        value: --ginkgo.focus=(\[sig-calico\]|Dataplane-BPF) --ginkgo.skip=(\[Slow\]|\[Disruptive\]|wireguard|Wireguard|WireGuard|calient|doNotTrack|performanceHints|Tiered-Policy|Feature:Maglev|both.pod.and.service.Proxy\b|proxy.through.a.service.and.a.pod|replica.with.a.public.image|DNS.for.ExternalName.services|DNS.for.pods.for.Hostname|DNS.for.pods.for.Subdomain|DNS.for.services|DNS.for.the.cluster|DNS.qualified.names.for.services)
+      - name: PROVISIONER
+        value: aws-eks
+    matrix:
+      - name: calico-calico-vpp-eks-yaml
+        env:
+          - name: EKS_CNI
+            value: calico
+          - name: VPP_MANIFEST_FILE
+            value: calico-vpp-eks.yaml
+    commands: |
+      .argoci/scripts/body_standard.sh
+  - name: k8s-e2e-st-vpp-eks-dpdk
+    services:
+      - docker
+    env:
+      - name: ENABLE_HUGEPAGES
+        value: "true"
+      - name: FAILSAFE_443
+        value: "true"
+      - name: IPV4_POD_CIDR
+        value: 172.16.0.0/16
+      - name: K8S_E2E_FLAGS
+        value: --ginkgo.focus=(\[sig-calico\]|Dataplane-BPF) --ginkgo.skip=(\[Slow\]|\[Disruptive\]|wireguard|Wireguard|WireGuard|calient|doNotTrack|performanceHints|Tiered-Policy|Feature:Maglev|both.pod.and.service.Proxy\b|proxy.through.a.service.and.a.pod|replica.with.a.public.image|DNS.for.ExternalName.services|DNS.for.pods.for.Hostname|DNS.for.pods.for.Subdomain|DNS.for.services|DNS.for.the.cluster|DNS.qualified.names.for.services)
+      - name: PROVISIONER
+        value: aws-eks
+    matrix:
+      - name: calico-calico-vpp-eks-dpdk-yaml
+        env:
+          - name: EKS_CNI
+            value: calico
+          - name: VPP_MANIFEST_FILE
+            value: calico-vpp-eks-dpdk.yaml
+    commands: |
+      .argoci/scripts/body_standard.sh
+  - name: k8s-e2e-st-vpp-kadm-ipsec-huge
+    services:
+      - docker
+    env:
+      - name: ENABLE_HUGEPAGES
+        value: "true"
+      - name: ENABLE_VPP_IPSEC
+        value: "true"
+    matrix:
+      - name: aws-kubeadm-calico-vpp-dpdk-yaml
+        env:
+          - name: PROVISIONER
+            value: aws-kubeadm
+          - name: VPP_MANIFEST_FILE
+            value: calico-vpp-dpdk.yaml
+    commands: |
+      .argoci/scripts/body_standard.sh
+  - name: vpp-openshift
+    services:
+      - docker
+    env:
+      - name: AWS_INSTANCE_TYPE
+        value: m5.xlarge
+    matrix:
+      - name: aws-openshift
+        env:
+          - name: PROVISIONER
+            value: aws-openshift
+    commands: |
+      .argoci/scripts/body_standard.sh
+  - name: iptables-openshift
+    services:
+      - docker
+    env:
+      - name: AWS_INSTANCE_TYPE
+        value: m5.xlarge
+      - name: DATAPLANE
+        value: CalicoIptables
+    matrix:
+      - name: aws-openshift
+        env:
+          - name: PROVISIONER
+            value: aws-openshift
+    commands: |
+      .argoci/scripts/body_standard.sh

--- a/.argoci/cron/e2e-windows.yaml
+++ b/.argoci/cron/e2e-windows.yaml
@@ -1,0 +1,58 @@
+# Condensed ArgoCI e2e workflow; cc-argoci-handler expands it into a CronWorkflow at runtime.
+# Migrated from the Semaphore e2e pipeline of the same name — maintained here by hand.
+version: condensed
+generateName: e2e-windows-
+schedule: 10 21 * * 5
+globalPrologue: |
+  cd "${CI_HOME}/${CI_GIT_DIR}"
+  export ARGO_WORKFLOW_NAME="{{workflow.name}}"
+  export ARGO_WORKFLOW_UID="{{workflow.uid}}"
+  export CREATE_WINDOWS_NODES="${CREATE_WINDOWS_NODES:-true}"
+  export E2E_PROCS="${E2E_PROCS:-1}"
+  export FUNCTIONAL_AREA="${FUNCTIONAL_AREA:-windows.yml}"
+  export INSTALLER="${INSTALLER:-operator}"
+  export K8S_E2E_FLAGS="${K8S_E2E_FLAGS:---ginkgo.focus=(\[sig-calico\].*\[RunsOnWindows\]) --ginkgo.skip=(\[LinuxOnly\])}"
+  export PRIVATE_REGISTRY="${PRIVATE_REGISTRY:-quay.io/}"
+  export RUN_LOCAL_TESTS="${RUN_LOCAL_TESTS:-true}"
+  export USE_PRIVATE_REGISTRY="${USE_PRIVATE_REGISTRY:-true}"
+  source .argoci/scripts/global_prologue.sh
+globalEpilogue: |
+  source "${CI_HOME}/${CI_GIT_DIR}/.argoci/scripts/global_epilogue.sh"
+defaults:
+  secretBundles:
+    - banzai-secrets
+steps:
+  - name: calico-windows-azr-aso-2022-stable-nftables-vxlan
+    services:
+      - docker
+    env:
+      - name: DATAPLANE
+        value: CalicoNftables
+      - name: ENCAPSULATION_TYPE
+        value: VXLAN
+      - name: K8S_VERSION
+        value: stable
+      - name: PROVISIONER
+        value: azr-aso
+      - name: WINDOWS_OS
+        value: "2022"
+    commands: |
+      .argoci/scripts/body_standard.sh
+  - name: calico-windows-azr-aks-2022-stable-1-iptables-no-encap-azure-cni
+    services:
+      - docker
+    env:
+      - name: DATAPLANE
+        value: CalicoIptables
+      - name: ENCAPSULATION_TYPE
+        value: None
+      - name: K8S_VERSION
+        value: stable-1
+      - name: PROVISIONER
+        value: azr-aks
+      - name: USE_VENDORED_CNI
+        value: "true"
+      - name: WINDOWS_OS
+        value: "2022"
+    commands: |
+      .argoci/scripts/body_standard.sh


### PR DESCRIPTION
## Release Note
\`\`\`release-note
None
\`\`\`

Adds condensed ArgoCI cron workflows under `.argoci/cron/` for the remaining OSS e2e pipelines (nftables is the proving case in #13124):

`bpf`, `iptables`, `vpp`, `certification`, `upgrade`, `benchmarking`, `windows`, `patch-verification`, `test`.

Each is generated by the `semaphore-to-argoci` skill (tigera-de-tools) from `.semaphore/end-to-end/pipelines/*.yml` — one condensed `step` per Semaphore job, matrices preserved, `cc-argoci-handler` expands them at runtime.

**Schedules** match the ACTIVE tasks in the `calico-monorepo-e2es` Semaphore project (e.g. `bpf` `10 21 * * 2`, `vpp` `0 16 * * 1,3,5`, `benchmarking` `0 21 * * 0`). `test` has no Semaphore schedule (manual-trigger), so it gets a never-fire cron.

**Depends on #13124** — the `.argoci/` scaffold + lifecycle scripts (`global_prologue.sh`, `body_standard.sh`, phases, `global_epilogue.sh`) that these crons source. Merge #13124 first (or together).

Generated files — do not hand-edit; regenerate via the `semaphore-to-argoci` skill (Tigera-internal). The crons are inert until the ArgoCI webhook + `[update-cron-workflows]` land on the default branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)