### PR TITLE
felix: support a host capability fallback for NFTablesMode=Auto

### DIFF
--- a/api/config/crd/projectcalico.org_felixconfigurations.yaml
+++ b/api/config/crd/projectcalico.org_felixconfigurations.yaml
@@ -1120,9 +1120,10 @@ spec:
                   type: integer
                 nftablesMode:
                   default: Auto
-                  description:
-                    "NFTablesMode configures nftables support in Felix. [Default:
-                    Auto]"
+                  description: |-
+                    NFTablesMode configures nftables support in Felix. In Auto mode, Felix uses the
+                    nftables dataplane if kube-proxy is detected to be running in nftables mode.
+                    [Default: Auto]
                   enum:
                     - Disabled
                     - Enabled

--- a/api/pkg/apis/projectcalico/v3/felixconfig.go
+++ b/api/pkg/apis/projectcalico/v3/felixconfig.go
@@ -674,7 +674,9 @@ type FelixConfigurationSpec struct {
 	// iptables. [Default: false]
 	GenericXDPEnabled *bool `json:"genericXDPEnabled,omitempty" confignamev1:"GenericXDPEnabled"`
 
-	// NFTablesMode configures nftables support in Felix. [Default: Auto]
+	// NFTablesMode configures nftables support in Felix. In Auto mode, Felix uses the
+	// nftables dataplane if kube-proxy is detected to be running in nftables mode.
+	// [Default: Auto]
 	// +kubebuilder:default=Auto
 	NFTablesMode *NFTablesMode `json:"nftablesMode,omitempty"`
 

--- a/api/pkg/client/applyconfiguration_generated/projectcalico/v3/felixconfigurationspec.go
+++ b/api/pkg/client/applyconfiguration_generated/projectcalico/v3/felixconfigurationspec.go
@@ -358,7 +358,9 @@ type FelixConfigurationSpecApplyConfiguration struct {
 	// modes can use XDP. This is not recommended since it doesn't provide better performance than
 	// iptables. [Default: false]
 	GenericXDPEnabled *bool `json:"genericXDPEnabled,omitempty"`
-	// NFTablesMode configures nftables support in Felix. [Default: Auto]
+	// NFTablesMode configures nftables support in Felix. In Auto mode, Felix uses the
+	// nftables dataplane if kube-proxy is detected to be running in nftables mode.
+	// [Default: Auto]
 	NFTablesMode *projectcalicov3.NFTablesMode `json:"nftablesMode,omitempty"`
 	// NftablesRefreshInterval controls the interval at which Felix periodically refreshes the nftables rules. [Default: 90s]
 	NftablesRefreshInterval *v1.Duration `json:"nftablesRefreshInterval,omitempty"`

--- a/api/pkg/openapi/generated.openapi.go
+++ b/api/pkg/openapi/generated.openapi.go
@@ -3694,7 +3694,7 @@ func schema_pkg_apis_projectcalico_v3_FelixConfigurationSpec(ref common.Referenc
 					},
 					"nftablesMode": {
 						SchemaProps: spec.SchemaProps{
-							Description: "NFTablesMode configures nftables support in Felix. [Default: Auto]\n\nPossible enum values:\n - `\"Auto\"`\n - `\"Disabled\"`\n - `\"Enabled\"`",
+							Description: "NFTablesMode configures nftables support in Felix. In Auto mode, Felix uses the nftables dataplane if kube-proxy is detected to be running in nftables mode. [Default: Auto]\n\nPossible enum values:\n - `\"Auto\"`\n - `\"Disabled\"`\n - `\"Enabled\"`",
 							Type:        []string{"string"},
 							Format:      "",
 							Enum:        []interface{}{"Auto", "Disabled", "Enabled"},

--- a/felix/DESIGN.md
+++ b/felix/DESIGN.md
@@ -162,6 +162,16 @@ Felix runs against one dataplane at a time (selected by
 - **Windows** (HNS/HCN) — separate dataplane in
   `dataplane/windows/`.
 
+`NFTablesMode=Auto` resolves by following the detected kube-proxy
+mode: an nftables-mode kube-proxy selects the nftables dataplane.
+That signal is about coexistence — Felix must use the same
+netfilter generation as kube-proxy — not host capability, so it
+must not be replaced by a capability probe on cluster hosts. See
+`useNftables()` in `dataplane/linux/int_dataplane.go`. The
+per-host escape hatch is `NFTablesMode=Disabled`/`Enabled` set
+locally (env var or config file), which overrides any
+datastore-inherited value.
+
 The `iptables` and `nftables` backends share a common rule-
 generation layer in `felix/rules/` and a common table-abstraction
 interface in `felix/generictables/`. Backend-neutral rule

--- a/felix/dataplane/linux/int_dataplane.go
+++ b/felix/dataplane/linux/int_dataplane.go
@@ -473,7 +473,7 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 	if err != nil {
 		log.WithError(err).Panic("Unable to detect kube-proxy nftables mode, shutting down")
 	}
-	nftablesEnabled := useNftables(config.RulesConfig.NFTablesMode, kubeProxyNftablesEnabled)
+	nftablesEnabled := useNftables(config.RulesConfig.NFTablesMode, kubeProxyNftablesEnabled, nil)
 
 	ruleRenderer := config.RuleRendererOverride
 	if ruleRenderer == nil {
@@ -1557,14 +1557,21 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 }
 
 // useNftables determines whether to use nftables based on the FelixConfig setting and
-// kube-proxy mode.
-func useNftables(mode string, proxyEnabled bool) bool {
+// the detected kube-proxy mode. In Auto mode, hostNftablesSupported, if non-nil, is
+// consulted as a fallback when kube-proxy is not detected to be in nftables mode.
+// Only supply it on hosts that never run kube-proxy (hosts outside any cluster): a
+// cluster host must follow its kube-proxy so that the two use the same dataplane.
+func useNftables(mode string, proxyEnabled bool, hostNftablesSupported func() bool) bool {
 	use := false
 
 	switch mode {
 	case "Auto":
-		// Detect based on kube-proxy mode.
+		// Detect based on kube-proxy mode, falling back to the host's own
+		// nftables support where there is no kube-proxy to give that signal.
 		use = proxyEnabled
+		if !use && hostNftablesSupported != nil {
+			use = hostNftablesSupported()
+		}
 	case "Enabled":
 		use = true
 	}

--- a/felix/dataplane/linux/nftables_detect_test.go
+++ b/felix/dataplane/linux/nftables_detect_test.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !windows
+
+package intdataplane
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	v3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
+)
+
+var _ = Describe("useNftables", func() {
+	var hostSupportConsulted bool
+	hostSupport := func(supported bool) func() bool {
+		return func() bool {
+			hostSupportConsulted = true
+			return supported
+		}
+	}
+
+	BeforeEach(func() {
+		hostSupportConsulted = false
+	})
+
+	It("should be disabled in Disabled mode regardless of detection", func() {
+		Expect(useNftables(string(v3.NFTablesModeDisabled), true, hostSupport(true))).To(BeFalse())
+		Expect(hostSupportConsulted).To(BeFalse())
+	})
+
+	It("should be enabled in Enabled mode regardless of detection", func() {
+		// hostSupport says false so a consult, if it happened, would also
+		// flip the result.
+		Expect(useNftables(string(v3.NFTablesModeEnabled), false, hostSupport(false))).To(BeTrue())
+		Expect(hostSupportConsulted).To(BeFalse())
+	})
+
+	It("Auto: should follow kube-proxy when no host capability check is supplied", func() {
+		Expect(useNftables(string(v3.NFTablesModeAuto), true, nil)).To(BeTrue())
+		Expect(useNftables(string(v3.NFTablesModeAuto), false, nil)).To(BeFalse())
+	})
+
+	It("Auto: should use the host capability check when kube-proxy is not detected", func() {
+		Expect(useNftables(string(v3.NFTablesModeAuto), false, hostSupport(true))).To(BeTrue())
+		Expect(hostSupportConsulted).To(BeTrue())
+	})
+
+	It("Auto: should fall back to iptables on an unsupported host", func() {
+		Expect(useNftables(string(v3.NFTablesModeAuto), false, hostSupport(false))).To(BeFalse())
+		Expect(hostSupportConsulted).To(BeTrue())
+	})
+
+	It("Auto: should prefer the kube-proxy signal over the host capability check", func() {
+		Expect(useNftables(string(v3.NFTablesModeAuto), true, hostSupport(false))).To(BeTrue())
+		Expect(hostSupportConsulted).To(BeFalse())
+	})
+})

--- a/felix/docs/config-params.json
+++ b/felix/docs/config-params.json
@@ -2156,8 +2156,8 @@
           "Required": false,
           "OnParseFailure": "ReplaceWithDefault",
           "AllowedConfigSources": "All",
-          "Description": "Configures nftables support in Felix.",
-          "DescriptionHTML": "<p>Configures nftables support in Felix.</p>",
+          "Description": "Configures nftables support in Felix. In Auto mode, Felix uses the\nnftables dataplane if kube-proxy is detected to be running in nftables mode.",
+          "DescriptionHTML": "<p>Configures nftables support in Felix. In Auto mode, Felix uses the\nnftables dataplane if kube-proxy is detected to be running in nftables mode.</p>",
           "UserEditable": true,
           "GoType": "*v3.NFTablesMode"
         },

--- a/felix/docs/config-params.md
+++ b/felix/docs/config-params.md
@@ -1163,7 +1163,8 @@ network stack is used.
 
 ### `NFTablesMode` (config file) / `nftablesMode` (YAML)
 
-Configures nftables support in Felix.
+Configures nftables support in Felix. In Auto mode, Felix uses the
+nftables dataplane if kube-proxy is detected to be running in nftables mode.
 
 | Detail |   |
 | --- | --- |

--- a/felix/nftables/utils.go
+++ b/felix/nftables/utils.go
@@ -15,14 +15,80 @@ package nftables
 
 import (
 	"context"
+	"io"
 	"time"
 
 	log "github.com/sirupsen/logrus"
 	"sigs.k8s.io/knftables"
+
+	"github.com/projectcalico/calico/felix/environment"
 )
 
 // NewNftablesDataplaneFn is a function type that creates a new nftables dataplane interface.
 type NewNftablesDataplaneFn func(knftables.Family, string, ...knftables.Option) (knftables.Interface, error)
+
+// MinKernelVersionForNftables is the minimum kernel version required for the
+// native nftables dataplane. Calico's documented nftables requirement is
+// "Linux kernel version 5.13 or later with nft >= 1.0.1"
+// (https://docs.tigera.io/calico/latest/getting-started/kubernetes/nftables),
+// mirroring kube-proxy's nftables mode requirement
+// (https://kubernetes.io/docs/reference/networking/virtual-ips/#proxy-mode-nftables).
+// The nft half of the requirement is enforced by knftables itself, which
+// refuses to drive an nft binary older than v1.0.1. Older kernels (e.g.
+// RHEL 8's 4.18) cannot reliably run the nftables dataplane under churn.
+var MinKernelVersionForNftables = environment.MustParseVersion("5.13")
+
+// HostNftablesSupportedFn returns a function that reports whether this host
+// meets the minimum requirements for the native nftables dataplane:
+//
+//   - a usable nft binary of a supported version (knftables enforces >= v1.0.1), and
+//   - a kernel of at least MinKernelVersionForNftables.
+//
+// It is used to resolve NFTablesMode=Auto on hosts that run no kube-proxy,
+// where the kube-proxy-based detection gives no signal.
+// Both dependencies are injectable for testing; pass nil for the defaults.
+func HostNftablesSupportedFn(newDataplane NewNftablesDataplaneFn, getKernelVersion func() (*environment.Version, error)) func() bool {
+	if newDataplane == nil {
+		newDataplane = knftables.New
+	}
+	if getKernelVersion == nil {
+		getKernelVersion = func() (*environment.Version, error) {
+			reader, err := environment.GetKernelVersionReader()
+			if err != nil {
+				return nil, err
+			}
+			if closer, ok := reader.(io.Closer); ok {
+				defer closer.Close()
+			}
+			return environment.GetKernelVersion(reader)
+		}
+	}
+
+	return func() bool {
+		kernelVersion, err := getKernelVersion()
+		if err != nil {
+			log.WithError(err).Warn(
+				"Failed to determine kernel version; assuming this host does not support the nftables dataplane.")
+			return false
+		}
+		if kernelVersion.Compare(MinKernelVersionForNftables) < 0 {
+			log.WithFields(log.Fields{
+				"kernelVersion": kernelVersion,
+				"minVersion":    MinKernelVersionForNftables,
+			}).Info("Kernel is older than the minimum required for the nftables dataplane.")
+			return false
+		}
+		if _, err := newDataplane(knftables.IPv4Family, "calico"); err != nil {
+			// knftables validates that the nft binary is present and recent
+			// enough for it to drive.
+			log.WithError(err).Info("This host does not have a usable nft binary for the nftables dataplane.")
+			return false
+		}
+		log.WithField("kernelVersion", kernelVersion).Info(
+			"This host meets the minimum requirements for the nftables dataplane.")
+		return true
+	}
+}
 
 // KubeProxyNftablesEnabledFn returns a function that can be used to check if kube-proxy is running
 // in nftables mode. It does this by checking for the presence of the nftables chains that

--- a/felix/nftables/utils_test.go
+++ b/felix/nftables/utils_test.go
@@ -1,0 +1,63 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nftables_test
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"sigs.k8s.io/knftables"
+
+	"github.com/projectcalico/calico/felix/environment"
+	"github.com/projectcalico/calico/felix/nftables"
+)
+
+var _ = Describe("HostNftablesSupportedFn", func() {
+	nftUsable := func(fam knftables.Family, name string, _ ...knftables.Option) (knftables.Interface, error) {
+		return NewFake(fam, name), nil
+	}
+	nftUnusable := func(knftables.Family, string, ...knftables.Option) (knftables.Interface, error) {
+		return nil, fmt.Errorf("nft version must be v1.0.1 or later")
+	}
+	kernel := func(version string) func() (*environment.Version, error) {
+		return func() (*environment.Version, error) {
+			return environment.MustParseVersion(version), nil
+		}
+	}
+	kernelErr := func() (*environment.Version, error) {
+		return nil, fmt.Errorf("cannot read /proc/version")
+	}
+
+	It("should report supported with a new enough kernel and a usable nft", func() {
+		Expect(nftables.HostNftablesSupportedFn(nftUsable, kernel("5.14.0"))()).To(BeTrue())
+	})
+
+	It("should report unsupported on an old kernel (RHEL 8)", func() {
+		Expect(nftables.HostNftablesSupportedFn(nftUsable, kernel("4.18.0"))()).To(BeFalse())
+	})
+
+	It("should report unsupported just below the minimum kernel", func() {
+		Expect(nftables.HostNftablesSupportedFn(nftUsable, kernel("5.12.19"))()).To(BeFalse())
+	})
+
+	It("should report unsupported when the nft binary is missing or too old", func() {
+		Expect(nftables.HostNftablesSupportedFn(nftUnusable, kernel("6.1.0"))()).To(BeFalse())
+	})
+
+	It("should report unsupported when the kernel version cannot be determined", func() {
+		Expect(nftables.HostNftablesSupportedFn(nftUsable, kernelErr)()).To(BeFalse())
+	})
+})

--- a/libcalico-go/config/crd/crd.projectcalico.org_felixconfigurations.yaml
+++ b/libcalico-go/config/crd/crd.projectcalico.org_felixconfigurations.yaml
@@ -1121,9 +1121,10 @@ spec:
                   type: integer
                 nftablesMode:
                   default: Auto
-                  description:
-                    "NFTablesMode configures nftables support in Felix. [Default:
-                    Auto]"
+                  description: |-
+                    NFTablesMode configures nftables support in Felix. In Auto mode, Felix uses the
+                    nftables dataplane if kube-proxy is detected to be running in nftables mode.
+                    [Default: Auto]
                   enum:
                     - Disabled
                     - Enabled

--- a/manifests/calico-bpf.yaml
+++ b/manifests/calico-bpf.yaml
@@ -3140,9 +3140,10 @@ spec:
                   type: integer
                 nftablesMode:
                   default: Auto
-                  description:
-                    "NFTablesMode configures nftables support in Felix. [Default:
-                    Auto]"
+                  description: |-
+                    NFTablesMode configures nftables support in Felix. In Auto mode, Felix uses the
+                    nftables dataplane if kube-proxy is detected to be running in nftables mode.
+                    [Default: Auto]
                   enum:
                     - Disabled
                     - Enabled

--- a/manifests/calico-policy-only.yaml
+++ b/manifests/calico-policy-only.yaml
@@ -3150,9 +3150,10 @@ spec:
                   type: integer
                 nftablesMode:
                   default: Auto
-                  description:
-                    "NFTablesMode configures nftables support in Felix. [Default:
-                    Auto]"
+                  description: |-
+                    NFTablesMode configures nftables support in Felix. In Auto mode, Felix uses the
+                    nftables dataplane if kube-proxy is detected to be running in nftables mode.
+                    [Default: Auto]
                   enum:
                     - Disabled
                     - Enabled

--- a/manifests/calico-typha.yaml
+++ b/manifests/calico-typha.yaml
@@ -3151,9 +3151,10 @@ spec:
                   type: integer
                 nftablesMode:
                   default: Auto
-                  description:
-                    "NFTablesMode configures nftables support in Felix. [Default:
-                    Auto]"
+                  description: |-
+                    NFTablesMode configures nftables support in Felix. In Auto mode, Felix uses the
+                    nftables dataplane if kube-proxy is detected to be running in nftables mode.
+                    [Default: Auto]
                   enum:
                     - Disabled
                     - Enabled

--- a/manifests/calico-v3-crds.yaml
+++ b/manifests/calico-v3-crds.yaml
@@ -3249,9 +3249,10 @@ spec:
                   type: integer
                 nftablesMode:
                   default: Auto
-                  description:
-                    "NFTablesMode configures nftables support in Felix. [Default:
-                    Auto]"
+                  description: |-
+                    NFTablesMode configures nftables support in Felix. In Auto mode, Felix uses the
+                    nftables dataplane if kube-proxy is detected to be running in nftables mode.
+                    [Default: Auto]
                   enum:
                     - Disabled
                     - Enabled

--- a/manifests/calico-vxlan.yaml
+++ b/manifests/calico-vxlan.yaml
@@ -3135,9 +3135,10 @@ spec:
                   type: integer
                 nftablesMode:
                   default: Auto
-                  description:
-                    "NFTablesMode configures nftables support in Felix. [Default:
-                    Auto]"
+                  description: |-
+                    NFTablesMode configures nftables support in Felix. In Auto mode, Felix uses the
+                    nftables dataplane if kube-proxy is detected to be running in nftables mode.
+                    [Default: Auto]
                   enum:
                     - Disabled
                     - Enabled

--- a/manifests/calico.yaml
+++ b/manifests/calico.yaml
@@ -3135,9 +3135,10 @@ spec:
                   type: integer
                 nftablesMode:
                   default: Auto
-                  description:
-                    "NFTablesMode configures nftables support in Felix. [Default:
-                    Auto]"
+                  description: |-
+                    NFTablesMode configures nftables support in Felix. In Auto mode, Felix uses the
+                    nftables dataplane if kube-proxy is detected to be running in nftables mode.
+                    [Default: Auto]
                   enum:
                     - Disabled
                     - Enabled

--- a/manifests/canal.yaml
+++ b/manifests/canal.yaml
@@ -3152,9 +3152,10 @@ spec:
                   type: integer
                 nftablesMode:
                   default: Auto
-                  description:
-                    "NFTablesMode configures nftables support in Felix. [Default:
-                    Auto]"
+                  description: |-
+                    NFTablesMode configures nftables support in Felix. In Auto mode, Felix uses the
+                    nftables dataplane if kube-proxy is detected to be running in nftables mode.
+                    [Default: Auto]
                   enum:
                     - Disabled
                     - Enabled

--- a/manifests/crds.yaml
+++ b/manifests/crds.yaml
@@ -3049,9 +3049,10 @@ spec:
                   type: integer
                 nftablesMode:
                   default: Auto
-                  description:
-                    "NFTablesMode configures nftables support in Felix. [Default:
-                    Auto]"
+                  description: |-
+                    NFTablesMode configures nftables support in Felix. In Auto mode, Felix uses the
+                    nftables dataplane if kube-proxy is detected to be running in nftables mode.
+                    [Default: Auto]
                   enum:
                     - Disabled
                     - Enabled

--- a/manifests/flannel-migration/calico.yaml
+++ b/manifests/flannel-migration/calico.yaml
@@ -3135,9 +3135,10 @@ spec:
                   type: integer
                 nftablesMode:
                   default: Auto
-                  description:
-                    "NFTablesMode configures nftables support in Felix. [Default:
-                    Auto]"
+                  description: |-
+                    NFTablesMode configures nftables support in Felix. In Auto mode, Felix uses the
+                    nftables dataplane if kube-proxy is detected to be running in nftables mode.
+                    [Default: Auto]
                   enum:
                     - Disabled
                     - Enabled

--- a/manifests/operator-crds.yaml
+++ b/manifests/operator-crds.yaml
@@ -37993,9 +37993,10 @@ spec:
                   type: integer
                 nftablesMode:
                   default: Auto
-                  description:
-                    "NFTablesMode configures nftables support in Felix. [Default:
-                    Auto]"
+                  description: |-
+                    NFTablesMode configures nftables support in Felix. In Auto mode, Felix uses the
+                    nftables dataplane if kube-proxy is detected to be running in nftables mode.
+                    [Default: Auto]
                   enum:
                     - Disabled
                     - Enabled

--- a/manifests/v1_crd_projectcalico_org.yaml
+++ b/manifests/v1_crd_projectcalico_org.yaml
@@ -37993,9 +37993,10 @@ spec:
                   type: integer
                 nftablesMode:
                   default: Auto
-                  description:
-                    "NFTablesMode configures nftables support in Felix. [Default:
-                    Auto]"
+                  description: |-
+                    NFTablesMode configures nftables support in Felix. In Auto mode, Felix uses the
+                    nftables dataplane if kube-proxy is detected to be running in nftables mode.
+                    [Default: Auto]
                   enum:
                     - Disabled
                     - Enabled

--- a/manifests/v3_projectcalico_org.yaml
+++ b/manifests/v3_projectcalico_org.yaml
@@ -38100,9 +38100,10 @@ spec:
                   type: integer
                 nftablesMode:
                   default: Auto
-                  description:
-                    "NFTablesMode configures nftables support in Felix. [Default:
-                    Auto]"
+                  description: |-
+                    NFTablesMode configures nftables support in Felix. In Auto mode, Felix uses the
+                    nftables dataplane if kube-proxy is detected to be running in nftables mode.
+                    [Default: Auto]
                   enum:
                     - Disabled
                     - Enabled


### PR DESCRIPTION
NFTablesMode=Auto resolves via kube-proxy detection, which gives no signal on a host that does not run kube-proxy: today such hosts always fall back to iptables. As more distros drop the iptables/ipset userspace in favor of nftables, hosts capable of running the nftables dataplane should be able to select it without per-distro pinned configuration.

Add a host capability check that useNftables consults in Auto mode, when supplied, as a fallback when kube-proxy is not detected: the host must have a usable nft binary (knftables enforces >= v1.0.1) and a kernel of at least 5.13. These floors are Calico's documented nftables requirement ("Linux kernel version 5.13 or later with nft >= 1.0.1"), which mirrors kube-proxy's own nftables mode requirement. That keeps e.g. RHEL 9+/Debian 12+/Ubuntu 22.04+ on nftables while RHEL 8 (4.18 kernel, nft 0.9.x) stays on iptables.

Nothing supplies the fallback yet, so behavior is unchanged: in a cluster, Auto must keep following kube-proxy - that signal is about running the same dataplane as kube-proxy, not about host capability. The caller for hosts that never run kube-proxy arrives separately.

Also document the existing Auto-mode resolution: on the NFTablesMode API field description (CRDs/docs regenerated) and in a paragraph in felix/DESIGN.md's "Dataplane backends" section.

<!-- Describe your changes, including the type of change (bug fix, feature, etc.),
why it should be merged, testing done, and links to related issues. -->

<!-- For any user-visible change, replace TBD with a one-line description. -->
**Release note:**
```release-note
TBD
```
