### PR TITLE
Fix: Potential Felix Graceful Shutdown Hangs in Policy Sync Binder

### DIFF
--- a/pod2daemon/binder/binder.go
+++ b/pod2daemon/binder/binder.go
@@ -86,7 +86,7 @@ EventLoop:
 		}
 	}
 	// Got stop signal! Stop directory watch.
-	stopWatch <- true
+	close(stopWatch)
 	// Close any open sockets
 	for _, wl := range b.workloads.getAll() {
 		_ = wl.listener.Close()

--- a/pod2daemon/binder/watcher.go
+++ b/pod2daemon/binder/watcher.go
@@ -102,7 +102,12 @@ func (p *pollWatcher) poll(events chan<- workloadEvent, stop <-chan bool) {
 			isCred, uid := parseFilename(file.Name())
 			if isCred {
 				if !known[uid] {
-					events <- workloadEvent{op: Added, uid: uid}
+					select {
+					case events <- workloadEvent{op: Added, uid: uid}:
+					case <-stop:
+						close(events)
+						return
+					}
 					known[uid] = true
 				}
 				delete(removed, uid)
@@ -110,7 +115,12 @@ func (p *pollWatcher) poll(events chan<- workloadEvent, stop <-chan bool) {
 		}
 		// Send updates for UIDs we no longer know about.
 		for uid := range removed {
-			events <- workloadEvent{op: Removed, uid: uid}
+			select {
+			case events <- workloadEvent{op: Removed, uid: uid}:
+			case <-stop:
+				close(events)
+				return
+			}
 			delete(known, uid)
 		}
 		time.Sleep(PollSleepTime)

--- a/pod2daemon/binder/watcher_test.go
+++ b/pod2daemon/binder/watcher_test.go
@@ -1,0 +1,58 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package binder
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestPollStopsWhileBlockedSendingAddedEvent(t *testing.T) {
+	dir := t.TempDir()
+	credDir := filepath.Join(dir, CredentialsSubdir)
+	if err := os.Mkdir(credDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	for _, uid := range []string{"workload-1", "workload-2"} {
+		if err := os.WriteFile(filepath.Join(credDir, uid+CredentialsExtension), []byte("{}"), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	p := &pollWatcher{path: dir}
+	events := make(chan workloadEvent)
+	stop := make(chan bool)
+	done := make(chan struct{})
+	go func() {
+		p.poll(events, stop)
+		close(done)
+	}()
+
+	select {
+	case <-events:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("poll did not send initial workload event")
+	}
+
+	close(stop)
+
+	select {
+	case <-done:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("poll did not stop while blocked sending workload event")
+	}
+}


### PR DESCRIPTION
<!-- Describe your changes, including the type of change (bug fix, feature, etc.),
why it should be merged, testing done, and links to related issues. -->


SearchAndBind() is consuming events from pollWatcher.poll() ， and  pollWatcher.poll() is also consuming  堵塞的 stop event from SearchAndBind().

when SearchAndBind exits and send `stopWatch <- true` to notify SearchAndBind() who may be sending `events <- workloadEvent` to SearchAndBind()


so they lock each other




SearchAndBind() consumes workload events produced by pollWatcher.poll() through the unbuffered events channel. 
At the same time, pollWatcher.poll() consumes the stop signal sent by SearchAndBind() through the unbuffered stopWatch channel.

There is potential deadlock issue during shutdown. 

```

func (b *binder) SearchAndBind(stop <-chan *sync.WaitGroup) {
	stopWatch := make(chan bool)
	events := w.watch(stopWatch)  <--- send stopWatch  to the pollWatcher.poll()

EventLoop:
	for {
		select {
		case event = <-events:     <------ receives event from poll()
			b.handleEvent(event)

		case stopWG = <-stop:
			break EventLoop
		}
	}
	// Got stop signal! Stop directory watch.
	stopWatch <- true     <----- notify poll() to exit . Maybe wait forever

}


func (p *pollWatcher) poll(events chan<- workloadEvent, stop <-chan bool) {
        ...
	events <- workloadEvent{op: Added, uid: uid}  <---- send to SearchAndBind() . Maybe wait forever
}

```

Once SearchAndBind() receives from its external stop channel, it exits the event loop and stops receiving from events. It then tries to notify the watcher by sending:

stopWatch <- true

However, at that exact time, pollWatcher.poll() may already be blocked trying to send a workload event:

events <- workloadEvent{op: Added, uid: uid}

Since SearchAndBind() has already stopped receiving from events, pollWatcher.poll() cannot complete that send. Because it is blocked on sending to events, it also cannot receive from stopWatch.

So the two goroutines wait on each other

SearchAndBind() waits for pollWatcher.poll() to receive from stopWatch.
pollWatcher.poll() waits for SearchAndBind() to receive from events.

This creates a deadlock during shutdown.




<!-- For any user-visible change, replace TBD with a one-line description. -->
**Release note:**
```release-note
Fix: Potential Felix Graceful Shutdown Hangs in Policy Sync Binder
```
