### PR TITLE
trigger-merge-queue: retry PR lookup to handle search-index lag

### DIFF
--- a/.github/workflows/trigger-merge-queue.yml
+++ b/.github/workflows/trigger-merge-queue.yml
@@ -15,16 +15,32 @@ jobs:
         id: pr
         env:
           GH_TOKEN: ${{ secrets.TIGERA_BOT_PAT }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.sha }}
         run: |
-          if ! PR_NUMBER=$(gh api "repos/${{ github.repository }}/commits/${{ github.sha }}/pulls" \
-            --jq 'map(select(.merged_at != null and .base.ref == "master")) | .[0].number // empty'); then
-            echo "::warning::Failed to query GitHub API for commit ${{ github.sha }} -- skipping merge-queue dispatch due to API error"
-            exit 0
-          fi
+          # The commits/{sha}/pulls endpoint can return an empty array for a
+          # few seconds right after a merge while GitHub's search index catches
+          # up. Retry a couple of times before giving up so a freshly-merged PR
+          # does not silently skip the merge-queue dispatch.
+          PR_NUMBER=""
+          for attempt in 1 2 3; do
+            if ! PR_NUMBER=$(gh api "repos/${REPO}/commits/${SHA}/pulls" \
+              --jq 'map(select(.merged_at != null and .base.ref == "master")) | .[0].number // empty'); then
+              echo "::warning::attempt ${attempt}: gh api failed for commit ${SHA}"
+              PR_NUMBER=""
+            fi
+            if [[ -n "$PR_NUMBER" && "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
+              break
+            fi
+            if [[ $attempt -lt 3 ]]; then
+              echo "::notice::attempt ${attempt}: no associated PR yet for ${SHA}, retrying in 5s"
+              sleep 5
+            fi
+          done
           if [[ -n "$PR_NUMBER" && "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
             echo "number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
           else
-            echo "::notice::No associated PR found for ${{ github.sha }} -- skipping merge-queue dispatch"
+            echo "::notice::No associated PR found for ${SHA} after retries -- skipping merge-queue dispatch"
           fi
 
       - name: Print information about the push


### PR DESCRIPTION
The `Trigger Merge Cat` workflow queries `repos/calico/commits/{sha}/pulls` immediately after a push to `master`. That endpoint occasionally returns an empty array for the first few seconds after a merge while GitHub's search index catches up. When that happened, the workflow silently skipped the merge-queue dispatch and the downstream bot never got the `OSS_MERGE` trigger for that PR.

Sampling the last 30 runs showed the miss rate at roughly 50%: 15 dispatched, 15 exited with `::notice::No associated PR found`. The workflow itself always reported `success`, so the failure was invisible from the Actions UI.

## Change

Retry the PR-number lookup up to 3 times with a 5s sleep between attempts. Same pattern used by `cherry_pick_candidate.js` (which has a comment noting the same failure mode). Also moves \`\${{ github.repository }}\` and \`\${{ github.sha }}\` into \`env:\` and references them as shell variables, matching current security guidance for workflow steps.

## Testing

Static change to a workflow shell script; the effect can only be observed on live pushes. Locally verified that the retry loop is well-formed bash and that all four exit paths (immediate hit, hit on retry, all attempts return empty, `gh api` transport error) produce the expected output.

**Release note:**
\`\`\`release-note
None
\`\`\`