### PR TITLE
felix: strip trace-printk from main BPF programs under lockdown via .rodata flag

### DIFF
--- a/felix/bpf-gpl/globals.h
+++ b/felix/bpf-gpl/globals.h
@@ -86,6 +86,27 @@ struct cali_xdp_preamble_globals {
 	struct cali_xdp_globals v6;
 };
 
+/* prog_flags holds per-program, load-time feature flags, distinct from the
+ * node-wide globals above: it lives in its own frozen read-only section so it
+ * does not disturb their layout, and Felix sets it per program at load. Because
+ * the section is frozen, the verifier folds each field to a constant and
+ * dead-code-eliminates the guarded branches (e.g. a program can load with no
+ * reference to the bpf_trace_printk helper at all). New per-program load-time
+ * flags belong here — append fields as needed.
+ */
+struct prog_flags {
+	/* no_trace_printk, when set, drops the code paths that call
+	 * bpf_trace_printk/bpf_trace_vprintk. Felix sets it on nodes running with
+	 * kernel lockdown=confidentiality, where ftrace is disabled and loading any
+	 * program that references the helper spams the kernel log on every load. */
+	__u8 no_trace_printk;
+};
+
+/* Instance lives in its own .rodata section; only objects that reference it get
+ * the map. Declared volatile const so the compiler emits real loads that the
+ * verifier can fold against the frozen map. */
+__attribute__((section(".rodata.prog_flags"))) volatile const struct prog_flags PROG_FLAGS;
+
 struct cali_ct_cleanup_globals {
     __u64 creation_grace;
 

--- a/felix/bpf-gpl/log.h
+++ b/felix/bpf-gpl/log.h
@@ -24,9 +24,16 @@
 #define IPVER_PFX	""
 #endif
 
+/* The no_trace_printk guard lets Felix strip every bpf_trace_printk reference
+ * from a program at load time (see struct prog_flags): the flag lives in
+ * frozen .rodata, so the verifier folds it and dead-code-eliminates the call.
+ * When the flag is clear (the normal case) the condition folds to always-true,
+ * so there is no runtime cost. */
 #define bpf_log(__fmt, ...) do { \
-		__attribute__((section(".rodata.cali_debug"))) static const char fmt[] = IPVER_PFX __fmt; \
-		bpf_trace_printk(fmt, sizeof(fmt), ## __VA_ARGS__); \
+		if (!PROG_FLAGS.no_trace_printk) { \
+			__attribute__((section(".rodata.cali_debug"))) static const char fmt[] = IPVER_PFX __fmt; \
+			bpf_trace_printk(fmt, sizeof(fmt), ## __VA_ARGS__); \
+		} \
 } while (0)
 
 #ifndef CALI_LOG

--- a/felix/bpf-gpl/skb.h
+++ b/felix/bpf-gpl/skb.h
@@ -208,6 +208,17 @@ static CALI_BPF_INLINE void skb_set_mark(struct __sk_buff *skb, __u32 mark)
 
 static CALI_BPF_INLINE void skb_log(struct cali_tc_ctx *ctx, bool accepted)
 {
+	/* skb_log's bpf_trace_vprintk/bpf_log calls are the only unconditional
+	 * reference to the trace-printk helpers in the main programs (they are gated
+	 * at runtime by CALI_ST_LOG_PACKET, not by CALI_LOG_LEVEL, so they survive
+	 * into the no_log builds). When Felix sets no_trace_printk (kernel
+	 * lockdown=confidentiality), this constant read folds and the verifier
+	 * dead-code-eliminates the rest of the function, so the loaded program
+	 * carries no trace-printk reference and its load does not spam the kernel
+	 * log. The policy Log action cannot work under that lockdown level anyway. */
+	if (PROG_FLAGS.no_trace_printk) {
+		return;
+	}
 	if (ctx->state->flags & CALI_ST_LOG_PACKET) {
 		if (bpf_core_enum_value_exists(enum bpf_func_id, BPF_FUNC_trace_vprintk)) {
 #if CALI_F_XDP

--- a/felix/bpf/bpf.go
+++ b/felix/bpf/bpf.go
@@ -2352,6 +2352,21 @@ func IterPerCpuMapCmdOutput(output []byte, f func(k, v []byte)) error {
 
 type ObjectConfigurator func(obj *libbpf.Obj) error
 
+// noTracePrintk, when true, makes loadObject set the no_trace_printk flag in
+// every loaded object's .rodata.prog_flags section, so the verifier eliminates
+// the bpf_trace_printk/bpf_trace_vprintk code paths at load time. Set once at
+// startup on nodes running with kernel lockdown=confidentiality, where loading
+// any program that references the helper spams the kernel log on every load.
+// See KernelLockdownConfidentiality.
+var noTracePrintk bool
+
+// SetNoTracePrintk configures whether subsequently loaded BPF programs have
+// their trace-printk code paths dead-code-eliminated at load time. It must be
+// called before any program is loaded.
+func SetNoTracePrintk(v bool) {
+	noTracePrintk = v
+}
+
 func LoadObject(file string, data libbpf.GlobalData, mapsToBePinned ...string) (*libbpf.Obj, error) {
 	return LoadObjectWithOptions(file, data, nil, mapsToBePinned...)
 }
@@ -2403,6 +2418,14 @@ func loadObject(obj *libbpf.Obj, data libbpf.GlobalData, mapPinOverrides map[str
 		// userspace before the program is loaded.
 		mapName := m.Name()
 		if m.IsMapInternal() {
+			// Per-object load-time feature flags (see struct prog_flags).
+			// Its own section so it does not disturb the main globals .rodata.
+			if strings.HasSuffix(mapName, ".rodata.prog_flags") {
+				if err := m.SetProgFlags(noTracePrintk); err != nil {
+					return nil, fmt.Errorf("failed to set rodata flags on %s map %s: %w", obj.Filename(), mapName, err)
+				}
+				continue
+			}
 			if !strings.HasSuffix(mapName, ".rodata") {
 				continue
 			}

--- a/felix/bpf/libbpf/libbpf.go
+++ b/felix/bpf/libbpf/libbpf.go
@@ -648,6 +648,19 @@ func (c *CTLBGlobalData) Set(m *Map) error {
 	return err
 }
 
+// SetProgFlags writes the per-object load-time feature flags into the
+// program's .rodata.prog_flags section before load (see struct
+// prog_flags in globals.h).
+func (m *Map) SetProgFlags(noTracePrintk bool) error {
+	var noTrace C.uint8_t
+	if noTracePrintk {
+		noTrace = 1
+	}
+	_, err := C.bpf_set_prog_flags(m.bpfMap, noTrace)
+
+	return err
+}
+
 func (x *XDPGlobalData) Set(m *Map) error {
 	cName := C.CString(x.IfaceName)
 	defer C.free(unsafe.Pointer(cName))

--- a/felix/bpf/libbpf/libbpf_api.h
+++ b/felix/bpf/libbpf/libbpf_api.h
@@ -360,6 +360,18 @@ void bpf_ct_cleanup_set_globals(
 	set_errno(bpf_map__set_initial_value(map, (void*)(&data), sizeof(data)));
 }
 
+// bpf_set_prog_flags sets the per-object load-time feature flags in the
+// program's .rodata.prog_flags section (see struct prog_flags). Kept
+// separate from the main globals so it does not perturb their layout.
+void bpf_set_prog_flags(struct bpf_map *map, uint8_t no_trace_printk)
+{
+	struct prog_flags data = {
+		.no_trace_printk = no_trace_printk,
+	};
+
+	set_errno(bpf_map__set_initial_value(map, (void*)(&data), sizeof(data)));
+}
+
 int bpf_xdp_program_id(int ifIndex) {
 	__u32 prog_id = 0, flags = 0;
 	int err;

--- a/felix/bpf/libbpf/libbpf_stub.go
+++ b/felix/bpf/libbpf/libbpf_stub.go
@@ -246,6 +246,10 @@ func (t *CTLBGlobalData) Set(m *Map) error {
 	panic("LIBBPF syscall stub")
 }
 
+func (m *Map) SetProgFlags(noTracePrintk bool) error {
+	panic("LIBBPF syscall stub")
+}
+
 func ProgQueryTcx(ifindex int, ingress bool) ([64]uint32, [64]uint32, uint32, error) {
 	panic("LIBBPF syscall stub")
 }

--- a/felix/bpf/ut/precompilation_test.go
+++ b/felix/bpf/ut/precompilation_test.go
@@ -20,7 +20,11 @@ import (
 	"fmt"
 	"math/rand"
 	"net"
+	"os"
+	"os/exec"
 	"path"
+	"regexp"
+	"strings"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -158,6 +162,76 @@ func helperCallIDs(file string) (map[int32]int, error) {
 		}
 	}
 	return calls, nil
+}
+
+// TestNoTracePrintkFlagStripsTraceHelper verifies the load-time dead-code
+// elimination: a main program carries skb_log's bpf_trace_printk/bpf_trace_vprintk
+// calls (the policy Log action) in its no_log build, but when Felix sets the
+// .rodata.prog_flags no_trace_printk flag before load, the verifier folds the
+// frozen constant and eliminates those code paths, so the loaded program
+// references no trace helper at all. That is what stops the "could not enable
+// bpf_trace_printk events" kernel-log spew under lockdown=confidentiality. With
+// the flag clear, the helper is still present.
+func TestNoTracePrintkFlagStripsTraceHelper(t *testing.T) {
+	RegisterTestingT(t)
+
+	bpffs, err := utils.MaybeMountBPFfs()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(bpffs).To(Equal("/sys/fs/bpf"))
+
+	// from_wep_no_log.o is a main program built at the "off" log level; it still
+	// carries skb_log's trace calls (gated at runtime, not by log level).
+	const obj = "from_wep_no_log.o"
+
+	// traceRe matches a trace-printk helper *call instruction*, whether bpftool
+	// renders the target by name (kallsyms/BTF available) or numerically by
+	// helper id (6 / 177). The leading "(85) call" (BPF_JMP|BPF_CALL opcode)
+	// distinguishes a real instruction from bpftool's interleaved source-line
+	// annotations (which start with ";" and mention the helper by name).
+	traceRe := regexp.MustCompile(`\(85\) call ((bpf_)?trace_v?printk|6\b|177\b)`)
+
+	loadedTraceHelperRefs := func(noTrace bool) int {
+		o, err := libbpf.OpenObject(path.Join(bpfdefs.ObjectDir, obj))
+		Expect(err).NotTo(HaveOccurred())
+		defer o.Close()
+
+		// Set the per-object flag before load so libbpf freezes it read-only and
+		// the verifier can fold it.
+		flagSet := false
+		for m, err := o.FirstMap(); m != nil && err == nil; m, err = m.NextMap() {
+			if strings.HasSuffix(m.Name(), ".rodata.prog_flags") {
+				Expect(m.SetProgFlags(noTrace)).NotTo(HaveOccurred())
+				flagSet = true
+			}
+		}
+		Expect(flagSet).To(BeTrue(), "object should carry a .rodata.prog_flags map")
+
+		Expect(o.Load()).NotTo(HaveOccurred())
+
+		pinDir := path.Join(bpffs, fmt.Sprintf("notrace-test-%x", rand.Uint32()))
+		Expect(os.MkdirAll(pinDir, 0o755)).NotTo(HaveOccurred())
+		defer os.RemoveAll(pinDir)
+		Expect(o.PinPrograms(pinDir)).NotTo(HaveOccurred())
+		defer func() { _ = o.UnpinPrograms(pinDir) }()
+
+		entries, err := os.ReadDir(pinDir)
+		Expect(err).NotTo(HaveOccurred())
+		refs := 0
+		for _, e := range entries {
+			out, err := exec.Command("bpftool", "prog", "dump", "xlated", "pinned",
+				path.Join(pinDir, e.Name())).CombinedOutput()
+			Expect(err).NotTo(HaveOccurred(), string(out))
+			refs += len(traceRe.FindAllString(string(out), -1))
+		}
+		return refs
+	}
+
+	// Baseline: without the flag the loaded program references the helper.
+	Expect(loadedTraceHelperRefs(false)).To(BeNumerically(">", 0),
+		"baseline: main program should reference a trace helper when no_trace_printk is clear")
+	// With the flag set, the verifier must have eliminated every trace helper.
+	Expect(loadedTraceHelperRefs(true)).To(BeZero(),
+		"with no_trace_printk set, the loaded program must reference no trace helper")
 }
 
 func createVeth() (string, netlink.Link) {

--- a/felix/dataplane/linux/int_dataplane.go
+++ b/felix/dataplane/linux/int_dataplane.go
@@ -995,7 +995,7 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 				"log level to off (ftrace is disabled, debug logging cannot work).")
 		}
 		// Make every BPF program loaded from here on drop its trace-printk code
-		// paths at load time (via the .rodata.cali_flags no_trace_printk flag),
+		// paths at load time (via the .rodata.prog_flags no_trace_printk flag),
 		// so their load does not spam the kernel log under confidentiality
 		// lockdown. Must be set before any program is loaded.
 		bpf.SetNoTracePrintk(kernelLockdownConfidentiality)

--- a/felix/dataplane/linux/int_dataplane.go
+++ b/felix/dataplane/linux/int_dataplane.go
@@ -994,6 +994,11 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 			log.Warn("Kernel lockdown=confidentiality detected: forcing BPF conntrack cleanup " +
 				"log level to off (ftrace is disabled, debug logging cannot work).")
 		}
+		// Make every BPF program loaded from here on drop its trace-printk code
+		// paths at load time (via the .rodata.cali_flags no_trace_printk flag),
+		// so their load does not spam the kernel log under confidentiality
+		// lockdown. Must be set before any program is loaded.
+		bpf.SetNoTracePrintk(kernelLockdownConfidentiality)
 
 		// Start IPv4 BPF dataplane components
 		conntrackScannerV4, workloadRemoveChanV4 = startBPFDataplaneComponents(proto.IPVersion_IPV4, bpfMaps.V4, ipSetIDAllocatorV4, &config, ipsetsManager, dp, kernelLockdownConfidentiality)

--- a/felix/design/bpf-tc-programs.md
+++ b/felix/design/bpf-tc-programs.md
@@ -134,6 +134,16 @@ trace-printk-free preamble variants (`*_notrace.o`,
 `AttachPoint.NoTracePrintk`), forcing `BPFLogLevel: Debug` off on such
 nodes.
 
+The main programs avoid `_notrace` duplicates (which would double the
+program matrix): each carries a `struct prog_flags` in its own frozen
+`.rodata.prog_flags` section. Felix sets `no_trace_printk` there before
+load (`bpf.SetNoTracePrintk` → `Map.SetProgFlags`); the frozen constant
+lets the verifier fold the flag and dead-code-eliminate `skb_log` (the
+policy `Log` action, which references the trace helper regardless of
+`BPFLogLevel`). **Per-program, load-time flags belong in `struct
+prog_flags`** — it is the vehicle for them, distinct from the node-wide
+globals.
+
 ### Two-tier jump maps
 
 Packet-processing programs are organised into two jump maps per


### PR DESCRIPTION
### Description

Follow-up to #13142 (now merged). This is a clean standalone change on top of it.

#13142 stopped the *constant, per-interface-attach* `could not enable bpf_trace_printk events` spew under kernel `lockdown=confidentiality` by loading trace-printk-free preamble variants. The **main dataplane programs**, however, still reference the helper unconditionally: `skb_log` (the policy `Log` action) is gated at runtime (`CALI_ST_LOG_PACKET`), not by `BPFLogLevel`, so it is compiled into every program including the `no_log` builds. Loading the main program set therefore still emits a bounded, one-off burst on each Felix program-load cycle (start/restart/reload/reboot).

Rather than doubling the compiled program matrix with `_notrace` variants, this adds a small, general **`struct cali_rodata_flags`** in each program's own frozen `.rodata.cali_flags` section (separate from the main globals, so their layout is untouched). When Felix detects confidentiality lockdown it sets `no_trace_printk` before load (`bpf.SetNoTracePrintk` → `Map.SetRodataFlags`, wired through `loadObject`); the `bpf_log` macro and `skb_log` guard on it. Because the section is read-only and frozen, the verifier folds the flag to a constant and **dead-code-eliminates** the guarded branches, so the loaded program references no trace helper and its load is silent — same object serves locked-down and normal nodes. The struct is the general vehicle for future load-time feature flags.

### Tests

New `bpf/ut` load test (`TestNoTracePrintkFlagStripsTraceHelper`): loads a main program with the flag clear and set, dumps the loaded (verified) program via `bpftool prog dump xlated`, and asserts trace-printk *call instructions* are present only when the flag is clear. Passes locally alongside the existing `TestPrecompiledBinariesAreLoadable` / preamble-notrace tests.

End-to-end verification on a real `lockdown=confidentiality` cluster is pending.

### Release Note

```release-note
NONE
```
