### PR TITLE
Fix EnsureBlock IPv6 branch using IPv4 pool selector

### DIFF
--- a/libcalico-go/lib/ipam/ipam.go
+++ b/libcalico-go/lib/ipam/ipam.go
@@ -2465,7 +2465,7 @@ func (c ipamClient) EnsureBlock(ctx context.Context, args BlockArgs) (*net.IPNet
 				return nil, nil, fmt.Errorf("provided IPv6 IPPools list contains one or more IPv4 IPPools")
 			}
 		}
-		v6Net, err = c.ensureBlock(ctx, args.HostReservedAttrIPv6s, args.IPv4Pools, 6, affinityCfg)
+		v6Net, err = c.ensureBlock(ctx, args.HostReservedAttrIPv6s, args.IPv6Pools, 6, affinityCfg)
 		if err != nil {
 			log.Errorf("Error ensure IPv6 block: %v", err)
 			return nil, nil, err

--- a/libcalico-go/lib/ipam/ipam_test.go
+++ b/libcalico-go/lib/ipam/ipam_test.go
@@ -3503,6 +3503,25 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 			Expect(outErr).NotTo(HaveOccurred())
 			Expect(v4_again).To(Equal(v4))
 		})
+
+		It("should allocate an IPv6 block from IPv6Pools, not IPv4Pools", func() {
+			Expect(bc.Clean()).To(Succeed())
+			deleteAllPools()
+
+			applyNode(bc, kc, host, nil)
+			applyPool(pool1.String(), true, "")
+			applyPool(pool4_v6.String(), true, "")
+
+			args := BlockArgs{
+				Hostname:              host,
+				IPv4Pools:             []cnet.IPNet{pool1},
+				IPv6Pools:             []cnet.IPNet{pool4_v6},
+				HostReservedAttrIPv6s: rsvdAttrWindows,
+			}
+			_, v6, outErr := ic.EnsureBlock(context.Background(), args)
+			Expect(outErr).NotTo(HaveOccurred())
+			Expect(pool4_v6.Contains(v6.IP)).To(BeTrue())
+		})
 	})
 
 	Describe("IPAM findOrClaimBlock test", func() {


### PR DESCRIPTION
## Summary

`ipamClient.EnsureBlock`'s IPv6 branch validates `args.IPv6Pools` but then passes `args.IPv4Pools` into the underlying `ensureBlock` call for the v6 allocation. As a result, a caller that supplies an explicit `IPv6Pools` selector alongside `HostReservedAttrIPv6s` gets the block allocated against the wrong pool list — either landing in an unintended IPv6 pool, or failing outright if the IPv4 CIDR isn't a valid IPv6 pool.

The only caller passing explicit `HostReservedAttrIPv6s`/pools is the Windows host-local block-ensure path in `node/pkg/lifecycle/startup/startup_windows.go`, so this has been latent rather than actively triggering failures.

Fix: pass `args.IPv6Pools` instead of `args.IPv4Pools` in the v6 branch.

## Test plan

- [x] Added a regression test in `libcalico-go/lib/ipam/ipam_test.go` (`should allocate an IPv6 block from IPv6Pools, not IPv4Pools`) that calls `EnsureBlock` with distinct `IPv4Pools`/`IPv6Pools` and asserts the returned v6 block CIDR falls inside the requested `IPv6Pools`.
- [x] Verified the test fails against the pre-fix code (etcd backend errors with `the given pool (10.0.0.0/24) does not exist, or is not enabled`, since the v4 CIDR is looked up against the v6 pool table).
- [x] Verified the test passes with the fix, and the full `libcalico-go/lib/ipam` suite still passes against the etcdv3 backend.

**Release note:**
```release-note
Fixed a latent bug where EnsureBlock could allocate an IPv6 block from the wrong IP pool when an explicit IPv6 pool selector was provided (Windows host-local IPAM block reservation).
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)