### PR TITLE
ci-notify: grant actions:write so the dedup cache marker actually saves

### DIFF
--- a/.github/workflows/ci-notify.yml
+++ b/.github/workflows/ci-notify.yml
@@ -49,6 +49,11 @@ concurrency:
 permissions:
   pull-requests: read
   contents: read
+  # actions/cache/save needs write scope on the cache store, or it silently
+  # fails ("cache write denied: token has no writable scopes") and the dedup
+  # marker below is never persisted, letting every duplicate status event send
+  # its own DM.
+  actions: write
 
 jobs:
   notify:


### PR DESCRIPTION
## Description

Fixes the root cause behind the double (often more-than-double) Slack DMs users have been seeing from `ci-notify.yml` since #12951 unblocked delivery.

Semaphore reposts the same terminal `status` event (same commit, same state) many times in a burst — the dedup marker added in `e48f913531` ("send only one DM per commit, state") exists specifically to collapse those into a single DM, via an `actions/cache` marker keyed on `(sha, state)`.

That marker was never actually being saved. `actions/cache/save` needs write scope on the cache store, but the workflow's `permissions:` block only granted `pull-requests: read` and `contents: read`. Every save attempt failed silently with:

```
##[warning]Cache reservation failed: cache write denied: token has no writable scopes
Failed to save: Unable to reserve cache with key ci-notify-sent-<sha>-<state>, another job may be creating this cache.
```

Since the marker never persisted, every duplicate status event in a burst found no cache hit and independently sent its own DM. Confirmed directly against recent runs on PR #13142: two runs seconds apart both logged "Cache not found", both proceeded to "Send Slack DM", and both actually sent the DM.

Fix: add `actions: write` to the permissions block so the cache save succeeds and the dedup gate works as designed.

**Release note:**
```release-note
TBD
```