### PR TITLE
felix: fix dataplane deadlock when GARP races with live-migration completion

### DIFF
--- a/felix/dataplane/linux/live_migration.go
+++ b/felix/dataplane/linux/live_migration.go
@@ -243,6 +243,7 @@ type liveMigrationFSM struct {
 	migrationUID string
 	timer        *time.Timer
 	pcapHandle   garpHandle
+	garpStopC    chan struct{}
 	garpWG       sync.WaitGroup
 	ipamSwapOnce sync.Once
 }
@@ -350,10 +351,11 @@ func (f *liveMigrationFSM) startGARPDetection() {
 		return
 	}
 	f.pcapHandle = handle
+	f.garpStopC = make(chan struct{})
 	f.garpWG.Add(1)
 	go func() {
 		defer f.garpWG.Done()
-		detectGARP(f.logCtx, f.id, handle, f.monitor.garpC)
+		detectGARP(f.logCtx, f.id, handle, f.monitor.garpC, f.garpStopC)
 	}()
 }
 
@@ -362,10 +364,20 @@ func (f *liveMigrationFSM) stopGARPDetection() {
 		if err := f.pcapHandle.Close(); err != nil {
 			f.logCtx.WithError(err).Debug("Error closing GARP detection handle")
 		}
+		// Closing garpStopC aborts any in-progress send to garpC.  This is
+		// essential to avoid a deadlock: garpC's only reader is the dataplane
+		// main loop, and stopGARPDetection itself runs on the main loop (via
+		// OnUpdate) when the FSM leaves the Target state.  If a GARP arrived
+		// just before the workload update that ends the Target state - e.g. a
+		// cutover RARP racing with the migration-complete update - then
+		// detectGARP would be blocked mid-send with no reader, and the Wait()
+		// below would block the main loop forever.
+		close(f.garpStopC)
 		// Wait for the detectGARP goroutine to exit.  Closing the handle causes
 		// packetSource.Packets() to return, so this should complete almost immediately.
 		f.garpWG.Wait()
 		f.pcapHandle = nil
+		f.garpStopC = nil
 	}
 }
 
@@ -406,9 +418,10 @@ func (m *liveMigrationMonitor) OnTimerPop(id types.WorkloadEndpointID) {
 
 // detectGARP reads packets from the given handle and sends the workload ID
 // to garpC when a GARP or RARP packet is detected.  It is a one-shot
-// goroutine: it returns after the first detection or when the handle is closed.
+// goroutine: it returns after the first detection, when the handle is closed,
+// or when stopC is closed.
 func detectGARP(logCtx *logrus.Entry, id types.WorkloadEndpointID,
-	handle garpHandle, garpC chan<- types.WorkloadEndpointID) {
+	handle garpHandle, garpC chan<- types.WorkloadEndpointID, stopC <-chan struct{}) {
 	// Note: handle is NOT defer-closed here. The FSM owns the handle lifecycle via
 	// stopGARPDetection(), which closes the handle and causes packetSource.Packets() to return,
 	// ending this goroutine.
@@ -416,7 +429,15 @@ func detectGARP(logCtx *logrus.Entry, id types.WorkloadEndpointID,
 	for packet := range packetSource.Packets() {
 		if isGARPOrRARP(packet) {
 			logCtx.Info("Detected GARP/RARP packet on workload interface")
-			garpC <- id
+			// garpC is unbuffered and its only reader is the dataplane main
+			// loop, which may currently be inside stopGARPDetection() waiting
+			// for this goroutine to exit; stopC guarantees this send cannot
+			// block forever in that case.
+			select {
+			case garpC <- id:
+			case <-stopC:
+				logCtx.Debug("GARP detection stopped while reporting detection")
+			}
 			return
 		}
 	}

--- a/felix/dataplane/linux/live_migration_test.go
+++ b/felix/dataplane/linux/live_migration_test.go
@@ -567,6 +567,106 @@ func TestLiveMigrationGARPChannel(t *testing.T) {
 	})
 }
 
+// TestGARPRaceWithTargetExit is a regression test for a dataplane main-loop
+// deadlock.  Scenario: the FSM is in Target with GARP detection running, and a
+// GARP/RARP is detected on the workload interface just before the main loop
+// processes an update that ends the Target state (e.g. the migration-complete
+// update flipping the role TARGET -> NO_ROLE, which can arrive within the same
+// scheduling window as the cutover RARP).  detectGARP is then blocked sending
+// on the unbuffered garpC - whose only reader is the main loop - while the
+// main loop is inside stopGARPDetection() waiting for detectGARP to exit.
+// Neither can proceed, wedging the dataplane loop permanently.
+//
+// The test simulates the main loop by calling OnUpdate directly, with nothing
+// reading garpC (just as the real main loop cannot read garpC while it is
+// inside OnUpdate).  Without the garpStopC abort mechanism, OnUpdate would
+// block forever and the test would fail by timeout.
+func TestGARPRaceWithTargetExit(t *testing.T) {
+	tests := []struct {
+		name       string
+		exitInput  func(m *liveMigrationMonitor)
+		wantStates []liveMigrationState
+	}{
+		{
+			name: "migration completes (NO_ROLE)",
+			exitInput: func(m *liveMigrationMonitor) {
+				m.OnUpdate(wepUpdate(wepID1, proto.LiveMigrationRole_NO_ROLE))
+			},
+			wantStates: []liveMigrationState{liveMigrationStateTimeWait},
+		},
+		{
+			name: "re-migration (SOURCE)",
+			exitInput: func(m *liveMigrationMonitor) {
+				m.OnUpdate(wepUpdate(wepID1, proto.LiveMigrationRole_SOURCE))
+			},
+			wantStates: []liveMigrationState{liveMigrationStateBase},
+		},
+		{
+			name: "workload removed",
+			exitInput: func(m *liveMigrationMonitor) {
+				m.OnUpdate(wepRemove(wepID1))
+			},
+			wantStates: []liveMigrationState{liveMigrationStateBase},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			m := newTestMonitor(testConvergenceTime)
+
+			garpBytes := buildGARPPacketBytes(t)
+			fakeHandle := newFakeGARPHandle(garpBytes)
+			m.newGARPHandle = func(ifaceName string) (garpHandle, error) {
+				return fakeHandle, nil
+			}
+
+			// Drive to Target; GARP detection starts and the fake handle
+			// delivers a GARP immediately, so detectGARP commits to the
+			// (blocking) garpC send.
+			m.OnUpdate(wepUpdate(wepID1, proto.LiveMigrationRole_TARGET))
+			expectUpdate(g, m, liveMigrationStateTarget)
+
+			// Wait until the packet has been consumed from the handle; from
+			// that point detectGARP is committed to sending on garpC even if
+			// the handle is subsequently closed.  Then yield briefly so that
+			// detectGARP very likely reaches the send itself, exercising the
+			// exact blocked-send interleaving from the field report.
+			g.Eventually(fakeHandle.AllDelivered, time.Second, time.Millisecond).Should(BeTrue())
+			time.Sleep(20 * time.Millisecond)
+
+			// Process the Target-exiting update as the main loop would, with
+			// nothing reading garpC.  Run it in a goroutine purely so that a
+			// regression fails the test by timeout instead of hanging the
+			// whole test binary.
+			done := make(chan struct{})
+			go func() {
+				defer close(done)
+				tt.exitInput(m)
+			}()
+			select {
+			case <-done:
+			case <-time.After(10 * time.Second):
+				t.Fatal("deadlock: OnUpdate blocked in stopGARPDetection while detectGARP blocked sending on garpC")
+			}
+
+			updates := drainUpdates(m)
+			g.Expect(updates).To(HaveLen(len(tt.wantStates)))
+			for i, want := range tt.wantStates {
+				g.Expect(updates[i].State).To(Equal(want))
+			}
+
+			// The aborted detection must not deliver a stale GARP.
+			select {
+			case <-m.garpC:
+				t.Fatal("unexpected GARP delivery after GARP detection was stopped")
+			case <-time.After(100 * time.Millisecond):
+				// Expected: no delivery.
+			}
+		})
+	}
+}
+
 // --- Section 6: GARP/RARP packet matching ---
 
 func TestIsGARPOrRARP(t *testing.T) {
@@ -743,6 +843,14 @@ func (f *fakeGARPHandle) IsClosed() bool {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	return f.closed
+}
+
+// AllDelivered reports whether every queued packet has been consumed via
+// ReadPacketData.
+func (f *fakeGARPHandle) AllDelivered() bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.idx == len(f.packets)
 }
 
 // --- Section 7: Migration UID tracking ---

--- a/felix/dataplane/linux/live_migration_test.go
+++ b/felix/dataplane/linux/live_migration_test.go
@@ -579,8 +579,15 @@ func TestLiveMigrationGARPChannel(t *testing.T) {
 // get past it.  detectGARP's only other park point - waiting for a packet -
 // shows as "chan receive", so these two states are unambiguous.
 func garpSenderBlocked() bool {
+	// Grow the buffer until the full goroutine dump fits: runtime.Stack
+	// truncates (n == len(buf)) when the buffer is too small, which could
+	// hide the detectGARP goroutine and time out the Eventually below.
 	buf := make([]byte, 1<<20)
 	n := runtime.Stack(buf, true)
+	for n == len(buf) {
+		buf = make([]byte, 2*len(buf))
+		n = runtime.Stack(buf, true)
+	}
 	for _, gr := range strings.Split(string(buf[:n]), "\n\n") {
 		if !strings.Contains(gr, "detectGARP") {
 			continue

--- a/felix/dataplane/linux/live_migration_test.go
+++ b/felix/dataplane/linux/live_migration_test.go
@@ -18,6 +18,8 @@ import (
 	"context"
 	"io"
 	"net"
+	"runtime"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -567,6 +569,29 @@ func TestLiveMigrationGARPChannel(t *testing.T) {
 	})
 }
 
+// garpSenderBlocked reports whether some goroutine is currently parked in
+// detectGARP's report-detection send.  Lets the regression test below wait
+// deterministically for the sender to be blocked reporting on garpC before
+// the Target-exit update is processed.  The goroutine state is "select" for
+// the select-based send (which stopGARPDetection can abort) and "chan send"
+// for a plain send (the pre-fix code); we match both so the test observes the
+// blocked sender either way and then proves whether the Target-exit path can
+// get past it.  detectGARP's only other park point - waiting for a packet -
+// shows as "chan receive", so these two states are unambiguous.
+func garpSenderBlocked() bool {
+	buf := make([]byte, 1<<20)
+	n := runtime.Stack(buf, true)
+	for _, gr := range strings.Split(string(buf[:n]), "\n\n") {
+		if !strings.Contains(gr, "detectGARP") {
+			continue
+		}
+		if strings.Contains(gr, "[select]") || strings.Contains(gr, "[chan send]") {
+			return true
+		}
+	}
+	return false
+}
+
 // TestGARPRaceWithTargetExit is a regression test for a dataplane main-loop
 // deadlock.  Scenario: the FSM is in Target with GARP detection running, and a
 // GARP/RARP is detected on the workload interface just before the main loop
@@ -627,13 +652,13 @@ func TestGARPRaceWithTargetExit(t *testing.T) {
 			m.OnUpdate(wepUpdate(wepID1, proto.LiveMigrationRole_TARGET))
 			expectUpdate(g, m, liveMigrationStateTarget)
 
-			// Wait until the packet has been consumed from the handle; from
-			// that point detectGARP is committed to sending on garpC even if
-			// the handle is subsequently closed.  Then yield briefly so that
-			// detectGARP very likely reaches the send itself, exercising the
-			// exact blocked-send interleaving from the field report.
-			g.Eventually(fakeHandle.AllDelivered, time.Second, time.Millisecond).Should(BeTrue())
-			time.Sleep(20 * time.Millisecond)
+			// Wait until detectGARP is parked in the garpC send.  This pins
+			// the test to the exact interleaving from the field report - the
+			// sender already blocked when the Target-exit update is processed
+			// - which would also catch a broken variant of the fix that
+			// checks the stop channel before a plain send instead of
+			// selecting over both.
+			g.Eventually(garpSenderBlocked, time.Second, time.Millisecond).Should(BeTrue())
 
 			// Process the Target-exiting update as the main loop would, with
 			// nothing reading garpC.  Run it in a goroutine purely so that a
@@ -843,14 +868,6 @@ func (f *fakeGARPHandle) IsClosed() bool {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	return f.closed
-}
-
-// AllDelivered reports whether every queued packet has been consumed via
-// ReadPacketData.
-func (f *fakeGARPHandle) AllDelivered() bool {
-	f.mu.Lock()
-	defer f.mu.Unlock()
-	return f.idx == len(f.packets)
 }
 
 // --- Section 7: Migration UID tracking ---


### PR DESCRIPTION
The live-migration monitor's garpC channel is unbuffered and its only reader is the dataplane main loop.  If a GARP/RARP was detected on the workload interface just before the main loop processed an update ending the FSM's Target state - e.g. the cutover RARP arriving in the same scheduling window as the migration-complete update that flips the role TARGET -> NO_ROLE - then detectGARP was blocked sending on garpC while the main loop, inside stopGARPDetection() on the OnUpdate path, waited in garpWG.Wait() for detectGARP to exit.  Closing the pcap handle does not help in that state, because detectGARP is no longer reading packets. Neither goroutine could proceed, permanently wedging the dataplane main loop: no further calc-graph updates were applied (new/changed workloads on the host lost networking), while the last-good dataplane state continued to carry existing traffic and the status-reporting goroutine kept reporting the agent as up.

Fix by giving each GARP-detection goroutine a stop channel that stopGARPDetection() closes before waiting: detectGARP now sends on garpC via a select over the stop channel, so the send can always be aborted.  The same hazard existed on every input that exits the Target state (role -> NO_ROLE, role -> SOURCE, and workload removal); the regression test covers all three and, without the fix, reproduces the deadlock deterministically.

Fixes a hang observed in production during OpenStack live migrations.

**Release note:**
```release-note
Fixed a Felix dataplane deadlock that could be triggered when a gratuitous ARP / RARP from a live-migrated VM raced with the migration-complete update from the datastore.
```
