### PR TITLE
Add s390x (big-endian) support to netfilter attribute deserialization

### DIFF
--- a/felix/nfnetlink/nfnl/nfnetlink_linux.go
+++ b/felix/nfnetlink/nfnl/nfnetlink_linux.go
@@ -94,12 +94,31 @@ func nfaAlignOf(attrlen int) int {
 	return (attrlen + syscall.NLA_ALIGNTO - 1) & ^(syscall.NLA_ALIGNTO - 1)
 }
 
+var nativeBigEndian = func() bool {
+	var i uint16 = 0x0102
+	b := (*[2]byte)(unsafe.Pointer(&i))
+	return b[0] == 0x01
+}()
+
+func swap16(v uint16) uint16 {
+	return (v >> 8) | (v << 8)
+}
+
 type NfAttr struct {
 	syscall.NlAttr
 }
 
 func DeserializeNfAttr(b []byte) *NfAttr {
-	return (*NfAttr)(unsafe.Pointer(&b[0:SizeofNfAttr][0]))
+	a := (*NfAttr)(unsafe.Pointer(&b[0:SizeofNfAttr][0]))
+	if !nativeBigEndian {
+		return a
+	}
+	return &NfAttr{
+		NlAttr: syscall.NlAttr{
+			Len:  swap16(a.NlAttr.Len),
+			Type: swap16(a.NlAttr.Type),
+		},
+	}
 }
 
 func (msg *NfAttr) Serialize() []byte {


### PR DESCRIPTION
This PR solves 2 test-case failures in the felix test-suite: 

- `felix/nfnetlink/conntrack_test.go`
- `felix/nfnetlink/nflog_test.go`

**Reason of failure**: `DeserializeNfAttr()` currently reinterprets the raw `nlattr` bytes using `unsafe.Pointer` and native struct layout. This works on little-endian systems, but on big-endian systems the 16-bit `Len` and `Type` fields are read byte-swapped.
This change preserves the existing little-endian fast path and normalizes `Len` and `Type` on big-endian systems before returning the deserialized attribute.

**Fix**: Added `nativeBigEndian` helper and `swap16` helper and used them to check and swap `NfAttr` pointer to return the correct `Len` and `Type` values in-case of Big-Endian systems.