### PR TITLE
Felix: avoid bpf_trace_printk dmesg spam under kernel lockdown=confidentiality

### DIFF
--- a/charts/calico/templates/calico-node.yaml
+++ b/charts/calico/templates/calico-node.yaml
@@ -471,6 +471,13 @@ spec:
             # parent directory.
             - name: bpffs
               mountPath: /sys/fs/bpf
+            # Felix reads /sys/kernel/security/lockdown to detect kernel
+            # lockdown=confidentiality; under it, ftrace is disabled and Felix
+            # loads trace-printk-free BPF program variants. securityfs is a
+            # separate filesystem from /sys/fs, so it needs its own mount.
+            - name: sys-kernel-security
+              mountPath: /sys/kernel/security
+              readOnly: true
             - name: cni-log-dir
               mountPath: /var/log/calico/cni
               readOnly: true
@@ -615,6 +622,12 @@ spec:
           hostPath:
             path: /sys/fs/bpf
             type: Directory
+        # securityfs, read by Felix to detect kernel lockdown=confidentiality.
+        # No type set (like nodeproc below) so nodes without securityfs still
+        # start; Felix treats an unreadable lockdown file as "not locked down".
+        - name: sys-kernel-security
+          hostPath:
+            path: /sys/kernel/security
         # mount /proc at /nodeproc to be used by ebpf-bootstrap initContainer to mount root cgroup2 fs.
         - name: nodeproc
           hostPath:

--- a/felix/Makefile
+++ b/felix/Makefile
@@ -185,7 +185,9 @@ protobuf proto/felixbackend.pb.go: proto/felixbackend.proto
 # We pre-build lots of different variants of the TC programs, defer to the script.
 BPF_GPL_O_FILES:=$(addprefix bpf-gpl/,$(shell bpf-gpl/list-objs))
 BPF_GPL_O_FILES+=bpf-gpl/bin/tc_preamble_ingress.o bpf-gpl/bin/tc_preamble_egress.o \
-		 bpf-gpl/bin/xdp_preamble.o bpf-gpl/bin/policy_default_ingress.o  bpf-gpl/bin/policy_default_egress.o \
+		 bpf-gpl/bin/tc_preamble_ingress_notrace.o bpf-gpl/bin/tc_preamble_egress_notrace.o \
+		 bpf-gpl/bin/xdp_preamble.o bpf-gpl/bin/xdp_preamble_notrace.o \
+		 bpf-gpl/bin/policy_default_ingress.o  bpf-gpl/bin/policy_default_egress.o \
 		 bpf-gpl/bin/tcx_test.o
 BPF_GPL_MAP_STUB_O_FILES:=$(addprefix bpf-gpl/bin/,common_map_stub.o ipv4_map_stub.o ipv6_map_stub.o xdp_map_stub.o common_map_stub_ing.o)
 BPF_GPL_O_FILES+=$(BPF_GPL_MAP_STUB_O_FILES)

--- a/felix/bpf-gpl/Makefile
+++ b/felix/bpf-gpl/Makefile
@@ -126,8 +126,14 @@ bin/xdp_map_stub.o: bin/%.o: %.c %.d | bin
 OBJS:=$(shell ./list-objs)
 OBJS+=bin/tc_preamble_ingress.o
 OBJS+=bin/tc_preamble_egress.o
+# Trace-printk-free preamble variants, loaded on nodes running with kernel
+# lockdown=confidentiality (where ftrace is disabled and any program
+# referencing bpf_trace_printk spams the kernel log on every load).
+OBJS+=bin/tc_preamble_ingress_notrace.o
+OBJS+=bin/tc_preamble_egress_notrace.o
 OBJS+=bin/tcx_test.o
 OBJS+=bin/xdp_preamble.o
+OBJS+=bin/xdp_preamble_notrace.o
 OBJS+=bin/policy_default_ingress.o
 OBJS+=bin/policy_default_egress.o
 OBJS+=$(MAP_OBJS)
@@ -177,11 +183,19 @@ tc_preamble_ingress.ll: tc_preamble.c tc_preamble.d
 	$(COMPILE)
 tc_preamble_egress.ll: tc_preamble.c tc_preamble.d
 	$(COMPILE)
+tc_preamble_ingress_notrace.ll: tc_preamble.c tc_preamble.d
+	$(COMPILE)
+tc_preamble_ingress_notrace.ll: CFLAGS += -DCALI_NO_TRACE_PRINTK
+tc_preamble_egress_notrace.ll: tc_preamble.c tc_preamble.d
+	$(COMPILE)
+tc_preamble_egress_notrace.ll: CFLAGS += -DCALI_NO_TRACE_PRINTK
 tcx_test.ll: tcx_test.c tcx_test.d
 	$(CC) $(CFLAGS) -c $< -o $@
 
 xdp_preamble.ll: xdp_preamble.c xdp_preamble.d
 	$(CC) $(CFLAGS) -DCALI_COMPILE_FLAGS=64 -c $< -o $@
+xdp_preamble_notrace.ll: xdp_preamble.c xdp_preamble.d
+	$(CC) $(CFLAGS) -DCALI_COMPILE_FLAGS=64 -DCALI_NO_TRACE_PRINTK -c $< -o $@
 
 policy_default_ingress.ll: policy_default.c policy_default.d
 	$(COMPILE)
@@ -255,9 +269,15 @@ bin/tc_preamble_ingress.o: tc_preamble_ingress.ll | bin
 	$(LINK)
 bin/tc_preamble_egress.o: tc_preamble_egress.ll | bin
 	$(LINK)
+bin/tc_preamble_ingress_notrace.o: tc_preamble_ingress_notrace.ll | bin
+	$(LINK)
+bin/tc_preamble_egress_notrace.o: tc_preamble_egress_notrace.ll | bin
+	$(LINK)
 bin/tcx_test.o: tcx_test.ll | bin
 	$(LINK)
 bin/xdp_preamble.o: xdp_preamble.ll | bin
+	$(LINK)
+bin/xdp_preamble_notrace.o: xdp_preamble_notrace.ll | bin
 	$(LINK)
 bin/policy_default_ingress.o: policy_default_ingress.ll | bin
 	$(LINK)

--- a/felix/bpf-gpl/log.h
+++ b/felix/bpf-gpl/log.h
@@ -30,7 +30,16 @@
 } while (0)
 
 #ifndef CALI_LOG
+#ifdef CALI_NO_TRACE_PRINTK
+// Programs built with CALI_NO_TRACE_PRINTK must not reference the
+// bpf_trace_printk helper at all: on a kernel with lockdown=confidentiality
+// ftrace is disabled at boot, so loading any program that references the
+// helper makes the kernel emit "could not enable bpf_trace_printk events" on
+// every load. Compile the default log macro out entirely for those builds.
+#define CALI_LOG(fmt, ...) do {} while (0)
+#else
 #define CALI_LOG bpf_log
+#endif
 #endif
 
 #define CALI_INFO_NO_FLAG(fmt, ...)  CALI_LOG_IF(CALI_LOG_LEVEL_INFO, fmt, ## __VA_ARGS__)

--- a/felix/bpf/attach.go
+++ b/felix/bpf/attach.go
@@ -36,6 +36,10 @@ type AttachPoint struct {
 	LogLevel    string
 	Profiling   string
 	IfIndex     int
+	// NoTracePrintk selects the trace-printk-free preamble object variants,
+	// used on nodes running with kernel lockdown=confidentiality. See
+	// KernelLockdownConfidentiality.
+	NoTracePrintk bool
 }
 
 func (ap *AttachPoint) LogVal() string {

--- a/felix/bpf/lockdown.go
+++ b/felix/bpf/lockdown.go
@@ -17,6 +17,7 @@ package bpf
 import (
 	"os"
 	"strings"
+	"sync"
 )
 
 const lockdownPath = "/sys/kernel/security/lockdown"
@@ -32,9 +33,22 @@ const lockdownPath = "/sys/kernel/security/lockdown"
 // It returns false when lockdown is off, at a lower level, or the state cannot
 // be determined (securityfs not mounted, file absent) — i.e. it never turns on
 // the workaround speculatively.
+//
+// The state is read once and memoized: what matters is the lockdown level at
+// boot (that is when ftrace is enabled or disabled), and a single read
+// guarantees every caller makes the same decision even if the level is raised
+// at runtime.
 func KernelLockdownConfidentiality() bool {
-	return kernelLockdownConfidentiality(lockdownPath)
+	lockdownOnce.Do(func() {
+		lockdownConfidentiality = kernelLockdownConfidentiality(lockdownPath)
+	})
+	return lockdownConfidentiality
 }
+
+var (
+	lockdownOnce            sync.Once
+	lockdownConfidentiality bool
+)
 
 func kernelLockdownConfidentiality(path string) bool {
 	data, err := os.ReadFile(path)

--- a/felix/bpf/lockdown.go
+++ b/felix/bpf/lockdown.go
@@ -1,0 +1,47 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bpf
+
+import (
+	"os"
+	"strings"
+)
+
+const lockdownPath = "/sys/kernel/security/lockdown"
+
+// KernelLockdownConfidentiality reports whether the kernel lockdown LSM is
+// active at "confidentiality" level. At that level the kernel disables ftrace
+// at boot (tracer_alloc_buffers returns -EPERM), so loading any BPF program
+// that references the bpf_trace_printk/bpf_trace_vprintk helper makes the
+// kernel log "could not enable bpf_trace_printk events" on every load. When
+// this returns true, Felix loads trace-printk-free variants of the preamble
+// programs to avoid that log spam.
+//
+// It returns false when lockdown is off, at a lower level, or the state cannot
+// be determined (securityfs not mounted, file absent) — i.e. it never turns on
+// the workaround speculatively.
+func KernelLockdownConfidentiality() bool {
+	return kernelLockdownConfidentiality(lockdownPath)
+}
+
+func kernelLockdownConfidentiality(path string) bool {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+	// The file lists the available modes with the active one in brackets, e.g.
+	// "none integrity [confidentiality]".
+	return strings.Contains(string(data), "[confidentiality]")
+}

--- a/felix/bpf/lockdown_test.go
+++ b/felix/bpf/lockdown_test.go
@@ -1,0 +1,50 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bpf
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestKernelLockdownConfidentiality(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		content string
+		want    bool
+	}{
+		{"confidentiality active", "none integrity [confidentiality]\n", true},
+		{"integrity active", "none [integrity] confidentiality\n", false},
+		{"none active", "[none] integrity confidentiality\n", false},
+		{"empty", "", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "lockdown")
+			if err := os.WriteFile(path, []byte(tc.content), 0o644); err != nil {
+				t.Fatalf("failed to write test file: %v", err)
+			}
+			if got := kernelLockdownConfidentiality(path); got != tc.want {
+				t.Errorf("kernelLockdownConfidentiality(%q) = %v, want %v", tc.content, got, tc.want)
+			}
+		})
+	}
+
+	t.Run("missing file", func(t *testing.T) {
+		if kernelLockdownConfidentiality(filepath.Join(t.TempDir(), "does-not-exist")) {
+			t.Error("expected false when the lockdown file is absent")
+		}
+	})
+}

--- a/felix/bpf/tc/attach.go
+++ b/felix/bpf/tc/attach.go
@@ -210,7 +210,11 @@ func (ap *AttachPoint) AttachProgram() error {
 	// only need to load and configure the preamble that will pass the
 	// configuration further to the selected set of programs.
 
-	binaryToLoad := path.Join(bpfdefs.ObjectDir, fmt.Sprintf("tc_preamble_%s.o", ap.Hook))
+	preambleName := fmt.Sprintf("tc_preamble_%s", ap.Hook)
+	if ap.NoTracePrintk {
+		preambleName += "_notrace"
+	}
+	binaryToLoad := path.Join(bpfdefs.ObjectDir, preambleName+".o")
 	if ap.IsNetkit() {
 		err := ap.attachNetkitProgram(binaryToLoad)
 		if err != nil {

--- a/felix/bpf/ut/precompilation_test.go
+++ b/felix/bpf/ut/precompilation_test.go
@@ -15,6 +15,8 @@
 package ut_test
 
 import (
+	"debug/elf"
+	"encoding/binary"
 	"fmt"
 	"math/rand"
 	"net"
@@ -29,6 +31,14 @@ import (
 	"github.com/projectcalico/calico/felix/bpf/hook"
 	"github.com/projectcalico/calico/felix/bpf/libbpf"
 	"github.com/projectcalico/calico/felix/bpf/utils"
+)
+
+// BPF helper-function IDs (uapi/linux/bpf.h). Programs that reference either of
+// these carry the bpf_trace/bpf_trace_printk trace event, which the kernel tries
+// to enable on every program load.
+const (
+	bpfFuncTracePrintk  = 6
+	bpfFuncTraceVprintk = 177
 )
 
 func TestPrecompiledBinariesAreLoadable(t *testing.T) {
@@ -56,6 +66,9 @@ func TestPrecompiledBinariesAreLoadable(t *testing.T) {
 	objects["tc_preamble_ingress.o"] = struct{}{}
 	objects["tc_preamble_egress.o"] = struct{}{}
 	objects["xdp_preamble.o"] = struct{}{}
+	objects["tc_preamble_ingress_notrace.o"] = struct{}{}
+	objects["tc_preamble_egress_notrace.o"] = struct{}{}
+	objects["xdp_preamble_notrace.o"] = struct{}{}
 	objects["conntrack_cleanup_debug_v4.o"] = struct{}{}
 	objects["conntrack_cleanup_debug_v6.o"] = struct{}{}
 	objects["conntrack_cleanup_no_log_v4.o"] = struct{}{}
@@ -74,6 +87,77 @@ func TestPrecompiledBinariesAreLoadable(t *testing.T) {
 			testObject(path.Join(bpfdefs.ObjectDir, obj))
 		})
 	}
+}
+
+// TestPreambleNoTraceVariantsAreTracePrintkFree checks that the _notrace
+// preamble objects carry no bpf_trace_printk/bpf_trace_vprintk helper call.
+// These variants are loaded on nodes running with kernel lockdown=confidentiality,
+// where ftrace is disabled at boot and loading any program that references the
+// helper makes the kernel log "could not enable bpf_trace_printk events" on
+// every load.
+func TestPreambleNoTraceVariantsAreTracePrintkFree(t *testing.T) {
+	RegisterTestingT(t)
+
+	for _, obj := range []string{
+		"tc_preamble_ingress_notrace.o",
+		"tc_preamble_egress_notrace.o",
+		"xdp_preamble_notrace.o",
+	} {
+		t.Run(obj, func(t *testing.T) {
+			RegisterTestingT(t)
+			calls, err := helperCallIDs(path.Join(bpfdefs.ObjectDir, obj))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(calls).NotTo(HaveKey(int32(bpfFuncTracePrintk)),
+				"notrace preamble must not call bpf_trace_printk")
+			Expect(calls).NotTo(HaveKey(int32(bpfFuncTraceVprintk)),
+				"notrace preamble must not call bpf_trace_vprintk")
+		})
+	}
+
+	// Guard against the helper being stripped everywhere: the regular preambles
+	// are expected to still carry it, so the checks above genuinely exercise the
+	// _notrace build.
+	for _, obj := range []string{"tc_preamble_ingress.o", "tc_preamble_egress.o"} {
+		t.Run(obj+" (baseline)", func(t *testing.T) {
+			RegisterTestingT(t)
+			calls, err := helperCallIDs(path.Join(bpfdefs.ObjectDir, obj))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(calls).To(HaveKey(int32(bpfFuncTracePrintk)),
+				"regular preamble expected to call bpf_trace_printk")
+		})
+	}
+}
+
+// helperCallIDs returns the set of BPF helper-function IDs (with counts)
+// invoked by a precompiled object. A helper call is opcode 0x85
+// (BPF_JMP|BPF_CALL) with src register 0; its immediate is the helper ID.
+// (src register 1 is a bpf-to-bpf call, 2 is a kfunc call — not helpers.)
+// BPF instructions are 8-byte units; the second slot of a 16-byte wide load
+// has a zero opcode byte, so stepping by 8 never mistakes it for a call.
+func helperCallIDs(file string) (map[int32]int, error) {
+	f, err := elf.Open(file)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = f.Close() }()
+
+	calls := map[int32]int{}
+	for _, sec := range f.Sections {
+		if sec.Type != elf.SHT_PROGBITS || sec.Flags&elf.SHF_EXECINSTR == 0 {
+			continue
+		}
+		data, err := sec.Data()
+		if err != nil {
+			return nil, err
+		}
+		for off := 0; off+8 <= len(data); off += 8 {
+			if data[off] != 0x85 || data[off+1]>>4 != 0 {
+				continue
+			}
+			calls[int32(binary.LittleEndian.Uint32(data[off+4:off+8]))]++
+		}
+	}
+	return calls, nil
 }
 
 func createVeth() (string, netlink.Link) {

--- a/felix/bpf/xdp/attach.go
+++ b/felix/bpf/xdp/attach.go
@@ -124,7 +124,11 @@ func (ap *AttachPoint) AttachProgram() error {
 	// only need to load and configure the preamble that will pass the
 	// configuration further to the selected set of programs.
 
-	binaryToLoad := path.Join(bpfdefs.ObjectDir, "xdp_preamble.o")
+	preambleName := "xdp_preamble.o"
+	if ap.NoTracePrintk {
+		preambleName = "xdp_preamble_notrace.o"
+	}
+	binaryToLoad := path.Join(bpfdefs.ObjectDir, preambleName)
 	ap.Log().Infof("Continue with attaching BPF program %s", binaryToLoad)
 	obj, err := bpf.LoadObject(binaryToLoad, ap.Configuration())
 	if err != nil {

--- a/felix/dataplane/linux/bpf_ep_mgr.go
+++ b/felix/dataplane/linux/bpf_ep_mgr.go
@@ -556,7 +556,7 @@ func NewBPFEndpointManager(
 	// trace-printk-free preamble variants, and drop debug logging (which cannot
 	// work anyway) so the debug programs — which carry the helper — are not
 	// loaded either.
-	bpfLogLevel := config.BPFLogLevel
+	bpfLogLevel := strings.ToLower(config.BPFLogLevel)
 	bpfNoTracePrintk := bpf.KernelLockdownConfidentiality()
 	if bpfNoTracePrintk && bpfLogLevel == "debug" {
 		logrus.Warn("Kernel lockdown=confidentiality detected: BPF debug logging and the " +

--- a/felix/dataplane/linux/bpf_ep_mgr.go
+++ b/felix/dataplane/linux/bpf_ep_mgr.go
@@ -303,8 +303,13 @@ type bpfEndpointManager struct {
 
 	dirtyIfaceNames set.Set[string]
 
-	logFilters              map[string]string
-	bpfLogLevel             string
+	logFilters  map[string]string
+	bpfLogLevel string
+	// bpfNoTracePrintk selects the trace-printk-free preamble variants; set
+	// when the kernel is running with lockdown=confidentiality (ftrace
+	// disabled), where loading a preamble that references bpf_trace_printk
+	// spams the kernel log on every attach.
+	bpfNoTracePrintk        bool
 	hostname                string
 	dataIfaceRegex          *regexp.Regexp
 	l3IfaceRegex            *regexp.Regexp
@@ -545,6 +550,21 @@ func NewBPFEndpointManager(
 		livenessCallback = func() {}
 	}
 
+	// Under kernel lockdown=confidentiality, ftrace is disabled at boot, so any
+	// BPF program that references bpf_trace_printk makes the kernel log "could
+	// not enable bpf_trace_printk events" on every load. Load the
+	// trace-printk-free preamble variants, and drop debug logging (which cannot
+	// work anyway) so the debug programs — which carry the helper — are not
+	// loaded either.
+	bpfLogLevel := config.BPFLogLevel
+	bpfNoTracePrintk := bpf.KernelLockdownConfidentiality()
+	if bpfNoTracePrintk && bpfLogLevel == "debug" {
+		logrus.Warn("Kernel lockdown=confidentiality detected: BPF debug logging and the " +
+			"policy Log action are unavailable on this node (ftrace is disabled); " +
+			"forcing BPFLogLevel to off.")
+		bpfLogLevel = "off"
+	}
+
 	m := &bpfEndpointManager{
 		initUnknownIfaces:       set.New[string](),
 		dp:                      dp,
@@ -558,7 +578,8 @@ func NewBPFEndpointManager(
 		profilesToWorkloads:     map[types.ProfileID]set.Set[any]{},
 		dirtyIfaceNames:         set.New[string](),
 		hostIfaceTrees:          make(bpfIfaceTrees),
-		bpfLogLevel:             config.BPFLogLevel,
+		bpfLogLevel:             bpfLogLevel,
+		bpfNoTracePrintk:        bpfNoTracePrintk,
 		logFilters:              config.BPFLogFilters,
 		hostname:                config.Hostname,
 		l3IfaceRegex:            config.BPFL3IfacePattern,
@@ -2266,10 +2287,11 @@ func (m *bpfEndpointManager) doApplyPolicyToDataIface(iface, masterIface string,
 
 	xdpAttachPoint := &xdp.AttachPoint{
 		AttachPoint: bpf.AttachPoint{
-			IfIndex:  ifIndex,
-			Hook:     hook.XDP,
-			Iface:    iface,
-			LogLevel: m.bpfLogLevel,
+			IfIndex:       ifIndex,
+			Hook:          hook.XDP,
+			Iface:         iface,
+			LogLevel:      m.bpfLogLevel,
+			NoTracePrintk: m.bpfNoTracePrintk,
 		},
 		Modes: m.xdpModes,
 	}
@@ -3536,7 +3558,8 @@ func (m *bpfEndpointManager) getEndpointType(ifaceName string) tcdefs.EndpointTy
 func (m *bpfEndpointManager) calculateTCAttachPoint(ifaceName string) *tc.AttachPoint {
 	ap := &tc.AttachPoint{
 		AttachPoint: bpf.AttachPoint{
-			Iface: ifaceName,
+			Iface:         ifaceName,
+			NoTracePrintk: m.bpfNoTracePrintk,
 		},
 		MaglevLUTSize: uint32(m.maglevLUTSize),
 	}

--- a/felix/dataplane/linux/int_dataplane.go
+++ b/felix/dataplane/linux/int_dataplane.go
@@ -990,7 +990,7 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 		// so downgrade it to the no-log build on such nodes (mirrors the
 		// endpoint manager forcing BPFLogLevel off).
 		kernelLockdownConfidentiality := bpf.KernelLockdownConfidentiality()
-		if kernelLockdownConfidentiality && config.BPFConntrackLogLevel == "debug" {
+		if kernelLockdownConfidentiality && strings.EqualFold(config.BPFConntrackLogLevel, "debug") {
 			log.Warn("Kernel lockdown=confidentiality detected: forcing BPF conntrack cleanup " +
 				"log level to off (ftrace is disabled, debug logging cannot work).")
 		}
@@ -3128,7 +3128,7 @@ func startBPFDataplaneComponents(
 	ctLogLevel := bpfconntrack.BPFLogLevelNone
 	// The debug cleanup program references bpf_trace_printk; skip it under
 	// lockdown=confidentiality where that would spam the kernel log on load.
-	if config.BPFConntrackLogLevel == "debug" && !kernelLockdownConfidentiality {
+	if strings.EqualFold(config.BPFConntrackLogLevel, "debug") && !kernelLockdownConfidentiality {
 		ctLogLevel = bpfconntrack.BPFLogLevelDebug
 	}
 

--- a/felix/dataplane/linux/int_dataplane.go
+++ b/felix/dataplane/linux/int_dataplane.go
@@ -983,15 +983,27 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 			ipSetIDAllocatorV4.ReserveWellKnownID(rules.IPSetIDAllIstioWEPs, bpfipsets.AllIstioWEPsID)
 		}
 
+		// Under kernel lockdown=confidentiality ftrace is disabled at boot, so
+		// loading any BPF program that references bpf_trace_printk makes the
+		// kernel log "could not enable bpf_trace_printk events" on every load.
+		// The conntrack cleanup program carries the helper in its debug build,
+		// so downgrade it to the no-log build on such nodes (mirrors the
+		// endpoint manager forcing BPFLogLevel off).
+		kernelLockdownConfidentiality := bpf.KernelLockdownConfidentiality()
+		if kernelLockdownConfidentiality && config.BPFConntrackLogLevel == "debug" {
+			log.Warn("Kernel lockdown=confidentiality detected: forcing BPF conntrack cleanup " +
+				"log level to off (ftrace is disabled, debug logging cannot work).")
+		}
+
 		// Start IPv4 BPF dataplane components
-		conntrackScannerV4, workloadRemoveChanV4 = startBPFDataplaneComponents(proto.IPVersion_IPV4, bpfMaps.V4, ipSetIDAllocatorV4, &config, ipsetsManager, dp)
+		conntrackScannerV4, workloadRemoveChanV4 = startBPFDataplaneComponents(proto.IPVersion_IPV4, bpfMaps.V4, ipSetIDAllocatorV4, &config, ipsetsManager, dp, kernelLockdownConfidentiality)
 		if config.BPFIpv6Enabled {
 			// Start IPv6 BPF dataplane components
 			ipSetIDAllocatorV6 = idalloc.New()
 			if config.RulesConfig.IstioAmbientModeEnabled {
 				ipSetIDAllocatorV6.ReserveWellKnownID(rules.IPSetIDAllIstioWEPs, bpfipsets.AllIstioWEPsID)
 			}
-			conntrackScannerV6, workloadRemoveChanV6 = startBPFDataplaneComponents(proto.IPVersion_IPV6, bpfMaps.V6, ipSetIDAllocatorV6, &config, ipsetsManagerV6, dp)
+			conntrackScannerV6, workloadRemoveChanV6 = startBPFDataplaneComponents(proto.IPVersion_IPV6, bpfMaps.V6, ipSetIDAllocatorV6, &config, ipsetsManagerV6, dp, kernelLockdownConfidentiality)
 		}
 
 		workloadIfaceRegex := regexp.MustCompile(strings.Join(interfaceRegexes, "|"))
@@ -3025,6 +3037,7 @@ func startBPFDataplaneComponents(
 	config *Config,
 	ipSetsMgr *dpsets.IPSetsManager,
 	dp *InternalDataplane,
+	kernelLockdownConfidentiality bool,
 ) (*bpfconntrack.Scanner, chan string) {
 	ipSetConfig := config.RulesConfig.IPSetConfigV4
 	ipSetEntry := bpfipsets.IPSetEntryFromBytes
@@ -3113,7 +3126,9 @@ func startBPFDataplaneComponents(
 
 	livenessScanner := bpfconntrack.NewLivenessScanner(config.BPFConntrackTimeouts, config.BPFNodePortDSREnabled)
 	ctLogLevel := bpfconntrack.BPFLogLevelNone
-	if config.BPFConntrackLogLevel == "debug" {
+	// The debug cleanup program references bpf_trace_printk; skip it under
+	// lockdown=confidentiality where that would spam the kernel log on load.
+	if config.BPFConntrackLogLevel == "debug" && !kernelLockdownConfidentiality {
 		ctLogLevel = bpfconntrack.BPFLogLevelDebug
 	}
 

--- a/felix/design/bpf-tc-programs.md
+++ b/felix/design/bpf-tc-programs.md
@@ -120,7 +120,19 @@ XDP has an equivalent preamble in `xdp_preamble.c`. The cgroup
 connect-time hooks ([bpf-services.md → Connect-Time Load Balancer (CTLB)](./bpf-services.md)) are attached directly — they have no preamble.
 
 Because the preamble is cheap to reload, Felix can swap it per
-interface without re-verifying the large program chain it fronts.
+interface without re-verifying the large program chain it fronts — and
+must, since it bakes per-interface config (jump-map indices, host IP,
+flags) into `.rodata`, some of which changes without a restart. So the
+preamble is re-loaded, and re-verified, on every attach.
+
+The preamble calls `bpf_trace_printk` on its drop/error paths
+regardless of `BPFLogLevel`. Under kernel `lockdown=confidentiality`
+ftrace is disabled, so every load makes the kernel log `could not
+enable bpf_trace_printk events`. Felix detects this at startup
+(`bpf.KernelLockdownConfidentiality`) and instead loads
+trace-printk-free preamble variants (`*_notrace.o`,
+`AttachPoint.NoTracePrintk`), forcing `BPFLogLevel: Debug` off on such
+nodes.
 
 ### Two-tier jump maps
 

--- a/manifests/calico-bpf.yaml
+++ b/manifests/calico-bpf.yaml
@@ -12685,6 +12685,13 @@ spec:
             # parent directory.
             - name: bpffs
               mountPath: /sys/fs/bpf
+            # Felix reads /sys/kernel/security/lockdown to detect kernel
+            # lockdown=confidentiality; under it, ftrace is disabled and Felix
+            # loads trace-printk-free BPF program variants. securityfs is a
+            # separate filesystem from /sys/fs, so it needs its own mount.
+            - name: sys-kernel-security
+              mountPath: /sys/kernel/security
+              readOnly: true
             - name: cni-log-dir
               mountPath: /var/log/calico/cni
               readOnly: true
@@ -12713,6 +12720,12 @@ spec:
           hostPath:
             path: /sys/fs/bpf
             type: Directory
+        # securityfs, read by Felix to detect kernel lockdown=confidentiality.
+        # No type set (like nodeproc below) so nodes without securityfs still
+        # start; Felix treats an unreadable lockdown file as "not locked down".
+        - name: sys-kernel-security
+          hostPath:
+            path: /sys/kernel/security
         # mount /proc at /nodeproc to be used by ebpf-bootstrap initContainer to mount root cgroup2 fs.
         - name: nodeproc
           hostPath:

--- a/manifests/calico-etcd.yaml
+++ b/manifests/calico-etcd.yaml
@@ -592,6 +592,13 @@ spec:
             # parent directory.
             - name: bpffs
               mountPath: /sys/fs/bpf
+            # Felix reads /sys/kernel/security/lockdown to detect kernel
+            # lockdown=confidentiality; under it, ftrace is disabled and Felix
+            # loads trace-printk-free BPF program variants. securityfs is a
+            # separate filesystem from /sys/fs, so it needs its own mount.
+            - name: sys-kernel-security
+              mountPath: /sys/kernel/security
+              readOnly: true
             - name: cni-log-dir
               mountPath: /var/log/calico/cni
               readOnly: true
@@ -620,6 +627,12 @@ spec:
           hostPath:
             path: /sys/fs/bpf
             type: Directory
+        # securityfs, read by Felix to detect kernel lockdown=confidentiality.
+        # No type set (like nodeproc below) so nodes without securityfs still
+        # start; Felix treats an unreadable lockdown file as "not locked down".
+        - name: sys-kernel-security
+          hostPath:
+            path: /sys/kernel/security
         # mount /proc at /nodeproc to be used by ebpf-bootstrap initContainer to mount root cgroup2 fs.
         - name: nodeproc
           hostPath:

--- a/manifests/calico-policy-only.yaml
+++ b/manifests/calico-policy-only.yaml
@@ -12564,6 +12564,13 @@ spec:
             # parent directory.
             - name: bpffs
               mountPath: /sys/fs/bpf
+            # Felix reads /sys/kernel/security/lockdown to detect kernel
+            # lockdown=confidentiality; under it, ftrace is disabled and Felix
+            # loads trace-printk-free BPF program variants. securityfs is a
+            # separate filesystem from /sys/fs, so it needs its own mount.
+            - name: sys-kernel-security
+              mountPath: /sys/kernel/security
+              readOnly: true
             - name: cni-log-dir
               mountPath: /var/log/calico/cni
               readOnly: true
@@ -12592,6 +12599,12 @@ spec:
           hostPath:
             path: /sys/fs/bpf
             type: Directory
+        # securityfs, read by Felix to detect kernel lockdown=confidentiality.
+        # No type set (like nodeproc below) so nodes without securityfs still
+        # start; Felix treats an unreadable lockdown file as "not locked down".
+        - name: sys-kernel-security
+          hostPath:
+            path: /sys/kernel/security
         # mount /proc at /nodeproc to be used by ebpf-bootstrap initContainer to mount root cgroup2 fs.
         - name: nodeproc
           hostPath:

--- a/manifests/calico-typha.yaml
+++ b/manifests/calico-typha.yaml
@@ -12686,6 +12686,13 @@ spec:
             # parent directory.
             - name: bpffs
               mountPath: /sys/fs/bpf
+            # Felix reads /sys/kernel/security/lockdown to detect kernel
+            # lockdown=confidentiality; under it, ftrace is disabled and Felix
+            # loads trace-printk-free BPF program variants. securityfs is a
+            # separate filesystem from /sys/fs, so it needs its own mount.
+            - name: sys-kernel-security
+              mountPath: /sys/kernel/security
+              readOnly: true
             - name: cni-log-dir
               mountPath: /var/log/calico/cni
               readOnly: true
@@ -12714,6 +12721,12 @@ spec:
           hostPath:
             path: /sys/fs/bpf
             type: Directory
+        # securityfs, read by Felix to detect kernel lockdown=confidentiality.
+        # No type set (like nodeproc below) so nodes without securityfs still
+        # start; Felix treats an unreadable lockdown file as "not locked down".
+        - name: sys-kernel-security
+          hostPath:
+            path: /sys/kernel/security
         # mount /proc at /nodeproc to be used by ebpf-bootstrap initContainer to mount root cgroup2 fs.
         - name: nodeproc
           hostPath:

--- a/manifests/calico-v3-crds.yaml
+++ b/manifests/calico-v3-crds.yaml
@@ -13049,6 +13049,13 @@ spec:
             # parent directory.
             - name: bpffs
               mountPath: /sys/fs/bpf
+            # Felix reads /sys/kernel/security/lockdown to detect kernel
+            # lockdown=confidentiality; under it, ftrace is disabled and Felix
+            # loads trace-printk-free BPF program variants. securityfs is a
+            # separate filesystem from /sys/fs, so it needs its own mount.
+            - name: sys-kernel-security
+              mountPath: /sys/kernel/security
+              readOnly: true
             - name: cni-log-dir
               mountPath: /var/log/calico/cni
               readOnly: true
@@ -13077,6 +13084,12 @@ spec:
           hostPath:
             path: /sys/fs/bpf
             type: Directory
+        # securityfs, read by Felix to detect kernel lockdown=confidentiality.
+        # No type set (like nodeproc below) so nodes without securityfs still
+        # start; Felix treats an unreadable lockdown file as "not locked down".
+        - name: sys-kernel-security
+          hostPath:
+            path: /sys/kernel/security
         # mount /proc at /nodeproc to be used by ebpf-bootstrap initContainer to mount root cgroup2 fs.
         - name: nodeproc
           hostPath:

--- a/manifests/calico-vxlan.yaml
+++ b/manifests/calico-vxlan.yaml
@@ -12642,6 +12642,13 @@ spec:
             # parent directory.
             - name: bpffs
               mountPath: /sys/fs/bpf
+            # Felix reads /sys/kernel/security/lockdown to detect kernel
+            # lockdown=confidentiality; under it, ftrace is disabled and Felix
+            # loads trace-printk-free BPF program variants. securityfs is a
+            # separate filesystem from /sys/fs, so it needs its own mount.
+            - name: sys-kernel-security
+              mountPath: /sys/kernel/security
+              readOnly: true
             - name: cni-log-dir
               mountPath: /var/log/calico/cni
               readOnly: true
@@ -12670,6 +12677,12 @@ spec:
           hostPath:
             path: /sys/fs/bpf
             type: Directory
+        # securityfs, read by Felix to detect kernel lockdown=confidentiality.
+        # No type set (like nodeproc below) so nodes without securityfs still
+        # start; Felix treats an unreadable lockdown file as "not locked down".
+        - name: sys-kernel-security
+          hostPath:
+            path: /sys/kernel/security
         # mount /proc at /nodeproc to be used by ebpf-bootstrap initContainer to mount root cgroup2 fs.
         - name: nodeproc
           hostPath:

--- a/manifests/calico.yaml
+++ b/manifests/calico.yaml
@@ -12644,6 +12644,13 @@ spec:
             # parent directory.
             - name: bpffs
               mountPath: /sys/fs/bpf
+            # Felix reads /sys/kernel/security/lockdown to detect kernel
+            # lockdown=confidentiality; under it, ftrace is disabled and Felix
+            # loads trace-printk-free BPF program variants. securityfs is a
+            # separate filesystem from /sys/fs, so it needs its own mount.
+            - name: sys-kernel-security
+              mountPath: /sys/kernel/security
+              readOnly: true
             - name: cni-log-dir
               mountPath: /var/log/calico/cni
               readOnly: true
@@ -12672,6 +12679,12 @@ spec:
           hostPath:
             path: /sys/fs/bpf
             type: Directory
+        # securityfs, read by Felix to detect kernel lockdown=confidentiality.
+        # No type set (like nodeproc below) so nodes without securityfs still
+        # start; Felix treats an unreadable lockdown file as "not locked down".
+        - name: sys-kernel-security
+          hostPath:
+            path: /sys/kernel/security
         # mount /proc at /nodeproc to be used by ebpf-bootstrap initContainer to mount root cgroup2 fs.
         - name: nodeproc
           hostPath:

--- a/manifests/canal-etcd.yaml
+++ b/manifests/canal-etcd.yaml
@@ -674,6 +674,13 @@ spec:
             # parent directory.
             - name: bpffs
               mountPath: /sys/fs/bpf
+            # Felix reads /sys/kernel/security/lockdown to detect kernel
+            # lockdown=confidentiality; under it, ftrace is disabled and Felix
+            # loads trace-printk-free BPF program variants. securityfs is a
+            # separate filesystem from /sys/fs, so it needs its own mount.
+            - name: sys-kernel-security
+              mountPath: /sys/kernel/security
+              readOnly: true
             - name: cni-log-dir
               mountPath: /var/log/calico/cni
               readOnly: true
@@ -774,6 +781,12 @@ spec:
           hostPath:
             path: /sys/fs/bpf
             type: Directory
+        # securityfs, read by Felix to detect kernel lockdown=confidentiality.
+        # No type set (like nodeproc below) so nodes without securityfs still
+        # start; Felix treats an unreadable lockdown file as "not locked down".
+        - name: sys-kernel-security
+          hostPath:
+            path: /sys/kernel/security
         # mount /proc at /nodeproc to be used by ebpf-bootstrap initContainer to mount root cgroup2 fs.
         - name: nodeproc
           hostPath:

--- a/manifests/canal.yaml
+++ b/manifests/canal.yaml
@@ -12599,6 +12599,13 @@ spec:
             # parent directory.
             - name: bpffs
               mountPath: /sys/fs/bpf
+            # Felix reads /sys/kernel/security/lockdown to detect kernel
+            # lockdown=confidentiality; under it, ftrace is disabled and Felix
+            # loads trace-printk-free BPF program variants. securityfs is a
+            # separate filesystem from /sys/fs, so it needs its own mount.
+            - name: sys-kernel-security
+              mountPath: /sys/kernel/security
+              readOnly: true
             - name: cni-log-dir
               mountPath: /var/log/calico/cni
               readOnly: true
@@ -12660,6 +12667,12 @@ spec:
           hostPath:
             path: /sys/fs/bpf
             type: Directory
+        # securityfs, read by Felix to detect kernel lockdown=confidentiality.
+        # No type set (like nodeproc below) so nodes without securityfs still
+        # start; Felix treats an unreadable lockdown file as "not locked down".
+        - name: sys-kernel-security
+          hostPath:
+            path: /sys/kernel/security
         # mount /proc at /nodeproc to be used by ebpf-bootstrap initContainer to mount root cgroup2 fs.
         - name: nodeproc
           hostPath:

--- a/manifests/flannel-migration/calico.yaml
+++ b/manifests/flannel-migration/calico.yaml
@@ -12644,6 +12644,13 @@ spec:
             # parent directory.
             - name: bpffs
               mountPath: /sys/fs/bpf
+            # Felix reads /sys/kernel/security/lockdown to detect kernel
+            # lockdown=confidentiality; under it, ftrace is disabled and Felix
+            # loads trace-printk-free BPF program variants. securityfs is a
+            # separate filesystem from /sys/fs, so it needs its own mount.
+            - name: sys-kernel-security
+              mountPath: /sys/kernel/security
+              readOnly: true
             - name: cni-log-dir
               mountPath: /var/log/calico/cni
               readOnly: true
@@ -12672,6 +12679,12 @@ spec:
           hostPath:
             path: /sys/fs/bpf
             type: Directory
+        # securityfs, read by Felix to detect kernel lockdown=confidentiality.
+        # No type set (like nodeproc below) so nodes without securityfs still
+        # start; Felix treats an unreadable lockdown file as "not locked down".
+        - name: sys-kernel-security
+          hostPath:
+            path: /sys/kernel/security
         # mount /proc at /nodeproc to be used by ebpf-bootstrap initContainer to mount root cgroup2 fs.
         - name: nodeproc
           hostPath:


### PR DESCRIPTION
### Description

On a kernel running with `lockdown=confidentiality` (e.g. Talos), ftrace is disabled at boot (`tracer_alloc_buffers()` returns `-EPERM`, so the global trace array is never registered). Whenever the verifier loads a BPF program that references the `bpf_trace_printk`/`bpf_trace_vprintk` helper, the kernel tries to enable the `bpf_trace_printk` trace event and, failing, logs `could not enable bpf_trace_printk events` (ratelimited). This fires at program **load/verify** time, not on execution.

Felix's TC/XDP **preamble** programs call `bpf_trace_printk` on their drop/error paths unconditionally — even at `BPFLogLevel: Off` — and the preamble is re-loaded on every interface attach (it carries per-interface config in `.rodata`, e.g. host IP, which changes without a Felix restart). The result is a constant dmesg spew that tracks BPF reprogramming. Stock distros don't enable confidentiality-mode lockdown, so the enable succeeds silently there — hence the issue reproduces only on Talos.

This PR builds trace-printk-free preamble variants (`*_notrace.o`, compiled with `-DCALI_NO_TRACE_PRINTK`) and loads them when Felix detects `lockdown=confidentiality` at startup (via `/sys/kernel/security/lockdown`). The regular printk-carrying preambles remain in use on all other platforms and log levels. On confidentiality-lockdown nodes, `BPFLogLevel: Debug` is additionally forced to off, since BPF debug logging (and the policy `Log` action) cannot function while ftrace is disabled.

### Release Note

```release-note
Fixed a kernel dmesg spew ("could not enable bpf_trace_printk events") on eBPF-dataplane nodes running with kernel lockdown=confidentiality (e.g. Talos).
```
