### PR TITLE
felix: reduce IPv6 ext-header parse verifier complexity

### DIFF
--- a/felix/bpf-gpl/parsing6.h
+++ b/felix/bpf-gpl/parsing6.h
@@ -125,12 +125,12 @@ static CALI_BPF_INLINE void tc_state_fill_from_iphdr_v6_offset(struct cali_tc_ct
 	for (i = 0; i < 8; i++) {
 		struct ipv6_opt_hdr opt;
 
-		CALI_DEBUG("loading extension at offset %d", ipoff + len);
 		if (bpf_load_bytes(ctx, ipoff + len, &opt, sizeof(opt))) {
 			CALI_DEBUG("Too short");
 			goto deny;
 		}
 
+		CALI_DEBUG("loading extension at offset %d", ipoff + len);
 		CALI_DEBUG("ext nexthdr %d hdrlen %d", opt.nexthdr, opt.hdrlen);
 
 		switch(hdr) {


### PR DESCRIPTION
**Description**

The IPv6 extension-header parse loop in `tc_state_fill_from_iphdr_v6_offset` (`felix/bpf-gpl/parsing6.h`) emitted a `CALI_DEBUG` immediately **before** `bpf_load_bytes()` on every iteration. A helper call ahead of the packet load forces the verifier to checkpoint state across the load, and because the loop is walked under many downstream policy states, the cost fans out combinatorially.

On the heaviest debug programs (from-HEP, IPv6), this pushed `from_hep_debug_v6.o` and `from_hep_dsr_debug_v6.o` past the verifier's 1,000,000-instruction complexity limit (`-E2BIG`) on newer kernels (observed on `6.8.0-1063-gcp`), so `TestPrecompiledBinariesAreLoadable` failed to load them.

This moves the log to **after** the load and length check, so both per-iteration debug logs sit on the single post-load success path.

Measured on `6.8.0-1063-gcp` (`calico_tc_main` in `from_hep_debug_v6.o`):

| | processed insns (limit 1,000,000) |
|---|---|
| before | >1,000,000 → rejected (`-E2BIG`) |
| after | 810,522 |

No change to `no_log` builds or dataplane behaviour. The only trade-off is that a `"Too short"` failure no longer logs the offset it failed to read.

**Testing**

`make FOCUS="TestPrecompiledBinariesAreLoadable" ut-bpf` passes (0 failures, all 101 objects load) on `6.8.0-1063-gcp`, including the two previously-failing objects.

**Release Note**

```release-note
Fix BPF IPv6 debug programs exceeding the kernel verifier's complexity limit on newer kernels.
```