### PR TITLE
[v3.32] Removed getenv from confd windows template; felix: fix dataplane deadlock when GARP races with live-migration completion; networking-calico: derive tap MAC from port MAC

### DIFF
--- a/confd/windows-packaging/templates/blocks.ps1.template
+++ b/confd/windows-packaging/templates/blocks.ps1.template
@@ -1,6 +1,7 @@
+{{- $config := getBGPConfig 4 . -}}
 
 $blocks =
-{{- $node_block_key := printf "/host/%s/ipv4/block" (getenv "NODENAME")}}
+{{- $node_block_key := printf "/host/%s/ipv4/block" $config.NodeName}}
 {{- range ls $node_block_key}}
     {{- $parts := split . "-"}}
     {{- $cidr := join $parts "/"}}

--- a/confd/windows-packaging/templates/peerings.ps1.template
+++ b/confd/windows-packaging/templates/peerings.ps1.template
@@ -1,12 +1,13 @@
+{{- $config := getBGPConfig 4 . -}}
 
-{{- $node_ip_key := printf "/host/%s/ip_addr_v4" (getenv "NODENAME")}}
+{{- $node_ip_key := printf "/host/%s/ip_addr_v4" $config.NodeName}}
 {{- $node_ip := getv $node_ip_key}}
 $local_ip = "{{$node_ip}}"
 
-{{- $bgp_id := getenv "CALICO_ROUTER_ID" ""}}
+{{- $bgp_id := $config.RouterID}}
 $bgp_id = "{{if ne "" ($bgp_id)}}{{$bgp_id}}{{else}}{{$node_ip}}{{end}}"
 
-{{- $node_as_key := printf "/host/%s/as_num" (getenv "NODENAME")}}
+{{- $node_as_key := printf "/host/%s/as_num" $config.NodeName}}
 $local_asn = {{if exists $node_as_key}}{{getv $node_as_key}}{{else}}{{getv "/global/as_num"}}{{end}}
 
 $peerings =
@@ -53,7 +54,7 @@ $peerings =
     {{- end}}
 
     # ------------- Node-specific peers -------------
-    {{- $node_peers_key := printf "/host/%s/peer_v4" (getenv "NODENAME")}}
+    {{- $node_peers_key := printf "/host/%s/peer_v4" $config.NodeName}}
     {{- if ls $node_peers_key}}
         {{- range gets (printf "%s/*" $node_peers_key)}}
             {{- $data := json .Value}}

--- a/felix/dataplane/linux/live_migration.go
+++ b/felix/dataplane/linux/live_migration.go
@@ -243,6 +243,7 @@ type liveMigrationFSM struct {
 	migrationUID string
 	timer        *time.Timer
 	pcapHandle   garpHandle
+	garpStopC    chan struct{}
 	garpWG       sync.WaitGroup
 	ipamSwapOnce sync.Once
 }
@@ -350,10 +351,11 @@ func (f *liveMigrationFSM) startGARPDetection() {
 		return
 	}
 	f.pcapHandle = handle
+	f.garpStopC = make(chan struct{})
 	f.garpWG.Add(1)
 	go func() {
 		defer f.garpWG.Done()
-		detectGARP(f.logCtx, f.id, handle, f.monitor.garpC)
+		detectGARP(f.logCtx, f.id, handle, f.monitor.garpC, f.garpStopC)
 	}()
 }
 
@@ -362,10 +364,20 @@ func (f *liveMigrationFSM) stopGARPDetection() {
 		if err := f.pcapHandle.Close(); err != nil {
 			f.logCtx.WithError(err).Debug("Error closing GARP detection handle")
 		}
+		// Closing garpStopC aborts any in-progress send to garpC.  This is
+		// essential to avoid a deadlock: garpC's only reader is the dataplane
+		// main loop, and stopGARPDetection itself runs on the main loop (via
+		// OnUpdate) when the FSM leaves the Target state.  If a GARP arrived
+		// just before the workload update that ends the Target state - e.g. a
+		// cutover RARP racing with the migration-complete update - then
+		// detectGARP would be blocked mid-send with no reader, and the Wait()
+		// below would block the main loop forever.
+		close(f.garpStopC)
 		// Wait for the detectGARP goroutine to exit.  Closing the handle causes
 		// packetSource.Packets() to return, so this should complete almost immediately.
 		f.garpWG.Wait()
 		f.pcapHandle = nil
+		f.garpStopC = nil
 	}
 }
 
@@ -406,9 +418,10 @@ func (m *liveMigrationMonitor) OnTimerPop(id types.WorkloadEndpointID) {
 
 // detectGARP reads packets from the given handle and sends the workload ID
 // to garpC when a GARP or RARP packet is detected.  It is a one-shot
-// goroutine: it returns after the first detection or when the handle is closed.
+// goroutine: it returns after the first detection, when the handle is closed,
+// or when stopC is closed.
 func detectGARP(logCtx *logrus.Entry, id types.WorkloadEndpointID,
-	handle garpHandle, garpC chan<- types.WorkloadEndpointID) {
+	handle garpHandle, garpC chan<- types.WorkloadEndpointID, stopC <-chan struct{}) {
 	// Note: handle is NOT defer-closed here. The FSM owns the handle lifecycle via
 	// stopGARPDetection(), which closes the handle and causes packetSource.Packets() to return,
 	// ending this goroutine.
@@ -416,7 +429,15 @@ func detectGARP(logCtx *logrus.Entry, id types.WorkloadEndpointID,
 	for packet := range packetSource.Packets() {
 		if isGARPOrRARP(packet) {
 			logCtx.Info("Detected GARP/RARP packet on workload interface")
-			garpC <- id
+			// garpC is unbuffered and its only reader is the dataplane main
+			// loop, which may currently be inside stopGARPDetection() waiting
+			// for this goroutine to exit; stopC guarantees this send cannot
+			// block forever in that case.
+			select {
+			case garpC <- id:
+			case <-stopC:
+				logCtx.Debug("GARP detection stopped while reporting detection")
+			}
 			return
 		}
 	}

--- a/felix/dataplane/linux/live_migration_test.go
+++ b/felix/dataplane/linux/live_migration_test.go
@@ -18,6 +18,8 @@ import (
 	"context"
 	"io"
 	"net"
+	"runtime"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -565,6 +567,136 @@ func TestLiveMigrationGARPChannel(t *testing.T) {
 		g.Expect(updates).To(HaveLen(1))
 		g.Expect(updates[0].State).To(Equal(liveMigrationStateLive))
 	})
+}
+
+// garpSenderBlocked reports whether some goroutine is currently parked in
+// detectGARP's report-detection send.  Lets the regression test below wait
+// deterministically for the sender to be blocked reporting on garpC before
+// the Target-exit update is processed.  The goroutine state is "select" for
+// the select-based send (which stopGARPDetection can abort) and "chan send"
+// for a plain send (the pre-fix code); we match both so the test observes the
+// blocked sender either way and then proves whether the Target-exit path can
+// get past it.  detectGARP's only other park point - waiting for a packet -
+// shows as "chan receive", so these two states are unambiguous.
+func garpSenderBlocked() bool {
+	// Grow the buffer until the full goroutine dump fits: runtime.Stack
+	// truncates (n == len(buf)) when the buffer is too small, which could
+	// hide the detectGARP goroutine and time out the Eventually below.
+	buf := make([]byte, 1<<20)
+	n := runtime.Stack(buf, true)
+	for n == len(buf) {
+		buf = make([]byte, 2*len(buf))
+		n = runtime.Stack(buf, true)
+	}
+	for _, gr := range strings.Split(string(buf[:n]), "\n\n") {
+		if !strings.Contains(gr, "detectGARP") {
+			continue
+		}
+		if strings.Contains(gr, "[select]") || strings.Contains(gr, "[chan send]") {
+			return true
+		}
+	}
+	return false
+}
+
+// TestGARPRaceWithTargetExit is a regression test for a dataplane main-loop
+// deadlock.  Scenario: the FSM is in Target with GARP detection running, and a
+// GARP/RARP is detected on the workload interface just before the main loop
+// processes an update that ends the Target state (e.g. the migration-complete
+// update flipping the role TARGET -> NO_ROLE, which can arrive within the same
+// scheduling window as the cutover RARP).  detectGARP is then blocked sending
+// on the unbuffered garpC - whose only reader is the main loop - while the
+// main loop is inside stopGARPDetection() waiting for detectGARP to exit.
+// Neither can proceed, wedging the dataplane loop permanently.
+//
+// The test simulates the main loop by calling OnUpdate directly, with nothing
+// reading garpC (just as the real main loop cannot read garpC while it is
+// inside OnUpdate).  Without the garpStopC abort mechanism, OnUpdate would
+// block forever and the test would fail by timeout.
+func TestGARPRaceWithTargetExit(t *testing.T) {
+	tests := []struct {
+		name       string
+		exitInput  func(m *liveMigrationMonitor)
+		wantStates []liveMigrationState
+	}{
+		{
+			name: "migration completes (NO_ROLE)",
+			exitInput: func(m *liveMigrationMonitor) {
+				m.OnUpdate(wepUpdate(wepID1, proto.LiveMigrationRole_NO_ROLE))
+			},
+			wantStates: []liveMigrationState{liveMigrationStateTimeWait},
+		},
+		{
+			name: "re-migration (SOURCE)",
+			exitInput: func(m *liveMigrationMonitor) {
+				m.OnUpdate(wepUpdate(wepID1, proto.LiveMigrationRole_SOURCE))
+			},
+			wantStates: []liveMigrationState{liveMigrationStateBase},
+		},
+		{
+			name: "workload removed",
+			exitInput: func(m *liveMigrationMonitor) {
+				m.OnUpdate(wepRemove(wepID1))
+			},
+			wantStates: []liveMigrationState{liveMigrationStateBase},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			m := newTestMonitor(testConvergenceTime)
+
+			garpBytes := buildGARPPacketBytes(t)
+			fakeHandle := newFakeGARPHandle(garpBytes)
+			m.newGARPHandle = func(ifaceName string) (garpHandle, error) {
+				return fakeHandle, nil
+			}
+
+			// Drive to Target; GARP detection starts and the fake handle
+			// delivers a GARP immediately, so detectGARP commits to the
+			// (blocking) garpC send.
+			m.OnUpdate(wepUpdate(wepID1, proto.LiveMigrationRole_TARGET))
+			expectUpdate(g, m, liveMigrationStateTarget)
+
+			// Wait until detectGARP is parked in the garpC send.  This pins
+			// the test to the exact interleaving from the field report - the
+			// sender already blocked when the Target-exit update is processed
+			// - which would also catch a broken variant of the fix that
+			// checks the stop channel before a plain send instead of
+			// selecting over both.
+			g.Eventually(garpSenderBlocked, time.Second, time.Millisecond).Should(BeTrue())
+
+			// Process the Target-exiting update as the main loop would, with
+			// nothing reading garpC.  Run it in a goroutine purely so that a
+			// regression fails the test by timeout instead of hanging the
+			// whole test binary.
+			done := make(chan struct{})
+			go func() {
+				defer close(done)
+				tt.exitInput(m)
+			}()
+			select {
+			case <-done:
+			case <-time.After(10 * time.Second):
+				t.Fatal("deadlock: OnUpdate blocked in stopGARPDetection while detectGARP blocked sending on garpC")
+			}
+
+			updates := drainUpdates(m)
+			g.Expect(updates).To(HaveLen(len(tt.wantStates)))
+			for i, want := range tt.wantStates {
+				g.Expect(updates[i].State).To(Equal(want))
+			}
+
+			// The aborted detection must not deliver a stale GARP.
+			select {
+			case <-m.garpC:
+				t.Fatal("unexpected GARP delivery after GARP detection was stopped")
+			case <-time.After(100 * time.Millisecond):
+				// Expected: no delivery.
+			}
+		})
+	}
 }
 
 // --- Section 6: GARP/RARP packet matching ---

--- a/networking-calico/networking_calico/plugins/ml2/drivers/calico/mech_calico.py
+++ b/networking-calico/networking_calico/plugins/ml2/drivers/calico/mech_calico.py
@@ -290,6 +290,42 @@ class TrackTask(oslo_context.context.RequestContext):
         return d
 
 
+# Fallback tap-side MAC used when we can't parse the port's own MAC.  In normal
+# operation ``get_vif_details`` overrides this per-port with a value derived from the
+# port MAC -- see ``_tap_mac_for_port_mac``.
+DEFAULT_TAP_MAC = "00:61:fe:ed:ca:fe"
+
+
+def _tap_mac_for_port_mac(port_mac):
+    """Derive the host-side tap MAC that older libvirt would have set.
+
+    Older libvirt (before 9.5.0) did not have an explicit ``managed`` parameter for a
+    domain interface: it always accepted a tap device that had already been created
+    externally (as OpenStack does via Nova), and it always went on to set the MAC
+    address on that tap by replacing the leading octet with ``0xfe`` and keeping the
+    remaining five.  With OpenStack's default ``base_mac`` of ``fa:16:3e:xx:xx:xx`` this
+    maps VM MAC ``fa:16:3e:aa:bb:cc`` to tap MAC ``fe:16:3e:aa:bb:cc``.
+
+    libvirt 9.5.0 split those behaviours behind ``managed``: ``managed=yes`` (the new
+    default) creates the tap and errors out if one already exists, while ``managed=no``
+    accepts an externally-created tap but no longer sets its MAC.  OpenStack must use
+    ``managed=no`` because Nova creates the tap, and that side-effect leaves the tap MAC
+    at whatever Nova put in ``VIF_DETAILS_TAP_MAC_ADDRESS`` -- historically the static
+    value in ``DEFAULT_TAP_MAC``.  Across a live migration between a pre-9.5.0 source
+    and a post-9.5.0 destination that flips the on-wire tap MAC and the VM's ARP cache
+    goes stale until it re-ARPs, causing tens of seconds of packet loss.
+
+    Returns ``None`` on any parse failure so the caller can fall back to
+    ``DEFAULT_TAP_MAC``.
+    """
+    if not port_mac:
+        return None
+    parts = port_mac.split(":")
+    if len(parts) != 6 or any(len(p) != 2 for p in parts):
+        return None
+    return ":".join(["fe"] + parts[1:])
+
+
 class CalicoMechanismDriver(mech_agent.SimpleAgentMechanismDriverBase):
     """Neutron/ML2 mechanism driver for Project Calico.
 
@@ -302,7 +338,7 @@ class CalicoMechanismDriver(mech_agent.SimpleAgentMechanismDriverBase):
         super(CalicoMechanismDriver, self).__init__(
             AGENT_TYPE_FELIX,
             "tap",
-            {"port_filter": True, "mac_address": "00:61:fe:ed:ca:fe"},
+            {"port_filter": True, "mac_address": DEFAULT_TAP_MAC},
         )
         qos_driver.register(self)
         # Lock to prevent concurrent initialisation.
@@ -777,6 +813,21 @@ class CalicoMechanismDriver(mech_agent.SimpleAgentMechanismDriverBase):
                 segment[api.ID],
             )
             return False
+
+    def get_vif_details(self, context, agent, segment):
+        # Nova reads ``vif_details['mac_address']`` at ``plug_tap`` time and sets that
+        # on the host-side tap interface.  Derive the value from the port's own MAC so
+        # it matches what older libvirt used to set implicitly; see
+        # ``_tap_mac_for_port_mac`` for the background.  Fall back to the base-class
+        # value (which is ``DEFAULT_TAP_MAC``) if we can't parse a port MAC.
+        details = dict(
+            super(CalicoMechanismDriver, self).get_vif_details(context, agent, segment)
+        )
+        port_mac = context.current.get("mac_address") if context.current else None
+        derived = _tap_mac_for_port_mac(port_mac)
+        if derived is not None:
+            details["mac_address"] = derived
+        return details
 
     def get_allowed_network_types(self, agent=None):
         return ("local", "flat")

--- a/networking-calico/networking_calico/plugins/ml2/drivers/calico/test/lib.py
+++ b/networking-calico/networking_calico/plugins/ml2/drivers/calico/test/lib.py
@@ -197,11 +197,17 @@ class PortNotFound(Exception):
 m_neutron_lib.exceptions.PortNotFound = PortNotFound
 
 
-# Define a stub class, that we will use as the base class for
-# CalicoMechanismDriver.
+# Define a stub class, that we will use as the base class for CalicoMechanismDriver.
+# The real ``neutron.plugins.ml2.drivers.mech_agent.SimpleAgentMechanismDriverBase``
+# stashes ``vif_details`` on the instance and exposes a ``get_vif_details`` accessor;
+# mirror both so overrides that call up to ``super().get_vif_details(...)`` behave the
+# same in tests as they do in production.
 class DriverBase(object):
     def __init__(self, agent_type, vif_type, vif_details):
-        pass
+        self.vif_details = dict(vif_details)
+
+    def get_vif_details(self, context, agent, segment):
+        return self.vif_details
 
 
 # Define another stub class that mocks out leader election: assume we're always

--- a/networking-calico/networking_calico/plugins/ml2/drivers/calico/test/test_plugin_etcd.py
+++ b/networking-calico/networking_calico/plugins/ml2/drivers/calico/test/test_plugin_etcd.py
@@ -1385,6 +1385,33 @@ class TestPluginEtcd(TestPluginEtcdBase):
             )
         )
 
+    def test_get_vif_details_derives_tap_mac_from_port_mac(self):
+        """tap MAC must match what the VM's ARP cache expects.
+
+        We reproduce older libvirt's implicit derivation (first octet -> 0xfe) so that
+        the tap MAC seen after a live migration to a libvirt >= 9.5.0 destination
+        matches the one the source's libvirt set.
+        """
+        context = mock.MagicMock()
+        context.current = {"mac_address": "fa:16:3e:aa:bb:cc"}
+        details = self.driver.get_vif_details(context, agent=None, segment=None)
+        self.assertEqual(details["mac_address"], "fe:16:3e:aa:bb:cc")
+        # port_filter (and any other keys the base class populated) still
+        # flow through.
+        self.assertTrue(details["port_filter"])
+
+    def test_get_vif_details_falls_back_when_port_mac_missing(self):
+        context = mock.MagicMock()
+        context.current = {}
+        details = self.driver.get_vif_details(context, agent=None, segment=None)
+        self.assertEqual(details["mac_address"], mech_calico.DEFAULT_TAP_MAC)
+
+    def test_get_vif_details_falls_back_on_malformed_port_mac(self):
+        context = mock.MagicMock()
+        context.current = {"mac_address": "not-a-mac"}
+        details = self.driver.get_vif_details(context, agent=None, segment=None)
+        self.assertEqual(details["mac_address"], mech_calico.DEFAULT_TAP_MAC)
+
     def test_neutron_rule_to_etcd_rule_icmp(self):
         # No type/code specified
         self.assertNeutronToEtcd(


### PR DESCRIPTION
**Cherry-pick history**
- Pick onto **release-v3.32**:
  - projectcalico/calico#13140
  - projectcalico/calico#13152
  - projectcalico/calico#13129

---
**Removed getenv from confd windows template** (projectcalico/calico#13140)
<!-- Describe your changes, including the type of change (bug fix, feature, etc.),
why it should be merged, testing done, and links to related issues. -->
This PR removes the `getenv` function from the template used by confd in windows and fixes #13139

<!-- For any user-visible change, replace TBD with a one-line description. -->
**Release note:**
```release-note
Bugfix: fix BIRD config generation on Windows, following some recent confd refactoring.
```
---
**felix: fix dataplane deadlock when GARP races with live-migration completion** (projectcalico/calico#13152)
The live-migration monitor's garpC channel is unbuffered and its only reader is the dataplane main loop.  If a GARP/RARP was detected on the workload interface just before the main loop processed an update ending the FSM's Target state - e.g. the cutover RARP arriving in the same scheduling window as the migration-complete update that flips the role TARGET -> NO_ROLE - then detectGARP was blocked sending on garpC while the main loop, inside stopGARPDetection() on the OnUpdate path, waited in garpWG.Wait() for detectGARP to exit.  Closing the pcap handle does not help in that state, because detectGARP is no longer reading packets. Neither goroutine could proceed, permanently wedging the dataplane main loop: no further calc-graph updates were applied (new/changed workloads on the host lost networking), while the last-good dataplane state continued to carry existing traffic and the status-reporting goroutine kept reporting the agent as up.

Fix by giving each GARP-detection goroutine a stop channel that stopGARPDetection() closes before waiting: detectGARP now sends on garpC via a select over the stop channel, so the send can always be aborted.  The same hazard existed on every input that exits the Target state (role -> NO_ROLE, role -> SOURCE, and workload removal); the regression test covers all three and, without the fix, reproduces the deadlock deterministically.

Fixes a hang observed in production during OpenStack live migrations.

**Release note:**
```release-note
Fixed a Felix dataplane deadlock that could be triggered when a gratuitous ARP / RARP from a live-migrated VM raced with the migration-complete update from the datastore.
```
---
**networking-calico: derive tap MAC from port MAC** (projectcalico/calico#13129)
Older libvirt (before 9.5.0) had no explicit ``managed`` parameter and always overwrote the tap-side MAC by replacing the leading octet with ``0xfe``.  libvirt 9.5.0 split that hybrid behaviour behind ``managed``, and OpenStack must now use ``managed=no`` (because Nova creates the tap), which incidentally stops libvirt from touching the tap MAC.  The result: the tap-side MAC on a post-9.5.0 hypervisor is whatever Nova put in ``vif_details['mac_address']`` -- historically our static ``00:61:fe:ed:ca:fe`` -- and the VM's ARP cache goes stale after a live migration from a pre-9.5.0 source until the guest re-ARPs.  That's the tens-of-seconds packet-loss regression in CI-1936.

Reproduce libvirt's old derivation per-port in ``get_vif_details`` so Nova sets the tap MAC to ``fe:<last-5-octets-of-VM-MAC>``.  Existing bound ports keep their old ``vif_details`` value until Neutron re-runs ``bind_port`` for them (port create, hard reboot, live-migration destination rebind) -- the fix takes effect on the next bind, which is also the only moment when the tap MAC is actually consumed.

**Release note:**
```release-note
Bugfix for OpenStack: Set the host-side MAC address in the same way as libvirt used (< 9.5.0) to do for Nova-plugged TAP interfaces, but now does not (because of those interfaces having to be marked as `managed=no`).  This allows for live migration from a hypervisor with libvirt<9.5.0 to one with libvirt>=9.5.0.
```

