### PR TITLE
[BPF] Do not drop non-Calico WireGuard traffic at host endpoints

### DIFF
--- a/felix/bpf-gpl/parsing.h
+++ b/felix/bpf-gpl/parsing.h
@@ -168,24 +168,25 @@ static CALI_BPF_INLINE int tc_state_fill_from_nexthdr(struct cali_tc_ctx *ctx, b
 			}
 		}
 		if (ctx->state->dport == WG_PORT) {
-			/* Wireguard packet. Allow if to/from known Calico host. */
+			/* Wireguard packet. Fast-allow if to/from a known Calico host so
+			 * that a user's HEP policy cannot accidentally block the cluster's
+			 * own host-to-host WireGuard mesh. Otherwise fall through to
+			 * policy: WG_PORT defaults to 51820, which is also the stock
+			 * WireGuard port, so the traffic may belong to a user-managed
+			 * WireGuard unrelated to Calico - we must not drop it outright. */
 			if (CALI_F_FROM_HEP) {
 				if (rt_addr_is_remote_host(&ctx->state->ip_src)) {
 					CALI_DEBUG("Wireguard packet from known Calico host, allow.");
 					goto allow;
 				} else {
-					CALI_DEBUG("Wireguard packet from unknown source, drop.");
-					deny_reason(ctx, CALI_REASON_UNAUTH_SOURCE);
-					goto deny;
+					CALI_DEBUG("Wireguard packet from unknown source, fall through to policy.");
 				}
 			} else if (CALI_F_TO_HEP && !CALI_F_L3_DEV) {
 				if (rt_addr_is_remote_host(&ctx->state->ip_dst)) {
 					CALI_DEBUG("Wireguard packet to known Calico host, allow.");
 					goto allow;
 				} else {
-					CALI_DEBUG("Wireguard packet to unknown dest, drop.");
-					deny_reason(ctx, CALI_REASON_UNAUTH_SOURCE);
-					goto deny;
+					CALI_DEBUG("Wireguard packet to unknown dest, fall through to policy.");
 				}
 			}
 		}

--- a/felix/bpf/ut/bpf_prog_test.go
+++ b/felix/bpf/ut/bpf_prog_test.go
@@ -83,6 +83,7 @@ func init() {
 const (
 	natTunnelMTU      = uint16(700)
 	testVxlanPort     = uint16(5665)
+	testWGPort        = uint16(5666)
 	testMaglevLUTSize = uint32(31)
 )
 
@@ -899,6 +900,7 @@ func objLoad(fname, bpfFsDir, ipFamily string, topts testOpts, polProg, hasHostC
 					IfaceName:     setLogPrefix(ifaceLog),
 					MaglevLUTSize: testMaglevLUTSize,
 					IPFragTimeout: topts.ipfragTimeout,
+					WgPort:        topts.wgPort,
 				}
 				if topts.flowLogsEnabled {
 					globals.Flags |= libbpf.GlobalsFlowLogsEnabled
@@ -1314,6 +1316,7 @@ type testOpts struct {
 	istioDSCP                     int8
 	workloadSrcSpoofingConfigured bool
 	ipfragTimeout                 uint32
+	wgPort                        uint16
 }
 
 type testOption func(opts *testOpts)
@@ -1432,6 +1435,12 @@ func withIstioDSCP(value uint8) testOption {
 func withIPFragTimeout(timeout uint32) testOption {
 	return func(o *testOpts) {
 		o.ipfragTimeout = timeout
+	}
+}
+
+func withWgPort(port uint16) testOption {
+	return func(o *testOpts) {
+		o.wgPort = port
 	}
 }
 

--- a/felix/bpf/ut/wireguard_test.go
+++ b/felix/bpf/ut/wireguard_test.go
@@ -1,0 +1,113 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ut_test
+
+import (
+	"net"
+	"testing"
+
+	"github.com/gopacket/gopacket/layers"
+	. "github.com/onsi/gomega"
+
+	"github.com/projectcalico/calico/felix/bpf/polprog"
+	"github.com/projectcalico/calico/felix/bpf/routes"
+	"github.com/projectcalico/calico/felix/ip"
+	"github.com/projectcalico/calico/felix/proto"
+)
+
+// Host-terminated traffic on a host interface is governed by host endpoint
+// policy (HostNormalTiers with ForHostInterface set), not by the workload
+// policy carried in Tiers. denyAllRulesHost (from failsafes_test.go) is the
+// deny-all counterpart.
+var allowAllRulesHost = &polprog.Rules{
+	ForHostInterface: true,
+	HostNormalTiers: []polprog.Tier{{
+		Policies: []polprog.Policy{{
+			Name:  "allow all",
+			Rules: []polprog.Rule{{Rule: &proto.Rule{Action: "Allow"}}},
+		}},
+	}},
+}
+
+// WG_PORT is Calico's configured WireGuard port (default 51820), which also
+// happens to be the stock WireGuard port. When a host endpoint sees traffic on
+// that port to/from a known Calico host, it is fast-allowed so that a user's HEP
+// policy cannot accidentally break the cluster's own host-to-host WireGuard mesh.
+// Any other traffic on that port must fall through to policy rather than be
+// dropped outright - it may belong to a user-managed WireGuard tunnel that is
+// unrelated to Calico. See issue #12900.
+func TestWireguardPortFromHEP(t *testing.T) {
+	RegisterTestingT(t)
+	defer resetBPFMaps()
+
+	// The node terminates the WireGuard tunnel, so the packets are destined to
+	// the local host on WG_PORT.
+	err := rtMap.Update(
+		routes.NewKey(ip.CIDRFromIPNet(&net.IPNet{IP: hostIP, Mask: net.CIDRMask(32, 32)}).(ip.V4CIDR)).AsBytes(),
+		routes.NewValue(routes.FlagsLocalHost).AsBytes(),
+	)
+	Expect(err).NotTo(HaveOccurred())
+
+	wgPacket := func(src net.IP) []byte {
+		ipv4 := *ipv4Default
+		ipv4.SrcIP = src
+		ipv4.DstIP = hostIP
+		udp := &layers.UDP{SrcPort: layers.UDPPort(testWGPort), DstPort: layers.UDPPort(testWGPort)}
+		_, _, _, _, pktBytes, err := testPacketV4(nil, &ipv4, udp, nil)
+		Expect(err).NotTo(HaveOccurred())
+		return pktBytes
+	}
+
+	// An allowed packet may end as TC_ACT_UNSPEC or, when the FIB forwards it,
+	// TC_ACT_REDIRECT; only TC_ACT_SHOT means dropped. So we assert on
+	// dropped-vs-not rather than the exact allow code.
+	runWG := func(src net.IP, rules *polprog.Rules, dropped bool) {
+		// Clear conntrack so each case is decided fresh, not by a CT entry
+		// left behind by a previously-allowed run.
+		resetCTMap(ctMap)
+		skbMark = 0
+		runBpfTest(t, "calico_from_host_ep", rules, func(bpfrun bpfProgRunFn) {
+			res, err := bpfrun(wgPacket(src))
+			Expect(err).NotTo(HaveOccurred())
+			if dropped {
+				Expect(res.Retval).To(Equal(resTC_ACT_SHOT))
+			} else {
+				Expect(res.Retval).NotTo(Equal(resTC_ACT_SHOT))
+			}
+		}, withWgPort(testWGPort))
+	}
+
+	// srcIP has no route: not a known Calico host. The packet must not be
+	// dropped at parse - it falls through to host policy, which allows it here.
+	t.Log("WG from unknown source, allow-all policy -> ALLOW (fall through to policy)")
+	runWG(srcIP, allowAllRulesHost, false)
+
+	// The same unknown-source packet must be governed by policy, so a deny
+	// policy drops it. Combined with the allow-all case above, this confirms
+	// the packet reaches policy rather than being decided at parse.
+	t.Log("WG from unknown source, deny-all policy -> DROP (policy governs)")
+	runWG(srcIP, &denyAllRulesHost, true)
+
+	// node2ip is a known remote Calico host: the WG packet is fast-allowed and
+	// bypasses policy, so even a deny-all policy does not drop it. This keeps
+	// the cluster's own WireGuard mesh working regardless of HEP policy.
+	t.Log("WG from known Calico host, deny-all policy -> ALLOW (fast path bypasses policy)")
+	err = rtMap.Update(
+		routes.NewKey(ip.CIDRFromIPNet(&net.IPNet{IP: node2ip, Mask: net.CIDRMask(32, 32)}).(ip.V4CIDR)).AsBytes(),
+		routes.NewValue(routes.FlagsRemoteHost).AsBytes(),
+	)
+	Expect(err).NotTo(HaveOccurred())
+	runWG(node2ip, &denyAllRulesHost, false)
+}

--- a/felix/design/bpf-overview.md
+++ b/felix/design/bpf-overview.md
@@ -140,6 +140,14 @@ stack (or lets them continue through it) when it cannot:
   applies to service traffic; host-originated traffic whose endpoint
   is in the host namespace (host-networked peer, host-local socket)
   obviously cannot skip the host stack and does not use this path.
+- **Tunnel-port traffic at a host endpoint.** UDP arriving on a host
+  interface on the VXLAN or WireGuard port is fast-allowed when it is
+  to/from a known Calico host, so that host-endpoint policy cannot
+  accidentally break the cluster's own overlay/encryption mesh. These
+  are well-known ports (WireGuard defaults to 51820) that a user may
+  also run their own VXLAN/WireGuard on, so a packet that is _not_
+  to/from a known Calico host is not assumed to be Calico's: BPF lets
+  it fall through to host-endpoint policy rather than dropping it.
 
 When BPF _can_ answer the question — FIB hit, known local pod, existing
 BPF conntrack entry, matched NAT frontend with an acceptable backend —


### PR DESCRIPTION
### Description

In eBPF mode, the host-endpoint TC programs treat **any** UDP packet on `WG_PORT` as Calico's own host-to-host WireGuard. Since #11308 such a packet is dropped (`CALI_REASON_UNAUTH_SOURCE`) unless the peer's *underlay* address is a known Calico host.

Two problems follow:

- `WG_PORT` defaults to `51820` — the stock WireGuard port — and is compiled in regardless of whether Calico's own WireGuard is enabled. A user-managed WireGuard mesh on `51820` therefore has all of its inbound traffic black-holed as soon as the eBPF dataplane attaches to the physical interface (the reporter's scenario in #12900: works on v3.31, breaks on v3.32).
- Even Calico's own WireGuard breaks when the underlay peer address differs from the node's Calico address (e.g. nodes behind NAT).

The adjacent VXLAN branch already handles the analogous case gracefully — it fast-allows known-host traffic but *falls through to policy* on a miss ("the user can be using VXLAN on a different VNI so we don't simply drop it"). This change makes the WireGuard branch do the same: keep the known-host fast-allow (so a user's HEP policy cannot break the cluster's own WireGuard mesh), but fall through to host-endpoint policy instead of dropping outright. Policy then governs the traffic like any other host-terminated flow.

Root cause and behavior verified against the compiled BPF program (new `bpf/ut` test loaded and run on a real kernel).

### What changed between v3.31 and v3.32

The regression was introduced by **#11308 ("[eBPF] - Fix host->host wireguard traffic", `b1d154380d`)**, which added the `if (dport == WG_PORT) { ... goto deny; }` block in `felix/bpf-gpl/parsing.h`. It builds on **#11230 ("Enable fib for ipip, wireguard", `d993149f60`)**, but #11230 only enabled FIB — the parse-time drop of unknown-source WireGuard traffic is #11308. Both landed in the v3.32 line and neither is in v3.31, which matches the report exactly:

| | WG_PORT drop in `parsing.h` | contains #11308 |
|---|---|---|
| v3.31.0 / v3.31.6 / release-v3.31 | absent | no |
| v3.32.0 / release-v3.32 | present | yes |

This PR relaxes that specific `goto deny` to a policy fall-through.

**Release note:**
```release-note
Fixed a regression in eBPF mode where traffic on the WireGuard port (51820 by default) arriving at a host interface was dropped unless it came from a known Calico node, breaking user-managed WireGuard overlays and Calico WireGuard between nodes with differing underlay addresses (e.g. behind NAT).
```

Fixes #12900
