### PR TITLE
felix/bpf: treat bridge-enslaved NICs as L2-only

### DIFF
--- a/felix/bpf/ifstate/map.go
+++ b/felix/bpf/ifstate/map.go
@@ -39,32 +39,34 @@ const (
 )
 
 const (
-	FlgWEP        = uint32(0x1)
-	FlgIPv4Ready  = uint32(0x2)
-	FlgIPv6Ready  = uint32(0x4)
-	FlgHEP        = uint32(0x8)
-	FlgBond       = uint32(0x10)
-	FlgBondSlave  = uint32(0x20)
-	FlgVxlan      = uint32(0x40)
-	FlgIPIP       = uint32(0x80)
-	FlgWireguard  = uint32(0x100)
-	FlgL3         = uint32(0x200)
-	FlgNotManaged = uint32(0x400)
-	FlgMax        = uint32(0x7ff)
+	FlgWEP         = uint32(0x1)
+	FlgIPv4Ready   = uint32(0x2)
+	FlgIPv6Ready   = uint32(0x4)
+	FlgHEP         = uint32(0x8)
+	FlgBond        = uint32(0x10)
+	FlgBondSlave   = uint32(0x20)
+	FlgVxlan       = uint32(0x40)
+	FlgIPIP        = uint32(0x80)
+	FlgWireguard   = uint32(0x100)
+	FlgL3          = uint32(0x200)
+	FlgNotManaged  = uint32(0x400)
+	FlgBridgeSlave = uint32(0x800)
+	FlgMax         = uint32(0xfff)
 )
 
 var flagsToStr = map[uint32]string{
-	FlgWEP:        "workload",
-	FlgIPv4Ready:  "v4Ready",
-	FlgIPv6Ready:  "v6Ready",
-	FlgHEP:        "host",
-	FlgBond:       "bond",
-	FlgBondSlave:  "bondslave",
-	FlgVxlan:      "vxlan",
-	FlgIPIP:       "ipip",
-	FlgWireguard:  "wg",
-	FlgL3:         "l3",
-	FlgNotManaged: "notmanaged",
+	FlgWEP:         "workload",
+	FlgIPv4Ready:   "v4Ready",
+	FlgIPv6Ready:   "v6Ready",
+	FlgHEP:         "host",
+	FlgBond:        "bond",
+	FlgBondSlave:   "bondslave",
+	FlgVxlan:       "vxlan",
+	FlgIPIP:        "ipip",
+	FlgWireguard:   "wg",
+	FlgL3:          "l3",
+	FlgNotManaged:  "notmanaged",
+	FlgBridgeSlave: "bridgeslave",
 }
 
 // FlagNames returns the human-readable names for the set bits in flags.

--- a/felix/dataplane/linux/bpf_ep_mgr.go
+++ b/felix/dataplane/linux/bpf_ep_mgr.go
@@ -144,6 +144,7 @@ const (
 	IfaceTypeL3
 	IfaceTypeBond
 	IfaceTypeBondSlave
+	IfaceTypeBridgeSlave
 	IfaceTypeNetkit
 	IfaceTypeUnknown
 )
@@ -1187,6 +1188,8 @@ func (m *bpfEndpointManager) getIfTypeFlags(name string, ifaceType IfaceType) ui
 			flags |= ifstate.FlgBond
 		case IfaceTypeBondSlave:
 			flags |= ifstate.FlgBondSlave
+		case IfaceTypeBridgeSlave:
+			flags |= ifstate.FlgBridgeSlave
 		case IfaceTypeL3:
 			flags |= ifstate.FlgL3
 		case IfaceTypeWireguard:
@@ -2371,9 +2374,30 @@ func (m *bpfEndpointManager) applyProgramsToDirtyDataInterfaces() {
 				logrus.WithField("iface", iface).Debug(
 					"Host Iface not found in tree")
 			} else {
+				ifaceType := m.getIfaceTypeFromLink(link)
 				isRoot := isRootIface(hostIf)
 				isLeaf := isLeafIface(hostIf)
-				if isRoot {
+				switch {
+				case ifaceType == IfaceTypeBridgeSlave:
+					// A device enslaved to a Linux bridge is an L2-only bridge
+					// port: the host's L3 (IP, routes) lives on the bridge or one
+					// of its VLAN sub-interfaces, not on the port. Never attach
+					// the L3 (TC/HEP) program to the port - the reverse-path
+					// check would be keyed on the port's ifindex while the return
+					// route resolves via the L3 device, breaking RPF. The L3
+					// device must match the bpfDataIfacePattern and is attached
+					// independently as its own data interface. This mirrors
+					// bonded-interface handling: attach XDP only, redirecting to
+					// the L3 device's host endpoint (a no-op if it carries no
+					// untracked policy). Unlike a bond, this is unconditional -
+					// the port is L2-only regardless of whether the L3 device is
+					// in the pattern.
+					masterName = getRootInterface(hostIf).name
+					logrus.WithField("iface", iface).Debug(
+						"Bridge port: attaching xdp only")
+					xdpMode = XDPModeOnly
+					attachTc = false
+				case isRoot:
 					// Root interface and not a leaf. Attach only Tc.
 					// set xdp mode to None and remove any previously attached
 					// xdp programs.
@@ -2381,7 +2405,7 @@ func (m *bpfEndpointManager) applyProgramsToDirtyDataInterfaces() {
 						xdpMode = XDPModeNone
 					}
 					// Root and leaf. Single interface tree. Attach both Tc and XDP.
-				} else if isLeaf {
+				case isLeaf:
 					masterIfa := getRootInterface(hostIf)
 					if err != nil {
 						logrus.Warnf("Failed to get master interface details for '%s'. Continuing to attach program", iface)
@@ -2396,7 +2420,7 @@ func (m *bpfEndpointManager) applyProgramsToDirtyDataInterfaces() {
 							attachTc = false
 						}
 					}
-				} else {
+				default:
 					xdpMode = XDPModeNone
 					attachTc = false
 				}
@@ -3509,7 +3533,7 @@ func (m *bpfEndpointManager) getEndpointType(ifaceName string) tcdefs.EndpointTy
 	ifaceType := m.nameToIface[ifaceName].info.ifaceType
 	m.ifacesLock.Unlock()
 	switch ifaceType {
-	case IfaceTypeData, IfaceTypeVXLAN, IfaceTypeBond, IfaceTypeBondSlave, IfaceTypeNetkit:
+	case IfaceTypeData, IfaceTypeVXLAN, IfaceTypeBond, IfaceTypeBondSlave, IfaceTypeBridgeSlave, IfaceTypeNetkit:
 		if ifaceName == "vxlan.calico" || ifaceName == "vxlan-v6.calico" {
 			return tcdefs.EpTypeVXLAN
 		}
@@ -5160,6 +5184,15 @@ func (m *bpfEndpointManager) getIfaceTypeFromLink(link netlink.Link) IfaceType {
 	attrs := link.Attrs()
 	if attrs.Slave != nil && attrs.Slave.SlaveType() == "bond" {
 		return IfaceTypeBondSlave
+	}
+
+	// A device enslaved to a Linux bridge is an L2-only bridge port: the host's
+	// L3 (IP, routes) lives on the bridge or one of its VLAN sub-interfaces, not
+	// on the port. The netlink library does not synthesise an attrs.Slave for
+	// bridge ports (only bond/vrf), but the kernel does set Protinfo
+	// (IFLA_PROTINFO) on bridge ports, so use that as the signal.
+	if attrs.MasterIndex != 0 && attrs.Protinfo != nil {
+		return IfaceTypeBridgeSlave
 	}
 
 	switch link.Type() {

--- a/felix/dataplane/linux/bpf_ep_mgr_test.go
+++ b/felix/dataplane/linux/bpf_ep_mgr_test.go
@@ -265,6 +265,23 @@ func (m *mockDataplane) createBondSlaves(name string, index, masterIndex int) er
 	return m.netlinkShim.LinkAdd(&slv)
 }
 
+// createBridgeSlaves adds a NIC enslaved to a Linux bridge. The netlink library
+// does not synthesise an attrs.Slave for bridge ports (only bond/vrf), but the
+// kernel sets Protinfo (IFLA_PROTINFO) on them, which is how the dataplane
+// classifies the port as IfaceTypeBridgeSlave.
+func (m *mockDataplane) createBridgeSlaves(name string, index, masterIndex int) error {
+	attr := netlink.NewLinkAttrs()
+	attr.Name = name
+	attr.Index = index
+	attr.Protinfo = &netlink.Protinfo{}
+	attr.MasterIndex = masterIndex
+	slv := netlink.GenericLink{
+		LinkAttrs: attr,
+		LinkType:  "device",
+	}
+	return m.netlinkShim.LinkAdd(&slv)
+}
+
 func (m *mockDataplane) getRules(key string) *polprog.Rules {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
@@ -858,6 +875,85 @@ var _ = Describe("BPF Endpoint Manager", func() {
 			Expect(dp.programAttached("eth20:ingress")).To(BeTrue())
 			Expect(dp.programAttached("eth20:egress")).To(BeTrue())
 			Expect(dp.programAttached("eth20:xdp")).To(BeFalse())
+		})
+
+		It("should attach the L3 program to the bridge sub-interface, not the bridge ports", func() {
+			dataIfacePattern = "^eth|^br0"
+			newBpfEpMgr(false)
+			genUntracked("default", "untracked1")()
+			newHEP := googleproto.Clone(hostEp).(*proto.HostEndpoint)
+			newHEP.UntrackedTiers = []*proto.TierInfo{{
+				Name:            "default",
+				IngressPolicies: []*proto.PolicyID{{Name: "untracked1", Kind: v3.KindGlobalNetworkPolicy}},
+			}}
+			// Bridge master with two enslaved NICs (the bridge ports).
+			err := dp.createIface("br0", 10, "bridge")
+			Expect(err).NotTo(HaveOccurred())
+			err = dp.createBridgeSlaves("eth10", 20, 10)
+			Expect(err).NotTo(HaveOccurred())
+			err = dp.createBridgeSlaves("eth20", 30, 10)
+			Expect(err).NotTo(HaveOccurred())
+			// The host L3 lives on a VLAN sub-interface of the bridge.
+			err = dp.createVlanIface("br0.100", 11, 10)
+			Expect(err).NotTo(HaveOccurred())
+
+			genHEPUpdate("br0.100", newHEP)()
+			genIfaceUpdate("br0.100", ifacemonitor.StateUp, 11)()
+			genIfaceUpdate("br0", ifacemonitor.StateUp, 10)()
+			genIfaceUpdate("eth10", ifacemonitor.StateUp, 20)()
+			genIfaceUpdate("eth20", ifacemonitor.StateUp, 30)()
+
+			// The L3 device (sub-interface) carries the host-endpoint program.
+			Expect(dp.programAttached("br0.100:ingress")).To(BeTrue())
+			Expect(dp.programAttached("br0.100:egress")).To(BeTrue())
+			Expect(dp.programAttached("br0.100:xdp")).To(BeFalse())
+
+			// The bridge ports are L2-only: no TC program. XDP from the
+			// untracked host endpoint is redirected to the ports, mirroring
+			// bonded-interface handling.
+			Expect(dp.programAttached("eth10:ingress")).To(BeFalse())
+			Expect(dp.programAttached("eth10:egress")).To(BeFalse())
+			Expect(dp.programAttached("eth10:xdp")).To(BeTrue())
+			Expect(dp.programAttached("eth20:ingress")).To(BeFalse())
+			Expect(dp.programAttached("eth20:egress")).To(BeFalse())
+			Expect(dp.programAttached("eth20:xdp")).To(BeTrue())
+			checkIfState(20, "eth10", ifstate.FlgIPv4Ready|ifstate.FlgBridgeSlave)
+			checkIfState(30, "eth20", ifstate.FlgIPv4Ready|ifstate.FlgBridgeSlave)
+
+			// The bridge itself (a middle node in the tree) carries nothing.
+			Expect(dp.programAttached("br0:ingress")).To(BeFalse())
+			Expect(dp.programAttached("br0:egress")).To(BeFalse())
+			Expect(dp.programAttached("br0:xdp")).To(BeFalse())
+
+			// When the NIC leaves the bridge it becomes an ordinary data
+			// interface again and regains its host-endpoint program.
+			err = dp.deleteIface("eth10")
+			Expect(err).NotTo(HaveOccurred())
+			err = dp.createIface("eth10", 20, "dummy")
+			Expect(err).NotTo(HaveOccurred())
+			genIfaceUpdate("eth10", ifacemonitor.StateUp, 20)()
+			Expect(dp.programAttached("eth10:ingress")).To(BeTrue())
+			Expect(dp.programAttached("eth10:egress")).To(BeTrue())
+			checkIfState(20, "eth10", ifstate.FlgIPv4Ready|ifstate.FlgHEP)
+		})
+
+		It("should keep a bridge port L2-only even when the L3 device is not in the data iface pattern", func() {
+			// Only the physical NICs match the pattern; the bridge and its
+			// sub-interface do not. Unlike a bond slave (which would fall back
+			// to attaching its own TC program and warn), a bridge port is
+			// unconditionally L2-only.
+			dataIfacePattern = "^eth"
+			newBpfEpMgr(false)
+			err := dp.createIface("br0", 10, "bridge")
+			Expect(err).NotTo(HaveOccurred())
+			err = dp.createBridgeSlaves("eth10", 20, 10)
+			Expect(err).NotTo(HaveOccurred())
+			genIfaceUpdate("br0", ifacemonitor.StateUp, 10)()
+			genIfaceUpdate("eth10", ifacemonitor.StateUp, 20)()
+
+			Expect(dp.programAttached("eth10:ingress")).To(BeFalse())
+			Expect(dp.programAttached("eth10:egress")).To(BeFalse())
+			checkIfState(20, "eth10", ifstate.FlgIPv4Ready|ifstate.FlgBridgeSlave)
 		})
 
 		It("should add host ifaces to iface tree", func() {

--- a/felix/design/bpf-overview.md
+++ b/felix/design/bpf-overview.md
@@ -85,6 +85,25 @@ support XDP; they carry untracked policy and can fast-drop hostile
 traffic before it reaches TC. Connect-time load-balancer programs
 ([bpf-services.md → Connect-Time Load Balancer (CTLB)](./bpf-services.md)) are attached to cgroup hooks rather than interfaces.
 
+**Enslaved L2 devices (bond/bridge ports).** A physical NIC that is
+enslaved to a Linux bond or bridge is an L2-only port: the host's L3
+(IP, routes) lives on the bond/bridge master or one of its VLAN
+sub-interfaces, not on the port. Felix never attaches the L3
+host-endpoint (TC) program to such a port — at most XDP, redirected
+from the L3 device's host endpoint. To get host-endpoint policy (and
+BPF RPF) on these nodes the L3-bearing device (the master, or the
+bridge VLAN sub-interface that carries the IP) must itself match
+`BPFDataIfacePattern`. Attaching the program to the port instead would
+break BPF reverse-path enforcement under `BPFEnforceRPF=Strict`: the
+check is keyed on the port's ingress ifindex while the return route
+resolves via the L3 device, so strict RPF would drop otherwise-valid
+inbound traffic. Bond slaves are detected via the netlink slave kind;
+bridge ports via their kernel `Protinfo` (the netlink library does not
+synthesise a slave object for them). The decision lives in
+`bpf_ep_mgr.go` (`getIfaceTypeFromLink`, `applyProgramsToDirtyDataInterfaces`),
+and the `ifstate` map flags such ports `bond`-/`bridgeslave` for
+introspection.
+
 ### Where BPF sits relative to netfilter
 
 On host-ingress (a packet arriving on an interface) the TC ingress

--- a/felix/fv/bpf_bridge_test.go
+++ b/felix/fv/bpf_bridge_test.go
@@ -1,0 +1,165 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fv_test
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/projectcalico/calico/felix/bpf/ifstate"
+	"github.com/projectcalico/calico/felix/fv/infrastructure"
+	"github.com/projectcalico/calico/libcalico-go/lib/apiconfig"
+)
+
+// These tests cover a host data interface (the node's own eth0) that is enslaved
+// to a Linux bridge. The host's L3 (IP, routes) lives on the bridge or one of its
+// VLAN sub-interfaces, so the BPF host-endpoint program must land there and not on
+// the enslaved port. With the program wrongly on the port, BPF reverse-path
+// enforcement keys off the port's ingress ifindex while the return route resolves
+// via the L3 device; under BPFEnforceRPF=Strict that mismatch drops otherwise-valid
+// inbound traffic (including the node's own datastore/return traffic). Running with
+// Strict RPF therefore makes the connectivity check a real regression guard.
+//
+// All of the bridge rewiring is done while Felix is held back (DelayFelixStart), so
+// Felix sees the final topology on its first interface scan rather than having the
+// node's main interface reconfigured underneath a running Felix.
+var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ Felix bridge-enslaved host interface",
+	[]apiconfig.DatastoreType{apiconfig.EtcdV3}, func(getInfra infrastructure.InfraFactory) {
+
+		if os.Getenv("FELIX_FV_ENABLE_BPF") != "true" {
+			// Non-BPF run.
+			return
+		}
+
+		var (
+			infra   infrastructure.DatastoreInfra
+			tc      infrastructure.TopologyContainers
+			options infrastructure.TopologyOptions
+			felix   *infrastructure.Felix
+		)
+
+		BeforeEach(func() {
+			infra = getInfra()
+			options = infrastructure.DefaultTopologyOptions()
+			options.DelayFelixStart = true
+			// Enforce strict RPF so that attaching the program to the wrong
+			// device (the bridge port) would drop the node's inbound traffic.
+			options.ExtraEnvVars["FELIX_BPFEnforceRPF"] = "Strict"
+		})
+
+		getBPFNet := func() []string {
+			out, _ := felix.ExecOutput("bpftool", "-jp", "net")
+			devs := []string{}
+			var output []struct {
+				Tc []struct {
+					Devname string `json:"devname"`
+				} `json:"tc"`
+			}
+			if err := json.Unmarshal([]byte(out), &output); err == nil && len(output) > 0 {
+				for _, t := range output[0].Tc {
+					devs = append(devs, t.Devname)
+				}
+			}
+			return devs
+		}
+
+		// rewireOntoBridge enslaves eth0 to br0 and moves the host L3 (address +
+		// default route) onto l3Dev, which is either br0 or a VLAN sub-interface of
+		// it. It runs as a single shell invocation so the node is never left without
+		// an address, and is called before Felix is started. The data iface pattern
+		// is set to match the node's eth0 (so the enslaved port is classified and
+		// suppressed) and the L3 device (so it gets the host-endpoint program).
+		rewireOntoBridge := func(script, l3Dev, dataIfacePattern string) {
+			felix.SetEnv(map[string]string{"FELIX_BPFDataIfacePattern": dataIfacePattern})
+
+			By("Rewiring eth0 onto a bridge before Felix starts")
+			felix.Exec("sh", "-ec", script)
+
+			By("Starting Felix against the final topology")
+			felix.TriggerDelayedStart()
+
+			By("Checking the host-endpoint program is on " + l3Dev + ", not the enslaved eth0")
+			Eventually(getBPFNet, "60s", "1s").Should(ContainElement(l3Dev))
+			Expect(getBPFNet()).NotTo(ContainElement("eth0"))
+
+			By("Checking the interface state flags")
+			// eth0 is now an L2-only bridge port; the L3 device carries the HEP.
+			ensureRightIFStateFlags(felix, ifstate.FlgIPv4Ready, ifstate.FlgBridgeSlave,
+				map[string]uint32{l3Dev: ifstate.FlgIPv4Ready | ifstate.FlgHEP})
+
+			By("Checking the host still has network")
+			// Felix reaching the datastore to program the above already proves the
+			// rewired uplink works under strict RPF; additionally confirm the node
+			// can reach its default gateway across the bridge.
+			gw, err := felix.ExecOutput("sh", "-c", "ip route show default | awk '{print $3; exit}'")
+			Expect(err).NotTo(HaveOccurred())
+			gw = strings.TrimSpace(gw)
+			Expect(gw).NotTo(BeEmpty())
+			Eventually(func() error {
+				return felix.ExecMayFail("ping", "-c", "1", "-W", "2", gw)
+			}, "30s", "1s").ShouldNot(HaveOccurred(), "node lost network after rewiring onto the bridge")
+		}
+
+		JustBeforeEach(func() {
+			tc, _ = infrastructure.StartNNodeTopology(1, options, infra)
+			felix = tc.Felixes[0]
+
+			err := infra.AddAllowToDatastore("host-endpoint=='true'")
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should attach the program to the bridge, not the enslaved port (IP on br0)", func() {
+			// eth0 -> br0, host L3 directly on br0 (untagged).
+			script := `
+GW=$(ip route show default | awk '{print $3; exit}')
+ADDR=$(ip -o -4 addr show dev eth0 | awk '{print $4; exit}')
+ip link add br0 type bridge
+ip link set eth0 master br0
+ip link set br0 up
+ip addr flush dev eth0
+ip addr add "$ADDR" dev br0
+[ -n "$GW" ] && ip route replace default via "$GW" dev br0
+for d in all default eth0 br0; do sysctl -w net.ipv4.conf.$d.rp_filter=0; done
+`
+			rewireOntoBridge(script, "br0", "^eth0$|^br0$")
+		})
+
+		It("should attach the program to the bridge VLAN sub-interface, not the enslaved port (IP on br0.100)", func() {
+			// eth0 -> br0 -> br0.100, host L3 on the VLAN sub-interface. The bridge
+			// is made VLAN-aware with the uplink port carrying PVID 100 untagged so
+			// the node's untagged traffic is mapped to VLAN 100 and reaches br0.100,
+			// preserving connectivity.
+			script := `
+GW=$(ip route show default | awk '{print $3; exit}')
+ADDR=$(ip -o -4 addr show dev eth0 | awk '{print $4; exit}')
+ip link add br0 type bridge vlan_filtering 1
+ip link set eth0 master br0
+ip link add link br0 name br0.100 type vlan id 100
+bridge vlan add dev br0 vid 100 self
+bridge vlan add dev eth0 vid 100 pvid untagged
+ip link set br0 up
+ip link set br0.100 up
+ip addr flush dev eth0
+ip addr add "$ADDR" dev br0.100
+[ -n "$GW" ] && ip route replace default via "$GW" dev br0.100
+for d in all default eth0 br0 br0/100; do sysctl -w net.ipv4.conf.$d.rp_filter=0 2>/dev/null || true; done
+`
+			rewireOntoBridge(script, "br0.100", "^eth0$|^br0\\.100$")
+		})
+	})


### PR DESCRIPTION
## Description

When a host NIC that matches `BPFDataIfacePattern` is enslaved to a Linux bridge, Felix's BPF dataplane attached the L3 host-endpoint (TC/HEP) program to that physical port. That's the wrong device — the host's L3 (IP, routes) lives on the bridge or one of its VLAN sub-interfaces, not on the port.

With `BPFEnforceRPF=Strict` this dropped inbound traffic for a node whose IP is on a bridge sub-interface: the HEP program on the port runs the reverse-path check keyed on the port's ingress ifindex, but the return route resolves via the sub-interface, so the ifindex mismatch fails RPF.

This treats a bridge port as L2-only and never attaches the L3 program to it, mirroring the existing bond-slave handling. The L3-bearing device (the bridge or its VLAN sub-interface) must itself match `BPFDataIfacePattern` and is attached independently. Bridge ports are detected via their kernel `Protinfo`, since the netlink library does not synthesise a slave object for them (only bond/vrf).

The suppression lives in the L3/HEP attach decision (`applyProgramsToDirtyDataInterfaces`); the attach plumbing is left intact.

CORE-13089

## Changes

- `getIfaceTypeFromLink`: classify bridge ports as a new `IfaceTypeBridgeSlave` via `MasterIndex != 0 && Protinfo != nil`.
- `applyProgramsToDirtyDataInterfaces`: unconditionally suppress the TC program on a bridge port (XDP-only, redirected to the L3 device's host endpoint).
- `getEndpointType` / `getIfTypeFlags`: handle the new type; `ifstate` gains `FlgBridgeSlave` (`bridgeslave`) for introspection.
- Docs: `felix/design/bpf-overview.md` documents the L2-enslaved-device rule and the RPF rationale.

## Testing

- Unit tests (`bpf_ep_mgr_test.go`): a bridge-enslaved NIC gets no TC program while the bridge sub-interface does; the port keeps working (regains its program) when removed from the bridge; and the suppression holds even when the L3 device is not in the pattern. Full `bpf_ep_mgr` UT suite passes.
- FV (`bpf_bridge_test.go`): the node's own `eth0` is enslaved to a bridge (IP on `br0`, and IP on a VLAN sub-interface `br0.100`) before Felix starts, under `BPFEnforceRPF=Strict`. Asserts the program lands on the L3 device (not `eth0`), the ifstate flags are correct, and the node retains network — which under strict RPF would fail if the program were on the port.

**Release note:**
```release-note
Felix eBPF: if a Calico-managed host data interface is enslaved to a Linux bridge, point BPFDataIfacePattern at the bridge or sub-interface that holds the host IP; the BPF host-endpoint program no longer attaches to the enslaved port (consistent with bonded interfaces).
```