### PR TITLE
Harden run-and-monitor against Semaphore agent job hangs

### DIFF
--- a/.semaphore/run-and-monitor
+++ b/.semaphore/run-and-monitor
@@ -81,7 +81,7 @@ grep_args+=( "-e" "${pattern:1}" )
 # Semaphore agent's command-completion marker detection, hanging the job.
 function sanitize()
 {
-  stdbuf -oL tr -d '\000-\010\013\014\016-\032\034-\037\177'
+  LC_ALL=C stdbuf -oL tr -d '\000-\010\013\014\016-\032\034-\037\177'
 }
 
 tail --pid $pid -n 1000000 -F "$log_file" | {

--- a/.semaphore/run-and-monitor
+++ b/.semaphore/run-and-monitor
@@ -24,6 +24,14 @@ log_monitor_regexps=(
   "Test batch"
 )
 
+# Save the terminal state so we can restore it before our final output.  The
+# wrapped command can leave the terminal in a bad state (for example with
+# output post-processing disabled); the Semaphore agent detects command
+# completion by scanning the terminal output for a marker, and a corrupted
+# terminal state can prevent that marker from being recognised, hanging the
+# job until it times out.
+saved_stty="$(stty -g < /dev/tty 2>/dev/null || true)"
+
 echo "Current dir: $(pwd)"
 my_dir="$(dirname $0)"
 repo_dir="${my_dir}/.."
@@ -67,12 +75,21 @@ for r in "${log_monitor_regexps[@]}"; do
 done
 grep_args+=( "-e" "${pattern:1}" )
 
+# Strip control characters (keeping tab, newline, CR and the ANSI colour
+# escape) from everything we copy from the log to the console.  Test output
+# can contain binary junk, and a raw 0x01 byte in particular confuses the
+# Semaphore agent's command-completion marker detection, hanging the job.
+function sanitize()
+{
+  stdbuf -oL tr -d '\000-\010\013\014\016-\032\034-\037\177'
+}
+
 tail --pid $pid -n 1000000 -F "$log_file" | {
   # Always output the first n lines.
   head -n $num_unfiltered_lines;
   echo "---- Output to screen filtered from here ----";
   grep "${grep_args[@]}";
-} &
+} | sanitize &
 mon_pid=$!
 
 final_result=1
@@ -80,13 +97,26 @@ final_msg="==== Command ${cmd_escaped}INTERRUPTED (PID=$pid).  Full command outp
 cmd_done=false
 function cleanup()
 {
-  kill $mon_pid || true
   if ! $cmd_done; then
     echo "==== Stopping command PID=${pid}..."
     kill $pid || true
   fi
 
   sleep 1 # So tail and grep can finish after stopping the main process.
+
+  # Kill the monitor and wait for it to die so that nothing can write to the
+  # console after our final output.  $mon_pid is the sanitizer, the last
+  # element of the pipeline; killing it severs the monitor's access to the
+  # console and the upstream elements then exit on SIGPIPE/EOF.
+  kill $mon_pid 2>/dev/null || true
+  wait $mon_pid 2>/dev/null || true
+
+  # Undo any terminal state changes made by the wrapped command; see comment
+  # at the top of the file.
+  if [ -n "$saved_stty" ]; then
+    stty "$saved_stty" < /dev/tty 2>/dev/null || true
+  fi
+
   output-tail
   echo "$final_msg; exit with RC=$final_result"
   exit $final_result
@@ -97,14 +127,14 @@ function output-tail()
 {
   # Output the last num_unfiltered_lines lines of the log, unless the log is short, in which case
   # don't log lines that were already logged by head, above.
-  num_lines=$(wc "$log_file" | cut -d ' ' -f1)
+  num_lines=$(wc -l < "$log_file")
   if (( num_lines > num_unfiltered_lines )); then
     num_lines_to_tail=$(( num_lines - num_unfiltered_lines ))
     if (( num_lines_to_tail > num_unfiltered_lines )); then
       num_lines_to_tail=$num_unfiltered_lines
     fi
     echo "---- Tail of output (may duplicate some lines that hit the log filter above) ----";
-    tail -n $num_lines_to_tail "$log_file"
+    tail -n $num_lines_to_tail "$log_file" | sanitize
   fi
 }
 

--- a/.semaphore/test-run-and-monitor.sh
+++ b/.semaphore/test-run-and-monitor.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Smoke tests for run-and-monitor. Not run in CI; run manually in an
+# environment with expect, stdbuf and script(1) available, e.g.:
+#   docker run --rm -v $PWD:/w -w /w ubuntu:24.04 bash -c \
+#     'apt-get update -qq && apt-get install -yqq expect bsdutils >/dev/null && .semaphore/test-run-and-monitor.sh'
+set -x
+cd "$(dirname "$0")/.."
+fails=0
+
+check() {
+  local desc="$1"; shift
+  if "$@"; then echo "PASS: $desc"; else echo "FAIL: $desc"; fails=$((fails+1)); fi
+}
+
+# 1. Success path: correct RC and final message.
+out=$(script -qec "./.semaphore/run-and-monitor t1.log echo hello" /dev/null); rc=$?
+check "success RC=0" [ "$rc" = 0 ]
+check "success message" grep -q "SUCCEEDED" <<<"$out"
+check "command output logged" grep -q hello artifacts/t1.log
+
+# 2. Failure path: RC propagated.
+script -qec "./.semaphore/run-and-monitor t2.log bash -c 'exit 3'" /dev/null; rc=$?
+check "failure RC nonzero" [ "$rc" != 0 ]
+
+# 3. Control characters in output are stripped from console (but kept in log);
+#    >2000 lines so both the head and the output-tail paths run.
+out=$(script -qec "./.semaphore/run-and-monitor t3.log bash -c 'for i in \$(seq 2500); do echo line\$i; done; printf \"SUCCESS junk:\\001\\002\\000here\\n\"'" /dev/null); rc=$?
+check "ctrl-chars RC=0" [ "$rc" = 0 ]
+check "no 0x01 on console" test -z "$(grep -aoP '\x01' <<<"$out")"
+check "output-tail ran" grep -q "Tail of output" <<<"$out"
+check "tail content sanitized" grep -q "junk:here" <<<"$out"
+check "log keeps raw bytes" grep -qP '\x01' artifacts/t3.log
+
+# 4. Terminal state restored: command disables ONLCR; final output must still
+#    have CRLF endings (i.e. state restored before the final message).
+out=$(script -qec "./.semaphore/run-and-monitor t4.log bash -c 'stty -onlcr < /dev/tty; echo done'" /dev/null); rc=$?
+check "stty RC=0" [ "$rc" = 0 ]
+check "final message has CRLF" grep -qP 'exit with RC=0\r$' <<<"$out"
+
+echo "FAILURES: $fails"
+exit $fails


### PR DESCRIPTION
A CI job hung after `run-and-monitor` printed its final `SUCCEEDED ... exit with RC=0` message, until the job timed out. Root cause: the log tail the wrapper copies to the console contained binary test output including a raw 0x01 byte. The Semaphore agent detects command completion by scanning console output for a 0x01-prefixed end marker, and its scanner can permanently discard the real marker when stray 0x01 bytes arrive just before it (`flushInputAll()` in buffering mode flushes through a partially-received marker). The wrapped command had also left the job terminal with output post-processing disabled, which breaks the agent's CRLF-sensitive start-marker detection for the next command.

This hardens the wrapper on three fronts:

- Strip control characters (keeping tab/LF/CR/ESC, so ANSI colour still works) from everything copied from the log file to the console.
- Save terminal state at startup and restore it in `cleanup()` before the final output.
- Kill the monitor pipeline's console-facing end and wait for it, so nothing can write to the console after the final message.

Also fixes the line count in `output-tail`: `wc`'s leading padding made `cut -d' ' -f1` return an empty string, so the tail of a long log was never printed.

Testing: added `.semaphore/test-run-and-monitor.sh`, a manual containerised smoke test covering the success, failure, control-character and terminal-state paths (all pass on ubuntu:24.04; see its header for the invocation). Verified on the live hung runner that restoring the terminal state and re-emitting the marker unstuck the agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)