### PR TITLE
k8sfv: dump metrics as protobuf text, not wire format

### DIFF
--- a/felix/k8sfv/k8sfv.go
+++ b/felix/k8sfv/k8sfv.go
@@ -26,7 +26,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/push"
 	log "github.com/sirupsen/logrus"
-	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/encoding/prototext"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/clientcmd/api"
@@ -126,9 +126,10 @@ var _ = ginkgo.AfterSuite(func() {
 	fmt.Println("")
 	for _, family := range metricFamilies {
 		if strings.HasPrefix(*family.Name, "k8sfv") {
-			out, err := proto.Marshal(family)
-			panicIfError(err)
-			fmt.Println(string(out))
+			// Text format, not proto.Marshal(): this goes to the CI log for
+			// humans to read (and raw wire-format bytes in the job output
+			// can hang the Semaphore agent's output scanning).
+			fmt.Println(prototext.Format(family))
 		}
 	}
 })

--- a/felix/k8sfv/k8sfv.go
+++ b/felix/k8sfv/k8sfv.go
@@ -126,9 +126,7 @@ var _ = ginkgo.AfterSuite(func() {
 	fmt.Println("")
 	for _, family := range metricFamilies {
 		if strings.HasPrefix(*family.Name, "k8sfv") {
-			// Text format, not proto.Marshal(): this goes to the CI log for
-			// humans to read (and raw wire-format bytes in the job output
-			// can hang the Semaphore agent's output scanning).
+			// Note, using prototext (not proto) to get human-readable encoding for the log.
 			fmt.Println(prototext.Format(family))
 		}
 	}


### PR DESCRIPTION
The gogoprotobuf migration (#8949) replaced `proto.MarshalTextString()` with `proto.Marshal()` + `string()` in the k8sfv `AfterSuite` metrics dump — `MarshalTextString` doesn't exist in `google.golang.org/protobuf`, and `proto.Marshal` is the binary wire encoding. Since then every k8sfv run has printed its `k8sfv_*` metric families as raw protobuf bytes instead of readable text.

Besides being unreadable, the raw bytes (including 0x01) in the job output can hang the Semaphore agent, which scans console output for a 0x01-prefixed command-completion marker — this was the trigger for a real job hang; #13193 adds the corresponding defence in `run-and-monitor`.

Restore text output with `prototext.Format()`. Log-output-only change to the test harness itself; verified by compiling the k8sfv test binary and checking `prototext.Format` renders a sample `MetricFamily` as the expected readable text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)