### PR TITLE
fix(ztunnel): cross-build arm64 ztunnel binary so the arm64 image runs

### DIFF
--- a/lib.Makefile
+++ b/lib.Makefile
@@ -361,6 +361,7 @@ DOCKER_GO_BUILD := $(DOCKER_RUN) $(CALICO_BUILD)
 DOCKER_RUST_BUILD := mkdir -p bin && \
 	docker run --rm \
 		--init \
+		--platform=linux/$(ARCH) \
 		--user $(LOCAL_USER_ID):$(LOCAL_GROUP_ID) \
 		$(EXTRA_DOCKER_ARGS) \
 		-v $(REPO_ROOT):/rust/src/github.com/projectcalico/calico:rw \

--- a/third_party/istio-ztunnel/Makefile
+++ b/third_party/istio-ztunnel/Makefile
@@ -43,7 +43,7 @@ VALIDARCHES = amd64 arm64
 .PHONY: build
 build: bin/ztunnel-$(ARCH)
 
-bin/ztunnel-$(ARCH): $(ZTUNNEL_DOWNLOADED)
+bin/ztunnel-$(ARCH): $(ZTUNNEL_DOWNLOADED) | register
 	$(DOCKER_RUST_BUILD) \
 		sh -c 'cd ztunnel && cargo build --release'
 	cp ztunnel/out/rust/release/ztunnel bin/ztunnel-$(ARCH)


### PR DESCRIPTION
### What's wrong

`calico/istio-ztunnel:v3.32.1` fails to start on arm64 nodes:

```
podman run --rm calico/istio-ztunnel:v3.32.1
{"msg":"exec container process `/usr/bin/ztunnel`: Exec format error", ...}
```

The image index advertises an arm64 entry, but the binary inside the arm64 image is actually amd64, so it can't exec. The sibling images (`istio-pilot`, `istio-install-cni`) are fine because they cross-build correctly. Reported in #13183.

### Root cause

On this branch the ztunnel binary is built by `third_party/istio-ztunnel/Makefile`:

```make
bin/ztunnel-$(ARCH): $(ZTUNNEL_DOWNLOADED)
	$(DOCKER_RUST_BUILD) sh -c 'cd ztunnel && cargo build --release'
	cp ztunnel/out/rust/release/ztunnel bin/ztunnel-$(ARCH)
```

`DOCKER_RUST_BUILD` here runs the rust container on the host platform, and `cargo build --release` has no target set. So on the amd64 build runner it always produces an amd64 binary, whatever `ARCH` is. The arm64 image then gets that amd64 binary while its manifest still says arm64.

This slipped in when the istio images came to OSS in #12039: that PR brought `DOCKER_RUST_BUILD` over without the `--platform=linux/$(ARCH)` flag master had, and without the `| register` prereq on the ztunnel target. master later moved to true cross-compilation in #12632, so master is fine, but that path depends on clang cross scaffolding that isn't on this release branch.

### The fix

Restore the two pieces master used to build a correct per-arch binary before #12632, adapted to this branch's layout:

- `lib.Makefile`: pass `--platform=linux/$(ARCH)` to the rust build container so cargo builds for the target arch (arm64 runs under emulation, same as it did on master).
- `third_party/istio-ztunnel/Makefile`: add the `| register` order-only prereq so binfmt is set up before the cross-arch container runs.

The `cp` path stays `out/rust/release/` since there's no `CARGO_BUILD_TARGET` in play, so cargo writes to the plain release dir.

This is deliberately small and self-contained rather than a cherry-pick of #12632, which also carries a CI topology change and needs the clang cross-compile scaffolding this branch doesn't have.

### Testing

- Confirmed the mechanism: `docker run --platform=linux/arm64 alpine uname -m` reports `aarch64` and `--platform=linux/amd64` reports `x86_64`, so the flag governs the arch cargo builds for.
- Built `bin/ztunnel-arm64` through the patched Makefile and checked the result is an aarch64 ELF.

Related: #13183, #12039, #12632

**Release note:**
```release-note
Fixed the calico/istio-ztunnel arm64 image, which shipped an amd64 binary and failed to start on arm64 nodes.
```
