### PR TITLE
argoci: make scaffold scripts bug-for-bug identical to Semaphore

### DIFF
--- a/.argoci/cron/e2e-nftables.yaml
+++ b/.argoci/cron/e2e-nftables.yaml
@@ -6,6 +6,7 @@ schedule: 10 21 * * 1
 globalPrologue: |
   cd "${CI_HOME}/${CI_GIT_DIR}"
   export ARGO_WORKFLOW_NAME="{{workflow.name}}"
+  export ARGO_WORKFLOW_UID="{{workflow.uid}}"
   export DATAPLANE="${DATAPLANE:-CalicoNftables}"
   export ENABLE_AUTOHEP="${ENABLE_AUTOHEP:-true}"
   export FUNCTIONAL_AREA="${FUNCTIONAL_AREA:-nftables.yml}"
@@ -74,6 +75,13 @@ steps:
     env:
       - name: CLUSTER_ROUTING_MODE
         value: Felix
+      # gcp-kubeadm uses the fixed semaphore-autotest VPC + reserved IPs, which
+      # exist only in us-central1; pin region/zone (the load-spread randomisation
+      # in the prologue can't apply to region-fixed jobs). See arm64-wg.
+      - name: GOOGLE_REGION
+        value: us-central1
+      - name: GOOGLE_ZONE
+        value: us-central1-a
       - name: K8S_VERSION
         value: stable
       - name: PROVISIONER
@@ -180,6 +188,13 @@ steps:
     env:
       - name: E2E_TEST_CONFIG
         value: e2e/config/gcp-kubevirt.yaml
+      # gcp-kubeadm uses the fixed semaphore-autotest VPC + reserved IPs, which
+      # exist only in us-central1; pin region/zone (the load-spread randomisation
+      # in the prologue can't apply to region-fixed jobs). See arm64-wg.
+      - name: GOOGLE_REGION
+        value: us-central1
+      - name: GOOGLE_ZONE
+        value: us-central1-a
       - name: K8S_VERSION
         value: stable-1.35
       - name: NUM_KUBEVIRT_VMS

--- a/.argoci/scripts/body_flannel-migration.sh
+++ b/.argoci/scripts/body_flannel-migration.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# body_flannel-migration.sh - flannel-to-Calico migration test flow.
+#
+# Provisions a cluster, installs flannel + a CNI plugin helper, runs a basic
+# connectivity smoke test, applies Calico + the flannel-migration job, waits
+# for the migration to complete, then runs the full e2e suite on Calico.
+#
+# Uses the legacy `./bz.sh tests:run` test runner (not the in-repo binary).
+# When the in-repo binary reaches parity, this script can migrate to
+# `make e2e-run` like body_standard.sh's run_tests_local.sh phase.
+set -exo pipefail
+
+PHASES="$(cd "$(dirname "$0")" && pwd)/phases"
+
+echo "[INFO] starting job..."
+
+export CNI_VERSION=${CNI_VERSION:-"v1.1.1"}
+export DOCS_BASE=${DOCS_BASE:-"https://github.com/projectcalico/calico"}
+export DOWNLEVEL_MANIFEST=${DOWNLEVEL_MANIFEST:-"https://github.com/projectcalico/calico/raw/release-${RELEASE_STREAM}/manifests/canal.yaml"}
+export CALICO_MANIFEST=${CALICO_MANIFEST:-"manifests/flannel-migration/calico.yaml"}
+export MIGRATION_MANIFEST=${MIGRATION_MANIFEST:-"manifests/flannel-migration/migration-job.yaml"}
+
+if [ "${USE_HASH_RELEASE}" == "true" ]; then
+  echo "[INFO] Using hash release for flannel migration"
+  LATEST_HASHREL="https://latest-os.docs.eng.tigera.net/${RELEASE_STREAM}.txt"
+  echo "Checking ${LATEST_HASHREL} for latest hash release url..."
+  DOCS_URL=$(curl --retry 9 --retry-all-errors -sS ${LATEST_HASHREL})
+  echo "Using $DOCS_URL for hash release base url"
+else
+  if [[ "${RELEASE_STREAM}" == "master" ]]; then
+    echo "Cannot use latest release on master branch"
+    exit 1
+  else
+    echo "[INFO] Using latest release for flannel migration"
+    export DOCS_URL=$DOCS_BASE/raw/release-${RELEASE_STREAM}
+  fi
+fi
+
+export BZ_LOCAL=${BZ_HOME}/.local
+export KUBECONFIG=$BZ_LOCAL/kubeconfig
+export PATH=$PATH:$BZ_LOCAL/bin
+
+# Modern OSes no longer include br_netfilter by default, which breaks flannel.
+echo "[INFO] installing br_netfilter..."
+sudo modprobe br_netfilter
+
+mkdir -p "$BZ_LOGS_DIR"
+cd "${BZ_HOME}"
+source "${PHASES}/provision.sh"
+
+# Install bridge CNI plugin (needed by kube-flannel manifest).
+kubectl apply -f - <<EOF
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: cni-installer
+  namespace: kube-system
+  labels:
+    app: cni-installer
+spec:
+  selector:
+    matchLabels:
+      app: cni-installer
+  template:
+    metadata:
+      labels:
+        app: cni-installer
+    spec:
+      nodeSelector:
+        kubernetes.io/os: linux
+      hostNetwork: true
+      terminationGracePeriodSeconds: 0
+      tolerations:
+        - effect: NoSchedule
+          operator: Exists
+        - key: CriticalAddonsOnly
+          operator: Exists
+        - effect: NoExecute
+          operator: Exists
+      terminationGracePeriodSeconds: 0
+      priorityClassName: system-node-critical
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      initContainers:
+      - name: cni-installer
+        image: quay.io/dosmith/cni-plugins:gen4
+        command: ["/bin/bash", "-c", "cp -f /usr/src/plugins/bin/* /opt/cni/bin"]
+        volumeMounts:
+        - name: bindir
+          mountPath: /opt/cni/bin
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: 10m
+            memory: 10Mi
+      containers:
+      - name: pause
+        image: registry.k8s.io/pause
+        resources:
+          requests:
+            cpu: 10m
+            memory: 10Mi
+      volumes:
+      - name: bindir
+        hostPath:
+          path: /opt/cni/bin
+EOF
+
+# Update flannel.yaml to use the podCIDR that CRC sets up.
+wget -O flannel.yaml "$DOWNLEVEL_MANIFEST"
+sed -i "s?10.244.0.0/16?192.168.0.0/16?g" ./flannel.yaml
+kubectl apply -f - < ./flannel.yaml
+sleep 30 # wait for flannel to come up
+kubectl get po -A -owide
+
+# Run a basic services test to check that flannel networking is working.
+K8S_E2E_FLAGS='--ginkgo.focus=should.serve.a.basic.endpoint.from.pods' \
+  ./bz.sh tests:run |& tee >(gzip --stdout > "${BZ_LOGS_DIR}/e2e-tests-pre.log")
+
+kubectl delete -n kube-system ds cni-installer || true  # remove the CNI installer daemonset
+kubectl apply -f "$DOCS_URL/$CALICO_MANIFEST"
+wget -O calico-migration.yaml "$DOCS_URL/$MIGRATION_MANIFEST"
+kubectl apply -f - < ./calico-migration.yaml
+sleep 5  # make sure the job has started before we check its status
+kubectl -n kube-system get jobs flannel-migration
+kubectl -n kube-system describe jobs flannel-migration
+kubectl get po -A -owide
+kubectl wait --for=condition=complete --timeout=600s -n kube-system job/flannel-migration
+kubectl -n kube-system get jobs flannel-migration
+kubectl -n kube-system describe jobs flannel-migration
+kubectl -n kube-system logs -l k8s-app=flannel-migration-controller
+kubectl get po -A -owide
+
+# Delete the migration job because the presence of a non-Running pod in
+# kube-system upsets the e2es.
+kubectl -n kube-system delete job/flannel-migration || true
+kubectl -n kube-system delete po -l k8s-app=flannel-migration-controller || true
+
+# Run e2e on uplevel calico.
+./bz.sh tests:run |& tee >(gzip --stdout > "${BZ_LOGS_DIR}/e2e-tests.log")

--- a/.argoci/scripts/global_epilogue.sh
+++ b/.argoci/scripts/global_epilogue.sh
@@ -16,7 +16,7 @@ CI_EXIT_CODE=${CI_EXIT_CODE:-0}
 ARTIFACT_DEST="gs://${GS_BUCKET}/${ARGO_WORKFLOW_NAME:-local}/${HOSTNAME:-pod}"
 
 # Capture diags on failure (or always for cert runs).
-if [[ "${CI_EXIT_CODE}" != "0" ]]; then
+if [[ "${CI_EXIT_CODE}" != "0" || "${TEST_TYPE}" == "ocp-cert" ]]; then
   echo "[INFO] capturing diags"
   bz diags |& tee "${BZ_LOGS_DIR}/diagnostic.log" || true
   gsutil cp "${BZ_LOCAL_DIR}/${DIAGS_ARCHIVE_FILENAME}" "${ARTIFACT_DEST}/diags.tgz" || true

--- a/.argoci/scripts/global_prologue.sh
+++ b/.argoci/scripts/global_prologue.sh
@@ -31,9 +31,47 @@ if [[ -f "${GOOGLE_APPLICATION_CREDENTIALS}" ]]; then
 else
   echo "[WARN] GOOGLE_APPLICATION_CREDENTIALS missing: ${GOOGLE_APPLICATION_CREDENTIALS}"
 fi
+# Azure SP login for azr-* (bz's azure path needs an active az session).
+# Creds via banzai-secrets: AZ_SP_ID/AZ_SP_PASSWORD/AZ_TENANT_ID/AZ_SUBSCRIPTION_ID.
+if [[ "${PROVISIONER:-}" == azr-* ]]; then
+  if command -v az >/dev/null 2>&1 && [[ -n "${AZ_SP_ID:-}" ]]; then
+    az login --service-principal -u "${AZ_SP_ID}" -p "${AZ_SP_PASSWORD}" --tenant "${AZ_TENANT_ID}" >/dev/null \
+      && az account set --subscription "${AZ_SUBSCRIPTION_ID}" \
+      && echo "[INFO] az login OK (subscription ${AZ_SUBSCRIPTION_ID})" \
+      || echo "[WARN] az login failed; azr-* provisioning will fail"
+  else
+    echo "[WARN] azr-* provisioner but az CLI or AZ_SP_ID missing; azure auth skipped"
+  fi
+fi
+
 export DOCKER_AUTH_FILE="${DOCKER_AUTH_FILE:-${HOME}/.docker/config.json}"
 chmod 0600 "${HOME}"/.keys/* 2>/dev/null || true
 if [[ -f "${HOME}/.keys/marvin" ]]; then eval "$(ssh-agent -s)" >/dev/null 2>&1 || true; ssh-add "${HOME}/.keys/marvin" 2>/dev/null || true; fi
+
+# AWS creds for aws-* provisioners. banzai-secrets ships them as $credentials, a
+# ~/.aws/credentials ini blob; the SDK reads the file, so materialise it. Fall back
+# to AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY env.
+mkdir -p "${HOME}/.aws"
+if [[ -n "${credentials:-}" ]]; then
+  printf '%s\n' "${credentials}" > "${HOME}/.aws/credentials"
+  chmod 0600 "${HOME}/.aws/credentials"
+  echo "[INFO] wrote ~/.aws/credentials from banzai-secrets 'credentials' key"
+elif [[ -n "${AWS_ACCESS_KEY_ID:-}" && -n "${AWS_SECRET_ACCESS_KEY:-}" ]]; then
+  {
+    echo "[default]"
+    echo "aws_access_key_id=${AWS_ACCESS_KEY_ID}"
+    echo "aws_secret_access_key=${AWS_SECRET_ACCESS_KEY}"
+    [[ -n "${AWS_SESSION_TOKEN:-}" ]] && echo "aws_session_token=${AWS_SESSION_TOKEN}"
+  } > "${HOME}/.aws/credentials"
+  chmod 0600 "${HOME}/.aws/credentials"
+  echo "[INFO] wrote ~/.aws/credentials from AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY env"
+else
+  echo "[WARN] no AWS creds in banzai-secrets ('credentials' or AWS_ACCESS_KEY_ID); aws-* provisioners will fail"
+fi
+
+# gobz install runs `gh`, which needs GH_TOKEN; banzai-secrets provides it as
+# GITHUB_ACCESS_TOKEN.
+export GH_TOKEN="${GH_TOKEN:-${GITHUB_ACCESS_TOKEN:-}}"
 
 git config --global user.name "${GITHUB_USER_NAME:-marvin-tigera}"
 git config --global user.email "${GITHUB_USER_EMAIL:-marvin@tigera.io}"
@@ -43,6 +81,9 @@ RANDOM_TOKEN1=$(LC_ALL=C tr -dc 'a-z0-9' </dev/urandom | head -c 5 || true)
 
 echo "[INFO] exporting default env vars..."
 export PRODUCT=${PRODUCT:-calico}
+# bz sets the eksctl createdBy CFN tag from $USER; CFN rejects an empty tag and the
+# runner leaves USER unset. Attribution only (custodian reaps on cluster name).
+export USER="${USER:-argoci}"
 export PROVISIONER=${PROVISIONER:-gcp-kubeadm}
 export INSTALLER=${INSTALLER:-"manual"}
 export DATAPLANE=${DATAPLANE:-CalicoIptables}
@@ -100,15 +141,23 @@ if ! command -v bz >/dev/null 2>&1; then
 fi
 echo "[INFO] bz resolved at $(command -v bz || echo '<none>')"
 
-# --- Ensure pyyaml for bz's provisioner python scripts. bz's destroy path runs
-# provisioners/scripts/cleanup.py, which `import yaml`; the ArgoCI runner image's
-# system python lacks it, so `bz destroy` fails ("No module named 'yaml'") and
-# leaks the cluster (observed on local-kind). Install it if missing. ---
+# bz's destroy path imports yaml (cleanup.py); the runner's system python lacks it,
+# so bz destroy fails and leaks the cluster. Install if missing.
 if ! python3 -c 'import yaml' 2>/dev/null; then
   echo "[INFO] installing pyyaml for bz provisioner scripts..."
   python3 -m pip install --quiet pyyaml 2>/dev/null \
     || python3 -m pip install --quiet --break-system-packages pyyaml 2>/dev/null \
     || echo "[WARN] could not install pyyaml; bz destroy for local-kind may fail"
+fi
+
+# bz builds its provisioner venv with python3.10, but the runner image ships only
+# python3.7/3.8-venv, so venv creation fails. Guard on python3.10 (default python3
+# is 3.7 and has ensurepip). Stopgap until the runner image adds it (argoci-images).
+if command -v python3.10 >/dev/null 2>&1 && ! python3.10 -c 'import ensurepip' 2>/dev/null; then
+  echo "[INFO] installing python3.10-venv (runner image lacks it)..."
+  sudo apt-get update -qq 2>/dev/null || true
+  sudo apt-get install -y python3.10-venv 2>/dev/null \
+    || echo "[WARN] could not install python3.10-venv; bz venv creation may fail"
 fi
 
 echo "[INFO] initialising bz profile..."

--- a/.argoci/scripts/global_prologue.sh
+++ b/.argoci/scripts/global_prologue.sh
@@ -44,12 +44,13 @@ RANDOM_TOKEN1=$(LC_ALL=C tr -dc 'a-z0-9' </dev/urandom | head -c 5 || true)
 echo "[INFO] exporting default env vars..."
 export PRODUCT=${PRODUCT:-calico}
 export PROVISIONER=${PROVISIONER:-gcp-kubeadm}
-export INSTALLER=${INSTALLER:-operator}
+export INSTALLER=${INSTALLER:-"manual"}
 export DATAPLANE=${DATAPLANE:-CalicoIptables}
 export TEST_TYPE=${TEST_TYPE:-k8s-e2e}
 export GOOGLE_PROJECT=${GOOGLE_PROJECT:-unique-caldron-775}
-export GOOGLE_REGION=${GOOGLE_REGION:-us-central1}
-export GOOGLE_ZONE=${GOOGLE_ZONE:-us-central1-a}
+export GOOGLE_REGIONS=("us-central1" "us-west1")
+export GOOGLE_REGION=${GOOGLE_REGION:-${GOOGLE_REGIONS[RANDOM%${#GOOGLE_REGIONS[@]}]}}
+export GOOGLE_ZONE=${GOOGLE_ZONE:-$(gcloud compute zones list --filter="region~'$GOOGLE_REGION'" --format="value(name)" | awk 'BEGIN {srand()} {a[NR]=$0} rand() * NR < 1 {zone=$0} END {print zone}')}
 export GOOGLE_NETWORK=${GOOGLE_NETWORK:-semaphore-autotest}
 export AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION:-us-west-2}
 
@@ -58,6 +59,11 @@ export AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION:-us-west-2}
 # Branch comes from the ArgoCI handler (CI_GIT_CLONED_BRANCH); fall back to
 # BRANCH then master. release-vX.Y -> vX.Y, else master.
 export RELEASE_STREAM=${RELEASE_STREAM:-$( _b="${CI_GIT_CLONED_BRANCH:-${BRANCH:-master}}"; [[ "${_b}" =~ ^release-(v[0-9]+\.[0-9]+)$ ]] && echo "${BASH_REMATCH[1]}" || echo "master" )}
+
+export K8S_VERSION=${K8S_VERSION:-stable-3}
+export K8S_E2E_EXTRA_FLAGS=${K8S_E2E_EXTRA_FLAGS:-" --e2ecfg.calicoctl-opensource-image=calico/ctl:release-${RELEASE_STREAM} "}
+export HELM_PATCH=${HELM_PATCH:-"0"}
+export CALICOCTL_INSTALL_TYPE=${CALICOCTL_INSTALL_TYPE:-"binary"}
 
 export CLUSTER_NAME=${CLUSTER_NAME:-bz-${PRODUCT}-${RANDOM_TOKEN1}}
 export DIAGS_ARCHIVE_FILENAME=${DIAGS_ARCHIVE_FILENAME:-${PROVISIONER}-${CLUSTER_NAME}-diags.tgz}

--- a/.argoci/scripts/phases/run_tests.sh
+++ b/.argoci/scripts/phases/run_tests.sh
@@ -1,18 +1,12 @@
 #!/usr/bin/env bash
 # run_tests.sh - acquire an e2e binary and run it, or defer to bz tests.
 #
-# Selection (automatic):
-#   - E2E_TEST_CONFIG set → structured label-based selection via `make e2e-run`.
-#     The e2e binary is acquired first: built from local source when
-#     RUN_LOCAL_TESTS is set (per-PR CI / GCP e2e block), otherwise downloaded
-#     from the hashrelease (scheduled CI).
-#   - Else → `bz tests`, which honours K8S_E2E_FLAGS (regex --ginkgo.focus/skip,
-#     read from the environment) for regex-selected e2e jobs, and also runs the
-#     non-e2e test types (benchmarks, certification, etc.).
-#
-# `make e2e-run` has no --ginkgo.focus, so K8S_E2E_FLAGS is inert there; regex
-# selection must go through `bz tests` (matches the Semaphore flannel-migration
-# body, which runs `K8S_E2E_FLAGS=... bz tests`).
+# Selection (automatic, matches Semaphore):
+#   - TEST_TYPE == k8s-e2e → run the monorepo e2e binary via `make e2e-run`.
+#     The binary is acquired first: built from local source when RUN_LOCAL_TESTS
+#     is set (per-PR CI), otherwise downloaded from the hashrelease (scheduled
+#     CI). E2E_TEST_CONFIG selects specs and may be empty (default config).
+#   - Else (non-e2e test types: benchmarks, certification, etc.) → `bz tests`.
 #
 # Required env:
 #   BZ_LOCAL_DIR, BZ_LOGS_DIR, HOME, REPORT_DIR, TEST_TYPE
@@ -34,7 +28,7 @@ if [[ -n "${RUN_LOCAL_TESTS:-}" ]]; then
   make -C e2e build |& tee >(gzip --stdout > "${BZ_LOGS_DIR}/${TEST_TYPE}-build.log.gz")
   E2E_BINARY=/go/src/github.com/projectcalico/calico/e2e/bin/k8s/e2e.test
   popd || exit
-elif [[ "${TEST_TYPE}" == "k8s-e2e" && -n "${E2E_TEST_CONFIG:-}" ]]; then
+elif [[ "${TEST_TYPE}" == "k8s-e2e" ]]; then
   # Scheduled CI: download the pre-built e2e binary from the hashrelease.
   echo "[INFO] downloading e2e binary from hashrelease..."
   HASHREL_URL=$(curl --retry 9 --retry-all-errors -sS "https://latest-os.docs.eng.tigera.net/${RELEASE_STREAM}.txt")
@@ -48,10 +42,10 @@ elif [[ "${TEST_TYPE}" == "k8s-e2e" && -n "${E2E_TEST_CONFIG:-}" ]]; then
 fi
 
 # E2E_BINARY is a set/unset sentinel (its value is not used here -- make
-# e2e-run locates the binary itself). Take the structured path only when a
-# k8s-e2e binary was acquired above AND E2E_TEST_CONFIG selects specs; regex
-# (K8S_E2E_FLAGS) and non-e2e jobs fall through to bz tests below.
-if [[ -n "${E2E_BINARY:-}" && -n "${E2E_TEST_CONFIG:-}" ]]; then
+# e2e-run locates the binary itself). Take the structured path whenever a
+# k8s-e2e binary was acquired above; non-e2e test types fall through to bz
+# tests below. E2E_TEST_CONFIG may be empty (selects the default config).
+if [[ -n "${E2E_BINARY:-}" ]]; then
   echo "[INFO] starting e2e tests..."
   pushd "${CI_HOME}/${CI_GIT_DIR}" || exit
 
@@ -82,6 +76,14 @@ if [[ -n "${E2E_BINARY:-}" && -n "${E2E_TEST_CONFIG:-}" ]]; then
   # the container, and we prepend that to PATH inside the bash -c below.
   make kubectl
 
+  # EKS kubeconfigs exec aws-iam-authenticator (PATH lookup), which the stock
+  # golang image lacks, so client-go fails before any tests run. The aws-eks
+  # provisioner installs it on the host; bind-mount it when present (no-op otherwise).
+  auth_mount=()
+  if [[ -x "${BZ_LOCAL_DIR}/bin/aws-iam-authenticator" ]]; then
+    auth_mount=(-v "${BZ_LOCAL_DIR}/bin/aws-iam-authenticator:/usr/local/bin/aws-iam-authenticator:ro")
+  fi
+
   # Capture the exit code so the JUnit copy below runs even when tests fail
   # (set -e would otherwise bail out before the cp).
   e2e_rc=0
@@ -92,6 +94,7 @@ if [[ -n "${E2E_BINARY:-}" && -n "${E2E_TEST_CONFIG:-}" ]]; then
     -e KUBECONFIG=/kubeconfig \
     -e PRODUCT=${PRODUCT:-calico} \
     ${K8S_E2E_DOCKER_EXTRA_FLAGS:-} \
+    "${auth_mount[@]}" \
     -v "$(pwd)":/go/src/github.com/projectcalico/calico:rw \
     -v "$(pwd)"/.go-pkg-cache:/go-cache:rw \
     -v "${BZ_LOCAL_DIR}/kubeconfig:/kubeconfig:ro" \
@@ -115,8 +118,7 @@ if [[ -n "${E2E_BINARY:-}" && -n "${E2E_TEST_CONFIG:-}" ]]; then
   # Propagate the original test exit code.
   exit ${e2e_rc}
 else
-  # Regex-selected e2e (K8S_E2E_FLAGS) or non-e2e test types -- defer to bz,
-  # which reads K8S_E2E_FLAGS from the environment.
+  # Non-e2e test types (benchmarks, certification, etc.) -- defer to bz.
   echo "[INFO] starting bz testing (K8S_E2E_FLAGS=${K8S_E2E_FLAGS:-<none>})..."
   bz tests ${VERBOSE} |& tee >(gzip --stdout > "${BZ_LOGS_DIR}/${TEST_TYPE}-tests.log.gz")
 fi

--- a/.argoci/scripts/phases/run_tests.sh
+++ b/.argoci/scripts/phases/run_tests.sh
@@ -79,9 +79,19 @@ if [[ -n "${E2E_BINARY:-}" ]]; then
   # EKS kubeconfigs exec aws-iam-authenticator (PATH lookup), which the stock
   # golang image lacks, so client-go fails before any tests run. The aws-eks
   # provisioner installs it on the host; bind-mount it when present (no-op otherwise).
+  # It also needs AWS creds in the container (else it exits 1 and
+  # SynchronizedBeforeSuite fails). Mount ~/.aws (written by the prologue) and point
+  # the SDK at it via env -- container runs as an arbitrary UID.
   auth_mount=()
+  aws_cred_env=()
   if [[ -x "${BZ_LOCAL_DIR}/bin/aws-iam-authenticator" ]]; then
     auth_mount=(-v "${BZ_LOCAL_DIR}/bin/aws-iam-authenticator:/usr/local/bin/aws-iam-authenticator:ro")
+    if [[ -d "${HOME}/.aws" ]]; then
+      auth_mount+=(-v "${HOME}/.aws:/aws-config:ro")
+      aws_cred_env=(-e AWS_SHARED_CREDENTIALS_FILE=/aws-config/credentials
+                    -e AWS_CONFIG_FILE=/aws-config/config
+                    -e "AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION:-us-west-2}")
+    fi
   fi
 
   # Capture the exit code so the JUnit copy below runs even when tests fail
@@ -95,6 +105,7 @@ if [[ -n "${E2E_BINARY:-}" ]]; then
     -e PRODUCT=${PRODUCT:-calico} \
     ${K8S_E2E_DOCKER_EXTRA_FLAGS:-} \
     "${auth_mount[@]}" \
+    "${aws_cred_env[@]}" \
     -v "$(pwd)":/go/src/github.com/projectcalico/calico:rw \
     -v "$(pwd)"/.go-pkg-cache:/go-cache:rw \
     -v "${BZ_LOCAL_DIR}/kubeconfig:/kubeconfig:ro" \


### PR DESCRIPTION
Aligns the `.argoci/scripts/*` scaffold (from #13124) with `.semaphore/end-to-end/scripts/*`, and wires the runtime environment Semaphore's host provided implicitly so ArgoCI runs behave identically. **Merging registers the `e2e-nftables` CronWorkflow (schedule: Mondays 21:10 UTC).**

Commits:
1. Make scaffold scripts bug-for-bug identical to Semaphore. Most impactful: `run_tests.sh` keys the `make e2e-run` path on `TEST_TYPE==k8s-e2e`, not an `E2E_TEST_CONFIG` gate — so empty-config k8s-e2e jobs run the monorepo suite Semaphore runs, not `bz tests`.
2. Port `body_flannel-migration.sh`.
3. Runtime adaptations for the isolated runner: AWS creds (banzai-secrets), EKS in-container auth, `az login`, `GH_TOKEN`, `USER`, python3.10-venv stopgap, `ARGO_WORKFLOW_UID`. Also pins `GOOGLE_REGION`/`GOOGLE_ZONE` on the region-fixed gcp-kubeadm jobs (kubevirt, talos-native-gcp) whose reserved IPs live only in us-central1 — the prologue's load-spread region randomisation stays for jobs that run anywhere.

Behaviour-changing fixes to Semaphore-inherited bugs are held for DE-4390 (#15).

## Release Note
```release-note
NONE
```