### PR TITLE
ci: verify semaphore.yml in the Go-consistency preflight job

### DIFF
--- a/.semaphore/semaphore-scheduled-builds.yml
+++ b/.semaphore/semaphore-scheduled-builds.yml
@@ -293,6 +293,9 @@ blocks:
             - make check-go-mod
             - make verify-go-mods
             - make gen-deps-files
+            # semaphore.yml is generated from the live Go import graph (same tool
+            # as deps.txt), so regenerate it here too.
+            - make gen-semaphore-yaml
             - make go-vet
             - >-
               if [ -n "$SEMAPHORE_GIT_PR_NUMBER" ]; then

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -293,6 +293,9 @@ blocks:
             - make check-go-mod
             - make verify-go-mods
             - make gen-deps-files
+            # semaphore.yml is generated from the live Go import graph (same tool
+            # as deps.txt), so regenerate it here too.
+            - make gen-semaphore-yaml
             - make go-vet
             - >-
               if [ -n "$SEMAPHORE_GIT_PR_NUMBER" ]; then

--- a/.semaphore/semaphore.yml.d/blocks/10-prerequisites.yml
+++ b/.semaphore/semaphore.yml.d/blocks/10-prerequisites.yml
@@ -45,6 +45,9 @@
           - make check-go-mod
           - make verify-go-mods
           - make gen-deps-files
+          # semaphore.yml is generated from the live Go import graph (same tool
+          # as deps.txt), so regenerate it here too.
+          - make gen-semaphore-yaml
           - make go-vet
           - >-
             if [ -n "$SEMAPHORE_GIT_PR_NUMBER" ]; then


### PR DESCRIPTION
## Description

`.semaphore/semaphore.yml` is generated by `hack/cmd/deps` from the **live Go import graph** — the same tool and inputs that produce the per-component `deps.txt` files. Its per-block `change_in` globs are literally the transitive dependency set of each component.

However, the CI guard that keeps it fresh ("Check SemaphoreCI files") only triggers on:

```
change_in(['/.semaphore', '/hack', '/Makefile', '/lib.Makefile', '/metadata.mk'])
```

So a PR that merely adds or imports a new Go package (e.g. `lib/std/log`) produces correct-but-different `semaphore.yml` output **without touching any path that fires that guard**. The stale file then sits latent until an unrelated `.semaphore`-touching PR finally trips the guard and fails `check-dirty` on globs it never introduced (this is what #13182 had to clean up).

`deps.txt` never has this problem because it is regenerated and `check-dirty`'d inside the **"Check Go"** job, which triggers on `/**/*.go` and `/**/deps.txt`.

### Fix

Run `make gen-semaphore-yaml` in the "Check Go" job too (right after `gen-deps-files`), so its sibling generated file is verified by the same Go-triggered job — by construction, the two files derived from the same source of truth can no longer diverge. The standalone "Check SemaphoreCI files" job keeps its narrow trigger to cover template / `hack` / Makefile edits that don't touch Go sources.

Only the template (`10-prerequisites.yml`) is hand-edited; the two generated files are `make gen-semaphore-yaml` output.

### Why "Check Go" and not a broader "Check SemaphoreCI files" trigger?

The other obvious fix is to broaden the "Check SemaphoreCI files" `when:` to also list the Go-source inputs (`/**/*.go`, `/**/deps.txt`, `/go.mod`, `/go.sum`). We chose to fold the regeneration into "Check Go" instead, for three reasons:

1. **Fixes the cause by symmetry, not by re-listing globs.** `semaphore.yml` and `deps.txt` are computed from the *same inputs by the same tool*. `deps.txt` has never gone stale precisely because it is regenerated and `check-dirty`'d in the Go-triggered job. Regenerating its sibling in that same job makes them consistent *by construction*, rather than relying on a hand-maintained trigger list staying in sync with the real input set — the very kind of list that drifted here in the first place.

2. **Cheaper.** By the time "Check Go" runs, it has already loaded every package for `gen-deps-files` and `go-vet`, so the marginal cost is one more `go run` against warm caches. Broadening the standalone job's trigger would instead spin up a **dedicated** job that re-loads the whole import graph from scratch on nearly every PR (almost every PR touches a `.go` file).

3. **Coverage stays complete with no duplication.** "Check Go" now covers the Go-import vector; the untouched "Check SemaphoreCI files" job still covers the other vector — `.semaphore` template, `hack/`, and Makefile edits that change `semaphore.yml` without touching any `.go` file. Between the two, every input to `semaphore.yml` is guarded, and neither job re-does the other's work.

## Release Note

```release-note
None
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.
- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.
- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.
