### PR TITLE
felix: support anycast failover for LoadBalancer VIPs

### DIFF
--- a/felix/bpf-gpl/nat_lookup.h
+++ b/felix/bpf-gpl/nat_lookup.h
@@ -157,7 +157,8 @@ static CALI_BPF_INLINE struct calico_nat_dest* calico_nat_lookup(ipv46_addr_t *i
 
 	if (count == 0) {
 		CALI_DEBUG("NAT: no backend");
-		*res = NAT_NO_BACKEND;
+		*res = nat_lv1_val->flags & NAT_FLG_NO_BACKEND_FORWARD ?
+			NAT_NO_BACKEND_FORWARD : NAT_NO_BACKEND;
 		return NULL;
 	}
 

--- a/felix/bpf-gpl/nat_types.h
+++ b/felix/bpf-gpl/nat_types.h
@@ -11,6 +11,7 @@ typedef enum calico_nat_lookup_result {
 	NAT_LOOKUP_ALLOW,
 	NAT_FE_LOOKUP_DROP,
 	NAT_NO_BACKEND,
+	NAT_NO_BACKEND_FORWARD,
 	NAT_EXCLUDE,
 	NAT_MAGLEV,
 } nat_lookup_result;
@@ -44,6 +45,8 @@ struct __attribute__((__packed__)) calico_nat_key {
 
 // This is used as a special ID along with count=0 to drop a packet at nat level1 lookup
 #define NAT_FE_DROP_COUNT  0xffffffff
+
+#define NAT_FLG_NO_BACKEND_FORWARD 0x10
 
 struct calico_nat_value {
 	__u32 id;

--- a/felix/bpf/nat/maps.go
+++ b/felix/bpf/nat/maps.go
@@ -203,17 +203,19 @@ func FrontendKeyFromBytes(b []byte) FrontendKeyInterface {
 }
 
 const (
-	NATFlgExternalLocal = 0x1
-	NATFlgInternalLocal = 0x2
-	NATFlgExclude       = 0x4
-	NATFlgMaglev        = 0x8
+	NATFlgExternalLocal     = 0x1
+	NATFlgInternalLocal     = 0x2
+	NATFlgExclude           = 0x4
+	NATFlgMaglev            = 0x8
+	NATFlgNoBackendForward = 0x10
 )
 
 var flgTostr = map[int]string{
-	NATFlgExternalLocal: "external-local",
-	NATFlgInternalLocal: "internal-local",
-	NATFlgExclude:       "nat-exclude",
-	NATFlgMaglev:        "maglev",
+	NATFlgExternalLocal:     "external-local",
+	NATFlgInternalLocal:     "internal-local",
+	NATFlgExclude:           "nat-exclude",
+	NATFlgMaglev:            "maglev",
+	NATFlgNoBackendForward: "no-backend-forward",
 }
 
 type FrontendValue [frontendValueSize]byte

--- a/felix/bpf/proxy/proxy.go
+++ b/felix/bpf/proxy/proxy.go
@@ -464,17 +464,20 @@ const (
 	ReapTerminatingUDPImmediatelly = "TerminatingImmediately"
 
 	ExcludeServiceAnnotation          = "projectcalico.org/natExcludeService"
+	NoEndpointsActionAnnotation       = "lb.projectcalico.org/no-endpoints-action"
 	ExternalTrafficStrategyAnnotation = "lb.projectcalico.org/external-traffic-strategy"
 )
 
 var (
 	ExternalTrafficStrategyMaglev = "maglev"
+	NoEndpointsActionForward      = "Forward"
 )
 
 type ServiceAnnotations interface {
 	ReapTerminatingUDP() bool
 	ExcludeService() bool
 	UseMaglev() bool
+	NoEndpointsAction() string
 	TopologyMode() string
 }
 
@@ -482,6 +485,7 @@ type servicePortAnnotations struct {
 	reapTerminatingUDP bool
 	excludeService     bool
 	useMaglev          bool
+	noEndpointsAction  string
 	topologyMode       string
 }
 
@@ -495,6 +499,10 @@ func (s *servicePortAnnotations) ExcludeService() bool {
 
 func (s *servicePortAnnotations) UseMaglev() bool {
 	return s.useMaglev
+}
+
+func (s *servicePortAnnotations) NoEndpointsAction() string {
+	return s.noEndpointsAction
 }
 
 func (s *servicePortAnnotations) TopologyMode() string {
@@ -524,6 +532,10 @@ func makeServiceInfo(_ *v1.ServicePort, s *v1.Service, baseSvc *k8sp.BaseService
 
 	if a, ok := s.Annotations[ExternalTrafficStrategyAnnotation]; ok && strings.EqualFold(a, ExternalTrafficStrategyMaglev) {
 		svc.useMaglev = true
+	}
+
+	if v, ok := s.Annotations[NoEndpointsActionAnnotation]; ok {
+		svc.noEndpointsAction = v
 	}
 
 	if v, ok := s.Annotations[v1.AnnotationTopologyMode]; ok {

--- a/felix/bpf/proxy/proxy_test.go
+++ b/felix/bpf/proxy/proxy_test.go
@@ -665,6 +665,7 @@ var _ = Describe("BPF Proxy", func() {
 
 				testSvc.Annotations = map[string]string{
 					proxy.ReapTerminatingUDPAnnotation: proxy.ReapTerminatingUDPImmediatelly,
+					proxy.NoEndpointsActionAnnotation:  proxy.NoEndpointsActionForward,
 				}
 
 				k8s = fake.NewClientset(testSvc)
@@ -674,13 +675,15 @@ var _ = Describe("BPF Proxy", func() {
 				dp.checkState(func(s proxy.DPSyncerState) {
 					Expect(len(s.SvcMap)).To(Equal(1))
 					Expect(len(s.EpsMap)).To(Equal(0))
-					Expect(s.SvcMap[k8sp.ServicePortName{
+					svc := s.SvcMap[k8sp.ServicePortName{
 						NamespacedName: types.NamespacedName{
 							Namespace: "default",
 							Name:      "testService",
 						},
 						Protocol: v1.ProtocolUDP,
-					}].(proxy.Service).ReapTerminatingUDP()).To(BeTrue())
+					}].(proxy.Service)
+					Expect(svc.ReapTerminatingUDP()).To(BeTrue())
+					Expect(svc.NoEndpointsAction()).To(Equal(proxy.NoEndpointsActionForward))
 				})
 			})
 		})

--- a/felix/bpf/proxy/syncer.go
+++ b/felix/bpf/proxy/syncer.go
@@ -614,6 +614,9 @@ func (s *Syncer) applyDerived(
 			flags |= nat.NATFlgMaglev
 		}
 	}
+	if strings.EqualFold(sinfo.NoEndpointsAction(), NoEndpointsActionForward) && t == svcTypeLoadBalancer {
+		flags |= nat.NATFlgNoBackendForward
+	}
 
 	switch t {
 	case svcTypeNodePort, svcTypeLoadBalancer, svcTypeNodePortRemote:

--- a/felix/calc/dataplane_passthru.go
+++ b/felix/calc/dataplane_passthru.go
@@ -203,13 +203,15 @@ func parseCIDR(s string) (string, bool) {
 }
 
 func kubernetesServiceToProto(s *kapiv1.Service) *proto.ServiceUpdate {
+	const noEndpointsActionAnnotation = "lb.projectcalico.org/no-endpoints-action"
 	up := &proto.ServiceUpdate{
-		Name:           s.Name,
-		Namespace:      s.Namespace,
-		Type:           string(s.Spec.Type),
-		ClusterIps:     s.Spec.ClusterIPs,
-		LoadbalancerIp: s.Spec.LoadBalancerIP,
-		ExternalIps:    s.Spec.ExternalIPs,
+		Name:              s.Name,
+		Namespace:         s.Namespace,
+		Type:              string(s.Spec.Type),
+		ClusterIps:        s.Spec.ClusterIPs,
+		LoadbalancerIp:    s.Spec.LoadBalancerIP,
+		ExternalIps:       s.Spec.ExternalIPs,
+		NoEndpointsAction: s.Annotations[noEndpointsActionAnnotation],
 	}
 
 	// Extract LoadBalancer ingress IPs from Status (the actual assigned IPs).

--- a/felix/dataplane/linux/int_dataplane.go
+++ b/felix/dataplane/linux/int_dataplane.go
@@ -1281,6 +1281,7 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 	dp.RegisterManager(dp.wireguardManager) // IPv4
 
 	dp.RegisterManager(newServiceLoopManager(filterTableV4, ruleRenderer, 4))
+	dp.RegisterManager(newLBNoEndpointsManager(filterTableV4, ruleRenderer, 4))
 
 	if config.IPv6Enabled {
 		// Build out both iptables and nftables implementations for IPv6.
@@ -1447,6 +1448,7 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 		dp.RegisterManager(newFloatingIPManager(natTableV6, ruleRenderer, 6, config.FloatingIPsEnabled))
 		dp.RegisterManager(newMasqManager(ipSetsV6, natTableV6, ruleRenderer, config.MaxIPSetSize, 6))
 		dp.RegisterManager(newServiceLoopManager(filterTableV6, ruleRenderer, 6))
+		dp.RegisterManager(newLBNoEndpointsManager(filterTableV6, ruleRenderer, 6))
 
 		if config.RulesConfig.NATOutgoingExclusions == string(apiv3.NATOutgoingExclusionsIPPoolsAndHostIPs) {
 			dp.RegisterManager(newHostsIPSetManager(ipSetsV6, 6, config))

--- a/felix/dataplane/linux/lb_no_endpoints_mgr.go
+++ b/felix/dataplane/linux/lb_no_endpoints_mgr.go
@@ -1,0 +1,71 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package intdataplane
+
+import (
+	"reflect"
+	"strings"
+
+	"github.com/projectcalico/calico/felix/generictables"
+	"github.com/projectcalico/calico/felix/proto"
+	"github.com/projectcalico/calico/felix/rules"
+)
+
+type lbNoEndpointsServiceID struct {
+	namespace string
+	name      string
+}
+
+// lbNoEndpointsManager maintains the policy-gated exceptions that allow packets
+// for opted-in LoadBalancer VIPs to reach normal routing when kube-proxy has no
+// local endpoint.
+type lbNoEndpointsManager struct {
+	ipVersion    uint8
+	filterTable  Table
+	ruleRenderer rules.RuleRenderer
+	services     map[lbNoEndpointsServiceID]*proto.ServiceUpdate
+	activeChains []*generictables.Chain
+	dirty        bool
+}
+
+func newLBNoEndpointsManager(filterTable Table, ruleRenderer rules.RuleRenderer, ipVersion uint8) *lbNoEndpointsManager {
+	return &lbNoEndpointsManager{
+		ipVersion: ipVersion, filterTable: filterTable, ruleRenderer: ruleRenderer,
+		services: map[lbNoEndpointsServiceID]*proto.ServiceUpdate{}, dirty: true,
+	}
+}
+
+func (m *lbNoEndpointsManager) OnUpdate(msg any) {
+	switch update := msg.(type) {
+	case *proto.ServiceUpdate:
+		id := lbNoEndpointsServiceID{namespace: update.GetNamespace(), name: update.GetName()}
+		if strings.EqualFold(update.GetNoEndpointsAction(), "Forward") {
+			m.services[id] = update
+		} else {
+			delete(m.services, id)
+		}
+		m.dirty = true
+	case *proto.ServiceRemove:
+		delete(m.services, lbNoEndpointsServiceID{namespace: update.GetNamespace(), name: update.GetName()})
+		m.dirty = true
+	}
+}
+
+func (m *lbNoEndpointsManager) CompleteDeferredWork() error {
+	if !m.dirty {
+		return nil
+	}
+	services := make([]*proto.ServiceUpdate, 0, len(m.services))
+	for _, service := range m.services {
+		services = append(services, service)
+	}
+	chains := m.ruleRenderer.LBNoEndpointServicesToIptablesChains(services, m.ipVersion)
+	if !reflect.DeepEqual(m.activeChains, chains) {
+		m.filterTable.RemoveChains(m.activeChains)
+		m.filterTable.UpdateChains(chains)
+		m.activeChains = chains
+	}
+	m.dirty = false
+	return nil
+}

--- a/felix/proto/felixbackend.pb.go
+++ b/felix/proto/felixbackend.pb.go
@@ -7,12 +7,11 @@
 package proto
 
 import (
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
 	sync "sync"
 	unsafe "unsafe"
-
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 )
 
 const (
@@ -6021,6 +6020,7 @@ type ServiceUpdate struct {
 	ExternalIps            []string               `protobuf:"bytes,6,rep,name=external_ips,json=externalIps,proto3" json:"external_ips,omitempty"`
 	Ports                  []*ServicePort         `protobuf:"bytes,7,rep,name=ports,proto3" json:"ports,omitempty"`
 	LoadbalancerIngressIps []string               `protobuf:"bytes,8,rep,name=loadbalancer_ingress_ips,json=loadbalancerIngressIps,proto3" json:"loadbalancer_ingress_ips,omitempty"`
+	NoEndpointsAction      string                 `protobuf:"bytes,9,opt,name=no_endpoints_action,json=noEndpointsAction,proto3" json:"no_endpoints_action,omitempty"`
 	unknownFields          protoimpl.UnknownFields
 	sizeCache              protoimpl.SizeCache
 }
@@ -6109,6 +6109,13 @@ func (x *ServiceUpdate) GetLoadbalancerIngressIps() []string {
 		return x.LoadbalancerIngressIps
 	}
 	return nil
+}
+
+func (x *ServiceUpdate) GetNoEndpointsAction() string {
+	if x != nil {
+		return x.NoEndpointsAction
+	}
+	return ""
 }
 
 type ServiceRemove struct {
@@ -6692,7 +6699,7 @@ const file_felixbackend_proto_rawDesc = "" +
 	"\vServicePort\x12\x1a\n" +
 	"\bProtocol\x18\x01 \x01(\tR\bProtocol\x12\x12\n" +
 	"\x04Port\x18\x02 \x01(\x05R\x04Port\x12\x1a\n" +
-	"\bNodePort\x18\x03 \x01(\x05R\bNodePort\"\xa6\x02\n" +
+	"\bNodePort\x18\x03 \x01(\x05R\bNodePort\"\xd6\x02\n" +
 	"\rServiceUpdate\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x1c\n" +
 	"\tnamespace\x18\x02 \x01(\tR\tnamespace\x12\x12\n" +
@@ -6702,7 +6709,8 @@ const file_felixbackend_proto_rawDesc = "" +
 	"\x0floadbalancer_ip\x18\x05 \x01(\tR\x0eloadbalancerIp\x12!\n" +
 	"\fexternal_ips\x18\x06 \x03(\tR\vexternalIps\x12(\n" +
 	"\x05ports\x18\a \x03(\v2\x12.felix.ServicePortR\x05ports\x128\n" +
-	"\x18loadbalancer_ingress_ips\x18\b \x03(\tR\x16loadbalancerIngressIps\"A\n" +
+	"\x18loadbalancer_ingress_ips\x18\b \x03(\tR\x16loadbalancerIngressIps\x12.\n" +
+	"\x13no_endpoints_action\x18\t \x01(\tR\x11noEndpointsAction\"A\n" +
 	"\rServiceRemove\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x1c\n" +
 	"\tnamespace\x18\x02 \x01(\tR\tnamespace*(\n" +

--- a/felix/proto/felixbackend.proto
+++ b/felix/proto/felixbackend.proto
@@ -813,6 +813,7 @@ message ServiceUpdate {
 	repeated string external_ips = 6;
 	repeated ServicePort ports = 7;
 	repeated string loadbalancer_ingress_ips = 8;
+	string no_endpoints_action = 9;
 }
 
 message ServiceRemove {

--- a/felix/proto/felixbackend_grpc.pb.go
+++ b/felix/proto/felixbackend_grpc.pb.go
@@ -8,7 +8,6 @@ package proto
 
 import (
 	context "context"
-
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"

--- a/felix/rules/nat.go
+++ b/felix/rules/nat.go
@@ -24,6 +24,7 @@ import (
 
 	tcdefs "github.com/projectcalico/calico/felix/bpf/tc/defs"
 	"github.com/projectcalico/calico/felix/generictables"
+	"github.com/projectcalico/calico/felix/proto"
 )
 
 func (r *DefaultRuleRenderer) MakeNatOutgoingRule(protocol string, action generictables.Action, ipVersion uint8) generictables.Rule {
@@ -177,4 +178,27 @@ func (r *DefaultRuleRenderer) BlockedCIDRsToIptablesChains(cidrs []string, ipVer
 		Name:  ChainCIDRBlock,
 		Rules: rules,
 	}}
+}
+
+func (r *DefaultRuleRenderer) LBNoEndpointServicesToIptablesChains(services []*proto.ServiceUpdate, ipVersion uint8) []*generictables.Chain {
+	var rendered []generictables.Rule
+	for _, service := range services {
+		if !strings.EqualFold(service.GetNoEndpointsAction(), "Forward") {
+			continue
+		}
+		for _, vip := range service.GetLoadbalancerIngressIps() {
+			parsed := net.ParseIP(vip)
+			if parsed == nil || (parsed.To4() == nil) != (ipVersion == 6) {
+				continue
+			}
+			for _, port := range service.GetPorts() {
+				rendered = append(rendered, generictables.Rule{
+					Match: r.NewMatch().Protocol(strings.ToLower(port.GetProtocol())).
+						DestNet(vip).DestPorts(uint16(port.GetPort())),
+					Action: r.Allow(),
+				})
+			}
+		}
+	}
+	return []*generictables.Chain{{Name: ChainLBNoEndpoints, Rules: rendered}}
 }

--- a/felix/rules/nat_test.go
+++ b/felix/rules/nat_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/projectcalico/calico/felix/generictables"
 	"github.com/projectcalico/calico/felix/ipsets"
 	. "github.com/projectcalico/calico/felix/iptables"
+	"github.com/projectcalico/calico/felix/proto"
 	. "github.com/projectcalico/calico/felix/rules"
 )
 
@@ -237,6 +238,29 @@ var _ = Describe("NAT", func() {
 			Name:  "cali-nat-outgoing",
 			Rules: nil,
 		}))
+	})
+
+	It("should render only Forward no-endpoints LoadBalancer VIP ports", func() {
+		chains := renderer.LBNoEndpointServicesToIptablesChains([]*proto.ServiceUpdate{
+			{
+				Name: "ntp", Namespace: "default", NoEndpointsAction: "Forward",
+				ClusterIps: []string{"10.96.0.1"}, ExternalIps: []string{"192.0.2.1"},
+				LoadbalancerIngressIps: []string{"1.2.3.4", "2001:db8::1"},
+				Ports: []*proto.ServicePort{{Protocol: "UDP", Port: 123}},
+			},
+			{
+				Name: "ordinary", Namespace: "default",
+				LoadbalancerIngressIps: []string{"5.6.7.8"},
+				Ports:                   []*proto.ServicePort{{Protocol: "TCP", Port: 80}},
+			},
+		}, 4)
+		Expect(chains).To(Equal([]*generictables.Chain{{
+			Name: ChainLBNoEndpoints,
+			Rules: []generictables.Rule{{
+				Match:  Match().Protocol("udp").DestNet("1.2.3.4").DestPorts(123),
+				Action: AcceptAction{},
+			}},
+		}}))
 	})
 })
 

--- a/felix/rules/rule_defs.go
+++ b/felix/rules/rule_defs.go
@@ -76,6 +76,7 @@ const (
 	ChainFIPSnat = ChainNamePrefix + "fip-snat"
 
 	ChainCIDRBlock = ChainNamePrefix + "cidr-block"
+	ChainLBNoEndpoints = ChainNamePrefix + "lb-no-endpoints"
 
 	PolicyInboundPfx   PolicyChainNamePrefix  = ChainNamePrefix + "pi-"
 	PolicyOutboundPfx  PolicyChainNamePrefix  = ChainNamePrefix + "po-"
@@ -342,6 +343,7 @@ type RuleRenderer interface {
 	DNATsToIptablesChains(dnats map[string]string) []*generictables.Chain
 	SNATsToIptablesChains(snats map[string]string) []*generictables.Chain
 	BlockedCIDRsToIptablesChains(cidrs []string, ipVersion uint8) []*generictables.Chain
+	LBNoEndpointServicesToIptablesChains(services []*proto.ServiceUpdate, ipVersion uint8) []*generictables.Chain
 
 	WireguardIncomingMarkChain() *generictables.Chain
 

--- a/felix/rules/static.go
+++ b/felix/rules/static.go
@@ -660,6 +660,14 @@ func (r *DefaultRuleRenderer) StaticFilterForwardChains() []*generictables.Chain
 	// Jump to chain for blocking service CIDR loops.
 	rules = append(rules,
 		generictables.Rule{
+			// A LoadBalancer VIP with no local backend may be configured to stay
+			// routable.  Only
+			// packets already accepted by Calico policy may bypass kube-proxy's
+			// later no-endpoints reject rule.
+			Match:  r.NewMatch().MarkSingleBitSet(r.MarkAccept),
+			Action: r.Jump(ChainLBNoEndpoints),
+		},
+		generictables.Rule{
 			Action: r.Jump(ChainCIDRBlock),
 		},
 	)

--- a/felix/rules/static_test.go
+++ b/felix/rules/static_test.go
@@ -350,6 +350,10 @@ var _ = Describe("Static", func() {
 								},
 								// Outgoing host endpoint chains.
 								{Action: iptables.JumpAction{Target: ChainDispatchToHostEndpointForward}},
+								{
+									Match:  iptables.Match().MarkSingleBitSet(0x10),
+									Action: iptables.JumpAction{Target: ChainLBNoEndpoints},
+								},
 								{Action: iptables.JumpAction{Target: ChainCIDRBlock}},
 							},
 						}))
@@ -1623,6 +1627,10 @@ var _ = Describe("Static", func() {
 						},
 						// Outgoing host endpoint chains.
 						{Action: iptables.JumpAction{Target: ChainDispatchToHostEndpointForward}},
+						{
+							Match:  iptables.Match().MarkSingleBitSet(0x10),
+							Action: iptables.JumpAction{Target: ChainLBNoEndpoints},
+						},
 						{Action: iptables.JumpAction{Target: ChainCIDRBlock}},
 					},
 				}))


### PR DESCRIPTION
### Description
Adds opt-in anycast failover for LoadBalancer VIPs using:

```projectcalico.org/anycast: "true"```

When no local endpoint is available:

- iptables traffic accepted by Calico policy bypasses kube-proxy’s no-endpoint rejection and follows normal routing.
- The BPF dataplane falls through to routing instead of returning ICMP unreachable.
- Rules are limited to the Service’s LoadBalancer VIPs, protocols, and ports.

Fixes #13136.

### Testing

- ```go test ./felix/rules```
- ```go test ./felix/calc```
- ```go test ./felix/bpf/proxy```
- Linux dataplane compile-only test
- Linux dataplane suite: 982 passed; 12 unrelated failures due to missing generated XDP fixtures

### Release note

Support opt-in anycast failover for LoadBalancer VIPs when local endpoints are unavailable.