### PR TITLE
hack: sniff out wrong-arch binaries in multi-arch images (#13183)

### DIFF
--- a/hack/Makefile
+++ b/hack/Makefile
@@ -50,6 +50,7 @@ st:
 .PHONY: shell-test
 shell-test:
 	bash cherry-pick-pull_test.sh
+	bash check-image-arch_test.sh
 
 ###############################################################################
 # CI

--- a/hack/check-image-arch.sh
+++ b/hack/check-image-arch.sh
@@ -24,7 +24,8 @@
 # (see https://github.com/projectcalico/calico/issues/13183).
 #
 # The binary is inspected, never executed, so this is safe for distroless and
-# scratch-based images. Exits non-zero if any image mismatches.
+# scratch-based images. Exits non-zero if any image has a wrong-arch binary or
+# cannot be verified (no entrypoint/command, or a non-ELF entrypoint).
 set -euo pipefail
 
 if [ "$#" -lt 2 ]; then
@@ -72,16 +73,21 @@ for img in "$@"; do
 		continue
 	fi
 
-	entrypoint=$(docker inspect --format '{{if .Config.Entrypoint}}{{index .Config.Entrypoint 0}}{{end}}' "$img")
+	# The binary to check is the entrypoint, falling back to the command. As a
+	# build gate, an image we were asked to check but cannot verify is a failure,
+	# not a pass -- otherwise a wrong-arch image could slip through unchecked.
+	entrypoint=$(docker inspect --format '{{if .Config.Entrypoint}}{{index .Config.Entrypoint 0}}{{else if .Config.Cmd}}{{index .Config.Cmd 0}}{{end}}' "$img")
 	if [ -z "$entrypoint" ]; then
-		echo "SKIP  $img  (no entrypoint to inspect)"
+		echo "FAIL  $img  (no entrypoint or command to inspect; cannot verify arch)"
+		rc=1
 		continue
 	fi
 
 	cid=$(docker create "$img")
 	tmp=$(mktemp)
 	if ! docker cp "$cid:$entrypoint" "$tmp" 2>/dev/null; then
-		echo "SKIP  $img  (entrypoint $entrypoint is not a copyable file)"
+		echo "FAIL  $img  (entrypoint $entrypoint is not a copyable file; cannot verify arch)"
+		rc=1
 		docker rm "$cid" >/dev/null
 		rm -f "$tmp"
 		continue
@@ -92,7 +98,8 @@ for img in "$@"; do
 	rm -f "$tmp"
 
 	if [ "$bin_arch" = notelf ]; then
-		echo "SKIP  $img  (entrypoint $entrypoint is not an ELF binary)"
+		echo "FAIL  $img  (entrypoint $entrypoint is not an ELF binary; cannot verify arch)"
+		rc=1
 		continue
 	fi
 

--- a/hack/check-image-arch.sh
+++ b/hack/check-image-arch.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2026 Tigera, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# check-image-arch.sh EXPECTED_ARCH IMAGE [IMAGE...]
+#
+# Verify that each image is really built for EXPECTED_ARCH: both the image
+# config's Architecture and the ELF machine of its entrypoint binary must
+# match. Guards against multi-arch builds that advertise an arch but ship a
+# wrong-arch binary, which fails at runtime with:
+#   exec /usr/bin/<binary>: Exec format error
+# (see https://github.com/projectcalico/calico/issues/13183).
+#
+# The binary is inspected, never executed, so this is safe for distroless and
+# scratch-based images. Exits non-zero if any image mismatches.
+set -euo pipefail
+
+if [ "$#" -lt 2 ]; then
+	echo "usage: $0 EXPECTED_ARCH IMAGE [IMAGE...]" >&2
+	exit 2
+fi
+
+expected=$1
+shift
+
+# ELF e_machine (EM_*) -> docker/GOARCH name, for the arches Calico builds.
+em_to_arch() {
+	case "$1" in
+	62)  echo amd64 ;;   # EM_X86_64
+	183) echo arm64 ;;   # EM_AARCH64
+	21)  echo ppc64le ;; # EM_PPC64
+	22)  echo s390x ;;   # EM_S390
+	243) echo riscv64 ;; # EM_RISCV
+	*)   echo "em:$1" ;;
+	esac
+}
+
+# Read the ELF e_machine field, honoring the header's endianness (EI_DATA),
+# so big-endian targets (s390x) are read correctly too.
+elf_arch() {
+	local f=$1 magic data b18 b19
+	magic=$(dd if="$f" bs=1 count=4 2>/dev/null | od -An -tx1 | tr -d ' \n')
+	[ "$magic" = "7f454c46" ] || { echo notelf; return; }
+	data=$(dd if="$f" bs=1 skip=5 count=1 2>/dev/null | od -An -tu1 | tr -d ' ')
+	b18=$(dd if="$f" bs=1 skip=18 count=1 2>/dev/null | od -An -tu1 | tr -d ' ')
+	b19=$(dd if="$f" bs=1 skip=19 count=1 2>/dev/null | od -An -tu1 | tr -d ' ')
+	if [ "$data" = 2 ]; then # ELFDATA2MSB (big-endian)
+		em_to_arch $((b18 * 256 + b19))
+	else # ELFDATA2LSB (little-endian)
+		em_to_arch $((b18 + b19 * 256))
+	fi
+}
+
+rc=0
+for img in "$@"; do
+	cfg_arch=$(docker inspect --format '{{.Architecture}}' "$img")
+	if [ "$cfg_arch" != "$expected" ]; then
+		echo "FAIL  $img  config.Architecture=$cfg_arch  expected=$expected"
+		rc=1
+		continue
+	fi
+
+	entrypoint=$(docker inspect --format '{{if .Config.Entrypoint}}{{index .Config.Entrypoint 0}}{{end}}' "$img")
+	if [ -z "$entrypoint" ]; then
+		echo "SKIP  $img  (no entrypoint to inspect)"
+		continue
+	fi
+
+	cid=$(docker create "$img")
+	tmp=$(mktemp)
+	if ! docker cp "$cid:$entrypoint" "$tmp" 2>/dev/null; then
+		echo "SKIP  $img  (entrypoint $entrypoint is not a copyable file)"
+		docker rm "$cid" >/dev/null
+		rm -f "$tmp"
+		continue
+	fi
+	docker rm "$cid" >/dev/null
+
+	bin_arch=$(elf_arch "$tmp")
+	rm -f "$tmp"
+
+	if [ "$bin_arch" = notelf ]; then
+		echo "SKIP  $img  (entrypoint $entrypoint is not an ELF binary)"
+		continue
+	fi
+
+	if [ "$bin_arch" = "$expected" ]; then
+		echo "OK    $img  arch=$expected  ($entrypoint)"
+	else
+		echo "FAIL  $img  binary=$bin_arch  expected=$expected  ($entrypoint)  <-- wrong-arch binary"
+		rc=1
+	fi
+done
+
+exit $rc

--- a/hack/check-image-arch_test.sh
+++ b/hack/check-image-arch_test.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2026 Tigera, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Tests for hack/check-image-arch.sh.
+# Builds tiny arm64 images, one carrying an amd64 entrypoint binary (the
+# projectcalico/calico#13183 failure) and one carrying an arm64 binary, and
+# asserts the checker fails on the former and passes on the latter.
+# Run with:  bash hack/check-image-arch_test.sh
+set -o errexit
+set -o nounset
+set -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHECK="${SCRIPT_DIR}/check-image-arch.sh"
+WORK="$(mktemp -d)"
+IMAGES=()
+trap 'docker rmi -f "${IMAGES[@]}" >/dev/null 2>&1 || true; rm -rf "${WORK}"' EXIT
+
+PASS=0
+FAIL=0
+
+# assert_exit EXPECTED_CODE MESSAGE -- CMD...
+assert_exit() {
+	local want="$1" msg="$2"; shift 3
+	local got=0
+	"$@" >/dev/null 2>&1 || got=$?
+	if [[ "${got}" == "${want}" ]]; then
+		echo "ok   - ${msg}"
+		PASS=$((PASS + 1))
+	else
+		echo "FAIL - ${msg} (want exit ${want}, got ${got})"
+		FAIL=$((FAIL + 1))
+	fi
+}
+
+# Write a minimal ELF header for the given e_machine value (EM_X86_64=62,
+# EM_AARCH64=183), little-endian, enough for the checker to read.
+write_elf_stub() {
+	local machine="$1" path="$2"
+	python3 - "${machine}" "${path}" <<'PY'
+import sys
+machine = int(sys.argv[1])
+b = bytearray(64)
+b[0:4] = b"\x7fELF"
+b[4] = 2            # EI_CLASS = ELFCLASS64
+b[5] = 1            # EI_DATA  = ELFDATA2LSB
+b[6] = 1            # EI_VERSION
+b[18] = machine & 0xFF
+b[19] = (machine >> 8) & 0xFF
+open(sys.argv[2], "wb").write(bytes(b))
+PY
+}
+
+# build_image TAG ELF_MACHINE -- an arm64 image whose entrypoint binary has the
+# given ELF machine. A wrong-arch binary (amd64 in an arm64 image) reproduces
+# the bug; a matching one is the fixed case.
+build_image() {
+	local tag="$1" machine="$2"
+	write_elf_stub "${machine}" "${WORK}/entry"
+	printf 'FROM scratch\nCOPY entry /entry\nENTRYPOINT ["/entry"]\n' >"${WORK}/Dockerfile"
+	docker build -q --platform=linux/arm64 -t "${tag}" "${WORK}" >/dev/null
+	IMAGES+=("${tag}")
+}
+
+build_image check-image-arch-test:wrong 62  # amd64 binary in an arm64 image
+build_image check-image-arch-test:right 183 # arm64 binary in an arm64 image
+
+assert_exit 1 "arm64 image with an amd64 binary is rejected" \
+	-- "${CHECK}" arm64 check-image-arch-test:wrong
+assert_exit 0 "arm64 image with an arm64 binary is accepted" \
+	-- "${CHECK}" arm64 check-image-arch-test:right
+
+echo "----"
+echo "PASS=${PASS} FAIL=${FAIL}"
+[[ "${FAIL}" == 0 ]]

--- a/hack/check-image-arch_test.sh
+++ b/hack/check-image-arch_test.sh
@@ -25,6 +25,12 @@ set -o pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CHECK="${SCRIPT_DIR}/check-image-arch.sh"
+
+if ! command -v docker >/dev/null 2>&1; then
+	echo "docker not available; skipping check-image-arch tests"
+	exit 0
+fi
+
 WORK="$(mktemp -d)"
 IMAGES=()
 trap 'docker rmi -f "${IMAGES[@]}" >/dev/null 2>&1 || true; rm -rf "${WORK}"' EXIT
@@ -75,13 +81,29 @@ build_image() {
 	IMAGES+=("${tag}")
 }
 
+# build_unverifiable_image TAG DOCKERFILE_BODY -- an arm64 image the checker
+# cannot verify (non-ELF entrypoint, or no entrypoint/command at all).
+build_unverifiable_image() {
+	local tag="$1" body="$2"
+	echo "not an elf binary" >"${WORK}/entry"
+	printf '%b' "${body}" >"${WORK}/Dockerfile"
+	docker build -q --platform=linux/arm64 -t "${tag}" "${WORK}" >/dev/null
+	IMAGES+=("${tag}")
+}
+
 build_image check-image-arch-test:wrong 62  # amd64 binary in an arm64 image
 build_image check-image-arch-test:right 183 # arm64 binary in an arm64 image
+build_unverifiable_image check-image-arch-test:nonelf 'FROM scratch\nCOPY entry /entry\nENTRYPOINT ["/entry"]\n'
+build_unverifiable_image check-image-arch-test:noentry 'FROM scratch\nCOPY entry /entry\n'
 
 assert_exit 1 "arm64 image with an amd64 binary is rejected" \
 	-- "${CHECK}" arm64 check-image-arch-test:wrong
 assert_exit 0 "arm64 image with an arm64 binary is accepted" \
 	-- "${CHECK}" arm64 check-image-arch-test:right
+assert_exit 1 "non-ELF entrypoint is rejected (cannot be verified)" \
+	-- "${CHECK}" arm64 check-image-arch-test:nonelf
+assert_exit 1 "image with no entrypoint or command is rejected" \
+	-- "${CHECK}" arm64 check-image-arch-test:noentry
 
 echo "----"
 echo "PASS=${PASS} FAIL=${FAIL}"

--- a/istio/Makefile
+++ b/istio/Makefile
@@ -112,6 +112,7 @@ sub-image-%:
 
 .PHONY: image
 image: $(BUILD_IMAGES)
+	$(MAKE) check-image-arch CHECK_ARCH=$(ARCH) CHECK_IMAGES="$(addsuffix :latest-$(ARCH),$(BUILD_IMAGES))"
 
 # Producer image carrying the patched nftables + libnftnl RPMs that the
 # install-cni image installs in its almalinux build stage. Tag is

--- a/lib.Makefile
+++ b/lib.Makefile
@@ -1116,6 +1116,18 @@ docker-compress:
 escapefs = $(subst :,---,$(subst /,___,$(1)))
 unescapefs = $(subst ---,:,$(subst ___,/,$(1)))
 
+# check-image-arch fails the build if any image in CHECK_IMAGES does not
+# actually contain a CHECK_ARCH binary: it compares both the image config's
+# architecture and the ELF machine of the entrypoint binary against CHECK_ARCH.
+# This guards against multi-arch builds that advertise an arch but ship a
+# wrong-arch binary, which fails at runtime with "exec ...: Exec format error"
+# (https://github.com/projectcalico/calico/issues/13183). The binary is
+# inspected, never executed, so it is safe for distroless / scratch images.
+# Usage: $(MAKE) check-image-arch CHECK_ARCH=<arch> CHECK_IMAGES="<img> ..."
+.PHONY: check-image-arch
+check-image-arch:
+	$(REPO_ROOT)/hack/check-image-arch.sh $(CHECK_ARCH) $(CHECK_IMAGES)
+
 # retag-build-images-with-registries retags the build / arch images specified by BUILD_IMAGES and VALIDARCHES with
 # the registries specified by DEV_REGISTRIES. The end tagged images are of the format
 # $(REGISTRY)/$(BUILD_IMAGES):<tag>-$(ARCH).


### PR DESCRIPTION
### Why

#13183 shipped a `calico/istio-ztunnel` arm64 image that advertised arm64 in its manifest but carried an amd64 binary, so it died at startup with `exec /usr/bin/ztunnel: Exec format error`. Nothing in the build checked that a per-arch image actually holds a binary for that arch, so it reached a release. This adds that check.

The build fix for #13183 itself goes to the release branch (release-v3.32 is affected; master already cross-compiles ztunnel correctly since #12632). This PR is the guard so the whole class can't slip through again.

### What

- `hack/check-image-arch.sh EXPECTED_ARCH IMAGE...` — for each image, compare both the image config's `Architecture` and the ELF machine of the entrypoint binary against the expected arch. The binary is inspected, never run, so it's safe for distroless and scratch images. Endianness is read from the ELF header, so ppc64le/s390x work too. Exits non-zero on any mismatch.
- `lib.Makefile` gains a reusable `check-image-arch` target so any component can gate its images with one line.
- `istio/Makefile` `image` target runs the check on all four istio images, so a wrong-arch binary fails the build instead of getting pushed.

### Testing

- `hack/check-image-arch_test.sh` (new): builds a tiny arm64 image carrying an amd64 binary and asserts the checker rejects it, plus the matching-arch case it accepts. Passes.
- Ran the checker against the real published v3.32.1 images: it flags `istio-ztunnel` arm64 (amd64 binary) and passes `istio-pilot` / `istio-install-cni` on both arches.
- Backed the #13183 fix out and back in against a locally built ztunnel image: checker fails on the broken build (exit 1), passes on the fixed one (exit 0).

Related: #13183

**Release note:**
```release-note
Multi-arch image builds now fail fast when an image contains a binary for the wrong architecture.
```

<!-- Suggested labels: docs-not-required, release-note-not-required -->
