### PR TITLE
Add eBPF-dataplane e2e job to the on-agent KinD block

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,8 @@ hack/test/kind/.*updated*
 hack/test/kind/kubectl
 hack/test/kind/kubectl-v*
 hack/test/kind/*kubeconfig.yaml
+hack/test/kind/external-node-key*
+hack/test/kind/external-node-ip
 hack/test/envtest/
 pod2daemon/node-driver-registrar/
 

--- a/.semaphore/semaphore-scheduled-builds.yml
+++ b/.semaphore/semaphore-scheduled-builds.yml
@@ -919,6 +919,9 @@ blocks:
               value: "projectcalico.org/v3"
             - name: E2E_TEST_CONFIG
               value: "e2e/config/kind-felix-routing.yaml"
+        - name: "E2E tests: sig-calico (dataplane: BPF)"
+          commands:
+            - .semaphore/run-and-monitor e2e-test-bpf.log make e2e-test-bpf
       epilogue:
         always:
           commands:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -3013,6 +3013,9 @@ blocks:
               value: "projectcalico.org/v3"
             - name: E2E_TEST_CONFIG
               value: "e2e/config/kind-felix-routing.yaml"
+        - name: "E2E tests: sig-calico (dataplane: BPF)"
+          commands:
+            - .semaphore/run-and-monitor e2e-test-bpf.log make e2e-test-bpf
       epilogue:
         always:
           commands:

--- a/.semaphore/semaphore.yml.d/blocks/20-e2e.yml
+++ b/.semaphore/semaphore.yml.d/blocks/20-e2e.yml
@@ -43,6 +43,9 @@
             value: "projectcalico.org/v3"
           - name: E2E_TEST_CONFIG
             value: "e2e/config/kind-felix-routing.yaml"
+      - name: "E2E tests: sig-calico (dataplane: BPF)"
+        commands:
+          - .semaphore/run-and-monitor e2e-test-bpf.log make e2e-test-bpf
     epilogue:
       always:
         commands:

--- a/Makefile
+++ b/Makefile
@@ -286,7 +286,7 @@ e2e-test-bpf:
 	SSH_AUTH_SOCK= \
 	$(MAKE) e2e-run \
 		KIND_NAME=kind \
-		KUBECONFIG=$(KIND_DIR)/kind-kubeconfig.yaml \
+		KUBECONFIG=$(KIND_KUBECONFIG) \
 		E2E_TEST_CONFIG=$(REPO_ROOT)/e2e/config/kind-bpf.yaml
 
 ## Create a kind cluster and run the ClusterNetworkPolicy specific e2e tests.

--- a/Makefile
+++ b/Makefile
@@ -267,6 +267,28 @@ e2e-test:
 	CLUSTER_ROUTING=$(CLUSTER_ROUTING) $(MAKE) kind-up
 	$(MAKE) e2e-run KUBECONFIG=$(KIND_KUBECONFIG)
 
+## Create a kind cluster with the BPF dataplane plus an external node, and run
+## the sig-calico BPF e2e tests (including the ExternalNode specs).
+## Uses kind-bpf.config (kube-proxy in iptables mode - eBPF does not support
+## ipvs kube-proxy) while keeping the cluster named "kind" so values.yaml's
+## control-plane nodeSelector still matches.
+e2e-test-bpf:
+	$(MAKE) -C e2e build
+	$(MAKE) kind-up KIND_NAME=kind KIND_CONFIG=$(KIND_DIR)/kind-bpf.config EXTRA_VALUES_FILES=$(KIND_INFRA_DIR)/values-bpf.yaml
+	$(KIND_DIR)/external-node.sh up
+	# EXT_* / SSH_AUTH_SOCK are passed as environment (the e2e binary reads them
+	# via os.Getenv); KIND_NAME/KUBECONFIG/E2E_TEST_CONFIG are make variables.
+	# SSH_AUTH_SOCK is cleared so the framework's ssh uses only EXT_KEY and does
+	# not trip over unrelated agent keys.
+	EXT_USER=ubuntu \
+	EXT_IP="$$(cat $(KIND_DIR)/external-node-ip)" \
+	EXT_KEY=$(KIND_DIR)/external-node-key \
+	SSH_AUTH_SOCK= \
+	$(MAKE) e2e-run \
+		KIND_NAME=kind \
+		KUBECONFIG=$(KIND_DIR)/kind-kubeconfig.yaml \
+		E2E_TEST_CONFIG=$(REPO_ROOT)/e2e/config/kind-bpf.yaml
+
 ## Create a kind cluster and run the ClusterNetworkPolicy specific e2e tests.
 e2e-test-clusternetworkpolicy:
 	$(MAKE) -C e2e build

--- a/e2e/config/kind-bpf.yaml
+++ b/e2e/config/kind-bpf.yaml
@@ -1,0 +1,38 @@
+# kind-bpf.yaml - test selection for the kind e2e CI job running the BPF
+# dataplane (values-bpf.yaml overlay).
+#
+# This config is standalone (doesn't extend base.yaml) because it uses a
+# narrower include scope (sig-calico only, no sig-network Conformance) that
+# can't be expressed as an additive extension of base's broader includes.
+
+include:
+  - sig-calico
+
+exclude:
+  labels:
+    - label: Slow
+      reason: "long-running tests not suitable for CI"
+
+    - label: Disruptive
+      reason: "breaks cluster state for other parallel tests"
+
+    - label: RequiresAWS
+      reason: "requires AWS-specific infrastructure (VPC routing layout, etc.)"
+
+    - label: RequiresBGPMesh
+      reason: "requires a full BGP mesh, not configured on this cluster"
+
+    - label: NoEncap
+      reason: "requires non-encapsulated routing, not configured on this cluster"
+
+    - label: Feature:Istio
+      reason: "Calico policy not enforced with Istio ambient on BPF dataplane"
+
+    - label: RequiresXtables
+      reason: "requires iptables or nftables dataplane, but this cluster uses BPF"
+
+    - label: RequiresCalicoAPIServer
+      reason: "kind clusters run in v3 CRD mode without the aggregated Calico API server"
+
+    - label: Feature:KubeVirt
+      reason: "e2e infra integration with Banzai not ready, currently run manually"

--- a/e2e/pkg/tests/hostendpoints/hostendpoints.go
+++ b/e2e/pkg/tests/hostendpoints/hostendpoints.go
@@ -415,25 +415,32 @@ var _ = describe.CalicoDescribe(
 				// We need to enable generic XDP to test XDP in Iptables mode, otherwise the raw table
 				// is used to implement doNotTrack GNP with deny action (because the interfaces used in e2e testing
 				// may not support XDP offload or driver modes)
-				felixConfig := v3.NewFelixConfiguration()
-				err := cli.Get(context.Background(), types.NamespacedName{Name: "default"}, felixConfig)
-				Expect(err).NotTo(HaveOccurred())
-
-				genericXDP := felixConfig.Spec.GenericXDPEnabled
-				if genericXDP == nil || !*genericXDP {
-					By("enabling generic XDP")
-					felixConfig.Spec.GenericXDPEnabled = ptr.To(true)
-					err = cli.Update(context.Background(), felixConfig)
+				//
+				// The BPF dataplane does NOT use this mechanism: it enforces the doNotTrack
+				// policy with its own XDP program regardless of GenericXDPEnabled. So skip the
+				// toggle under BPF - it is a no-op there, and flipping GenericXDPEnabled
+				// restarts Felix, which would race with the connectivity assertion below.
+				if !utils.DetectDataplane(cli, f.ClientSet).IsBPF() {
+					felixConfig := v3.NewFelixConfiguration()
+					err := cli.Get(context.Background(), types.NamespacedName{Name: "default"}, felixConfig)
 					Expect(err).NotTo(HaveOccurred())
 
-					defer func() {
-						By("restoring generic XDP setting")
-						err = cli.Get(context.Background(), types.NamespacedName{Name: "default"}, felixConfig)
-						Expect(err).NotTo(HaveOccurred())
-						felixConfig.Spec.GenericXDPEnabled = genericXDP
+					genericXDP := felixConfig.Spec.GenericXDPEnabled
+					if genericXDP == nil || !*genericXDP {
+						By("enabling generic XDP")
+						felixConfig.Spec.GenericXDPEnabled = ptr.To(true)
 						err = cli.Update(context.Background(), felixConfig)
 						Expect(err).NotTo(HaveOccurred())
-					}()
+
+						defer func() {
+							By("restoring generic XDP setting")
+							err = cli.Get(context.Background(), types.NamespacedName{Name: "default"}, felixConfig)
+							Expect(err).NotTo(HaveOccurred())
+							felixConfig.Spec.GenericXDPEnabled = genericXDP
+							err = cli.Update(context.Background(), felixConfig)
+							Expect(err).NotTo(HaveOccurred())
+						}()
+					}
 				}
 
 				// The GlobalNetworkSet needed to list the source addresses needed by the following GNP

--- a/e2e/pkg/tests/hostendpoints/hostendpoints.go
+++ b/e2e/pkg/tests/hostendpoints/hostendpoints.go
@@ -420,7 +420,7 @@ var _ = describe.CalicoDescribe(
 				// policy with its own XDP program regardless of GenericXDPEnabled. So skip the
 				// toggle under BPF - it is a no-op there, and flipping GenericXDPEnabled
 				// restarts Felix, which would race with the connectivity assertion below.
-				if !utils.DetectDataplane(cli, f.ClientSet).IsBPF() {
+				if utils.DetectCalicoDataplane(cli) != utils.DataplaneBPF {
 					felixConfig := v3.NewFelixConfiguration()
 					err := cli.Get(context.Background(), types.NamespacedName{Name: "default"}, felixConfig)
 					Expect(err).NotTo(HaveOccurred())

--- a/e2e/pkg/tests/ipam/ipam_strict_affinity.go
+++ b/e2e/pkg/tests/ipam/ipam_strict_affinity.go
@@ -158,6 +158,15 @@ var _ = describe.CalicoDescribe(
 									TopologyKey:       "kubernetes.io/hostname",
 									WhenUnsatisfiable: corev1.DoNotSchedule,
 									LabelSelector:     &metav1.LabelSelector{MatchLabels: labels},
+									// Honor node taints so nodes the pod can't tolerate (e.g. a
+									// tainted control-plane) are excluded from the skew calculation.
+									// With the default Ignore policy, a tainted control-plane counts
+									// as a topology domain with zero pods; MaxSkew:1 then caps every
+									// schedulable worker at one pod, so on an N-worker cluster the
+									// (N+1)th replica is permanently unschedulable (stuck Pending,
+									// never gets an IP). Honor scopes the spread to the schedulable
+									// workers, matching the test's intent. Requires k8s >= 1.26.
+									NodeTaintsPolicy: ptr.To(corev1.NodeInclusionPolicyHonor),
 								}},
 								TerminationGracePeriodSeconds: ptr.To(int64(1)),
 							},

--- a/hack/test/kind/external-node.sh
+++ b/hack/test/kind/external-node.sh
@@ -52,23 +52,32 @@ up() {
 	log "starting $NAME ($IMAGE) on network $NETWORK"
 	docker run -d --privileged --name "$NAME" --network "$NETWORK" "$IMAGE" >/dev/null
 
-	# Wait for the in-container dockerd (dind) to come up.
+	# Wait for the in-container dockerd (dind) to come up, and fail clearly if it
+	# never does (otherwise `sudo docker` on the node fails later with an obscure
+	# error mid-test).
 	for _ in $(seq 1 30); do
 		docker exec "$NAME" docker info >/dev/null 2>&1 && break
 		sleep 1
 	done
+	if ! docker exec "$NAME" docker info >/dev/null 2>&1; then
+		log "ERROR: dockerd did not become ready in $NAME"
+		return 1
+	fi
 
 	docker exec "$NAME" apk add --no-cache openssh sudo iproute2 curl bash >/dev/null
-	# Create the ubuntu user for the framework to SSH in as. NOTE: alpine's
-	# `adduser -D` leaves the account locked (! in /etc/shadow), which silently
-	# blocks public-key auth, so unlock it with a password.
+	# Create the ubuntu user for the framework to SSH in as, and harden sshd to
+	# key-only auth. NOTE: alpine's `adduser -D` leaves the account locked (! in
+	# /etc/shadow), which silently blocks public-key auth; unlock it with a random
+	# password. Password auth is disabled below regardless, so the password is
+	# never a usable remote credential.
 	docker exec "$NAME" sh -c '
 		set -e
 		adduser -D -s /bin/sh ubuntu 2>/dev/null || true
-		echo "ubuntu:ubuntu" | chpasswd
+		echo "ubuntu:$(head -c 18 /dev/urandom | base64)" | chpasswd
 		echo "ubuntu ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/ubuntu
 		install -d -m 700 -o ubuntu -g ubuntu /home/ubuntu/.ssh
 		ssh-keygen -A >/dev/null
+		printf "PasswordAuthentication no\nPermitRootLogin no\nPubkeyAuthentication yes\n" >> /etc/ssh/sshd_config
 	'
 	docker exec -i "$NAME" sh -c \
 		'cat > /home/ubuntu/.ssh/authorized_keys \
@@ -97,7 +106,9 @@ up() {
 
 down() {
 	docker rm -f "$NAME" >/dev/null 2>&1 || true
-	rm -f "$IP_FILE"
+	# Remove the generated IP file and keypair (regenerated on the next `up`) so
+	# key material isn't left on disk / picked up as a CI artifact.
+	rm -f "$IP_FILE" "$KEY" "${KEY}.pub"
 	log "down: removed $NAME"
 }
 

--- a/hack/test/kind/external-node.sh
+++ b/hack/test/kind/external-node.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2026 Tigera, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# external-node.sh - manage an "external node" for kind-based e2e tests.
+#
+# Creates (up) or removes (down) a container on the kind Docker network that is
+# NOT a Kubernetes node, so the e2e framework can drive it over SSH to exercise
+# ExternalNode-labeled specs (external->NodePort, doNotTrack DoS mitigation,
+# packet-size/MTU, ...).
+#
+# The framework's externalnode client simply SSHes to EXT_IP as EXT_USER with
+# EXT_KEY and runs commands (curl, sudo docker) there, so any SSH-able host with
+# docker works. This mirrors the banzai/GCP external node (ubuntu user + SSH key
+# + docker). Because the container sits on the kind network but is not a k8s
+# node, Calico treats its traffic as coming from outside the cluster.
+#
+# `up` writes the node IP to <kind-dir>/external-node-ip and generates the SSH
+# key at <kind-dir>/external-node-key(.pub). Callers point the e2e run at it with:
+#   EXT_USER=ubuntu
+#   EXT_IP=$(cat <kind-dir>/external-node-ip)
+#   EXT_KEY=<kind-dir>/external-node-key
+set -euo pipefail
+
+KIND_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+NAME="${EXTERNAL_NODE_NAME:-kind-external-node}"
+NETWORK="${KIND_NETWORK:-kind}"
+# docker-in-docker: provides an sshd-able base plus a Docker daemon for tests
+# that launch client/server containers on the external node.
+IMAGE="${EXTERNAL_NODE_IMAGE:-docker:28-dind}"
+KEY="${KIND_DIR}/external-node-key"
+IP_FILE="${KIND_DIR}/external-node-ip"
+
+log() { echo "[external-node] $*"; }
+
+up() {
+	[[ -f "$KEY" ]] || ssh-keygen -t ed25519 -N "" -f "$KEY" -C external-node >/dev/null
+
+	docker rm -f "$NAME" >/dev/null 2>&1 || true
+	log "starting $NAME ($IMAGE) on network $NETWORK"
+	docker run -d --privileged --name "$NAME" --network "$NETWORK" "$IMAGE" >/dev/null
+
+	# Wait for the in-container dockerd (dind) to come up.
+	for _ in $(seq 1 30); do
+		docker exec "$NAME" docker info >/dev/null 2>&1 && break
+		sleep 1
+	done
+
+	docker exec "$NAME" apk add --no-cache openssh sudo iproute2 curl bash >/dev/null
+	# Create the ubuntu user for the framework to SSH in as. NOTE: alpine's
+	# `adduser -D` leaves the account locked (! in /etc/shadow), which silently
+	# blocks public-key auth, so unlock it with a password.
+	docker exec "$NAME" sh -c '
+		set -e
+		adduser -D -s /bin/sh ubuntu 2>/dev/null || true
+		echo "ubuntu:ubuntu" | chpasswd
+		echo "ubuntu ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/ubuntu
+		install -d -m 700 -o ubuntu -g ubuntu /home/ubuntu/.ssh
+		ssh-keygen -A >/dev/null
+	'
+	docker exec -i "$NAME" sh -c \
+		'cat > /home/ubuntu/.ssh/authorized_keys \
+		 && chmod 600 /home/ubuntu/.ssh/authorized_keys \
+		 && chown ubuntu:ubuntu /home/ubuntu/.ssh/authorized_keys' \
+		<"${KEY}.pub"
+	docker exec "$NAME" /usr/sbin/sshd
+
+	local ip
+	ip="$(docker inspect "$NAME" --format "{{(index .NetworkSettings.Networks \"$NETWORK\").IPAddress}}")"
+	echo "$ip" >"$IP_FILE"
+
+	# Confirm SSH is reachable before returning so the e2e run doesn't race sshd.
+	for _ in $(seq 1 15); do
+		if SSH_AUTH_SOCK= ssh -o ConnectTimeout=3 -o StrictHostKeyChecking=no \
+			-o UserKnownHostsFile=/dev/null -o IdentitiesOnly=yes -i "$KEY" \
+			"ubuntu@${ip}" true 2>/dev/null; then
+			log "up: ip=$ip user=ubuntu key=$KEY"
+			return 0
+		fi
+		sleep 1
+	done
+	log "ERROR: external node SSH not reachable at $ip"
+	return 1
+}
+
+down() {
+	docker rm -f "$NAME" >/dev/null 2>&1 || true
+	rm -f "$IP_FILE"
+	log "down: removed $NAME"
+}
+
+case "${1:-up}" in
+up) up ;;
+down) down ;;
+*)
+	echo "usage: $(basename "$0") up|down" >&2
+	exit 1
+	;;
+esac

--- a/hack/test/kind/infra/values-bpf.yaml
+++ b/hack/test/kind/infra/values-bpf.yaml
@@ -1,0 +1,52 @@
+# BPF-dataplane overlay for values.yaml. Layered on top via a second `helm -f`
+# flag by the E2E BPF CI job. Keep this file minimal - add only the fields that
+# need to differ from the base values.yaml.
+#
+# bpfNetworkBootstrap and kubeProxyManagement both default to Disabled in the
+# operator, so they must be set explicitly. They live here (not in values.yaml)
+# because bpfNetworkBootstrap=Enabled is only valid when linuxDataplane is BPF -
+# the operator rejects it otherwise, which would break the iptables-based
+# BIRD/Felix-routing e2e jobs that share values.yaml.
+installation:
+  calicoNetwork:
+    linuxDataplane: BPF
+    # Bootstrap API-server access via the kubernetes Service/EndpointSlices,
+    # since kube-proxy is disabled and the BPF dataplane isn't programming
+    # service NAT yet at start-of-day.
+    bpfNetworkBootstrap: Enabled
+    # Let the operator disable the kube-proxy DaemonSet (Calico's BPF dataplane
+    # replaces it).
+    kubeProxyManagement: Enabled
+    # The base values.yaml leaves ipPool encapsulation unset, so the operator
+    # defaults the v4 pool to IPIP - which BPF doesn't manage (tunl0 is not a BPF
+    # data interface). Pin the v4 pool to VXLAN (Always, not CrossSubnet): all
+    # kind nodes share one subnet, so CrossSubnet would route pod traffic
+    # directly over eth0 and never use vxlan.calico. Host-endpoint e2e tests bind
+    # the HEP to the encap device for host-originated traffic, so the traffic
+    # must actually traverse vxlan.calico (which BPF manages) for policy to apply.
+    # Always also matches the GCP BPF e2e job's VXLAN cluster. Helm replaces list
+    # values, so both pools are restated here (keep in sync with values.yaml).
+    ipPools:
+    - cidr: 192.168.0.0/16
+      encapsulation: VXLAN
+      natOutgoing: Enabled
+    - cidr: fd00:10:244::/64
+      encapsulation: None
+
+  # On kernel 5.11+ BPF map memory is charged to the container's memory cgroup.
+  # The base values.yaml caps calico-node at 512Mi (fine for iptables/nftables),
+  # but the BPF dataplane's map set (NAT, conntrack, etc.) pushes past it and the
+  # container is OOMKilled while loading maps. Raise the limit for BPF.
+  calicoNodeDaemonSet:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: calico-node
+            resources:
+              requests:
+                cpu: 100m
+                memory: 512Mi
+              limits:
+                cpu: 500m
+                memory: 1Gi

--- a/hack/test/kind/kind-bpf.config
+++ b/hack/test/kind/kind-bpf.config
@@ -1,0 +1,55 @@
+# Configuration for a multi-node local kind cluster used by the eBPF-dataplane
+# e2e job. Identical to kind.config EXCEPT kube-proxy runs in iptables mode
+# instead of ipvs.
+#
+# Calico's eBPF dataplane does not support kube-proxy in ipvs mode: a leftover
+# kube-ipvs0 device (with its bound service IPs and IPVS rules) is incompatible
+# with BPF, and the eBPF migration docs require switching kube-proxy to iptables
+# before enabling eBPF. Creating the cluster in iptables mode from the start
+# avoids any ipvs state. Select this config with
+# KIND_CONFIG=hack/test/kind/kind-bpf.config (KIND_NAME then becomes "kind-bpf").
+#
+# Keep in sync with kind.config; the only intended difference is the kube-proxy
+# mode below.
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+networking:
+  disableDefaultCNI: true
+  podSubnet: "192.168.0.0/16,fd00:10:244::/64"
+  ipFamily: dual
+  dnsSearch: []
+
+nodes:
+- role: control-plane
+- role: worker
+- role: worker
+- role: worker
+
+featureGates:
+  "MutatingAdmissionPolicy": true
+
+runtimeConfig:
+  "admissionregistration.k8s.io/v1beta1": "true"
+
+# Note: containerd in kind reads per-host config from /etc/containerd/certs.d/.
+# registry.sh writes the localhost:5000 -> http://kind-registry:5000 mapping
+# to each node after cluster creation; the older containerdConfigPatches
+# `mirrors` syntax is rejected when config_path is set.
+
+kubeadmConfigPatches:
+- |
+  apiVersion: kubeadm.k8s.io/v1beta3
+  kind: ClusterConfiguration
+  metadata:
+    name: config
+  controllerManager:
+    extraArgs:
+      cluster-cidr: "192.168.0.0/16"
+- |
+  apiVersion: kubeproxy.config.k8s.io/v1alpha1
+  kind: KubeProxyConfiguration
+  metadata:
+    name: config
+  mode: iptables
+  conntrack:
+    maxPerCore: 0

--- a/lib.Makefile
+++ b/lib.Makefile
@@ -1661,6 +1661,9 @@ endif
 	touch $@
 
 kind-cluster-destroy kind-down: $(KIND) $(KUBECTL)
+	# Tear down the e2e external node (if any) alongside the cluster. Idempotent
+	# and a no-op when no external node was created (e.g. non-BPF jobs).
+	-$(KIND_DIR)/external-node.sh down
 	# We need to drain the cluster gracefully when shutting down to avoid a netdev unregister error from the kernel.
 	# This requires we execute CNI del on pods with pod networking.
 	-$(KIND) delete cluster --name $(KIND_NAME)


### PR DESCRIPTION
## Description

Adds an on-agent KinD e2e job that runs the sig-calico suite against a KinD cluster in **eBPF dataplane mode**, giving the eBPF datapath PR-gating e2e coverage on the existing Semaphore agent — no GCP VM required.

`e2e/config/kind-bpf.yaml` mirrors `gcp-bpf.yaml`'s sig-calico scope (identical include + excluded labels), so this job can stand in for the heavier GCP-kubeadm BPF job (`20-e2e-gcp.yml`). **Both jobs are intentionally left running for now** so their results and wall-clock/resource cost can be compared side-by-side in the same CI run before the GCP job is removed - or demoted to nightly.

### What's added

A new `make e2e-test-bpf` target orchestrates the flow:

- **`hack/test/kind/kind-bpf.config`** — KinD config with kube-proxy in **iptables** mode. eBPF doesn't support ipvs kube-proxy: a leftover `kube-ipvs0` device (with its bound service IPs / IPVS rules) is incompatible with the BPF dataplane, and the [eBPF migration docs](https://docs.tigera.io/calico/latest/operations/ebpf/enabling-ebpf) require switching kube-proxy to iptables first. `KIND_NAME` is kept as `kind` so `values.yaml`'s control-plane nodeSelector still matches.
- **`hack/test/kind/infra/values-bpf.yaml`** — Helm overlay: BPF dataplane, `bpfNetworkBootstrap`/`kubeProxyManagement` enabled, VXLAN encapsulation (BPF doesn't manage `tunl0`, and `VXLANCrossSubnet` wouldn't actually tunnel on single-subnet KinD, which the host-endpoint datapath tests depend on), and a **1Gi** calico-node memory limit (BPF map memory is memcg-accounted on kernel 5.11+, so the base 512Mi is OOMKilled during map creation; observed peak ~290 MiB).
- **`hack/test/kind/external-node.sh`** — stands up an off-cluster node on the KinD network (SSH + docker) so the `ExternalNode` specs run; torn down with the cluster via `kind-cluster-destroy`.
- **`e2e/config/kind-bpf.yaml`** — sig-calico test selection mirroring `gcp-bpf.yaml`.

### Test fixes (dataplane-agnostic; also fix the in-repo GCP BPF job)

- **`e2e/pkg/tests/ipam/ipam_strict_affinity.go`** — set `NodeTaintsPolicy: Honor` so the 4-replica topology spread isn't rendered unschedulable by the tainted control-plane counting as an empty topology domain on a 3-worker cluster.
- **`e2e/pkg/tests/hostendpoints/hostendpoints.go`** — skip the `GenericXDPEnabled` toggle under the BPF dataplane; it's an iptables-mode concern, and toggling it restarts felix, which races the connectivity assertion.

### Testing done

Validated end-to-end on a local KinD BPF cluster: the full sig-calico BPF suite passes, all four `ExternalNode` specs pass, and calico-node comes up cleanly — no felix restart loop, no OOMKill.

**Release note:**
```release-note
None
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
