### PR TITLE
Felix: fix rare start-of-day deadlock on restart-requiring config change

### DIFF
--- a/felix/daemon/daemon.go
+++ b/felix/daemon/daemon.go
@@ -711,25 +711,13 @@ configRetry:
 	}
 
 	// Send the opening message to the dataplane driver, giving it its
-	// config.  Do this before starting the calculation graph so that the
-	// dataplane driver is guaranteed to receive its config before the
-	// stream of updates from the calculation graph.
-	//
-	// Starting the calc graph first used to allow a rare start-of-day
-	// deadlock: the graph's first flushed event is always a ConfigUpdate,
-	// and if it carried a restart-triggering change it could park the
-	// connector in shutDownProcess() — reporting on failureReportChan —
-	// before monitorAndManageShutdown(), the only reader of that channel,
-	// had started.  This opening ConfigUpdate can't itself trigger a
-	// restart: handleConfigUpdate diffs it against the very config object
-	// it was generated from.
+	// config.  Do this before starting the calculation graph so that we
+	// don't race with it to send the first message.  We used to start calc
+	// graph first but that could result in blocking or even deadlocking
+	// here.
 	dpConnector.ToDataplane <- configParams.ToConfigUpdate()
 
 	// Now the dataplane driver has its config, start the calculation graph.
-	// Every consumer of its output channels is already running (the
-	// connector pump, the policy-sync processor, the collector's
-	// DataplaneInfoReader); the syncer has meanwhile been accumulating
-	// updates in the syncerToValidator dedupe buffer.
 	go syncerToValidator.SendToSinkForever(validator)
 	asyncCalcGraph.Start()
 	log.Infof("Started the processing graph")
@@ -1499,13 +1487,14 @@ func (fc *DataplaneConnector) shutDownProcess(reason string) {
 	select {
 	case fc.failureReportChan <- reason:
 	case <-timeout:
-		log.Panic("Managed shutdown failed: timed out reporting shutdown reason. Panicking.")
+		log.WithField("reason", reason).Panic(
+			"Managed shutdown failed: timed out reporting shutdown reason. Panicking.")
 	}
 	// time.After fires only once; the send won the select above, so this
 	// receives the eventual tick, giving the monitor the full timeout to
 	// tear us down.
 	<-timeout
-	log.Panic("Managed shutdown failed. Panicking.")
+	log.WithField("reason", reason).Panic("Managed shutdown failed. Panicking.")
 }
 
 // Start creates goroutines for:

--- a/felix/daemon/daemon.go
+++ b/felix/daemon/daemon.go
@@ -414,15 +414,29 @@ configRetry:
 	var dpDriverCmd *exec.Cmd
 
 	failureReportChan := make(chan string)
+	// These callbacks run on dataplane goroutines and report a shutdown
+	// reason to the shutdown monitor.  The send is on the unbuffered
+	// failureReportChan; time it out with a panic backstop so a stuck send
+	// can't hang the goroutine forever with the backstop unreachable.
 	configChangedRestartCallback := func() {
-		failureReportChan <- reasonConfigChanged
-		time.Sleep(gracefulShutdownTimeout)
+		timeout := time.After(gracefulShutdownTimeout)
+		select {
+		case failureReportChan <- reasonConfigChanged:
+		case <-timeout:
+			log.Panic("Graceful shutdown failed: timed out reporting config change")
+		}
+		<-timeout
 		log.Panic("Graceful shutdown took too long")
 	}
 	fatalErrorCallback := func(err error) {
 		log.WithError(err).Error("Shutting down due to fatal error")
-		failureReportChan <- reasonFatalError
-		time.Sleep(gracefulShutdownTimeout)
+		timeout := time.After(gracefulShutdownTimeout)
+		select {
+		case failureReportChan <- reasonFatalError:
+		case <-timeout:
+			log.Panic("Graceful shutdown failed: timed out reporting fatal error")
+		}
+		<-timeout
 		log.Panic("Graceful shutdown took too long")
 	}
 
@@ -653,9 +667,6 @@ configRetry:
 	// calculation graph.
 	validator := calc.NewValidationFilter(asyncCalcGraph, configParams)
 
-	go syncerToValidator.SendToSinkForever(validator)
-	asyncCalcGraph.Start()
-	log.Infof("Started the processing graph")
 	var stopSignalChans []chan<- *sync.WaitGroup
 	if configParams.EndpointReportingEnabled {
 		delay := configParams.EndpointReportingDelaySecs
@@ -700,8 +711,28 @@ configRetry:
 	}
 
 	// Send the opening message to the dataplane driver, giving it its
-	// config.
+	// config.  Do this before starting the calculation graph so that the
+	// dataplane driver is guaranteed to receive its config before the
+	// stream of updates from the calculation graph.
+	//
+	// Starting the calc graph first used to allow a rare start-of-day
+	// deadlock: the graph's first flushed event is always a ConfigUpdate,
+	// and if it carried a restart-triggering change it could park the
+	// connector in shutDownProcess() — reporting on failureReportChan —
+	// before monitorAndManageShutdown(), the only reader of that channel,
+	// had started.  This opening ConfigUpdate can't itself trigger a
+	// restart: handleConfigUpdate diffs it against the very config object
+	// it was generated from.
 	dpConnector.ToDataplane <- configParams.ToConfigUpdate()
+
+	// Now the dataplane driver has its config, start the calculation graph.
+	// Every consumer of its output channels is already running (the
+	// connector pump, the policy-sync processor, the collector's
+	// DataplaneInfoReader); the syncer has meanwhile been accumulating
+	// updates in the syncerToValidator dedupe buffer.
+	go syncerToValidator.SendToSinkForever(validator)
+	asyncCalcGraph.Start()
+	log.Infof("Started the processing graph")
 
 	if configParams.PrometheusMetricsEnabled {
 		log.Info("Prometheus metrics enabled.")
@@ -1146,6 +1177,11 @@ type DataplaneConnector struct {
 	datastore         bapi.Client
 	datastorev3       client.Interface
 
+	// shutdownReportTimeout bounds how long shutDownProcess waits to hand
+	// its failure reason to the shutdown monitor before panicking as a
+	// backstop.  Overridable in tests.
+	shutdownReportTimeout time.Duration
+
 	firstStatusReportSent bool
 
 	wireguardStatUpdateFromDataplane chan *proto.WireguardStatusUpdate
@@ -1172,6 +1208,7 @@ func newConnector(configParams *config.Config,
 		statusUpdatesFromDataplaneConsumers: nil,
 		failureReportChan:                   failureReportChan,
 		dataplane:                           dataplane,
+		shutdownReportTimeout:               gracefulShutdownTimeout,
 		wireguardStatUpdateFromDataplane:    make(chan *proto.WireguardStatusUpdate, 1),
 	}
 
@@ -1448,12 +1485,26 @@ func (fc *DataplaneConnector) sendMessagesToDataplaneDriver() {
 	}
 }
 
+// shutDownProcess reports the given reason to the shutdown monitor
+// (monitorAndManageShutdown) and then blocks, expecting the monitor to tear
+// the process down.  It never returns; callers rely on that.
+//
+// Both steps have a panic backstop.  Reporting the reason is a blocking send
+// on the unbuffered failureReportChan, so we time it out: if the monitor
+// isn't reading (e.g. it hasn't started yet at start-of-day), we panic rather
+// than deadlock.  Once the reason is delivered we wait out the remainder of
+// the same timer and panic if the managed shutdown hasn't finished.
 func (fc *DataplaneConnector) shutDownProcess(reason string) {
-	// Send a failure report to the managed shutdown thread then give it
-	// a few seconds to do the shutdown.
-	fc.failureReportChan <- reason
-	time.Sleep(5 * time.Second)
-	// The graceful shutdown failed, terminate the process.
+	timeout := time.After(fc.shutdownReportTimeout)
+	select {
+	case fc.failureReportChan <- reason:
+	case <-timeout:
+		log.Panic("Managed shutdown failed: timed out reporting shutdown reason. Panicking.")
+	}
+	// time.After fires only once; the send won the select above, so this
+	// receives the eventual tick, giving the monitor the full timeout to
+	// tear us down.
+	<-timeout
 	log.Panic("Managed shutdown failed. Panicking.")
 }
 

--- a/felix/daemon/shutdown_test.go
+++ b/felix/daemon/shutdown_test.go
@@ -1,0 +1,68 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package daemon
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("shutDownProcess", func() {
+	// shutDownProcess never returns: it reports the reason to the shutdown
+	// monitor and then panics as a backstop.  Run it in a goroutine and
+	// recover so a stray panic can't outlive the spec.
+	runInBackground := func(fc *DataplaneConnector, reason string) <-chan any {
+		panicked := make(chan any, 1)
+		go func() {
+			defer func() { panicked <- recover() }()
+			fc.shutDownProcess(reason)
+		}()
+		return panicked
+	}
+
+	// Regression test for the start-of-day deadlock: if the shutdown monitor
+	// (the only reader of failureReportChan) hasn't started, the report send
+	// must not block forever.  Before the fix, the panic backstop sat after
+	// an unconditional blocking send, so this hung indefinitely.
+	It("panics instead of blocking when the shutdown monitor never reads", func() {
+		fc := &DataplaneConnector{
+			failureReportChan:     make(chan string), // Unbuffered, no reader.
+			shutdownReportTimeout: 100 * time.Millisecond,
+		}
+
+		panicked := runInBackground(fc, reasonConfigChanged)
+		Eventually(panicked, "5s").Should(Receive(Not(BeNil())))
+	})
+
+	It("delivers the reason to the monitor and then panics as a backstop", func() {
+		reportChan := make(chan string)
+		fc := &DataplaneConnector{
+			failureReportChan:     reportChan,
+			shutdownReportTimeout: 100 * time.Millisecond,
+		}
+
+		received := make(chan string, 1)
+		go func() { received <- <-reportChan }()
+
+		panicked := runInBackground(fc, reasonConfigChanged)
+
+		// The reason reaches the monitor: the send is not lost.
+		Eventually(received, "5s").Should(Receive(Equal(reasonConfigChanged)))
+		// The backstop still fires once the monitor fails to tear us down.
+		Eventually(panicked, "5s").Should(Receive(Not(BeNil())))
+	})
+})


### PR DESCRIPTION
Bug fix for a rare but permanent start-of-day deadlock in Felix, seen as an FV flake ("Spoof tests ... should drop spoofed traffic" timing out waiting for felix to restart after `NodeIP`/`IpInIpTunnelAddr` were written during topology setup).

The deadlock is a three-way cycle in `daemon.Run()`:

1. The calc graph was started before the opening `ConfigUpdate` was sent to the dataplane connector. Its first flushed event is always a `ConfigUpdate` (`EventSequencer.Flush()` flushes config first), so it could win the race onto the unbuffered `ToDataplane` channel.
2. If that `ConfigUpdate` carried a restart-requiring change, the connector pump parked in `shutDownProcess()` on an unconditional send to the unbuffered `failureReportChan` — whose only reader, `monitorAndManageShutdown()`, had not started yet.
3. The main goroutine could never start it: it was parked sending the opening `ConfigUpdate` that the pump would never consume. The panic backstop in `shutDownProcess()` sat *after* the blocking send, so it never fired; felix hung forever instead of restarting.

Changes:

- **Reorder start of day**: start the calc graph only after the opening `ConfigUpdate` has been handed to the connector. This removes the deadlock's enabling condition structurally (at the handoff, main is the only sender and has no further blocking channel ops before the shutdown monitor starts) and restores the documented protocol ordering — the dataplane driver receives its config before the stream of calc-graph updates ("ConfigUpdate is sent at start of day", `felixbackend.proto`).
- **Make the shutdown backstops reachable** (defence in depth): `shutDownProcess()` and the config-changed/fatal-error callbacks now time out their failure-report send, so a stuck send panics (and restarts felix) rather than deadlocking. `shutDownProcess()`'s backstop is extended from 5s to `gracefulShutdownTimeout` (30s) so it cannot beat a legitimately slow external-driver shutdown (~7s worst case in the monitor's kill path).
- **Regression test**: `felix/daemon/shutdown_test.go` asserts `shutDownProcess()` panics rather than blocking forever when the shutdown monitor never reads (hangs on the old code), and that the reason is still delivered when a reader exists.

Testing: new UTs plus the existing `felix/daemon` suite pass; `go vet` clean. The reordered graceful-restart path is exercised by the existing FV restart tests; the original failure is timing-dependent and not reproducible on demand.

**Release note:**
```release-note
Fixed a rare start-of-day deadlock that could prevent Felix from restarting when a restart-requiring configuration change (e.g. the node IP being set) arrived while Felix was still starting up.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)