### PR TITLE
argoci: HCP support (vendored scripts + GCS cross-stage handoff)

### DIFF
--- a/.argoci/design/hcp.md
+++ b/.argoci/design/hcp.md
@@ -54,33 +54,68 @@ before tests (teardown happens in the epilogue). The literal `"hosting"` value i
 vestigial (no cert stage uses it) but kept for faithfulness.
 
 ## GCS handoff (replaces cache + artifact)
-The hosting cluster state is the setup job's `BZ_HOME` (terraform state +
-`.local/kubeconfig`). One object per run:
+Semaphore passes the hosting cluster between stages **two ways** — the whole
+`BZ_HOME` via `cache` (for destroy) and just the kubeconfig via `artifact` (for
+hosted). ArgoCI has neither, so both become GCS objects, keyed by
+`ARGO_WORKFLOW_NAME` (run-unique) + `HOSTING_CLUSTER`:
 
-    BLOB=gs://${GS_BUCKET}/${ARGO_WORKFLOW_NAME}/hcp/${HOSTING_CLUSTER}/hosting-bzhome.tgz
+    BLOB=gs://${GS_BUCKET}/${ARGO_WORKFLOW_NAME}/hcp/${HOSTING_CLUSTER}/hosting-bzhome.tgz    # whole BZ_HOME → destroy-hosting
+    KCFG=gs://${GS_BUCKET}/${ARGO_WORKFLOW_NAME}/hcp/${HOSTING_CLUSTER}/hosting-kubeconfig    # just kubeconfig → hosted
 
-The tar is **contents-relative** (`-C "$BZ_HOME" .`), not `basename`-anchored —
-each stage's `BZ_HOME` has a different name (per-job `BZ_PROFILE_NAME`), so the
-restore side must not depend on the setup job's dir name.
+The BZ_HOME tar is **contents-relative** (`-C "$BZ_HOME" .`; restore
+`-C "$BZ_HOME"`), so the tar carries no absolute path — the restore side controls
+where the tree lands. (setup-hosting and destroy-hosting are pinned to the *same*
+`BZ_HOME` path — see the venv trap below — so the extracted tree, including the
+`.local/venv` inside it, lands exactly where it was created.)
 
-- **setup-hosting** (epilogue): after install, `set -o pipefail;
-  tar czf - -C "$BZ_HOME" . | gsutil cp - "$BLOB"`. The epilogue must **not**
-  `bz destroy` here (the hosting cluster must survive for hosted).
-- **hosted** (prologue): `mkdir -p "${BZ_LOCAL_DIR}/hosting"; gsutil cp "$BLOB" - |
-  tar xzf - -C "${BZ_LOCAL_DIR}/hosting" ./.local/kubeconfig`; export
-  `OPENSHIFT_HOSTING_KUBECONFIG=${BZ_LOCAL_DIR}/hosting/.local/kubeconfig`. Absent
-  blob (or missing that path) ⇒ fail fast. The hosted job keeps its own fresh
-  `BZ_HOME` for its hosted cluster; its epilogue `bz destroy` tears down **its**
-  hosted cluster (normal).
-- **destroy-hosting** (prologue): restore the hosting state into `BZ_HOME`
-  (`mkdir -p "$BZ_HOME"; gsutil cp "$BLOB" - | tar xzf - -C "$BZ_HOME"`) so
-  `bz destroy` has the terraform state; absent blob ⇒ nothing to destroy, exit 0.
-  Epilogue `bz destroy` tears the hosting cluster down; then `gsutil rm` the blob
-  (only on destroy success).
+Provenance — this reproduces the Semaphore mechanism (`.semaphore/end-to-end/
+scripts/`): `install.sh:20` caches BZ_HOME under `${WORKFLOW_ID}-hosting-
+${HOSTING_CLUSTER}`; `global_epilogue.sh:175` pushes the kubeconfig artifact;
+`global_prologue.sh:186/193` restores the cache and **repoints `BZ_HOME` to its
+original path** (the key move — see the venv trap below); `:198` pulls the
+kubeconfig artifact; `global_epilogue.sh:186-187` yanks the artifact + deletes
+the cache after destroy.
 
-Keyed by `ARGO_WORKFLOW_NAME` (run-unique) + `HOSTING_CLUSTER`. Ordering:
-`hosted depends: setup-hosting`; `destroy-hosting` is an `onExit` handler, so it
-needs no `depends` — Argo runs it once after the workflow regardless of outcome.
+- **setup-hosting** (epilogue): `tar czf - -C "$BZ_HOME" . | gsutil cp - "$BLOB"`
+  **and** `gsutil cp "${BZ_LOCAL_DIR}/kubeconfig" "$KCFG"` (the scaffold sets
+  `BZ_LOCAL_DIR=${BZ_HOME}/.local`; `bz` writes the cluster's admin kubeconfig
+  there). Must **not** `bz destroy` (the hosting cluster must survive for hosted).
+- **hosted** (prologue): `gsutil cp "$KCFG" "${BZ_LOCAL_DIR}/hosting-kubeconfig"`;
+  export `OPENSHIFT_HOSTING_KUBECONFIG=${BZ_LOCAL_DIR}/hosting-kubeconfig`. Absent
+  object ⇒ fail fast. The hosted job keeps its own fresh `BZ_HOME` for its hosted
+  cluster; its epilogue `bz destroy` tears down **its** hosted cluster (normal).
+- **destroy-hosting** (prologue): restore the hosting `BZ_HOME`
+  (`gsutil cp "$BLOB" - | tar xzf - -C "$BZ_HOME"`) so `bz destroy` has the
+  terraform state. Absent blob ⇒ nothing to destroy, exit 0. Epilogue `bz destroy`
+  tears the hosting cluster down; then `gsutil rm "$BLOB" "$KCFG"` (only on
+  destroy success).
+
+### BZ_HOME must be pinned across hosting stages (the venv trap)
+A restored Python **venv is not relocatable** — its `bin/pip` etc. hardcode the
+absolute path of the dir it was created in. If setup-hosting and destroy-hosting
+land on different `BZ_HOME` paths, `bz destroy` fails on
+`.local/venv/bin/pip: no such file`. The scaffold default
+`BZ_PROFILE_NAME=${ARGO_WORKFLOW_NAME}-${RANDOM_TOKEN1}` is random per step, so
+the prologue **pins** it for hosting stages
+(`HCP_STAGE == *-hosting → BZ_PROFILE_NAME=${ARGO_WORKFLOW_NAME}-hosting-
+${HOSTING_CLUSTER}`), giving both stages the same `BZ_HOME` and letting the
+restored venv resolve. This is how Semaphore avoids the trap too — its
+`cache restore` puts `BZ_HOME` back at its original absolute path
+(`global_prologue.sh:193`); we make the path deterministic instead of random.
+
+Path-pinning is what makes the venv resolve. We **keep** Semaphore's post-restore
+`pip install -r ${BZ_HOME}/scripts/requirements.txt` (its `global_prologue.sh:195`)
+too — it refreshes destroy-time system deps and its purpose is not solely pathing,
+so dropping it would be an unproven bet; it is made non-fatal (`|| warn`).
+
+**Deviation from Semaphore:** line 195 also `export PROVISIONER=aws-openshift`.
+We omit only that — `PROVISIONER` comes from the cron step's `env` (cert:
+`aws-openshift`), keeping the script provisioner-agnostic so the local-kind
+plumbing smoke can exercise the same path.
+
+Ordering: `hosted depends: setup-hosting`; `destroy-hosting` is an `onExit`
+handler, so it needs no `depends` — Argo runs it once after the workflow
+regardless of outcome.
 
 ## Epilogue destroy gating (the subtle part)
 `global_epilogue.sh`'s `bz destroy` must run for **hosted** (destroy the hosted
@@ -91,12 +126,13 @@ bz destroy as normal`.
 
 ## Files touched
 - `.argoci/scripts/body_standard.sh` — restore the two `HCP_STAGE` guards above.
-- `.argoci/scripts/global_prologue.sh` — `HCP_STAGE` branch: `hosted` pulls the
-  hosting kubeconfig + sets `OPENSHIFT_HOSTING_KUBECONFIG`; `destroy-hosting`
-  restores the hosting `BZ_HOME`.
-- `.argoci/scripts/global_epilogue.sh` — `setup-hosting`: push hosting `BZ_HOME`,
-  skip `bz destroy`; `destroy-hosting`: `bz destroy` then `gsutil rm` the blob;
-  `hosted`/non-HCP: unchanged.
+- `.argoci/scripts/global_prologue.sh` — pin `BZ_PROFILE_NAME` for `*-hosting`
+  stages (venv trap); `HCP_STAGE` branch: `hosted` pulls the hosting kubeconfig
+  object + sets `OPENSHIFT_HOSTING_KUBECONFIG`; `destroy-hosting` restores the
+  hosting `BZ_HOME`.
+- `.argoci/scripts/global_epilogue.sh` — `setup-hosting`: push hosting `BZ_HOME`
+  + kubeconfig, skip `bz destroy`; `destroy-hosting`: `bz destroy` then
+  `gsutil rm` both objects; `hosted`/non-HCP: unchanged.
 - `.argoci/cron/e2e-certification.yaml` — the `hcp-setup-hosting` +
   `hcp-hosted-setup-and-tests` (matrix) steps already carry `HCP_STAGE`/
   `HOSTING_CLUSTER`/`OPENSHIFT_CLUSTER_TYPE`/`OPENSHIFT_VERSION`. Add
@@ -117,7 +153,19 @@ bz destroy as normal`.
 - hosted fails → its epilogue `bz destroy` tears down **its** hosted cluster.
 - **teardown always runs** — `destroy-hosting` is an `onExit` handler, so Argo
   runs it after the workflow regardless of the hosted cells' outcomes (no
-  skipped-teardown-on-failure/eviction gap).
+  skipped-teardown-on-failure/eviction gap). Confirmed empirically: the local-kind
+  plumbing smoke's `onExit` step ran the full prologue+epilogue.
+- **teardown ordering is safe.** `onExit` fires only after every DAG node reaches
+  a terminal state — including each hosted cell's own epilogue `bz destroy` of its
+  hosted cluster. So all hosted clusters are gone *before* destroy-hosting tears
+  down the hosting cluster underneath them; no hosted-on-vanished-hosting race.
+- **concurrency / `hcp-shared-hosting` naming is inherited from Semaphore, not
+  introduced here.** `HOSTING_CLUSTER` is a `bz` cluster-name label; 3 hosted
+  cells sharing one hosting cluster, and cross-run isolation of a fixed hosting
+  name, are properties of the existing cert pipeline that `bz` owns. The GCS blob
+  key adds `ARGO_WORKFLOW_NAME`, so per-run *state objects* never collide even if
+  `bz`'s cluster naming does; anything beyond that is out of scope for a faithful
+  port.
 - destroy-hosting fails → hosting cluster leaks → shared cluster-leak reaper; blob
   left for retry.
 - **`HOSTING_CLUSTER` is a fixed label set identically on all three cron steps**
@@ -126,9 +174,31 @@ bz destroy as normal`.
   lifecycle TTL (e.g. 7d) on `*/hcp/**` as the backstop, same as the standing
   argoci-artifacts policy.
 
+## Validation
+A throwaway local-kind cron on the smoke fork exercised the whole path
+(setup-hosting → hosted → onExit destroy-hosting). Confirmed: both objects push;
+hosted pulls the kubeconfig, provisions, and runs the monorepo e2e suite; the
+`BZ_HOME` pin lands destroy-hosting on setup's path so the restored venv resolves
+(before the pin: `venv/bin/pip: no such file`; after: pip is found and runs).
+`onExit` gets the full prologue+epilogue.
+
+The **restored venv depends on the runner's system Python matching the venv's
+Python.** The local-kind smoke image ships system py3.7 but `bz` builds a py3.10
+venv, so the restored venv's pip then dies on `ModuleNotFoundError: distutils.cmd`
+inside `local-kind:destroy` — an image quirk of that step, not the handoff (a
+*fresh* local-kind venv destroys fine; only the restored one trips it, and only on
+the mismatched image). The real cert path is `aws-openshift`, whose runner has
+matching Python (the existing non-HCP openshift cert job proves this) — the same
+condition under which Semaphore's restore works. So on the target path the pin is
+sufficient; full aws-openshift confirmation waits on AWS-creds onboarding.
+
 ## Open questions
 1. Confirm `bz`'s aws-openshift provisioner honours `OPENSHIFT_CLUSTER_TYPE=HCP-
    hosting/HCP-hosted` + `OPENSHIFT_HOSTING_KUBECONFIG` from the ArgoCI runner (the
    non-HCP openshift cert job already uses aws-openshift — a check, not a risk).
 2. Exact GCS push point for setup-hosting: end-of-body vs epilogue. Epilogue is
    safer (runs on failure via the EXIT trap) — used above.
+3. Confirm the aws-openshift runner's system Python matches the `bz` venv Python
+   (expected — non-HCP openshift cert already runs there), so the restored
+   hosting venv resolves for `aws-openshift:destroy`. Verified only once a real
+   aws-openshift HCP run is possible.

--- a/.argoci/design/hcp.md
+++ b/.argoci/design/hcp.md
@@ -28,8 +28,13 @@ hosted, destroy-hosting}`; `bz` (aws-openshift provisioner) interprets
   `OPENSHIFT_CLUSTER_TYPE=HCP-hosted`): pull the hosting kubeconfig; standard
   provision+install+test creates **one hosted cluster of that version** on the
   hosting cluster and runs the cert suite. Cells are independent.
-- **destroy-hosting** (added step): restore the hosting cluster's state; skip
-  provision/install; the epilogue's `bz destroy` tears the hosting cluster down.
+- **destroy-hosting** (an `onExit` handler, `HCP_STAGE=destroy-hosting`): restore
+  the hosting cluster's state; skip provision/install; the epilogue's `bz destroy`
+  tears the hosting cluster down. As an `onExit` step it runs **once after the
+  whole workflow regardless of how the hosted cells finished** — so teardown is
+  guaranteed and there is no fan-in `depends` to express. (`onExit` steps get the
+  full `globalPrologue`/`globalEpilogue` wrapping, same as normal steps, so the
+  restore + `bz destroy` fire as designed.)
 
 Different hosting/hosted OCP versions are supported (`bz` takes them per job); the
 3 versions come from the hosted **matrix**, each cell one cluster — not from any
@@ -74,8 +79,8 @@ restore side must not depend on the setup job's dir name.
   (only on destroy success).
 
 Keyed by `ARGO_WORKFLOW_NAME` (run-unique) + `HOSTING_CLUSTER`. Ordering:
-`hosted depends: setup-hosting`; `destroy-hosting depends: "(hcp-hosted-setup-and-tests.Succeeded
-|| .Failed || .Errored) || (hcp-setup-hosting.Failed || .Errored)"`.
+`hosted depends: setup-hosting`; `destroy-hosting` is an `onExit` handler, so it
+needs no `depends` — Argo runs it once after the workflow regardless of outcome.
 
 ## Epilogue destroy gating (the subtle part)
 `global_epilogue.sh`'s `bz destroy` must run for **hosted** (destroy the hosted
@@ -92,10 +97,12 @@ bz destroy as normal`.
 - `.argoci/scripts/global_epilogue.sh` — `setup-hosting`: push hosting `BZ_HOME`,
   skip `bz destroy`; `destroy-hosting`: `bz destroy` then `gsutil rm` the blob;
   `hosted`/non-HCP: unchanged.
-- `.argoci/cron/e2e-certification.yaml` — the setup-hosting + hosted(matrix) steps
-  exist; add a `hcp-destroy-hosting` step with the fan-in `depends`. Set
-  `HOSTING_CLUSTER`/`OPENSHIFT_CLUSTER_TYPE`/`OPENSHIFT_VERSION`/`HCP_STAGE` as in
-  the Semaphore pipeline (already present in the converted cron). **No `HCP_ENABLED`.**
+- `.argoci/cron/e2e-certification.yaml` — the `hcp-setup-hosting` +
+  `hcp-hosted-setup-and-tests` (matrix) steps already carry `HCP_STAGE`/
+  `HOSTING_CLUSTER`/`OPENSHIFT_CLUSTER_TYPE`/`OPENSHIFT_VERSION`. Add
+  **`hcp-destroy-hosting` as an `onExit:` entry** (env `HCP_STAGE=destroy-hosting`
+  + `HOSTING_CLUSTER=hcp-shared-hosting`, `commands: body_standard.sh`) — no DAG
+  step, no `depends`. **No `HCP_ENABLED`** anywhere.
 - **Remove** the vendored `.argoci/scripts/hcp/*` and `phases/hcp.sh` from #13162.
 - Guard: the scaffold edits widen the golden → `check-scaffold-parity.sh --update`
   + review (sanctioned path). No new `phases/hcp.sh`, so no UNPORTED change.
@@ -105,12 +112,14 @@ bz destroy as normal`.
 - **setup-hosting fails.** `hosted depends: hcp-setup-hosting` (Argo default
   `.Succeeded`) so `hosted` doesn't run on setup failure — the "hosted pull fails
   fast" path is only the defensive case (blob absent/partial). setup's epilogue
-  still pushes on the failure path (EXIT trap), so `destroy-hosting` (fan-in on
-  setup `.Failed`/`.Errored`) has state to tear any partial hosting cluster down.
+  still pushes on the failure path (EXIT trap), so the `destroy-hosting` `onExit`
+  handler has state to tear any partial hosting cluster down.
 - hosted fails → its epilogue `bz destroy` tears down **its** hosted cluster.
+- **teardown always runs** — `destroy-hosting` is an `onExit` handler, so Argo
+  runs it after the workflow regardless of the hosted cells' outcomes (no
+  skipped-teardown-on-failure/eviction gap).
 - destroy-hosting fails → hosting cluster leaks → shared cluster-leak reaper; blob
   left for retry.
-- `depends` includes `.Errored` so teardown isn't skipped on pod eviction.
 - **`HOSTING_CLUSTER` is a fixed label set identically on all three cron steps**
   (it + `ARGO_WORKFLOW_NAME` form the shared blob key); this is an invariant.
 - **blob leak** (workflow aborted before destroy-hosting runs) → one-time bucket

--- a/.argoci/design/hcp.md
+++ b/.argoci/design/hcp.md
@@ -1,0 +1,125 @@
+# HCP on ArgoCI: standard flow gated by HCP_STAGE + GCS hosting-state handoff
+
+## Goal
+Run the OSS Calico **certification** pipeline's HCP (hosted control plane) stages
+on ArgoCI. Cert HCP is the **standard `body_standard.sh` flow gated by `HCP_STAGE`**
+— `bz` provisions OpenShift hosting/hosted clusters based on `OPENSHIFT_CLUSTER_TYPE`.
+The only ArgoCI gap is the cross-stage handoff: Semaphore passes the hosting
+cluster between stages via `cache` (BZ_HOME) + `artifact` (hosting kubeconfig),
+neither of which ArgoCI has. Replace that with a **GCS object**.
+
+## Non-goals
+- The `banzai-utils/ocp-hcp` multicluster orchestrator / the `HCP_ENABLED` path —
+  the cert pipeline does **not** set `HCP_ENABLED` and does not use those scripts.
+  (This supersedes the earlier vendor-ocp-hcp approach.)
+- Byte-identity of the handoff transport (GCS ≠ cache/artifact); the per-stage
+  test/provision behaviour is preserved.
+
+## Model (from Semaphore certification.yml + body_standard.sh)
+All three HCP jobs run `body_standard.sh`, gated by `HCP_STAGE ∈ {setup-hosting,
+hosted, destroy-hosting}`; `bz` (aws-openshift provisioner) interprets
+`OPENSHIFT_CLUSTER_TYPE` (`HCP-hosting`/`HCP-hosted`), `OPENSHIFT_VERSION`, and
+`OPENSHIFT_HOSTING_KUBECONFIG`.
+
+- **setup-hosting** (one job, `OPENSHIFT_CLUSTER_TYPE=HCP-hosting`): standard
+  provision+install creates the **hosting** cluster; no tests (see guards). Push
+  the hosting cluster's state to GCS.
+- **hosted** (3-cell matrix on `OPENSHIFT_VERSION` = 4.20.1/4.19.17/4.18.27,
+  `OPENSHIFT_CLUSTER_TYPE=HCP-hosted`): pull the hosting kubeconfig; standard
+  provision+install+test creates **one hosted cluster of that version** on the
+  hosting cluster and runs the cert suite. Cells are independent.
+- **destroy-hosting** (added step): restore the hosting cluster's state; skip
+  provision/install; the epilogue's `bz destroy` tears the hosting cluster down.
+
+Different hosting/hosted OCP versions are supported (`bz` takes them per job); the
+3 versions come from the hosted **matrix**, each cell one cluster — not from any
+multicluster loop.
+
+### body_standard.sh guards (restore verbatim from Semaphore)
+    # HCP hosting/destroy-hosting stages join an existing cluster; skip provision/install.
+    if [[ "${HCP_STAGE}" != "hosting" && "${HCP_STAGE}" != "destroy-hosting" ]]; then
+      source "${PHASES}/provision.sh"; source "${PHASES}/install.sh"
+    fi
+    ...
+    # hosting stages only stand up infra for other jobs; they don't run tests.
+    if [[ ${MCM_STAGE:-} == *-mgmt* || ${HCP_STAGE:-} == *-hosting* ]]; then exit 0; fi
+So: setup-hosting → provision+install, then exit before tests (`*-hosting*`);
+hosted → provision+install+test; destroy-hosting → skip provision/install, exit
+before tests (teardown happens in the epilogue). The literal `"hosting"` value is
+vestigial (no cert stage uses it) but kept for faithfulness.
+
+## GCS handoff (replaces cache + artifact)
+The hosting cluster state is the setup job's `BZ_HOME` (terraform state +
+`.local/kubeconfig`). One object per run:
+
+    BLOB=gs://${GS_BUCKET}/${ARGO_WORKFLOW_NAME}/hcp/${HOSTING_CLUSTER}/hosting-bzhome.tgz
+
+The tar is **contents-relative** (`-C "$BZ_HOME" .`), not `basename`-anchored —
+each stage's `BZ_HOME` has a different name (per-job `BZ_PROFILE_NAME`), so the
+restore side must not depend on the setup job's dir name.
+
+- **setup-hosting** (epilogue): after install, `set -o pipefail;
+  tar czf - -C "$BZ_HOME" . | gsutil cp - "$BLOB"`. The epilogue must **not**
+  `bz destroy` here (the hosting cluster must survive for hosted).
+- **hosted** (prologue): `mkdir -p "${BZ_LOCAL_DIR}/hosting"; gsutil cp "$BLOB" - |
+  tar xzf - -C "${BZ_LOCAL_DIR}/hosting" ./.local/kubeconfig`; export
+  `OPENSHIFT_HOSTING_KUBECONFIG=${BZ_LOCAL_DIR}/hosting/.local/kubeconfig`. Absent
+  blob (or missing that path) ⇒ fail fast. The hosted job keeps its own fresh
+  `BZ_HOME` for its hosted cluster; its epilogue `bz destroy` tears down **its**
+  hosted cluster (normal).
+- **destroy-hosting** (prologue): restore the hosting state into `BZ_HOME`
+  (`mkdir -p "$BZ_HOME"; gsutil cp "$BLOB" - | tar xzf - -C "$BZ_HOME"`) so
+  `bz destroy` has the terraform state; absent blob ⇒ nothing to destroy, exit 0.
+  Epilogue `bz destroy` tears the hosting cluster down; then `gsutil rm` the blob
+  (only on destroy success).
+
+Keyed by `ARGO_WORKFLOW_NAME` (run-unique) + `HOSTING_CLUSTER`. Ordering:
+`hosted depends: setup-hosting`; `destroy-hosting depends: "(hcp-hosted-setup-and-tests.Succeeded
+|| .Failed || .Errored) || (hcp-setup-hosting.Failed || .Errored)"`.
+
+## Epilogue destroy gating (the subtle part)
+`global_epilogue.sh`'s `bz destroy` must run for **hosted** (destroy the hosted
+cluster) and **destroy-hosting** (destroy the hosting cluster), but be **skipped
+for setup-hosting** (keep the hosting cluster alive). So gate:
+`if HCP_STAGE == "setup-hosting": push hosting BZ_HOME, skip bz destroy; else:
+bz destroy as normal`.
+
+## Files touched
+- `.argoci/scripts/body_standard.sh` — restore the two `HCP_STAGE` guards above.
+- `.argoci/scripts/global_prologue.sh` — `HCP_STAGE` branch: `hosted` pulls the
+  hosting kubeconfig + sets `OPENSHIFT_HOSTING_KUBECONFIG`; `destroy-hosting`
+  restores the hosting `BZ_HOME`.
+- `.argoci/scripts/global_epilogue.sh` — `setup-hosting`: push hosting `BZ_HOME`,
+  skip `bz destroy`; `destroy-hosting`: `bz destroy` then `gsutil rm` the blob;
+  `hosted`/non-HCP: unchanged.
+- `.argoci/cron/e2e-certification.yaml` — the setup-hosting + hosted(matrix) steps
+  exist; add a `hcp-destroy-hosting` step with the fan-in `depends`. Set
+  `HOSTING_CLUSTER`/`OPENSHIFT_CLUSTER_TYPE`/`OPENSHIFT_VERSION`/`HCP_STAGE` as in
+  the Semaphore pipeline (already present in the converted cron). **No `HCP_ENABLED`.**
+- **Remove** the vendored `.argoci/scripts/hcp/*` and `phases/hcp.sh` from #13162.
+- Guard: the scaffold edits widen the golden → `check-scaffold-parity.sh --update`
+  + review (sanctioned path). No new `phases/hcp.sh`, so no UNPORTED change.
+- `.argoci/design/hcp.md` — this doc.
+
+## Edge cases & failure modes
+- **setup-hosting fails.** `hosted depends: hcp-setup-hosting` (Argo default
+  `.Succeeded`) so `hosted` doesn't run on setup failure — the "hosted pull fails
+  fast" path is only the defensive case (blob absent/partial). setup's epilogue
+  still pushes on the failure path (EXIT trap), so `destroy-hosting` (fan-in on
+  setup `.Failed`/`.Errored`) has state to tear any partial hosting cluster down.
+- hosted fails → its epilogue `bz destroy` tears down **its** hosted cluster.
+- destroy-hosting fails → hosting cluster leaks → shared cluster-leak reaper; blob
+  left for retry.
+- `depends` includes `.Errored` so teardown isn't skipped on pod eviction.
+- **`HOSTING_CLUSTER` is a fixed label set identically on all three cron steps**
+  (it + `ARGO_WORKFLOW_NAME` form the shared blob key); this is an invariant.
+- **blob leak** (workflow aborted before destroy-hosting runs) → one-time bucket
+  lifecycle TTL (e.g. 7d) on `*/hcp/**` as the backstop, same as the standing
+  argoci-artifacts policy.
+
+## Open questions
+1. Confirm `bz`'s aws-openshift provisioner honours `OPENSHIFT_CLUSTER_TYPE=HCP-
+   hosting/HCP-hosted` + `OPENSHIFT_HOSTING_KUBECONFIG` from the ArgoCI runner (the
+   non-HCP openshift cert job already uses aws-openshift — a check, not a risk).
+2. Exact GCS push point for setup-hosting: end-of-body vs epilogue. Epilogue is
+   safer (runs on failure via the EXIT trap) — used above.

--- a/.argoci/scripts/body_flannel-migration.sh
+++ b/.argoci/scripts/body_flannel-migration.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# body_flannel-migration.sh - flannel-to-Calico migration test flow.
+#
+# Provisions a cluster, installs flannel + a CNI plugin helper, runs a basic
+# connectivity smoke test, applies Calico + the flannel-migration job, waits
+# for the migration to complete, then runs the full e2e suite on Calico.
+#
+# Uses the legacy `./bz.sh tests:run` test runner (not the in-repo binary).
+# When the in-repo binary reaches parity, this script can migrate to
+# `make e2e-run` like body_standard.sh's run_tests_local.sh phase.
+set -exo pipefail
+
+PHASES="$(cd "$(dirname "$0")" && pwd)/phases"
+
+echo "[INFO] starting job..."
+
+export CNI_VERSION=${CNI_VERSION:-"v1.1.1"}
+export DOCS_BASE=${DOCS_BASE:-"https://github.com/projectcalico/calico"}
+export DOWNLEVEL_MANIFEST=${DOWNLEVEL_MANIFEST:-"https://github.com/projectcalico/calico/raw/release-${RELEASE_STREAM}/manifests/canal.yaml"}
+export CALICO_MANIFEST=${CALICO_MANIFEST:-"manifests/flannel-migration/calico.yaml"}
+export MIGRATION_MANIFEST=${MIGRATION_MANIFEST:-"manifests/flannel-migration/migration-job.yaml"}
+
+if [ "${USE_HASH_RELEASE}" == "true" ]; then
+  echo "[INFO] Using hash release for flannel migration"
+  LATEST_HASHREL="https://latest-os.docs.eng.tigera.net/${RELEASE_STREAM}.txt"
+  echo "Checking ${LATEST_HASHREL} for latest hash release url..."
+  DOCS_URL=$(curl --retry 9 --retry-all-errors -sS ${LATEST_HASHREL})
+  echo "Using $DOCS_URL for hash release base url"
+else
+  if [[ "${RELEASE_STREAM}" == "master" ]]; then
+    echo "Cannot use latest release on master branch"
+    exit 1
+  else
+    echo "[INFO] Using latest release for flannel migration"
+    export DOCS_URL=$DOCS_BASE/raw/release-${RELEASE_STREAM}
+  fi
+fi
+
+export BZ_LOCAL=${BZ_HOME}/.local
+export KUBECONFIG=$BZ_LOCAL/kubeconfig
+export PATH=$PATH:$BZ_LOCAL/bin
+
+# Modern OSes no longer include br_netfilter by default, which breaks flannel.
+echo "[INFO] installing br_netfilter..."
+sudo modprobe br_netfilter
+
+mkdir -p "$BZ_LOGS_DIR"
+cd "${BZ_HOME}"
+source "${PHASES}/provision.sh"
+
+# Install bridge CNI plugin (needed by kube-flannel manifest).
+kubectl apply -f - <<EOF
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: cni-installer
+  namespace: kube-system
+  labels:
+    app: cni-installer
+spec:
+  selector:
+    matchLabels:
+      app: cni-installer
+  template:
+    metadata:
+      labels:
+        app: cni-installer
+    spec:
+      nodeSelector:
+        kubernetes.io/os: linux
+      hostNetwork: true
+      terminationGracePeriodSeconds: 0
+      tolerations:
+        - effect: NoSchedule
+          operator: Exists
+        - key: CriticalAddonsOnly
+          operator: Exists
+        - effect: NoExecute
+          operator: Exists
+      terminationGracePeriodSeconds: 0
+      priorityClassName: system-node-critical
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      initContainers:
+      - name: cni-installer
+        image: quay.io/dosmith/cni-plugins:gen4
+        command: ["/bin/bash", "-c", "cp -f /usr/src/plugins/bin/* /opt/cni/bin"]
+        volumeMounts:
+        - name: bindir
+          mountPath: /opt/cni/bin
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: 10m
+            memory: 10Mi
+      containers:
+      - name: pause
+        image: registry.k8s.io/pause
+        resources:
+          requests:
+            cpu: 10m
+            memory: 10Mi
+      volumes:
+      - name: bindir
+        hostPath:
+          path: /opt/cni/bin
+EOF
+
+# Update flannel.yaml to use the podCIDR that CRC sets up.
+wget -O flannel.yaml "$DOWNLEVEL_MANIFEST"
+sed -i "s?10.244.0.0/16?192.168.0.0/16?g" ./flannel.yaml
+kubectl apply -f - < ./flannel.yaml
+sleep 30 # wait for flannel to come up
+kubectl get po -A -owide
+
+# Run a basic services test to check that flannel networking is working.
+K8S_E2E_FLAGS='--ginkgo.focus=should.serve.a.basic.endpoint.from.pods' \
+  ./bz.sh tests:run |& tee >(gzip --stdout > "${BZ_LOGS_DIR}/e2e-tests-pre.log")
+
+kubectl delete -n kube-system ds cni-installer || true  # remove the CNI installer daemonset
+kubectl apply -f "$DOCS_URL/$CALICO_MANIFEST"
+wget -O calico-migration.yaml "$DOCS_URL/$MIGRATION_MANIFEST"
+kubectl apply -f - < ./calico-migration.yaml
+sleep 5  # make sure the job has started before we check its status
+kubectl -n kube-system get jobs flannel-migration
+kubectl -n kube-system describe jobs flannel-migration
+kubectl get po -A -owide
+kubectl wait --for=condition=complete --timeout=600s -n kube-system job/flannel-migration
+kubectl -n kube-system get jobs flannel-migration
+kubectl -n kube-system describe jobs flannel-migration
+kubectl -n kube-system logs -l k8s-app=flannel-migration-controller
+kubectl get po -A -owide
+
+# Delete the migration job because the presence of a non-Running pod in
+# kube-system upsets the e2es.
+kubectl -n kube-system delete job/flannel-migration || true
+kubectl -n kube-system delete po -l k8s-app=flannel-migration-controller || true
+
+# Run e2e on uplevel calico.
+./bz.sh tests:run |& tee >(gzip --stdout > "${BZ_LOGS_DIR}/e2e-tests.log")

--- a/.argoci/scripts/body_standard.sh
+++ b/.argoci/scripts/body_standard.sh
@@ -2,9 +2,11 @@
 # body_standard.sh - ArgoCI orchestrator for the standard OSS e2e flow.
 #
 # Dispatches to the phase scripts in phases/. Ported from
-# .semaphore/end-to-end/scripts/body_standard.sh, trimmed to the OSS path
-# (the Semaphore version's HCP/MCM/hosting branches are Calico-Enterprise-only
-# and are dropped here). Each phase is self-contained; see phases/*.sh.
+# .semaphore/end-to-end/scripts/body_standard.sh, trimmed to the OSS path (the
+# Semaphore version's MCM branch and its HCP_ENABLED/ocp-hcp path are
+# Calico-Enterprise-only / unused by OSS and dropped). The HCP_STAGE gating used
+# by the certification pipeline IS kept (see .argoci/design/hcp.md). Each phase
+# is self-contained; see phases/*.sh.
 set -eo pipefail
 
 PHASES="$(cd "$(dirname "$0")" && pwd)/phases"
@@ -14,8 +16,19 @@ echo "[INFO] starting job (PROVISIONER=${PROVISIONER} DATAPLANE=${DATAPLANE} REL
 # bz commands must run from the profile dir (== BZ_HOME); PHASES is absolute above.
 cd "${BZ_HOME}"
 
-source "${PHASES}/provision.sh"
-source "${PHASES}/install.sh"
+# HCP hosting/destroy-hosting stages join an existing cluster provisioned by a
+# prior workflow step, so they skip provisioning and install entirely.
+if [[ "${HCP_STAGE}" != "hosting" && "${HCP_STAGE}" != "destroy-hosting" ]]; then
+  source "${PHASES}/provision.sh"
+  source "${PHASES}/install.sh"
+fi
 source "${PHASES}/configure.sh"
 source "${PHASES}/migrate.sh"
+
+# Hosting stages only stand up infrastructure for other jobs to test against;
+# they don't run tests themselves.
+if [[ "${HCP_STAGE:-}" == *-hosting* ]]; then
+  exit 0
+fi
+
 source "${PHASES}/run_tests.sh"

--- a/.argoci/scripts/global_epilogue.sh
+++ b/.argoci/scripts/global_epilogue.sh
@@ -16,7 +16,7 @@ CI_EXIT_CODE=${CI_EXIT_CODE:-0}
 ARTIFACT_DEST="gs://${GS_BUCKET}/${ARGO_WORKFLOW_NAME:-local}/${HOSTNAME:-pod}"
 
 # Capture diags on failure (or always for cert runs).
-if [[ "${CI_EXIT_CODE}" != "0" ]]; then
+if [[ "${CI_EXIT_CODE}" != "0" || "${TEST_TYPE}" == "ocp-cert" ]]; then
   echo "[INFO] capturing diags"
   bz diags |& tee "${BZ_LOGS_DIR}/diagnostic.log" || true
   gsutil cp "${BZ_LOCAL_DIR}/${DIAGS_ARCHIVE_FILENAME}" "${ARTIFACT_DEST}/diags.tgz" || true

--- a/.argoci/scripts/global_epilogue.sh
+++ b/.argoci/scripts/global_epilogue.sh
@@ -37,8 +37,22 @@ if [[ -n "${GITHUB_ACCESS_TOKEN:-}" ]]; then
     chmod +x /tmp/run-lens.sh && /tmp/run-lens.sh || true
 fi
 
-# Tear the cluster down.
-echo "[INFO] destroying cluster ${CLUSTER_NAME}"
-bz destroy |& tee "${BZ_LOGS_DIR}/destroy.log" || true
+# Tear the cluster down. HCP setup-hosting must keep its hosting cluster alive
+# for the hosted stage, so instead of destroying it, push its BZ_HOME to GCS for
+# the hosted/destroy-hosting stages (see .argoci/design/hcp.md).
+HCP_BLOB="gs://${GS_BUCKET}/${ARGO_WORKFLOW_NAME}/hcp/${HOSTING_CLUSTER}/hosting-bzhome.tgz"
+if [[ "${HCP_STAGE:-}" == "setup-hosting" ]]; then
+  echo "[INFO] hcp: pushing hosting state to ${HCP_BLOB}"
+  ( set -o pipefail; tar czf - -C "${BZ_HOME}" . | gsutil cp - "${HCP_BLOB}" ) \
+    || echo "[WARN] hcp: hosting-state push failed"
+else
+  echo "[INFO] destroying cluster ${CLUSTER_NAME}"
+  destroy_rc=0
+  bz destroy |& tee "${BZ_LOGS_DIR}/destroy.log" || destroy_rc=$?
+  # destroy-hosting: drop the hosting-state blob once the hosting cluster is gone.
+  if [[ "${HCP_STAGE:-}" == "destroy-hosting" && "${destroy_rc}" == "0" ]]; then
+    gsutil rm "${HCP_BLOB}" || true
+  fi
+fi
 
 echo "[INFO] exiting global_epilogue (CI_EXIT_CODE=${CI_EXIT_CODE})"

--- a/.argoci/scripts/global_epilogue.sh
+++ b/.argoci/scripts/global_epilogue.sh
@@ -38,20 +38,24 @@ if [[ -n "${GITHUB_ACCESS_TOKEN:-}" ]]; then
 fi
 
 # Tear the cluster down. HCP setup-hosting must keep its hosting cluster alive
-# for the hosted stage, so instead of destroying it, push its BZ_HOME to GCS for
-# the hosted/destroy-hosting stages (see .argoci/design/hcp.md).
+# for the hosted stage, so instead of destroying it, push its state to GCS for
+# the hosted/destroy-hosting stages: the whole BZ_HOME (for destroy-hosting's
+# terraform state) plus just the kubeconfig (for hosted). See design/hcp.md.
 HCP_BLOB="gs://${GS_BUCKET}/${ARGO_WORKFLOW_NAME}/hcp/${HOSTING_CLUSTER}/hosting-bzhome.tgz"
+HCP_KUBECONFIG="gs://${GS_BUCKET}/${ARGO_WORKFLOW_NAME}/hcp/${HOSTING_CLUSTER}/hosting-kubeconfig"
 if [[ "${HCP_STAGE:-}" == "setup-hosting" ]]; then
   echo "[INFO] hcp: pushing hosting state to ${HCP_BLOB}"
   ( set -o pipefail; tar czf - -C "${BZ_HOME}" . | gsutil cp - "${HCP_BLOB}" ) \
     || echo "[WARN] hcp: hosting-state push failed"
+  gsutil cp "${BZ_LOCAL_DIR}/kubeconfig" "${HCP_KUBECONFIG}" \
+    || echo "[WARN] hcp: hosting-kubeconfig push failed"
 else
   echo "[INFO] destroying cluster ${CLUSTER_NAME}"
   destroy_rc=0
   bz destroy |& tee "${BZ_LOGS_DIR}/destroy.log" || destroy_rc=$?
-  # destroy-hosting: drop the hosting-state blob once the hosting cluster is gone.
+  # destroy-hosting: drop the hosting-state objects once the cluster is gone.
   if [[ "${HCP_STAGE:-}" == "destroy-hosting" && "${destroy_rc}" == "0" ]]; then
-    gsutil rm "${HCP_BLOB}" || true
+    gsutil rm "${HCP_BLOB}" "${HCP_KUBECONFIG}" || true
   fi
 fi
 

--- a/.argoci/scripts/global_prologue.sh
+++ b/.argoci/scripts/global_prologue.sh
@@ -72,6 +72,14 @@ export DIAGS_ARCHIVE_FILENAME=${DIAGS_ARCHIVE_FILENAME:-${PROVISIONER}-${CLUSTER
 # 'bz init profile -n NAME' creates the profile at <cwd>/NAME, and bz provision/
 # install/destroy must run from that dir. Init from $HOME (in a subshell so the
 # parent stays at repo root for the relative body_standard.sh call); BZ_HOME=$HOME/NAME.
+# HCP hosting stages (setup-hosting/destroy-hosting) must land on the SAME BZ_HOME
+# path across steps: the hosting BZ_HOME is handed off whole (see design/hcp.md),
+# and a restored Python venv hardcodes absolute paths, so a per-step random name
+# would leave bz destroy calling a venv pip that no longer exists. Pin it
+# deterministically from the run + hosting cluster (both stages share these).
+if [[ "${HCP_STAGE:-}" == *-hosting ]]; then
+  export BZ_PROFILE_NAME="${BZ_PROFILE_NAME:-${ARGO_WORKFLOW_NAME}-hosting-${HOSTING_CLUSTER}}"
+fi
 export BZ_PROFILE_NAME="${BZ_PROFILE_NAME:-${ARGO_WORKFLOW_NAME:-local}-${RANDOM_TOKEN1}}"
 export BZ_HOME="${BZ_HOME:-${HOME}/${BZ_PROFILE_NAME}}"
 export USE_HASH_RELEASE="${USE_HASH_RELEASE:-true}"
@@ -124,26 +132,32 @@ else
   echo "[WARN] ${HOME}/.docker/config.json missing; docker_auth not staged"
 fi
 
-# HCP cross-stage handoff (see .argoci/design/hcp.md). The hosting cluster's
-# state is passed between stages via one GCS object (Semaphore used cache +
-# artifact, which ArgoCI lacks). setup-hosting pushes it in the epilogue.
+# HCP cross-stage handoff (see .argoci/design/hcp.md). Semaphore passes the
+# hosting cluster between stages via cache (whole BZ_HOME) + artifact (just the
+# kubeconfig); ArgoCI has neither, so both go to GCS. setup-hosting pushes them
+# in the epilogue.
 if [[ -n "${HCP_STAGE:-}" ]]; then
   HCP_BLOB="gs://${GS_BUCKET}/${ARGO_WORKFLOW_NAME}/hcp/${HOSTING_CLUSTER}/hosting-bzhome.tgz"
+  HCP_KUBECONFIG="gs://${GS_BUCKET}/${ARGO_WORKFLOW_NAME}/hcp/${HOSTING_CLUSTER}/hosting-kubeconfig"
   case "${HCP_STAGE}" in
     hosted)
       # Join the existing hosting cluster: pull just its kubeconfig.
-      mkdir -p "${BZ_LOCAL_DIR}/hosting"
-      if gsutil cp "${HCP_BLOB}" - | tar xzf - -C "${BZ_LOCAL_DIR}/hosting" ./.local/kubeconfig; then
-        export OPENSHIFT_HOSTING_KUBECONFIG="${BZ_LOCAL_DIR}/hosting/.local/kubeconfig"
+      if gsutil cp "${HCP_KUBECONFIG}" "${BZ_LOCAL_DIR}/hosting-kubeconfig"; then
+        export OPENSHIFT_HOSTING_KUBECONFIG="${BZ_LOCAL_DIR}/hosting-kubeconfig"
         echo "[INFO] hcp: hosting kubeconfig at ${OPENSHIFT_HOSTING_KUBECONFIG}"
       else
-        echo "[ERROR] hcp: hosting state not found at ${HCP_BLOB}"; exit 1
+        echo "[ERROR] hcp: hosting kubeconfig not found at ${HCP_KUBECONFIG}"; exit 1
       fi
       ;;
     destroy-hosting)
-      # Restore the hosting BZ_HOME so bz destroy has its terraform state.
+      # Restore the hosting BZ_HOME so bz destroy has its terraform state. BZ_HOME
+      # is pinned to the same path setup-hosting used (see above), so the restored
+      # venv's hardcoded absolute paths resolve. The pip install mirrors Semaphore
+      # global_prologue.sh:195 (refresh destroy-time deps); non-fatal.
       if gsutil -q stat "${HCP_BLOB}"; then
         gsutil cp "${HCP_BLOB}" - | tar xzf - -C "${BZ_HOME}"
+        python3 -m pip install -r "${BZ_HOME}/scripts/requirements.txt" || \
+          echo "[WARN] hcp: destroy-deps pip install failed (continuing)"
       else
         echo "[INFO] hcp: no hosting state to destroy"
       fi

--- a/.argoci/scripts/global_prologue.sh
+++ b/.argoci/scripts/global_prologue.sh
@@ -124,4 +124,31 @@ else
   echo "[WARN] ${HOME}/.docker/config.json missing; docker_auth not staged"
 fi
 
+# HCP cross-stage handoff (see .argoci/design/hcp.md). The hosting cluster's
+# state is passed between stages via one GCS object (Semaphore used cache +
+# artifact, which ArgoCI lacks). setup-hosting pushes it in the epilogue.
+if [[ -n "${HCP_STAGE:-}" ]]; then
+  HCP_BLOB="gs://${GS_BUCKET}/${ARGO_WORKFLOW_NAME}/hcp/${HOSTING_CLUSTER}/hosting-bzhome.tgz"
+  case "${HCP_STAGE}" in
+    hosted)
+      # Join the existing hosting cluster: pull just its kubeconfig.
+      mkdir -p "${BZ_LOCAL_DIR}/hosting"
+      if gsutil cp "${HCP_BLOB}" - | tar xzf - -C "${BZ_LOCAL_DIR}/hosting" ./.local/kubeconfig; then
+        export OPENSHIFT_HOSTING_KUBECONFIG="${BZ_LOCAL_DIR}/hosting/.local/kubeconfig"
+        echo "[INFO] hcp: hosting kubeconfig at ${OPENSHIFT_HOSTING_KUBECONFIG}"
+      else
+        echo "[ERROR] hcp: hosting state not found at ${HCP_BLOB}"; exit 1
+      fi
+      ;;
+    destroy-hosting)
+      # Restore the hosting BZ_HOME so bz destroy has its terraform state.
+      if gsutil -q stat "${HCP_BLOB}"; then
+        gsutil cp "${HCP_BLOB}" - | tar xzf - -C "${BZ_HOME}"
+      else
+        echo "[INFO] hcp: no hosting state to destroy"
+      fi
+      ;;
+  esac
+fi
+
 echo "[INFO] exiting prologue (PROVISIONER=${PROVISIONER} RELEASE_STREAM=${RELEASE_STREAM} CLUSTER_NAME=${CLUSTER_NAME})"

--- a/.argoci/scripts/global_prologue.sh
+++ b/.argoci/scripts/global_prologue.sh
@@ -44,12 +44,13 @@ RANDOM_TOKEN1=$(LC_ALL=C tr -dc 'a-z0-9' </dev/urandom | head -c 5 || true)
 echo "[INFO] exporting default env vars..."
 export PRODUCT=${PRODUCT:-calico}
 export PROVISIONER=${PROVISIONER:-gcp-kubeadm}
-export INSTALLER=${INSTALLER:-operator}
+export INSTALLER=${INSTALLER:-"manual"}
 export DATAPLANE=${DATAPLANE:-CalicoIptables}
 export TEST_TYPE=${TEST_TYPE:-k8s-e2e}
 export GOOGLE_PROJECT=${GOOGLE_PROJECT:-unique-caldron-775}
-export GOOGLE_REGION=${GOOGLE_REGION:-us-central1}
-export GOOGLE_ZONE=${GOOGLE_ZONE:-us-central1-a}
+export GOOGLE_REGIONS=("us-central1" "us-west1")
+export GOOGLE_REGION=${GOOGLE_REGION:-${GOOGLE_REGIONS[RANDOM%${#GOOGLE_REGIONS[@]}]}}
+export GOOGLE_ZONE=${GOOGLE_ZONE:-$(gcloud compute zones list --filter="region~'$GOOGLE_REGION'" --format="value(name)" | awk 'BEGIN {srand()} {a[NR]=$0} rand() * NR < 1 {zone=$0} END {print zone}')}
 export GOOGLE_NETWORK=${GOOGLE_NETWORK:-semaphore-autotest}
 export AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION:-us-west-2}
 
@@ -58,6 +59,11 @@ export AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION:-us-west-2}
 # Branch comes from the ArgoCI handler (CI_GIT_CLONED_BRANCH); fall back to
 # BRANCH then master. release-vX.Y -> vX.Y, else master.
 export RELEASE_STREAM=${RELEASE_STREAM:-$( _b="${CI_GIT_CLONED_BRANCH:-${BRANCH:-master}}"; [[ "${_b}" =~ ^release-(v[0-9]+\.[0-9]+)$ ]] && echo "${BASH_REMATCH[1]}" || echo "master" )}
+
+export K8S_VERSION=${K8S_VERSION:-stable-3}
+export K8S_E2E_EXTRA_FLAGS=${K8S_E2E_EXTRA_FLAGS:-" --e2ecfg.calicoctl-opensource-image=calico/ctl:release-${RELEASE_STREAM} "}
+export HELM_PATCH=${HELM_PATCH:-"0"}
+export CALICOCTL_INSTALL_TYPE=${CALICOCTL_INSTALL_TYPE:-"binary"}
 
 export CLUSTER_NAME=${CLUSTER_NAME:-bz-${PRODUCT}-${RANDOM_TOKEN1}}
 export DIAGS_ARCHIVE_FILENAME=${DIAGS_ARCHIVE_FILENAME:-${PROVISIONER}-${CLUSTER_NAME}-diags.tgz}

--- a/.argoci/scripts/phases/run_tests.sh
+++ b/.argoci/scripts/phases/run_tests.sh
@@ -1,18 +1,12 @@
 #!/usr/bin/env bash
 # run_tests.sh - acquire an e2e binary and run it, or defer to bz tests.
 #
-# Selection (automatic):
-#   - E2E_TEST_CONFIG set → structured label-based selection via `make e2e-run`.
-#     The e2e binary is acquired first: built from local source when
-#     RUN_LOCAL_TESTS is set (per-PR CI / GCP e2e block), otherwise downloaded
-#     from the hashrelease (scheduled CI).
-#   - Else → `bz tests`, which honours K8S_E2E_FLAGS (regex --ginkgo.focus/skip,
-#     read from the environment) for regex-selected e2e jobs, and also runs the
-#     non-e2e test types (benchmarks, certification, etc.).
-#
-# `make e2e-run` has no --ginkgo.focus, so K8S_E2E_FLAGS is inert there; regex
-# selection must go through `bz tests` (matches the Semaphore flannel-migration
-# body, which runs `K8S_E2E_FLAGS=... bz tests`).
+# Selection (automatic, matches Semaphore):
+#   - TEST_TYPE == k8s-e2e → run the monorepo e2e binary via `make e2e-run`.
+#     The binary is acquired first: built from local source when RUN_LOCAL_TESTS
+#     is set (per-PR CI), otherwise downloaded from the hashrelease (scheduled
+#     CI). E2E_TEST_CONFIG selects specs and may be empty (default config).
+#   - Else (non-e2e test types: benchmarks, certification, etc.) → `bz tests`.
 #
 # Required env:
 #   BZ_LOCAL_DIR, BZ_LOGS_DIR, HOME, REPORT_DIR, TEST_TYPE
@@ -34,7 +28,7 @@ if [[ -n "${RUN_LOCAL_TESTS:-}" ]]; then
   make -C e2e build |& tee >(gzip --stdout > "${BZ_LOGS_DIR}/${TEST_TYPE}-build.log.gz")
   E2E_BINARY=/go/src/github.com/projectcalico/calico/e2e/bin/k8s/e2e.test
   popd || exit
-elif [[ "${TEST_TYPE}" == "k8s-e2e" && -n "${E2E_TEST_CONFIG:-}" ]]; then
+elif [[ "${TEST_TYPE}" == "k8s-e2e" ]]; then
   # Scheduled CI: download the pre-built e2e binary from the hashrelease.
   echo "[INFO] downloading e2e binary from hashrelease..."
   HASHREL_URL=$(curl --retry 9 --retry-all-errors -sS "https://latest-os.docs.eng.tigera.net/${RELEASE_STREAM}.txt")
@@ -48,10 +42,10 @@ elif [[ "${TEST_TYPE}" == "k8s-e2e" && -n "${E2E_TEST_CONFIG:-}" ]]; then
 fi
 
 # E2E_BINARY is a set/unset sentinel (its value is not used here -- make
-# e2e-run locates the binary itself). Take the structured path only when a
-# k8s-e2e binary was acquired above AND E2E_TEST_CONFIG selects specs; regex
-# (K8S_E2E_FLAGS) and non-e2e jobs fall through to bz tests below.
-if [[ -n "${E2E_BINARY:-}" && -n "${E2E_TEST_CONFIG:-}" ]]; then
+# e2e-run locates the binary itself). Take the structured path whenever a
+# k8s-e2e binary was acquired above; non-e2e test types fall through to bz
+# tests below. E2E_TEST_CONFIG may be empty (selects the default config).
+if [[ -n "${E2E_BINARY:-}" ]]; then
   echo "[INFO] starting e2e tests..."
   pushd "${CI_HOME}/${CI_GIT_DIR}" || exit
 
@@ -82,6 +76,14 @@ if [[ -n "${E2E_BINARY:-}" && -n "${E2E_TEST_CONFIG:-}" ]]; then
   # the container, and we prepend that to PATH inside the bash -c below.
   make kubectl
 
+  # EKS kubeconfigs exec aws-iam-authenticator (PATH lookup), which the stock
+  # golang image lacks, so client-go fails before any tests run. The aws-eks
+  # provisioner installs it on the host; bind-mount it when present (no-op otherwise).
+  auth_mount=()
+  if [[ -x "${BZ_LOCAL_DIR}/bin/aws-iam-authenticator" ]]; then
+    auth_mount=(-v "${BZ_LOCAL_DIR}/bin/aws-iam-authenticator:/usr/local/bin/aws-iam-authenticator:ro")
+  fi
+
   # Capture the exit code so the JUnit copy below runs even when tests fail
   # (set -e would otherwise bail out before the cp).
   e2e_rc=0
@@ -92,6 +94,7 @@ if [[ -n "${E2E_BINARY:-}" && -n "${E2E_TEST_CONFIG:-}" ]]; then
     -e KUBECONFIG=/kubeconfig \
     -e PRODUCT=${PRODUCT:-calico} \
     ${K8S_E2E_DOCKER_EXTRA_FLAGS:-} \
+    "${auth_mount[@]}" \
     -v "$(pwd)":/go/src/github.com/projectcalico/calico:rw \
     -v "$(pwd)"/.go-pkg-cache:/go-cache:rw \
     -v "${BZ_LOCAL_DIR}/kubeconfig:/kubeconfig:ro" \
@@ -115,8 +118,7 @@ if [[ -n "${E2E_BINARY:-}" && -n "${E2E_TEST_CONFIG:-}" ]]; then
   # Propagate the original test exit code.
   exit ${e2e_rc}
 else
-  # Regex-selected e2e (K8S_E2E_FLAGS) or non-e2e test types -- defer to bz,
-  # which reads K8S_E2E_FLAGS from the environment.
+  # Non-e2e test types (benchmarks, certification, etc.) -- defer to bz.
   echo "[INFO] starting bz testing (K8S_E2E_FLAGS=${K8S_E2E_FLAGS:-<none>})..."
   bz tests ${VERBOSE} |& tee >(gzip --stdout > "${BZ_LOGS_DIR}/${TEST_TYPE}-tests.log.gz")
 fi


### PR DESCRIPTION
Runs the OSS **certification** pipeline's HCP (hosted control plane) stages on ArgoCI.

HCP uses a multi-cluster `bzprofiles` tree (not `BZ_HOME`) and, on Semaphore, hands state between stages via the `cache`/`artifact` CLIs that ArgoCI lacks. So this vendors the `banzai-utils` `ocp-hcp/*` scripts into `.argoci/scripts/hcp/` (env-driven, logic unchanged) and adds `phases/hcp.sh`, which dispatches on `HCP_STAGE` (`setup-hosting`/`hosted`/`destroy-hosting`) and replaces the cache/artifact handoff with a single **GCS object** (the whole tree, tarred).

Scaffold edits: prologue sets `BZ_PROFILES_PATH`/`BZ_SECRETS_PATH`; `body_standard` sources `hcp.sh` when `HCP_ENABLED=true`; epilogue skips the single-cluster `bz diags`/`bz destroy` for HCP and glob-publishes junit.

Design rationale: `.argoci/design/hcp.md` (5-round design review; may be removed before merge).

🚧 **Stacked on #13153** (faithful-scaffold) — the scaffold edits build on it; the diff will settle once #13153 merges. Cron wiring (`HCP_ENABLED`/destroy-hosting step in `e2e-certification.yaml`) rides in #13133.

## Release Note
```release-note
NONE
```