### PR TITLE
ci: disambiguate release tool error messages [release-v3.31]

### DIFF
--- a/release/pkg/manager/calico/manager.go
+++ b/release/pkg/manager/calico/manager.go
@@ -397,7 +397,7 @@ func (r *CalicoManager) PreHashreleaseValidate() error {
 		match := fmt.Sprintf(`^(%s|%s-v\d+\.\d+(?:-\d+)?)$`, utils.DefaultBranch, r.releaseBranchPrefix)
 		re := regexp.MustCompile(match)
 		if !re.MatchString(branch) {
-			errStack = errors.Join(errStack, fmt.Errorf("not on a release branch"))
+			errStack = errors.Join(errStack, fmt.Errorf("calico checkout is not on a release branch"))
 		}
 	}
 	dirty, err := utils.GitIsDirty(r.repoRoot)

--- a/release/pkg/manager/operator/manager.go
+++ b/release/pkg/manager/operator/manager.go
@@ -234,7 +234,7 @@ func (o *OperatorManager) PreBuildValidation() error {
 		match := fmt.Sprintf(`^(%s|%s-v\d+\.\d+(?:-\d+)?)$`, utils.DefaultBranch, o.releaseBranchPrefix)
 		re := regexp.MustCompile(match)
 		if !re.MatchString(branch) {
-			errStack = errors.Join(errStack, fmt.Errorf("not on a release branch"))
+			errStack = errors.Join(errStack, fmt.Errorf("operator checkout is not on a release branch"))
 		}
 		dirty, err := utils.GitIsDirty(o.dir)
 		if err != nil {


### PR DESCRIPTION
Cherry-pick of #13178 onto `release-v3.31`.

Original PR: https://github.com/projectcalico/calico/pull/13178

