### PR TITLE
argoci: prologue + epilogue migration scaffold fixes

### DIFF
--- a/.argoci/scripts/body_flannel-migration.sh
+++ b/.argoci/scripts/body_flannel-migration.sh
@@ -24,7 +24,7 @@ if [ "${USE_HASH_RELEASE}" == "true" ]; then
   echo "[INFO] Using hash release for flannel migration"
   LATEST_HASHREL="https://latest-os.docs.eng.tigera.net/${RELEASE_STREAM}.txt"
   echo "Checking ${LATEST_HASHREL} for latest hash release url..."
-  DOCS_URL=$(curl --retry 9 --retry-all-errors -sS ${LATEST_HASHREL})
+  DOCS_URL=$(curl --retry 9 --retry-all-errors -fsS ${LATEST_HASHREL})
   echo "Using $DOCS_URL for hash release base url"
 else
   if [[ "${RELEASE_STREAM}" == "master" ]]; then
@@ -109,7 +109,7 @@ spec:
 EOF
 
 # Update flannel.yaml to use the podCIDR that CRC sets up.
-wget -O flannel.yaml "$DOWNLEVEL_MANIFEST"
+wget --tries=3 --waitretry=5 -O flannel.yaml "$DOWNLEVEL_MANIFEST"
 sed -i "s?10.244.0.0/16?192.168.0.0/16?g" ./flannel.yaml
 kubectl apply -f - < ./flannel.yaml
 sleep 30 # wait for flannel to come up
@@ -121,7 +121,7 @@ K8S_E2E_FLAGS='--ginkgo.focus=should.serve.a.basic.endpoint.from.pods' \
 
 kubectl delete -n kube-system ds cni-installer || true  # remove the CNI installer daemonset
 kubectl apply -f "$DOCS_URL/$CALICO_MANIFEST"
-wget -O calico-migration.yaml "$DOCS_URL/$MIGRATION_MANIFEST"
+wget --tries=3 --waitretry=5 -O calico-migration.yaml "$DOCS_URL/$MIGRATION_MANIFEST"
 kubectl apply -f - < ./calico-migration.yaml
 sleep 5  # make sure the job has started before we check its status
 kubectl -n kube-system get jobs flannel-migration

--- a/.argoci/scripts/body_flannel-migration.sh
+++ b/.argoci/scripts/body_flannel-migration.sh
@@ -109,7 +109,7 @@ spec:
 EOF
 
 # Update flannel.yaml to use the podCIDR that CRC sets up.
-wget --tries=3 --waitretry=5 -O flannel.yaml "$DOWNLEVEL_MANIFEST"
+wget -O flannel.yaml "$DOWNLEVEL_MANIFEST"
 sed -i "s?10.244.0.0/16?192.168.0.0/16?g" ./flannel.yaml
 kubectl apply -f - < ./flannel.yaml
 sleep 30 # wait for flannel to come up
@@ -121,7 +121,7 @@ K8S_E2E_FLAGS='--ginkgo.focus=should.serve.a.basic.endpoint.from.pods' \
 
 kubectl delete -n kube-system ds cni-installer || true  # remove the CNI installer daemonset
 kubectl apply -f "$DOCS_URL/$CALICO_MANIFEST"
-wget --tries=3 --waitretry=5 -O calico-migration.yaml "$DOCS_URL/$MIGRATION_MANIFEST"
+wget -O calico-migration.yaml "$DOCS_URL/$MIGRATION_MANIFEST"
 kubectl apply -f - < ./calico-migration.yaml
 sleep 5  # make sure the job has started before we check its status
 kubectl -n kube-system get jobs flannel-migration

--- a/.argoci/scripts/global_epilogue.sh
+++ b/.argoci/scripts/global_epilogue.sh
@@ -12,7 +12,12 @@ echo "[INFO] starting global_epilogue"
 # bz diags/destroy must run from the profile dir (== BZ_HOME).
 cd "${BZ_HOME}" 2>/dev/null || echo "[WARN] could not cd to BZ_HOME=${BZ_HOME}"
 
-CI_EXIT_CODE=${CI_EXIT_CODE:-0}
+# The handler wraps the step body in an EXIT trap that exposes the body's exit
+# status as CI_STEP_EXIT_CODE (set in both the container and VM paths); plain
+# CI_EXIT_CODE is never set for container steps, so reading it here defaulted
+# every failure to 0 and skipped the diags capture below. Read the handler's
+# variable, falling back to CI_EXIT_CODE then 0.
+CI_EXIT_CODE=${CI_STEP_EXIT_CODE:-${CI_EXIT_CODE:-0}}
 ARTIFACT_DEST="gs://${GS_BUCKET}/${ARGO_WORKFLOW_NAME:-local}/${HOSTNAME:-pod}"
 
 # Capture diags on failure (or always for cert runs).

--- a/.argoci/scripts/global_prologue.sh
+++ b/.argoci/scripts/global_prologue.sh
@@ -141,10 +141,32 @@ if ! command -v bz >/dev/null 2>&1; then
   : "${BZ_REPO:?BZ_REPO not set (expected from banzai-secrets)}"
   : "${GITHUB_ACCESS_TOKEN:?GITHUB_ACCESS_TOKEN not set (expected from banzai-secrets)}"
   [[ -n "${BZ_VERSION:-}" ]] && BZ_RELEASE="tags/${BZ_VERSION}" || BZ_RELEASE="latest"
-  BZ_ASSET_ID=$(curl --retry 9 --retry-all-errors -H "Authorization: token ${GITHUB_ACCESS_TOKEN}" -H "Accept: application/vnd.github.v3.raw" -s "https://api.github.com/repos/${BZ_REPO}/releases/${BZ_RELEASE}" | jq '.assets[] | select(.name|test("^bz.*linux-amd64"))| .id')
-  echo "[INFO] bz asset id=${BZ_ASSET_ID}"
-  wget -q --auth-no-challenge --header='Accept:application/octet-stream' "https://${GITHUB_ACCESS_TOKEN}:@api.github.com/repos/${BZ_REPO}/releases/assets/${BZ_ASSET_ID}" -O "${BZ_GLOBAL_BIN}/bz"
-  chmod +x "${BZ_GLOBAL_BIN}/bz"
+  # GitHub rate-limits (esp. the secondary/concurrent limit) when the whole
+  # pipeline fans out ~50 pods at once. A 403 returns a JSON error body, not a
+  # curl error, so plain `curl -s` (no -f) let it through and `jq '.assets[]'`
+  # hit "Cannot iterate over null" -> empty asset id -> bz never installed and
+  # the job died pre-provision. Retry with backoff + per-pod jitter, fail curl
+  # on HTTP errors, validate the asset id is numeric and the binary is sane.
+  bz_ok=""
+  for attempt in $(seq 1 8); do
+    api=$(curl -fsS --retry 3 --retry-all-errors \
+            -H "Authorization: token ${GITHUB_ACCESS_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/${BZ_REPO}/releases/${BZ_RELEASE}" 2>/dev/null || true)
+    BZ_ASSET_ID=$(printf '%s' "${api}" | jq -r 'if (type=="object" and (.assets|type)=="array") then (.assets[]|select(.name|test("^bz.*linux-amd64"))|.id) else empty end' 2>/dev/null | head -1)
+    if [[ "${BZ_ASSET_ID}" =~ ^[0-9]+$ ]] \
+       && wget -q --tries=3 --waitretry=5 --auth-no-challenge --header='Accept:application/octet-stream' \
+            "https://${GITHUB_ACCESS_TOKEN}:@api.github.com/repos/${BZ_REPO}/releases/assets/${BZ_ASSET_ID}" -O "${BZ_GLOBAL_BIN}/bz" \
+       && [[ $(stat -c%s "${BZ_GLOBAL_BIN}/bz" 2>/dev/null || echo 0) -gt 1000000 ]]; then
+      chmod +x "${BZ_GLOBAL_BIN}/bz"
+      echo "[INFO] bz installed (asset id=${BZ_ASSET_ID}, attempt ${attempt})"
+      bz_ok=1; break
+    fi
+    sleep_s=$(( attempt * 5 + RANDOM % 10 ))
+    echo "[WARN] bz install attempt ${attempt}/8 failed (asset_id='${BZ_ASSET_ID:-}'); retrying in ${sleep_s}s"
+    sleep "${sleep_s}"
+  done
+  [[ -n "${bz_ok}" ]] || { echo "[ERROR] failed to install bz from ${BZ_REPO} after 8 attempts (GitHub rate limit?)"; exit 1; }
 fi
 echo "[INFO] bz resolved at $(command -v bz || echo '<none>')"
 

--- a/.argoci/scripts/global_prologue.sh
+++ b/.argoci/scripts/global_prologue.sh
@@ -95,7 +95,10 @@ export TEST_TYPE=${TEST_TYPE:-k8s-e2e}
 export GOOGLE_PROJECT=${GOOGLE_PROJECT:-unique-caldron-775}
 export GOOGLE_REGIONS=("us-central1" "us-west1")
 export GOOGLE_REGION=${GOOGLE_REGION:-${GOOGLE_REGIONS[RANDOM%${#GOOGLE_REGIONS[@]}]}}
-export GOOGLE_ZONE=${GOOGLE_ZONE:-$(gcloud compute zones list --filter="region~'$GOOGLE_REGION'" --format="value(name)" | awk 'BEGIN {srand()} {a[NR]=$0} rand() * NR < 1 {zone=$0} END {print zone}')}
+# --project is required: without it gcloud uses the runner's default project
+# (tigera-cc-dev on ArgoCI, where the SA can't list zones) instead of the e2e
+# project, and GOOGLE_ZONE fails to resolve for every unpinned gcp job.
+export GOOGLE_ZONE=${GOOGLE_ZONE:-$(gcloud compute zones list --project "${GOOGLE_PROJECT}" --filter="region~'$GOOGLE_REGION'" --format="value(name)" | awk 'BEGIN {srand()} {a[NR]=$0} rand() * NR < 1 {zone=$0} END {print zone}')}
 export GOOGLE_NETWORK=${GOOGLE_NETWORK:-semaphore-autotest}
 export AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION:-us-west-2}
 

--- a/.argoci/scripts/global_prologue.sh
+++ b/.argoci/scripts/global_prologue.sh
@@ -22,6 +22,10 @@ sleep $((RANDOM % 60))
 createLocalSecret "marvin" "${HOME}/.keys/marvin" || true
 createLocalSecret "banzai-google-service-account.json" "${HOME}/secrets/banzai-google-service-account.json" || true
 createLocalSecret "docker_cfg.json" "${HOME}/.docker/config.json" || true
+# Red Hat pull secret for aws-openshift provisioning; no-op until the secret is
+# added to the argoci store (see aws-openshift:check-prereqs). Staged into the
+# bz profile below.
+createLocalSecret "redhat-pull-secret.txt" "${HOME}/secrets/redhat-pull-secret.txt" || true
 
 # GCP auth for provisioning + docker registry auth (ported from Semaphore prologue
 # lines 122-123 / 166; our first port dropped these, assuming ArgoCI provided them).
@@ -171,6 +175,12 @@ if [[ -f "${HOME}/.docker/config.json" ]]; then
   echo "[INFO] staged docker_auth.json into ${BZ_LOCAL_DIR}/config"
 else
   echo "[WARN] ${HOME}/.docker/config.json missing; docker_auth not staged"
+fi
+# aws-openshift:check-prereqs expects the Red Hat pull secret at this path.
+if [[ -f "${HOME}/secrets/redhat-pull-secret.txt" ]]; then
+  cp "${HOME}/secrets/redhat-pull-secret.txt" "${BZ_LOCAL_DIR}/config/redhat-pull-secret.txt"
+  chmod 0600 "${BZ_LOCAL_DIR}/config/redhat-pull-secret.txt"
+  echo "[INFO] staged redhat-pull-secret.txt into ${BZ_LOCAL_DIR}/config"
 fi
 
 echo "[INFO] exiting prologue (PROVISIONER=${PROVISIONER} RELEASE_STREAM=${RELEASE_STREAM} CLUSTER_NAME=${CLUSTER_NAME})"

--- a/.argoci/scripts/global_prologue.sh
+++ b/.argoci/scripts/global_prologue.sh
@@ -189,6 +189,16 @@ if command -v python3.10 >/dev/null 2>&1 && ! python3.10 -c 'import ensurepip' 2
     || echo "[WARN] could not install python3.10-venv; bz venv creation may fail"
 fi
 
+# Windows jobs' check-prereqs runs puttygen (Windows SSH-key conversion); the
+# runner image lacks putty-tools (Semaphore's agent shipped it). Only needed when
+# provisioning Windows nodes. Stopgap until the runner image adds it (argoci-images).
+if [[ "${CREATE_WINDOWS_NODES:-false}" == "true" ]] && ! command -v puttygen >/dev/null 2>&1; then
+  echo "[INFO] installing putty-tools (runner image lacks puttygen; needed by windows:check-prereqs)..."
+  sudo apt-get update -qq 2>/dev/null || true
+  sudo apt-get install -y putty-tools 2>/dev/null \
+    || echo "[WARN] could not install putty-tools; windows check-prereqs may fail"
+fi
+
 echo "[INFO] initialising bz profile..."
 ( cd "${HOME}" && bz init profile -n "${BZ_PROFILE_NAME}" --skip-prompt --secretsPath "${HOME}/secrets" ) \
   |& tee "${BZ_LOGS_DIR}/initialize.log" || true

--- a/.argoci/scripts/global_prologue.sh
+++ b/.argoci/scripts/global_prologue.sh
@@ -162,9 +162,13 @@ if ! command -v bz >/dev/null 2>&1; then
       echo "[INFO] bz installed (asset id=${BZ_ASSET_ID}, attempt ${attempt})"
       bz_ok=1; break
     fi
-    sleep_s=$(( attempt * 5 + RANDOM % 10 ))
-    echo "[WARN] bz install attempt ${attempt}/8 failed (asset_id='${BZ_ASSET_ID:-}'); retrying in ${sleep_s}s"
-    sleep "${sleep_s}"
+    if [[ ${attempt} -lt 8 ]]; then
+      sleep_s=$(( attempt * 5 + RANDOM % 10 ))
+      echo "[WARN] bz install attempt ${attempt}/8 failed (asset_id='${BZ_ASSET_ID:-}'); retrying in ${sleep_s}s"
+      sleep "${sleep_s}"
+    else
+      echo "[WARN] bz install attempt ${attempt}/8 failed (asset_id='${BZ_ASSET_ID:-}')"
+    fi
   done
   [[ -n "${bz_ok}" ]] || { echo "[ERROR] failed to install bz from ${BZ_REPO} after 8 attempts (GitHub rate limit?)"; exit 1; }
 fi
@@ -213,8 +217,7 @@ else
 fi
 # aws-openshift:check-prereqs expects the Red Hat pull secret at this path.
 if [[ -f "${HOME}/secrets/redhat-pull-secret.txt" ]]; then
-  cp "${HOME}/secrets/redhat-pull-secret.txt" "${BZ_LOCAL_DIR}/config/redhat-pull-secret.txt"
-  chmod 0600 "${BZ_LOCAL_DIR}/config/redhat-pull-secret.txt"
+  install -m 0600 "${HOME}/secrets/redhat-pull-secret.txt" "${BZ_LOCAL_DIR}/config/redhat-pull-secret.txt"
   echo "[INFO] staged redhat-pull-secret.txt into ${BZ_LOCAL_DIR}/config"
 fi
 

--- a/.argoci/scripts/phases/run_tests.sh
+++ b/.argoci/scripts/phases/run_tests.sh
@@ -31,7 +31,7 @@ if [[ -n "${RUN_LOCAL_TESTS:-}" ]]; then
 elif [[ "${TEST_TYPE}" == "k8s-e2e" ]]; then
   # Scheduled CI: download the pre-built e2e binary from the hashrelease.
   echo "[INFO] downloading e2e binary from hashrelease..."
-  HASHREL_URL=$(curl --retry 9 --retry-all-errors -sS "https://latest-os.docs.eng.tigera.net/${RELEASE_STREAM}.txt")
+  HASHREL_URL=$(curl --retry 9 --retry-all-errors -fsS "https://latest-os.docs.eng.tigera.net/${RELEASE_STREAM}.txt")
   echo "[INFO] hashrelease URL: ${HASHREL_URL}"
   ARCH=$(uname -m); [[ "$ARCH" == "x86_64" ]] && ARCH=amd64; [[ "$ARCH" == "aarch64" ]] && ARCH=arm64
   mkdir -p "${CI_HOME}/${CI_GIT_DIR}/e2e/bin/k8s"

--- a/.argoci/scripts/test_scripts/operator_migrate.sh
+++ b/.argoci/scripts/test_scripts/operator_migrate.sh
@@ -9,7 +9,7 @@ echo "[INFO] starting operator migration..."
 if [[ "${USE_HASH_RELEASE}" == "true" ]]; then
   LATEST_HASHREL="https://latest-os.docs.eng.tigera.net/${RELEASE_STREAM}.txt"
   echo "Checking ${LATEST_HASHREL} for latest hash release url..."
-  BASE_URL=$(curl --retry 9 --retry-all-errors -sS ${LATEST_HASHREL})
+  BASE_URL=$(curl --retry 9 --retry-all-errors -fsS ${LATEST_HASHREL})
   echo "Using $BASE_URL for hash release base url"
 else
   if [[ "${RELEASE_STREAM}" == "master" ]]; then


### PR DESCRIPTION
Migration-introduced scaffold fixes in `.argoci/scripts/`, each surfaced by real ArgoCI e2e runs (none present on Semaphore):

- **Zone lookup** (`global_prologue.sh`): pass `--project "${GOOGLE_PROJECT}"` to `gcloud compute zones list` — without it, unpinned gcp-kubeadm jobs never resolved `GOOGLE_ZONE` and failed to provision.
- **Diags on failure** (`global_epilogue.sh`): read the handler's `CI_STEP_EXIT_CODE` (was reading the never-set `CI_EXIT_CODE` → always `0`), so `bz diags` runs on failed container-step jobs instead of being skipped.
- **bz-cli install** (`global_prologue.sh`): retry with backoff on GitHub-API rate-limits — a 403 previously left `bz` uninstalled and killed jobs pre-provision across a fan-out.
- **RH pull secret** (`global_prologue.sh`): stage `redhat-pull-secret.txt` (via `install -m 0600`) for `aws-openshift:check-prereqs`. Inert until the secret lands in the argoci bundle (DE-4390 handoff).
- **puttygen** (`global_prologue.sh`): install `putty-tools` (gated on `CREATE_WINDOWS_NODES`) for `windows:check-prereqs`.
- **Fetch hardening** (`run_tests.sh`, `operator_migrate.sh`, `body_flannel-migration.sh`): add `-f` to the three `curl … --retry-all-errors -sS <hashrel-pointer>` calls so a 403/404 body no longer becomes the URL var (and `-f` lets `--retry-all-errors` actually retry the HTTP error) — same robustness class as the bz fix.

## Test
`bash -n` clean; diags-fix, bz-retry, and puttygen each validated on ArgoCI re-runs.

## Release Note
```release-note
NONE
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)