### PR TITLE
argoci: query GOOGLE_PROJECT in the zone lookup

### DIFF
--- a/.argoci/scripts/global_prologue.sh
+++ b/.argoci/scripts/global_prologue.sh
@@ -91,7 +91,10 @@ export TEST_TYPE=${TEST_TYPE:-k8s-e2e}
 export GOOGLE_PROJECT=${GOOGLE_PROJECT:-unique-caldron-775}
 export GOOGLE_REGIONS=("us-central1" "us-west1")
 export GOOGLE_REGION=${GOOGLE_REGION:-${GOOGLE_REGIONS[RANDOM%${#GOOGLE_REGIONS[@]}]}}
-export GOOGLE_ZONE=${GOOGLE_ZONE:-$(gcloud compute zones list --filter="region~'$GOOGLE_REGION'" --format="value(name)" | awk 'BEGIN {srand()} {a[NR]=$0} rand() * NR < 1 {zone=$0} END {print zone}')}
+# --project is required: without it gcloud uses the runner's default project
+# (tigera-cc-dev on ArgoCI, where the SA can't list zones) instead of the e2e
+# project, and GOOGLE_ZONE fails to resolve for every unpinned gcp job.
+export GOOGLE_ZONE=${GOOGLE_ZONE:-$(gcloud compute zones list --project "${GOOGLE_PROJECT}" --filter="region~'$GOOGLE_REGION'" --format="value(name)" | awk 'BEGIN {srand()} {a[NR]=$0} rand() * NR < 1 {zone=$0} END {print zone}')}
 export GOOGLE_NETWORK=${GOOGLE_NETWORK:-semaphore-autotest}
 export AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION:-us-west-2}
 


### PR DESCRIPTION
## Problem
The prologue's zone lookup passed no `--project`:
```
gcloud compute zones list --filter="region~'$GOOGLE_REGION'" ...
```
On the ArgoCI runner, gcloud then uses the **runner's default project** (`tigera-cc-dev`, where the service account has no `compute.zones.list`) instead of `GOOGLE_PROJECT` (`unique-caldron-775`). The lookup fails:
```
ERROR: (gcloud.compute.zones.list) Some requests did not succeed:
 - Required 'compute.zones.list' permission for 'projects/tigera-cc-dev'
```
so `GOOGLE_ZONE` never resolves and **every gcp-kubeadm job that doesn't pin its zone fails to provision.** This was the dominant blocker across the iptables/bpf pipeline runs.

## Fix
Pass `--project "${GOOGLE_PROJECT}"` to the zones list, so it queries the e2e project the SA can actually read.

## Test
`bash -n` clean; validated on an ArgoCI run.

## Release Note
```release-note
NONE
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)