### PR TITLE
felix: abort parked live-migration timer pops when TimeWait is exited

### DIFF
--- a/felix/dataplane/linux/live_migration.go
+++ b/felix/dataplane/linux/live_migration.go
@@ -241,8 +241,8 @@ type liveMigrationFSM struct {
 	monitor      *liveMigrationMonitor
 	currentState liveMigrationState
 	migrationUID string
-	timer        *time.Timer
 	timerStopC   chan struct{}
+	timerWG      sync.WaitGroup
 	pcapHandle   garpHandle
 	garpStopC    chan struct{}
 	garpWG       sync.WaitGroup
@@ -385,29 +385,57 @@ func (f *liveMigrationFSM) stopGARPDetection() {
 func (f *liveMigrationFSM) startElevatedRoutingTimer() {
 	f.logCtx.WithField("duration", f.monitor.convergenceTime).Debug("Starting elevated routing timer")
 	id := f.id
+
 	// timerC is unbuffered and its only reader is the dataplane main loop, so if the timer
-	// fires while the main loop is busy, this callback parks in the send.  stopC lets
-	// stopElevatedRoutingTimer() abort such a parked send: without that, an already-fired timer
-	// could deliver its pop late, after the FSM has left TimeWait - and if a re-migration has
-	// put the FSM back into TimeWait by then, OnTimerPop would misattribute the stale pop to
-	// the new episode and cut its TimeWait short, reverting the workload's route to normal
-	// priority before routing has converged.
+	// fires while the main loop is busy, the goroutine below parks in the send.  Without a way
+	// to abort that send, an already-fired timer could deliver its pop late, after the FSM has
+	// left TimeWait - and if a re-migration has put the FSM back into TimeWait by then,
+	// OnTimerPop would misattribute the stale pop to the new episode and cut its TimeWait
+	// short, reverting the workload's route to normal priority before routing has converged.
+	//
+	// stopC alone is not enough to close that hole: if the goroutine reaches its select after
+	// stopC is closed and the main loop is back at its own select, both cases are ready and Go
+	// chooses between them at random.  The guarantee comes from stopElevatedRoutingTimer()
+	// waiting on timerWG: while the main loop is blocked in that Wait() it cannot be receiving
+	// from timerC, so the send case cannot fire and the goroutine must take the stop case.
+	if f.timerStopC != nil {
+		// Shouldn't happen: the FSM never enters TimeWait twice without leaving it in between.
+		// But an overwritten stop channel would leave the previous goroutine unstoppable and
+		// wedge a later Wait(), so stop the old one properly rather than leak it.
+		f.logCtx.Warn("Elevated routing timer already running; stopping it before restart")
+		f.stopElevatedRoutingTimer()
+	}
 	stopC := make(chan struct{})
 	f.timerStopC = stopC
-	f.timer = time.AfterFunc(f.monitor.convergenceTime, func() {
-		select {
-		case f.monitor.timerC <- id:
-		case <-stopC:
+	f.timerWG.Add(1)
+	go func() {
+		defer f.timerWG.Done()
+		timer := time.NewTimer(f.monitor.convergenceTime)
+		defer timer.Stop()
+		// The send case is disabled (nil channel) until the timer fires.
+		var popC chan<- types.WorkloadEndpointID
+		for {
+			select {
+			case <-timer.C:
+				popC = f.monitor.timerC
+			case popC <- id:
+				return
+			case <-stopC:
+				return
+			}
 		}
-	})
+	}()
 }
 
 func (f *liveMigrationFSM) stopElevatedRoutingTimer() {
-	if f.timer != nil {
+	if f.timerStopC != nil {
 		f.logCtx.Debug("Stopping elevated routing timer")
-		f.timer.Stop()
 		close(f.timerStopC)
-		f.timer = nil
+		// Wait for the timer goroutine to exit.  This runs on the dataplane main loop - the
+		// sole reader of timerC - so during the Wait() there can be no receiver for the
+		// goroutine's send case, forcing it to take the stop case.  After this returns, no
+		// pop from this TimeWait episode can ever be delivered.
+		f.timerWG.Wait()
 		f.timerStopC = nil
 	}
 }
@@ -419,10 +447,9 @@ func (m *liveMigrationMonitor) OnGARPDetected(id types.WorkloadEndpointID) {
 }
 
 // OnTimerPop is called by the main loop when a timer fires for a workload.  Stale deliveries are
-// prevented at source: a fired timer's send parks on the unbuffered timerC until the main loop
-// reads it, and stopElevatedRoutingTimer() aborts any parked send via timerStopC, so a pop that
-// does get through was sent by a timer that had not been stopped.  The state check here is kept as
-// cheap defence in depth.
+// prevented at source: stopElevatedRoutingTimer() waits for the timer goroutine to exit before
+// returning, so a pop that does get through here was sent by a timer that had not been stopped.
+// The state check here is kept as cheap defence in depth.
 func (m *liveMigrationMonitor) OnTimerPop(id types.WorkloadEndpointID) {
 	fsm, exists := m.fsms[id]
 	if !exists || fsm.currentState != liveMigrationStateTimeWait {

--- a/felix/dataplane/linux/live_migration.go
+++ b/felix/dataplane/linux/live_migration.go
@@ -386,38 +386,30 @@ func (f *liveMigrationFSM) startElevatedRoutingTimer() {
 	f.logCtx.WithField("duration", f.monitor.convergenceTime).Debug("Starting elevated routing timer")
 	id := f.id
 
-	// timerC is unbuffered and its only reader is the dataplane main loop, so if the timer
-	// fires while the main loop is busy, the goroutine below parks in the send.  Without a way
-	// to abort that send, an already-fired timer could deliver its pop late, after the FSM has
-	// left TimeWait - and if a re-migration has put the FSM back into TimeWait by then,
-	// OnTimerPop would misattribute the stale pop to the new episode and cut its TimeWait
-	// short, reverting the workload's route to normal priority before routing has converged.
-	//
-	// stopC alone is not enough to close that hole: if the goroutine reaches its select after
-	// stopC is closed and the main loop is back at its own select, both cases are ready and Go
-	// chooses between them at random.  The guarantee comes from stopElevatedRoutingTimer()
-	// waiting on timerWG: while the main loop is blocked in that Wait() it cannot be receiving
-	// from timerC, so the send case cannot fire and the goroutine must take the stop case.
 	if f.timerStopC != nil {
-		// Shouldn't happen: the FSM never enters TimeWait twice without leaving it in
+		// This shouldn't happen: the FSM never enters TimeWait twice without leaving it in
 		// between.  But an overwritten stop channel would leave the previous goroutine
 		// unstoppable and wedge a later Wait(), so stop the old one properly rather than
 		// leak it.
 		f.logCtx.Warn("Elevated routing timer already running; stopping it before restart")
 		f.stopElevatedRoutingTimer()
 	}
+
+	// Deliver the pop from a goroutine whose send stopElevatedRoutingTimer() can
+	// cancel and reap, so that a stale pop can never be delivered after TimeWait
+	// is exited and misattributed to a later TimeWait episode (see OnTimerPop).
 	stopC := make(chan struct{})
 	f.timerStopC = stopC
 	f.timerWG.Add(1)
 	go func() {
 		defer f.timerWG.Done()
-		timer := time.NewTimer(f.monitor.convergenceTime)
-		defer timer.Stop()
+		fireC := time.After(f.monitor.convergenceTime)
+
 		// The send case is disabled (nil channel) until the timer fires.
 		var popC chan<- types.WorkloadEndpointID
 		for {
 			select {
-			case <-timer.C:
+			case <-fireC:
 				popC = f.monitor.timerC
 			case popC <- id:
 				return
@@ -432,10 +424,11 @@ func (f *liveMigrationFSM) stopElevatedRoutingTimer() {
 	if f.timerStopC != nil {
 		f.logCtx.Debug("Stopping elevated routing timer")
 		close(f.timerStopC)
-		// Wait for the timer goroutine to exit.  This runs on the dataplane main loop - the
-		// sole reader of timerC - so during the Wait() there can be no receiver for the
-		// goroutine's send case, forcing it to take the stop case.  After this returns, no
-		// pop from this TimeWait episode can ever be delivered.
+
+		// Must wait for the goroutine to exit, to stop a just-cancelled timer from
+		// delivering a stale pop: with both stopC and a pop receiver ready, select
+		// picks at random.  Waiting here is what closes that race - we run on the
+		// main loop, timerC's only reader, so no receiver exists until we return.
 		f.timerWG.Wait()
 		f.timerStopC = nil
 	}

--- a/felix/dataplane/linux/live_migration.go
+++ b/felix/dataplane/linux/live_migration.go
@@ -399,9 +399,10 @@ func (f *liveMigrationFSM) startElevatedRoutingTimer() {
 	// waiting on timerWG: while the main loop is blocked in that Wait() it cannot be receiving
 	// from timerC, so the send case cannot fire and the goroutine must take the stop case.
 	if f.timerStopC != nil {
-		// Shouldn't happen: the FSM never enters TimeWait twice without leaving it in between.
-		// But an overwritten stop channel would leave the previous goroutine unstoppable and
-		// wedge a later Wait(), so stop the old one properly rather than leak it.
+		// Shouldn't happen: the FSM never enters TimeWait twice without leaving it in
+		// between.  But an overwritten stop channel would leave the previous goroutine
+		// unstoppable and wedge a later Wait(), so stop the old one properly rather than
+		// leak it.
 		f.logCtx.Warn("Elevated routing timer already running; stopping it before restart")
 		f.stopElevatedRoutingTimer()
 	}

--- a/felix/dataplane/linux/live_migration.go
+++ b/felix/dataplane/linux/live_migration.go
@@ -242,6 +242,7 @@ type liveMigrationFSM struct {
 	currentState liveMigrationState
 	migrationUID string
 	timer        *time.Timer
+	timerStopC   chan struct{}
 	pcapHandle   garpHandle
 	garpStopC    chan struct{}
 	garpWG       sync.WaitGroup
@@ -384,8 +385,20 @@ func (f *liveMigrationFSM) stopGARPDetection() {
 func (f *liveMigrationFSM) startElevatedRoutingTimer() {
 	f.logCtx.WithField("duration", f.monitor.convergenceTime).Debug("Starting elevated routing timer")
 	id := f.id
+	// timerC is unbuffered and its only reader is the dataplane main loop, so if the timer
+	// fires while the main loop is busy, this callback parks in the send.  stopC lets
+	// stopElevatedRoutingTimer() abort such a parked send: without that, an already-fired timer
+	// could deliver its pop late, after the FSM has left TimeWait - and if a re-migration has
+	// put the FSM back into TimeWait by then, OnTimerPop would misattribute the stale pop to
+	// the new episode and cut its TimeWait short, reverting the workload's route to normal
+	// priority before routing has converged.
+	stopC := make(chan struct{})
+	f.timerStopC = stopC
 	f.timer = time.AfterFunc(f.monitor.convergenceTime, func() {
-		f.monitor.timerC <- id
+		select {
+		case f.monitor.timerC <- id:
+		case <-stopC:
+		}
 	})
 }
 
@@ -393,7 +406,9 @@ func (f *liveMigrationFSM) stopElevatedRoutingTimer() {
 	if f.timer != nil {
 		f.logCtx.Debug("Stopping elevated routing timer")
 		f.timer.Stop()
+		close(f.timerStopC)
 		f.timer = nil
+		f.timerStopC = nil
 	}
 }
 
@@ -403,10 +418,11 @@ func (m *liveMigrationMonitor) OnGARPDetected(id types.WorkloadEndpointID) {
 	m.executeFSM(id, liveMigrationInputGARPDetected)
 }
 
-// OnTimerPop is called by the main loop when a timer fires for a workload.
-// The timer may fire just before stopElevatedRoutingTimer() is called, so we
-// guard against stale deliveries by checking the FSM still exists and is in
-// TimeWait before driving it.
+// OnTimerPop is called by the main loop when a timer fires for a workload.  Stale deliveries are
+// prevented at source: a fired timer's send parks on the unbuffered timerC until the main loop
+// reads it, and stopElevatedRoutingTimer() aborts any parked send via timerStopC, so a pop that
+// does get through was sent by a timer that had not been stopped.  The state check here is kept as
+// cheap defence in depth.
 func (m *liveMigrationMonitor) OnTimerPop(id types.WorkloadEndpointID) {
 	fsm, exists := m.fsms[id]
 	if !exists || fsm.currentState != liveMigrationStateTimeWait {

--- a/felix/dataplane/linux/live_migration_test.go
+++ b/felix/dataplane/linux/live_migration_test.go
@@ -569,19 +569,18 @@ func TestLiveMigrationGARPChannel(t *testing.T) {
 	})
 }
 
-// garpSenderBlocked reports whether some goroutine is currently parked in
-// detectGARP's report-detection send.  Lets the regression test below wait
-// deterministically for the sender to be blocked reporting on garpC before
-// the Target-exit update is processed.  The goroutine state is "select" for
-// the select-based send (which stopGARPDetection can abort) and "chan send"
-// for a plain send (the pre-fix code); we match both so the test observes the
-// blocked sender either way and then proves whether the Target-exit path can
-// get past it.  detectGARP's only other park point - waiting for a packet -
-// shows as "chan receive", so these two states are unambiguous.
-func garpSenderBlocked() bool {
-	// Grow the buffer until the full goroutine dump fits: runtime.Stack
-	// truncates (n == len(buf)) when the buffer is too small, which could
-	// hide the detectGARP goroutine and time out the Eventually below.
+// senderParkedIn reports whether some goroutine whose stack mentions fnSubstring is currently
+// parked in a channel send.  Lets the regression tests below wait deterministically for a sender to
+// be blocked delivering to the monitor's (unbuffered, main-loop-read) channels.  The goroutine
+// state is "select" for a select-based send (which can be aborted via a stop channel) and "chan
+// send" for a plain send (the pre-fix code); we match both so a test observes the blocked sender
+// either way and then proves whether the code under test can get past it.  The senders' only other
+// park points - e.g. detectGARP waiting for a packet - show as "chan receive", so these two states
+// are unambiguous.
+func senderParkedIn(fnSubstring string) bool {
+	// Grow the buffer until the full goroutine dump fits: runtime.Stack truncates (n ==
+	// len(buf)) when the buffer is too small, which could hide the target goroutine and time
+	// out the caller's Eventually.
 	buf := make([]byte, 1<<20)
 	n := runtime.Stack(buf, true)
 	for n == len(buf) {
@@ -589,7 +588,7 @@ func garpSenderBlocked() bool {
 		n = runtime.Stack(buf, true)
 	}
 	for _, gr := range strings.Split(string(buf[:n]), "\n\n") {
-		if !strings.Contains(gr, "detectGARP") {
+		if !strings.Contains(gr, fnSubstring) {
 			continue
 		}
 		if strings.Contains(gr, "[select]") || strings.Contains(gr, "[chan send]") {
@@ -597,6 +596,18 @@ func garpSenderBlocked() bool {
 		}
 	}
 	return false
+}
+
+// garpSenderBlocked reports whether some goroutine is currently parked in detectGARP's
+// report-detection send.
+func garpSenderBlocked() bool {
+	return senderParkedIn("detectGARP")
+}
+
+// timerSenderBlocked reports whether some elevated-routing-timer callback is currently parked
+// sending its pop on timerC.
+func timerSenderBlocked() bool {
+	return senderParkedIn("startElevatedRoutingTimer")
 }
 
 // TestGARPRaceWithTargetExit is a regression test for a dataplane main-loop
@@ -697,6 +708,60 @@ func TestGARPRaceWithTargetExit(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestTimerPopRaceWithTimeWaitExit is a regression test for stale timer-pop misattribution.
+// Scenario: the FSM is in TimeWait and its elevated-routing timer fires while the main loop is
+// busy, so the pop parks on the unbuffered timerC.  Before the main loop drains it, the same batch
+// re-migrates the workload: a SOURCE update exits TimeWait (discarding the FSM) and a subsequent
+// TARGET -> NO_ROLE sequence enters TimeWait again with a fresh timer.  When the parked episode-1
+// pop is finally drained, OnTimerPop's state check ("FSM exists and is in TimeWait") cannot tell it
+// from a genuine pop for the new episode, so it would cut the new TimeWait short - reverting the
+// workload's route to normal priority before routing has converged.
+//
+// stopElevatedRoutingTimer must therefore abort a parked pop via the timer's stop channel when
+// TimeWait is exited, so a stale pop can never be delivered.  The test simulates the main loop by
+// calling OnUpdate directly, with nothing reading timerC (just as the real main loop cannot read
+// timerC while it is processing a batch).
+func TestTimerPopRaceWithTimeWaitExit(t *testing.T) {
+	g := NewWithT(t)
+	// Short convergence so episode 1's timer fires promptly.
+	m := newTestMonitor(10 * time.Millisecond)
+
+	// Episode 1: drive to TimeWait via the missed-GARP path; the timer fires
+	// and its pop parks on timerC.
+	m.OnUpdate(wepUpdate(wepID1, proto.LiveMigrationRole_TARGET))
+	drainUpdates(m)
+	m.OnUpdate(wepUpdate(wepID1, proto.LiveMigrationRole_NO_ROLE))
+	drainUpdates(m)
+	g.Eventually(timerSenderBlocked, time.Second, time.Millisecond).Should(BeTrue())
+
+	// Exit TimeWait while the pop is parked, as the main loop would when processing a
+	// re-migration batch.  This must abort the parked pop.
+	m.OnUpdate(wepUpdate(wepID1, proto.LiveMigrationRole_SOURCE))
+	drainUpdates(m)
+
+	// Episode 2: re-enter TimeWait with a convergence time long enough that its own timer
+	// cannot fire during the test, so any pop delivered below can only be the stale one from
+	// episode 1.
+	m.convergenceTime = time.Hour
+	m.OnUpdate(wepUpdate(wepID1, proto.LiveMigrationRole_TARGET))
+	drainUpdates(m)
+	m.OnUpdate(wepUpdate(wepID1, proto.LiveMigrationRole_NO_ROLE))
+	drainUpdates(m)
+	g.Expect(m.fsms[wepID1].currentState).To(Equal(liveMigrationStateTimeWait))
+
+	// Drain timerC as the main loop would.  The stale episode-1 pop must not arrive; if it did,
+	// OnTimerPop would misattribute it to episode 2 and end its TimeWait prematurely.
+	select {
+	case id := <-m.timerC:
+		m.OnTimerPop(id)
+		t.Fatalf("stale timer pop delivered and misattributed; FSM state now %v",
+			m.fsms[wepID1])
+	case <-time.After(200 * time.Millisecond):
+		// Expected: no delivery.
+	}
+	g.Expect(m.fsms[wepID1].currentState).To(Equal(liveMigrationStateTimeWait))
 }
 
 // --- Section 6: GARP/RARP packet matching ---

--- a/felix/dataplane/linux/live_migration_test.go
+++ b/felix/dataplane/linux/live_migration_test.go
@@ -604,8 +604,8 @@ func garpSenderBlocked() bool {
 	return senderParkedIn("detectGARP")
 }
 
-// timerSenderBlocked reports whether some elevated-routing-timer callback is currently parked
-// sending its pop on timerC.
+// timerSenderBlocked reports whether some elevated-routing-timer goroutine is currently parked
+// in its select - either waiting for the timer to fire or sending its pop on timerC.
 func timerSenderBlocked() bool {
 	return senderParkedIn("startElevatedRoutingTimer")
 }
@@ -729,17 +729,45 @@ func TestTimerPopRaceWithTimeWaitExit(t *testing.T) {
 	m := newTestMonitor(10 * time.Millisecond)
 
 	// Episode 1: drive to TimeWait via the missed-GARP path; the timer fires
-	// and its pop parks on timerC.
+	// and its pop parks on timerC.  The timer goroutine parks in a select both
+	// before and after the timer fires, so also wait out several convergence
+	// times to make it overwhelmingly likely the fired-pop-parked-in-send
+	// interleaving from the field scenario is the one we exercise; the exit
+	// path below must reap the goroutine in either interleaving regardless.
+	start := time.Now()
 	m.OnUpdate(wepUpdate(wepID1, proto.LiveMigrationRole_TARGET))
 	drainUpdates(m)
 	m.OnUpdate(wepUpdate(wepID1, proto.LiveMigrationRole_NO_ROLE))
 	drainUpdates(m)
-	g.Eventually(timerSenderBlocked, time.Second, time.Millisecond).Should(BeTrue())
+	g.Eventually(func() bool {
+		return time.Since(start) > 50*time.Millisecond && timerSenderBlocked()
+	}, time.Second, time.Millisecond).Should(BeTrue())
+
+	// Hold a reference to the episode-1 FSM: the TimeWait exit below discards it
+	// from the monitor's map, but we need it to verify its goroutine is reaped.
+	fsm1 := m.fsms[wepID1]
+	g.Expect(fsm1).NotTo(BeNil())
 
 	// Exit TimeWait while the pop is parked, as the main loop would when processing a
 	// re-migration batch.  This must abort the parked pop.
 	m.OnUpdate(wepUpdate(wepID1, proto.LiveMigrationRole_SOURCE))
 	drainUpdates(m)
+
+	// stopElevatedRoutingTimer waits for the timer goroutine to exit before returning, so by
+	// the time the exit update has been processed the goroutine must already be gone -
+	// synchronously, not eventually.  Verify via the FSM's own WaitGroup (a global stack scan
+	// would be polluted by TimeWait timer goroutines leaked by other tests in this package).
+	reaped := make(chan struct{})
+	go func() {
+		fsm1.timerWG.Wait()
+		close(reaped)
+	}()
+	select {
+	case <-reaped:
+	case <-time.After(time.Second):
+		t.Fatal("timer goroutine still running after the TimeWait-exiting update returned")
+	}
+	g.Expect(fsm1.timerStopC).To(BeNil(), "stopElevatedRoutingTimer should have cleared timerStopC")
 
 	// Episode 2: re-enter TimeWait with a convergence time long enough that its own timer
 	// cannot fire during the test, so any pop delivered below can only be the stale one from
@@ -762,6 +790,10 @@ func TestTimerPopRaceWithTimeWaitExit(t *testing.T) {
 		// Expected: no delivery.
 	}
 	g.Expect(m.fsms[wepID1].currentState).To(Equal(liveMigrationStateTimeWait))
+
+	// Reap episode 2's timer goroutine rather than leak it into the rest of the
+	// test binary.
+	m.OnUpdate(wepRemove(wepID1))
 }
 
 // --- Section 6: GARP/RARP packet matching ---


### PR DESCRIPTION
The elevated-routing timer's AfterFunc callback delivers its pop over the unbuffered timerC, whose only reader is the dataplane main loop. If the timer fires while the main loop is busy processing a batch, the callback parks in the send.  Unlike the GARP-detection case (fixed previously), nothing waits for this callback, so it cannot deadlock the main loop - but a parked pop could be delivered late, after the FSM had left TimeWait.  If a re-migration in the same batch had put the FSM back into TimeWait by then, OnTimerPop's staleness check ("FSM exists and is in TimeWait") would misattribute the stale pop to the new episode and cut its TimeWait short, reverting the workload's route to normal priority before routing had converged - the transient misrouting that TimeWait exists to prevent.

Apply the same abort pattern as GARP detection: the callback sends via a select over a per-timer stop channel that stopElevatedRoutingTimer() closes, so leaving TimeWait always aborts a parked pop before any new episode can begin.  The regression test parks an episode-1 pop, drives the FSM out of and back into TimeWait, and verifies the stale pop is never delivered; without the fix it reproduces the misattribution deterministically.

**Release note:**
```release-note
Fixed a rare race in OpenStack/KubeVirt live migration handling where, after back-to-back migrations of the same VM, Felix could revert the VM's route to normal priority before BGP routing had converged.
```
