### PR TITLE
calico-node: fix install-cni to call `component cni install` (monobinary regression)

### DIFF
--- a/charts/calico/templates/calico-node.yaml
+++ b/charts/calico/templates/calico-node.yaml
@@ -95,7 +95,7 @@ spec:
         - name: install-cni
           image: {{.Values.calico.registry}}/{{.Values.calico.image}}:{{ .Values.version }}
           imagePullPolicy: {{.Values.imagePullPolicy}}
-          args: ["cni", "install"]
+          args: ["component", "cni", "install"]
           envFrom:
             - configMapRef:
                 # Allow KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT to be overridden for eBPF mode.

--- a/manifests/calico-bpf.yaml
+++ b/manifests/calico-bpf.yaml
@@ -12458,7 +12458,7 @@ spec:
         - name: install-cni
           image: quay.io/calico/calico:master
           imagePullPolicy: IfNotPresent
-          args: ["cni", "install"]
+          args: ["component", "cni", "install"]
           envFrom:
             - configMapRef:
                 # Allow KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT to be overridden for eBPF mode.

--- a/manifests/calico-etcd.yaml
+++ b/manifests/calico-etcd.yaml
@@ -367,7 +367,7 @@ spec:
         - name: install-cni
           image: quay.io/calico/calico:master
           imagePullPolicy: IfNotPresent
-          args: ["cni", "install"]
+          args: ["component", "cni", "install"]
           envFrom:
             - configMapRef:
                 # Allow KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT to be overridden for eBPF mode.

--- a/manifests/calico-policy-only.yaml
+++ b/manifests/calico-policy-only.yaml
@@ -12391,7 +12391,7 @@ spec:
         - name: install-cni
           image: quay.io/calico/calico:master
           imagePullPolicy: IfNotPresent
-          args: ["cni", "install"]
+          args: ["component", "cni", "install"]
           envFrom:
             - configMapRef:
                 # Allow KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT to be overridden for eBPF mode.

--- a/manifests/calico-typha.yaml
+++ b/manifests/calico-typha.yaml
@@ -12478,7 +12478,7 @@ spec:
         - name: install-cni
           image: quay.io/calico/calico:master
           imagePullPolicy: IfNotPresent
-          args: ["cni", "install"]
+          args: ["component", "cni", "install"]
           envFrom:
             - configMapRef:
                 # Allow KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT to be overridden for eBPF mode.

--- a/manifests/calico-v3-crds.yaml
+++ b/manifests/calico-v3-crds.yaml
@@ -12847,7 +12847,7 @@ spec:
         - name: install-cni
           image: quay.io/calico/calico:master
           imagePullPolicy: IfNotPresent
-          args: ["cni", "install"]
+          args: ["component", "cni", "install"]
           envFrom:
             - configMapRef:
                 # Allow KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT to be overridden for eBPF mode.

--- a/manifests/calico-vxlan.yaml
+++ b/manifests/calico-vxlan.yaml
@@ -12442,7 +12442,7 @@ spec:
         - name: install-cni
           image: quay.io/calico/calico:master
           imagePullPolicy: IfNotPresent
-          args: ["cni", "install"]
+          args: ["component", "cni", "install"]
           envFrom:
             - configMapRef:
                 # Allow KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT to be overridden for eBPF mode.

--- a/manifests/calico.yaml
+++ b/manifests/calico.yaml
@@ -12442,7 +12442,7 @@ spec:
         - name: install-cni
           image: quay.io/calico/calico:master
           imagePullPolicy: IfNotPresent
-          args: ["cni", "install"]
+          args: ["component", "cni", "install"]
           envFrom:
             - configMapRef:
                 # Allow KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT to be overridden for eBPF mode.

--- a/manifests/canal-etcd.yaml
+++ b/manifests/canal-etcd.yaml
@@ -451,7 +451,7 @@ spec:
         - name: install-cni
           image: quay.io/calico/calico:master
           imagePullPolicy: IfNotPresent
-          args: ["cni", "install"]
+          args: ["component", "cni", "install"]
           envFrom:
             - configMapRef:
                 # Allow KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT to be overridden for eBPF mode.

--- a/manifests/canal.yaml
+++ b/manifests/canal.yaml
@@ -12414,7 +12414,7 @@ spec:
         - name: install-cni
           image: quay.io/calico/calico:master
           imagePullPolicy: IfNotPresent
-          args: ["cni", "install"]
+          args: ["component", "cni", "install"]
           envFrom:
             - configMapRef:
                 # Allow KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT to be overridden for eBPF mode.

--- a/manifests/flannel-migration/calico.yaml
+++ b/manifests/flannel-migration/calico.yaml
@@ -12444,7 +12444,7 @@ spec:
         - name: install-cni
           image: quay.io/calico/calico:master
           imagePullPolicy: IfNotPresent
-          args: ["cni", "install"]
+          args: ["component", "cni", "install"]
           envFrom:
             - configMapRef:
                 # Allow KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT to be overridden for eBPF mode.


### PR DESCRIPTION
## Description

The consolidation of Calico components into the single `calico` binary (#12225) registered the CNI plugin under `calico component cni` and updated the `calico-node` / `calico-kube-controllers` manifests to the `calico component <name>` form — but the **`install-cni` init container was left calling `calico cni install`**.

The combined binary has no top-level `cni` subcommand (it lives under `component`), so the init container exits immediately with:

```
Error: unknown command "cni" for "calico"
Did you mean this?  ctl
```

`calico-node` therefore never gets past its init containers — every pod sits in `Init:CrashLoopBackOff` — so **every manifest-based (non-operator) install of `master` fails to come up**. Operator installs are unaffected (the operator invokes the binary itself).

Found via e2e triage: all `calico.yaml`/`canal.yaml`-based install jobs (datastore, dual-stack, distro-support, wireguard, kind) fail at `manual:calico:verify-components` waiting for `calico-node` Ready; diags show the init container crash above.

## Fix

`charts/calico/templates/calico-node.yaml` — `install-cni` args `["cni", "install"]` → `["component", "cni", "install"]`, matching the sibling `node` (`command: ["calico","component","node","init",...]`) and `kube-controllers` (`args: ["component","kube-controllers"]`) invocations. Regenerated the 10 affected static manifests (`make gen-manifests`).

## Release Note

```release-note
Fixed calico-node install-cni init container crash-looping on manifest-based (non-operator) installs (regression from the single-binary consolidation), which prevented calico-node from starting.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)