### PR TITLE
felix: answer IPv6 DAD probes in proxy-NDP

### DIFF
--- a/felix/dataplane/linux/proxy_neigh_mgr.go
+++ b/felix/dataplane/linux/proxy_neigh_mgr.go
@@ -190,7 +190,7 @@ func newProxyNeighManager(dpConfig Config, ipVersion uint8) *proxyNeighManager {
 			if err != nil {
 				return nil, nil, err
 			}
-			conn, _, err := ndp.Listen(ifi, ndp.Unspecified)
+			conn, _, err := ndp.Listen(ifi, ndp.LinkLocal)
 			if err != nil {
 				return nil, nil, err
 			}
@@ -808,10 +808,13 @@ func (l *ifaceListener) runNDPListener() {
 		// If the NS source is the unspecified address (::), this is a
 		// Duplicate Address Detection probe (RFC 4862). We can't unicast
 		// back to ::, so reply to the all-nodes multicast address and
-		// clear the Solicited flag (RFC 4861 §4.4).
+		// clear the Solicited flag (RFC 4861 §4.4). The socket tags the
+		// source with the interface zone (e.g. ::%eth0) and
+		// netip.Addr.IsUnspecified is zone-sensitive, so strip the zone
+		// before the test.
 		dst := srcAddr
 		solicited := true
-		if !srcAddr.IsValid() || srcAddr.IsUnspecified() {
+		if src := srcAddr.WithZone(""); !src.IsValid() || src.IsUnspecified() {
 			dst = netip.MustParseAddr(ipv6AllNodesMulticast)
 			solicited = false
 		}

--- a/felix/dataplane/linux/proxy_neigh_mgr_test.go
+++ b/felix/dataplane/linux/proxy_neigh_mgr_test.go
@@ -901,19 +901,23 @@ var _ = Describe("Proxy NDP manager (IPv6)", func() {
 			Expect(lla.Addr).To(Equal(ndpTestHWAddr))
 		})
 
-		It("replies to a  Duplicate Address Detection probe (unspecified source) via all-nodes multicast", func() {
-			// A solicitation from :: is Duplicate Address Detection; we can't
-			// unicast back, so the NA goes to ff02::1 with the Solicited flag clear.
-			ndpConns["eth0"].injectNS("::", ownedIP)
+		// A solicitation from :: is Duplicate Address Detection; we can't
+		// unicast back, so the NA goes to ff02::1 with the Solicited flag clear.
+		DescribeTable("replies to a DAD probe (unspecified source) via all-nodes multicast",
+			func(src string) {
+				ndpConns["eth0"].injectNS(src, ownedIP)
 
-			Eventually(func() int { return len(ndpConns["eth0"].getWrites()) }).Should(Equal(1))
-			write := ndpConns["eth0"].getWrites()[0]
-			na, ok := write.msg.(*ndp.NeighborAdvertisement)
-			Expect(ok).To(BeTrue())
-			Expect(na.TargetAddress.String()).To(Equal(ownedIP))
-			Expect(na.Solicited).To(BeFalse())
-			Expect(write.dst.String()).To(Equal("ff02::1"))
-		})
+				Eventually(func() int { return len(ndpConns["eth0"].getWrites()) }).Should(Equal(1))
+				write := ndpConns["eth0"].getWrites()[0]
+				na, ok := write.msg.(*ndp.NeighborAdvertisement)
+				Expect(ok).To(BeTrue())
+				Expect(na.TargetAddress.String()).To(Equal(ownedIP))
+				Expect(na.Solicited).To(BeFalse())
+				Expect(write.dst.String()).To(Equal("ff02::1"))
+			},
+			Entry("bare unspecified source", "::"),
+			Entry("unspecified source with interface zone", "::%eth0"),
+		)
 
 		It("ignores a solicitation for an IP it does not own", func() {
 			ndpConns["eth0"].injectNS("fe80::1234", "fd00::99")

--- a/felix/fv/proxy_neigh_test.go
+++ b/felix/fv/proxy_neigh_test.go
@@ -157,6 +157,44 @@ var _ = infrastructure.DatastoreDescribe(
 					tgt.family, extL2.Name, tgt.ip)
 			}
 		})
+
+		// A node bringing up a proxied IPv6 runs Duplicate Address Detection: it
+		// sends a Neighbor Solicitation from the unspecified source (::) to the
+		// address's solicited-node multicast group. Felix must answer it (to
+		// ff02::1 with the Solicited flag clear) so the node sees the address is
+		// taken and backs off; otherwise two hosts end up using the pod IP.
+		It("defends a proxied pod IPv6 against a Duplicate Address Detection probe", func() {
+			w := workload.New(tc.Felixes[0], "wl-pod", "default", podV4, "8080", "tcp",
+				workload.WithIPv6Address(podV6))
+			Expect(w.Start(infra)).To(Succeed())
+			w.ConfigureInInfra(infra)
+
+			// Wait until the pod IPv6 is actually answered, so we know Felix's NDP
+			// listener is up and has joined its solicited-node group.
+			Eventually(func() *connectivity.Result {
+				return extL2.CanConnectTo(podV6, "8080", "tcp")
+			}, "30s", "2s").ShouldNot(BeNil(), "proxy NDP not up yet for %s", podV6)
+
+			v6Net, err := felixSubnet(tc.Felixes[0], true)
+			Expect(err).NotTo(HaveOccurred())
+			ones, _ := v6Net.Mask.Size()
+
+			// Ensure DAD is active on the client, then have it tentatively claim
+			// the pod's IPv6. Its kernel sends the DAD probe; if Felix defends the
+			// address, DAD fails and it is flagged "dadfailed".
+			extL2.Exec("sysctl", "-w", "net.ipv6.conf.eth0.accept_dad=1")
+			extL2.Exec("sysctl", "-w", "net.ipv6.conf.eth0.dad_transmits=1")
+			_, err = extL2.ExecOutput("ip", "-6", "addr", "add",
+				fmt.Sprintf("%s/%d", podV6, ones), "dev", "eth0")
+			Expect(err).NotTo(HaveOccurred(), "adding tentative %s on %s", podV6, extL2.Name)
+
+			Eventually(func() (string, error) {
+				return extL2.ExecOutput("ip", "-6", "-o", "addr", "show", "dev", "eth0")
+			}, "20s", "1s").Should(And(
+				ContainSubstring(podV6),
+				ContainSubstring("dadfailed"),
+			), "Felix did not defend %s against DAD (address not flagged dadfailed)", podV6)
+		})
 	},
 )
 

--- a/felix/fv/proxy_neigh_test.go
+++ b/felix/fv/proxy_neigh_test.go
@@ -27,7 +27,6 @@ import (
 	. "github.com/onsi/gomega"
 	api "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
 
-	"github.com/projectcalico/calico/felix/fv/connectivity"
 	"github.com/projectcalico/calico/felix/fv/containers"
 	"github.com/projectcalico/calico/felix/fv/infrastructure"
 	"github.com/projectcalico/calico/felix/fv/utils"
@@ -150,9 +149,9 @@ var _ = infrastructure.DatastoreDescribe(
 				{"IPv6 (NDP)", podV6},
 			} {
 				By(fmt.Sprintf("Connecting from %s to %s pod IP %s", extL2.Name, tgt.family, tgt.ip))
-				Eventually(func() *connectivity.Result {
-					return extL2.CanConnectTo(tgt.ip, "8080", "tcp")
-				}, "30s", "2s").ShouldNot(BeNil(),
+				Eventually(func() bool {
+					return extL2.CanConnectTo(tgt.ip, "8080", "tcp").HasConnectivity()
+				}, "30s", "2s").Should(BeTrue(),
 					"no %s connectivity from %s to pod IP %s — Felix did not answer for it",
 					tgt.family, extL2.Name, tgt.ip)
 			}
@@ -171,9 +170,9 @@ var _ = infrastructure.DatastoreDescribe(
 
 			// Wait until the pod IPv6 is actually answered, so we know Felix's NDP
 			// listener is up and has joined its solicited-node group.
-			Eventually(func() *connectivity.Result {
-				return extL2.CanConnectTo(podV6, "8080", "tcp")
-			}, "30s", "2s").ShouldNot(BeNil(), "proxy NDP not up yet for %s", podV6)
+			Eventually(func() bool {
+				return extL2.CanConnectTo(podV6, "8080", "tcp").HasConnectivity()
+			}, "30s", "2s").Should(BeTrue(), "proxy NDP not up yet for %s", podV6)
 
 			v6Net, err := felixSubnet(tc.Felixes[0], true)
 			Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
<!-- Describe your changes, including the type of change (bug fix, feature, etc.),
why it should be merged, testing done, and links to related issues. -->
Felix's IPv6 proxy-NDP listener silently ignored Duplicate Address Detection probes, so it never defended a proxied pod/LB IP against another host claiming the same address. Bind the NDP socket to the interface link-local and strip the interface zone before the unspecified-source check, so DAD probes now reach the handler and are answered.
<!-- For any user-visible change, replace TBD with a one-line description. -->
**Release note:**
```release-note
TBD
```
