### PR TITLE
Wait for calico-node Ready before deploying kind add-ons

### DIFF
--- a/hack/test/kind/deploy_resources.sh
+++ b/hack/test/kind/deploy_resources.sh
@@ -198,6 +198,14 @@ done
 echo "Helm values files: ${VALUES_FILE} ${EXTRA_VALUES_FILES:-}"
 ${HELM} install calico ${CHART} "${helm_values_args[@]}" -n tigera-operator --create-namespace
 
+# Wait for calico-node to be Ready before deploying anything else: until it is,
+# nodes stay NotReady (unschedulable) and CNI ADD fails, so add-on pods can't
+# get a sandbox. In particular this keeps the metallb rollout-status wait below
+# from racing the dataplane bring-up and timing out -- the BPF dataplane takes
+# longer to come up than that rollout timeout allows.
+echo "Wait for calico-node to be Ready before deploying add-ons"
+wait_pod_ready -l k8s-app=calico-node -n calico-system
+
 echo "Install calicoctl as a pod"
 ${kubectl} apply -f ${INFRA_DIR}/calicoctl.yaml
 echo


### PR DESCRIPTION
## Description

Follow-up to #13159 (eBPF-dataplane e2e job on the on-agent KinD block).

The kind e2e deploy (`hack/test/kind/deploy_resources.sh`) raced the dataplane bring-up. Right after `helm install calico` it applied calicoctl and rolled out the MetalLB controller, then blocked on `kubectl -n metallb-system rollout status deploy/controller --timeout=2m`. Until calico-node is Ready, nodes stay `NotReady`/unschedulable and CNI ADD fails (`stat /var/lib/calico/nodename: no such file`), so add-on pods never get a sandbox. The BPF dataplane comes up slower than that 2m rollout timeout allows, so the new eBPF-dataplane e2e job intermittently failed the MetalLB wait even though calico-node itself was healthy (0 restarts).

The fix gates on `calico-node` readiness immediately after the Helm install — before calicoctl and MetalLB are applied — so add-ons only deploy once the dataplane can actually give them networking. This benefits both the iptables and BPF kind jobs; it just surfaced under BPF because of the slower bring-up.

## Release Note

\`\`\`release-note
None
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)