### PR TITLE
argoci: add .argoci/config.yaml to onboard the repo

### DIFF
--- a/.argoci/config.yaml
+++ b/.argoci/config.yaml
@@ -1,0 +1,6 @@
+# ArgoCI config: scheduled e2e only. Suites are CronWorkflows in
+# .argoci/cron/*.yaml, registered on merge to the default branch. No per-PR
+# workflow (empty `workflows`, no `ciFile`). Required to onboard the repo —
+# without it the handler treats ArgoCI as not set up and skips cron registration.
+version: v2
+workflows: []


### PR DESCRIPTION
Adds the per-repo ArgoCI config. Without it, `cc-argoci-handler` finds no config, treats ArgoCI as not set up, and skips cron registration on merge — so the `.argoci/cron/` suites never register.

V2, cron-only: empty `workflows`, no `ciFile` (a `ciFile` makes the handler fetch a per-PR workflow that does not exist, erroring on every `.argoci/` PR).

## Release Note
```release-note
NONE
```