### PR TITLE
kube-controllers: support annotations on auto host endpoint templates

### DIFF
--- a/api/config/crd/projectcalico.org_kubecontrollersconfigurations.yaml
+++ b/api/config/crd/projectcalico.org_kubecontrollersconfigurations.yaml
@@ -115,6 +115,13 @@ spec:
                                 AutoHostEndpoints
                               items:
                                 properties:
+                                  annotations:
+                                    additionalProperties:
+                                      type: string
+                                    description:
+                                      Annotations adds the specified annotations
+                                      to the generated AutoHostEndpoint.
+                                    type: object
                                   generateName:
                                     description:
                                       GenerateName is appended to the end
@@ -344,6 +351,13 @@ spec:
                                     AutoHostEndpoints
                                   items:
                                     properties:
+                                      annotations:
+                                        additionalProperties:
+                                          type: string
+                                        description:
+                                          Annotations adds the specified
+                                          annotations to the generated AutoHostEndpoint.
+                                        type: object
                                       generateName:
                                         description:
                                           GenerateName is appended to the

--- a/api/pkg/apis/projectcalico/v3/kubecontrollersconfig.go
+++ b/api/pkg/apis/projectcalico/v3/kubecontrollersconfig.go
@@ -185,6 +185,9 @@ type Template struct {
 	// Labels adds the specified labels to the generated AutoHostEndpoint, labels from node with the same name will be overwritten by values from the template label
 	Labels map[string]string `json:"labels,omitempty" validate:"omitempty,labels"`
 
+	// Annotations adds the specified annotations to the generated AutoHostEndpoint.
+	Annotations map[string]string `json:"annotations,omitempty"`
+
 	// NodeSelector allows the AutoHostEndpoint to be created only for specific nodes
 	NodeSelector string `json:"nodeSelector,omitempty" validate:"omitempty,selector"`
 }

--- a/api/pkg/apis/projectcalico/v3/kubecontrollersconfig.go
+++ b/api/pkg/apis/projectcalico/v3/kubecontrollersconfig.go
@@ -155,7 +155,7 @@ type AutoHostEndpointConfig struct {
 
 	// Templates contains definition for creating AutoHostEndpoints
 	// +listType=atomic
-	Templates []Template `json:"templates,omitempty" validate:"omitempty"`
+	Templates []Template `json:"templates,omitempty" validate:"omitempty,dive"`
 }
 
 // DefaultHostEndpointMode controls whether a default host endpoint is created for each node.

--- a/api/pkg/apis/projectcalico/v3/kubecontrollersconfig.go
+++ b/api/pkg/apis/projectcalico/v3/kubecontrollersconfig.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2021 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2026 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/api/pkg/apis/projectcalico/v3/zz_generated.deepcopy.go
+++ b/api/pkg/apis/projectcalico/v3/zz_generated.deepcopy.go
@@ -4066,6 +4066,13 @@ func (in *Template) DeepCopyInto(out *Template) {
 			(*out)[key] = val
 		}
 	}
+	if in.Annotations != nil {
+		in, out := &in.Annotations, &out.Annotations
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	return
 }
 

--- a/api/pkg/client/applyconfiguration_generated/internal/internal.go
+++ b/api/pkg/client/applyconfiguration_generated/internal/internal.go
@@ -2347,6 +2347,11 @@ var schemaYAML = typed.YAMLObject(`types:
 - name: com.github.projectcalico.api.pkg.apis.projectcalico.v3.Template
   map:
     fields:
+    - name: annotations
+      type:
+        map:
+          elementType:
+            scalar: string
     - name: generateName
       type:
         scalar: string

--- a/api/pkg/client/applyconfiguration_generated/projectcalico/v3/template.go
+++ b/api/pkg/client/applyconfiguration_generated/projectcalico/v3/template.go
@@ -18,6 +18,8 @@ type TemplateApplyConfiguration struct {
 	InterfacePattern *string `json:"interfacePattern,omitempty"`
 	// Labels adds the specified labels to the generated AutoHostEndpoint, labels from node with the same name will be overwritten by values from the template label
 	Labels map[string]string `json:"labels,omitempty"`
+	// Annotations adds the specified annotations to the generated AutoHostEndpoint.
+	Annotations map[string]string `json:"annotations,omitempty"`
 	// NodeSelector allows the AutoHostEndpoint to be created only for specific nodes
 	NodeSelector *string `json:"nodeSelector,omitempty"`
 }
@@ -64,6 +66,20 @@ func (b *TemplateApplyConfiguration) WithLabels(entries map[string]string) *Temp
 	}
 	for k, v := range entries {
 		b.Labels[k] = v
+	}
+	return b
+}
+
+// WithAnnotations puts the entries into the Annotations field in the declarative configuration
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the entries provided by each call will be put on the Annotations field,
+// overwriting an existing map entries in Annotations field with the same key.
+func (b *TemplateApplyConfiguration) WithAnnotations(entries map[string]string) *TemplateApplyConfiguration {
+	if b.Annotations == nil && len(entries) > 0 {
+		b.Annotations = make(map[string]string, len(entries))
+	}
+	for k, v := range entries {
+		b.Annotations[k] = v
 	}
 	return b
 }

--- a/api/pkg/openapi/generated.openapi.go
+++ b/api/pkg/openapi/generated.openapi.go
@@ -7833,6 +7833,22 @@ func schema_pkg_apis_projectcalico_v3_Template(ref common.ReferenceCallback) com
 							},
 						},
 					},
+					"annotations": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Annotations adds the specified annotations to the generated AutoHostEndpoint.",
+							Type:        []string{"object"},
+							AdditionalProperties: &spec.SchemaOrBool{
+								Allows: true,
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
+									},
+								},
+							},
+						},
+					},
 					"nodeSelector": {
 						SchemaProps: spec.SchemaProps{
 							Description: "NodeSelector allows the AutoHostEndpoint to be created only for specific nodes",

--- a/kube-controllers/pkg/config/config_test.go
+++ b/kube-controllers/pkg/config/config_test.go
@@ -202,8 +202,16 @@ var _ = Describe("Config", func() {
 						Node: &v3.NodeControllerConfig{
 							ReconcilerPeriod: nil,
 							SyncLabels:       v3.Disabled,
-							HostEndpoint:     &v3.AutoHostEndpointConfig{AutoCreate: v3.Enabled, CreateDefaultHostEndpoint: v3.DefaultHostEndpointsEnabled},
-							LeakGracePeriod:  &v1.Duration{Duration: 20 * time.Minute},
+							HostEndpoint: &v3.AutoHostEndpointConfig{
+								AutoCreate:                v3.Enabled,
+								CreateDefaultHostEndpoint: v3.DefaultHostEndpointsEnabled,
+								Templates: []v3.Template{{
+									GenerateName: "template",
+									Labels:       map[string]string{"template-label": "template-value"},
+									Annotations:  map[string]string{"template.projectcalico.org/annotation": "annotation-value"},
+								}},
+							},
+							LeakGracePeriod: &v1.Duration{Duration: 20 * time.Minute},
 						},
 						Policy: &v3.PolicyControllerConfig{
 							ReconcilerPeriod: &v1.Duration{Duration: time.Second * 30},
@@ -246,6 +254,11 @@ var _ = Describe("Config", func() {
 					AutoHostEndpointConfig: &config.AutoHostEndpointConfig{
 						AutoCreate:                true,
 						CreateDefaultHostEndpoint: v3.DefaultHostEndpointsEnabled,
+						Templates: []config.AutoHostEndpointTemplate{{
+							GenerateName: "template",
+							Labels:       map[string]string{"template-label": "template-value"},
+							Annotations:  map[string]string{"template.projectcalico.org/annotation": "annotation-value"},
+						}},
 					},
 					DeleteNodes:     true,
 					LeakGracePeriod: &v1.Duration{Duration: 20 * time.Minute},

--- a/kube-controllers/pkg/config/config_test.go
+++ b/kube-controllers/pkg/config/config_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 - 2025 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017-2026 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/kube-controllers/pkg/config/runconfig.go
+++ b/kube-controllers/pkg/config/runconfig.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Tigera, Inc. All rights reserved.
+// Copyright (c) 2025-2026 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/kube-controllers/pkg/config/runconfig.go
+++ b/kube-controllers/pkg/config/runconfig.go
@@ -96,6 +96,7 @@ type AutoHostEndpointTemplate struct {
 	InterfaceCIDRs   []string
 	InterfacePattern string
 	Labels           map[string]string
+	Annotations      map[string]string
 	NodeSelector     string
 }
 
@@ -471,6 +472,7 @@ func mergeAutoHostEndpoints(envVars map[string]string, status *v3.KubeController
 					InterfacePattern: template.InterfacePattern,
 					NodeSelector:     template.NodeSelector,
 					Labels:           template.Labels,
+					Annotations:      template.Annotations,
 				}
 
 				templates = append(templates, rcTemplate)
@@ -508,6 +510,7 @@ func mergeAutoHostEndpoints(envVars map[string]string, status *v3.KubeController
 					InterfacePattern: rcTemplate.InterfacePattern,
 					NodeSelector:     rcTemplate.NodeSelector,
 					Labels:           rcTemplate.Labels,
+					Annotations:      rcTemplate.Annotations,
 				}
 
 				templates = append(templates, scTemplate)

--- a/kube-controllers/pkg/controllers/node/auto_hep_fv_test.go
+++ b/kube-controllers/pkg/controllers/node/auto_hep_fv_test.go
@@ -194,7 +194,7 @@ var _ = Describe("Auto Hostendpoint FV tests", Ordered, ContinueOnFailure, func(
 		}
 		expectedIPs := []string{"172.16.1.1", "fe80::1", "192.168.100.1"}
 		Eventually(func() error {
-			return testutils.ExpectHostendpoint(c, expectedHepName, expectedHepLabels, expectedIPs, autoHepProfiles, defaultInterfaceName)
+			return testutils.ExpectHostendpoint(c, expectedHepName, expectedHepLabels, nil, expectedIPs, autoHepProfiles, defaultInterfaceName)
 		}, time.Second*15, 500*time.Millisecond).Should(BeNil())
 
 		// Update the Kubernetes node labels.
@@ -210,7 +210,7 @@ var _ = Describe("Auto Hostendpoint FV tests", Ordered, ContinueOnFailure, func(
 		// Expect the hostendpoint labels to sync.
 		expectedHepLabels["label1"] = "value2"
 		Eventually(func() error {
-			return testutils.ExpectHostendpoint(c, expectedHepName, expectedHepLabels, expectedIPs, autoHepProfiles, defaultInterfaceName)
+			return testutils.ExpectHostendpoint(c, expectedHepName, expectedHepLabels, nil, expectedIPs, autoHepProfiles, defaultInterfaceName)
 		}, time.Second*15, 500*time.Millisecond).Should(BeNil())
 
 		// Update the Calico node with new IPs.
@@ -224,7 +224,7 @@ var _ = Describe("Auto Hostendpoint FV tests", Ordered, ContinueOnFailure, func(
 		// Expect the hostendpoint's expectedIPs to sync the new node IPs.
 		expectedIPs = []string{"172.100.2.3", "fe80::1", "10.10.20.1", "dead:beef::1"}
 		Eventually(func() error {
-			return testutils.ExpectHostendpoint(c, expectedHepName, expectedHepLabels, expectedIPs, autoHepProfiles, defaultInterfaceName)
+			return testutils.ExpectHostendpoint(c, expectedHepName, expectedHepLabels, nil, expectedIPs, autoHepProfiles, defaultInterfaceName)
 		}, time.Second*15, 500*time.Millisecond).Should(BeNil())
 
 		// Update the wireguard IPs.
@@ -238,7 +238,7 @@ var _ = Describe("Auto Hostendpoint FV tests", Ordered, ContinueOnFailure, func(
 		// Expect the HEP to include the wireguard IPs.
 		expectedIPs = []string{"172.100.2.3", "fe80::1", "10.10.20.1", "dead:beef::1", "192.168.100.1", "dead:beef::100:1"}
 		Eventually(func() error {
-			return testutils.ExpectHostendpoint(c, expectedHepName, expectedHepLabels, expectedIPs, autoHepProfiles, defaultInterfaceName)
+			return testutils.ExpectHostendpoint(c, expectedHepName, expectedHepLabels, nil, expectedIPs, autoHepProfiles, defaultInterfaceName)
 		}, time.Second*15, 500*time.Millisecond).Should(BeNil())
 
 		// Add an internal IP and an external IP to the Addresses in the node spec.
@@ -290,7 +290,7 @@ var _ = Describe("Auto Hostendpoint FV tests", Ordered, ContinueOnFailure, func(
 		// Expect the HEP to include the internal IP from Addresses.
 		expectedIPs = []string{"172.100.2.3", "fe80::1", "10.10.20.1", "dead:beef::1", "192.168.100.1", "dead:beef::100:1", "192.168.200.1", "192.168.200.3", "192.168.200.4", "192.168.200.5"}
 		Eventually(func() error {
-			return testutils.ExpectHostendpoint(c, expectedHepName, expectedHepLabels, expectedIPs, autoHepProfiles, defaultInterfaceName)
+			return testutils.ExpectHostendpoint(c, expectedHepName, expectedHepLabels, nil, expectedIPs, autoHepProfiles, defaultInterfaceName)
 		}, time.Second*15, 500*time.Millisecond).Should(BeNil())
 
 		// Delete the Kubernetes node.
@@ -331,7 +331,7 @@ var _ = Describe("Auto Hostendpoint FV tests", Ordered, ContinueOnFailure, func(
 		expectedHepLabels["projectcalico.org/created-by"] = "calico-kube-controllers"
 		expectedIPs := []string{"172.16.1.1", "fe80::1", "192.168.100.1"}
 		Eventually(func() error {
-			return testutils.ExpectHostendpoint(c, expectedHepName, expectedHepLabels, expectedIPs, autoHepProfiles, defaultInterfaceName)
+			return testutils.ExpectHostendpoint(c, expectedHepName, expectedHepLabels, nil, expectedIPs, autoHepProfiles, defaultInterfaceName)
 		}, time.Second*15, 500*time.Millisecond).Should(BeNil())
 	})
 
@@ -407,7 +407,7 @@ var _ = Describe("Auto Hostendpoint FV tests", Ordered, ContinueOnFailure, func(
 		var noExpectedIPs []string
 		var noProfiles []string
 		Eventually(func() error {
-			return testutils.ExpectHostendpoint(c, userHep.Name, map[string]string{"env": "staging"}, noExpectedIPs, noProfiles, defaultInterfaceName)
+			return testutils.ExpectHostendpoint(c, userHep.Name, map[string]string{"env": "staging"}, nil, noExpectedIPs, noProfiles, defaultInterfaceName)
 		}, time.Second*15, 500*time.Millisecond).Should(BeNil())
 
 		// Expect an auto hostendpoint was created for the Calico node.
@@ -418,7 +418,7 @@ var _ = Describe("Auto Hostendpoint FV tests", Ordered, ContinueOnFailure, func(
 			"projectcalico.org/created-by": "calico-kube-controllers",
 		}
 		Eventually(func() error {
-			return testutils.ExpectHostendpoint(c, autoHepName, expectedHepLabels, expectedIPs, autoHepProfiles, defaultInterfaceName)
+			return testutils.ExpectHostendpoint(c, autoHepName, expectedHepLabels, nil, expectedIPs, autoHepProfiles, defaultInterfaceName)
 		}, time.Second*15, 500*time.Millisecond).Should(BeNil())
 	})
 
@@ -459,7 +459,7 @@ var _ = Describe("Auto Hostendpoint FV tests", Ordered, ContinueOnFailure, func(
 			"projectcalico.org/created-by": "calico-kube-controllers",
 		}
 		Eventually(func() error {
-			return testutils.ExpectHostendpoint(c, expectedHepName, expectedHepLabels, expectedIPs, autoHepProfiles, defaultInterfaceName)
+			return testutils.ExpectHostendpoint(c, expectedHepName, expectedHepLabels, nil, expectedIPs, autoHepProfiles, defaultInterfaceName)
 		}, time.Second*15, 500*time.Millisecond).Should(BeNil())
 
 		// Restart the controller but with auto hostendpoints disabled.
@@ -493,7 +493,7 @@ var _ = Describe("Auto Hostendpoint FV tests", Ordered, ContinueOnFailure, func(
 			"projectcalico.org/created-by": "calico-kube-controllers",
 		}
 		Eventually(func() error {
-			return testutils.ExpectHostendpoint(c, expectedDefaultHepName, expectedDefaultHepLabels, expectedDefaultIPs, autoHepProfiles, defaultInterfaceName)
+			return testutils.ExpectHostendpoint(c, expectedDefaultHepName, expectedDefaultHepLabels, nil, expectedDefaultIPs, autoHepProfiles, defaultInterfaceName)
 		}, time.Second*15, 500*time.Millisecond).Should(BeNil())
 
 		// Expect a template hostendpoint to be created.
@@ -505,7 +505,7 @@ var _ = Describe("Auto Hostendpoint FV tests", Ordered, ContinueOnFailure, func(
 			"template-label":               "template-value",
 		}
 		Eventually(func() error {
-			return testutils.ExpectHostendpoint(c, expectedTemplateHepName, expectedTemplateHepLabels, expectedTemplateIPs, autoHepProfiles, templateInterfaceName)
+			return testutils.ExpectHostendpoint(c, expectedTemplateHepName, expectedTemplateHepLabels, nil, expectedTemplateIPs, autoHepProfiles, templateInterfaceName)
 		}, time.Second*15, 500*time.Millisecond).Should(BeNil())
 
 		// Restart the controller but with auto hostendpoints disabled.
@@ -523,7 +523,61 @@ var _ = Describe("Auto Hostendpoint FV tests", Ordered, ContinueOnFailure, func(
 
 		// Expect the template hostendpoint to be unchanged
 		Eventually(func() error {
-			return testutils.ExpectHostendpoint(c, expectedTemplateHepName, expectedTemplateHepLabels, expectedTemplateIPs, autoHepProfiles, templateInterfaceName)
+			return testutils.ExpectHostendpoint(c, expectedTemplateHepName, expectedTemplateHepLabels, nil, expectedTemplateIPs, autoHepProfiles, templateInterfaceName)
+		}, time.Second*15, 500*time.Millisecond).Should(BeNil())
+	})
+
+	It("should set template annotations on generated host endpoints and keep them in sync", func() {
+		kcc := autoHepInterfaceTemplateKcc.DeepCopy()
+		kcc.Spec.Controllers.Node.HostEndpoint.Templates[0].Annotations = map[string]string{"template.projectcalico.org/annotation": "annotation-value"}
+		_, err := c.KubeControllersConfiguration().Create(context.Background(), kcc, options.SetOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		nodeController = testutils.RunNodeController(apiconfig.EtcdV3, etcd.IP, kconfigFile)
+
+		cn := internalapi.NewNode()
+		cn.Name = "node"
+		cn.Spec = internalapi.NodeSpec{
+			Interfaces: []internalapi.NodeInterface{
+				{Name: "eth0", Addresses: []string{"5.5.5.5"}},
+			},
+		}
+		_, err = c.Nodes().Create(context.Background(), cn, options.SetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		// The generated template host endpoint should carry the template annotations.
+		expectedHepName := cn.Name + "-template-eth0-auto-hep"
+		expectedIPs := []string{"5.5.5.5"}
+		expectedHepLabels := map[string]string{
+			"projectcalico.org/created-by": "calico-kube-controllers",
+			"template-label":               "template-value",
+		}
+		expectedHepAnnotations := map[string]string{"template.projectcalico.org/annotation": "annotation-value"}
+		expectedInterface := "eth0"
+		Eventually(func() error {
+			return testutils.ExpectHostendpoint(c, expectedHepName, expectedHepLabels, expectedHepAnnotations, expectedIPs, autoHepProfiles, expectedInterface)
+		}, time.Second*15, 500*time.Millisecond).Should(BeNil())
+
+		// Updating the template annotations should update the host endpoint.
+		expectedHepAnnotations["template.projectcalico.org/annotation2"] = "annotation-value2"
+		kcc, err = c.KubeControllersConfiguration().Get(context.Background(), "default", options.GetOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		kcc.Spec.Controllers.Node.HostEndpoint.Templates[0].Annotations = expectedHepAnnotations
+		_, err = c.KubeControllersConfiguration().Update(context.Background(), kcc, options.SetOptions{})
+		Expect(err).ToNot(HaveOccurred())
+
+		Eventually(func() error {
+			return testutils.ExpectHostendpoint(c, expectedHepName, expectedHepLabels, expectedHepAnnotations, expectedIPs, autoHepProfiles, expectedInterface)
+		}, time.Second*15, 500*time.Millisecond).Should(BeNil())
+
+		// Removing all template annotations should clear them from the host endpoint.
+		kcc, err = c.KubeControllersConfiguration().Get(context.Background(), "default", options.GetOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		kcc.Spec.Controllers.Node.HostEndpoint.Templates[0].Annotations = nil
+		_, err = c.KubeControllersConfiguration().Update(context.Background(), kcc, options.SetOptions{})
+		Expect(err).ToNot(HaveOccurred())
+
+		Eventually(func() error {
+			return testutils.ExpectHostendpoint(c, expectedHepName, expectedHepLabels, nil, expectedIPs, autoHepProfiles, expectedInterface)
 		}, time.Second*15, 500*time.Millisecond).Should(BeNil())
 	})
 
@@ -544,7 +598,7 @@ var _ = Describe("Auto Hostendpoint FV tests", Ordered, ContinueOnFailure, func(
 			"projectcalico.org/created-by": "calico-kube-controllers",
 		}
 		Eventually(func() error {
-			return testutils.ExpectHostendpoint(c, expectedDefaultHepName, expectedDefaultHepLabels, expectedDefaultIPs, autoHepProfiles, defaultInterfaceName)
+			return testutils.ExpectHostendpoint(c, expectedDefaultHepName, expectedDefaultHepLabels, nil, expectedDefaultIPs, autoHepProfiles, defaultInterfaceName)
 		}, time.Second*15, 500*time.Millisecond).Should(BeNil())
 
 		// Expect a template hostendpoint to be created.
@@ -556,7 +610,7 @@ var _ = Describe("Auto Hostendpoint FV tests", Ordered, ContinueOnFailure, func(
 			"template-label":               "template-value",
 		}
 		Eventually(func() error {
-			return testutils.ExpectHostendpoint(c, expectedTemplateHepName, expectedTemplateHepLabels, expectedTemplateIPs, autoHepProfiles, templateInterfaceName)
+			return testutils.ExpectHostendpoint(c, expectedTemplateHepName, expectedTemplateHepLabels, nil, expectedTemplateIPs, autoHepProfiles, templateInterfaceName)
 		}, time.Second*15, 500*time.Millisecond).Should(BeNil())
 
 		// Update node labels
@@ -571,7 +625,7 @@ var _ = Describe("Auto Hostendpoint FV tests", Ordered, ContinueOnFailure, func(
 			"calico-label1":                "calico-value1",
 		}
 		Eventually(func() error {
-			return testutils.ExpectHostendpoint(c, expectedDefaultHepName, expectedDefaultHepLabels, expectedDefaultIPs, autoHepProfiles, defaultInterfaceName)
+			return testutils.ExpectHostendpoint(c, expectedDefaultHepName, expectedDefaultHepLabels, nil, expectedDefaultIPs, autoHepProfiles, defaultInterfaceName)
 		}, time.Second*15, 500*time.Millisecond).Should(BeNil())
 
 		// Template host endpoint labels should be updated
@@ -582,7 +636,7 @@ var _ = Describe("Auto Hostendpoint FV tests", Ordered, ContinueOnFailure, func(
 			"calico-label1":                "calico-value1",
 		}
 		Eventually(func() error {
-			return testutils.ExpectHostendpoint(c, expectedTemplateHepName, expectedTemplateHepLabels, expectedTemplateIPs, autoHepProfiles, templateInterfaceName)
+			return testutils.ExpectHostendpoint(c, expectedTemplateHepName, expectedTemplateHepLabels, nil, expectedTemplateIPs, autoHepProfiles, templateInterfaceName)
 		}, time.Second*15, 500*time.Millisecond).Should(BeNil())
 	})
 
@@ -603,7 +657,7 @@ var _ = Describe("Auto Hostendpoint FV tests", Ordered, ContinueOnFailure, func(
 			"projectcalico.org/created-by": "calico-kube-controllers",
 		}
 		Eventually(func() error {
-			return testutils.ExpectHostendpoint(c, expectedDefaultHepName, expectedDefaultHepLabels, expectedDefaultIPs, autoHepProfiles, defaultInterfaceName)
+			return testutils.ExpectHostendpoint(c, expectedDefaultHepName, expectedDefaultHepLabels, nil, expectedDefaultIPs, autoHepProfiles, defaultInterfaceName)
 		}, time.Second*15, 500*time.Millisecond).Should(BeNil())
 
 		// Expect a template hostendpoint to be created.
@@ -615,7 +669,7 @@ var _ = Describe("Auto Hostendpoint FV tests", Ordered, ContinueOnFailure, func(
 			"template-label":               "template-value",
 		}
 		Eventually(func() error {
-			return testutils.ExpectHostendpoint(c, expectedTemplateHepName, expectedTemplateHepLabels, expectedTemplateIPs, autoHepProfiles, templateInterfaceName)
+			return testutils.ExpectHostendpoint(c, expectedTemplateHepName, expectedTemplateHepLabels, nil, expectedTemplateIPs, autoHepProfiles, templateInterfaceName)
 		}, time.Second*15, 500*time.Millisecond).Should(BeNil())
 
 		// Restart the controller with updated template name
@@ -635,13 +689,13 @@ var _ = Describe("Auto Hostendpoint FV tests", Ordered, ContinueOnFailure, func(
 
 		// Expect default hostendpoint to be unchanged
 		Eventually(func() error {
-			return testutils.ExpectHostendpoint(c, expectedDefaultHepName, expectedDefaultHepLabels, expectedDefaultIPs, autoHepProfiles, defaultInterfaceName)
+			return testutils.ExpectHostendpoint(c, expectedDefaultHepName, expectedDefaultHepLabels, nil, expectedDefaultIPs, autoHepProfiles, defaultInterfaceName)
 		}, time.Second*15, 500*time.Millisecond).Should(BeNil())
 
 		// Expect template hostendpoint to have new name
 		expectedTemplateHepName = cn.Name + "-template-new-name-auto-hep"
 		Eventually(func() error {
-			return testutils.ExpectHostendpoint(c, expectedTemplateHepName, expectedTemplateHepLabels, expectedTemplateIPs, autoHepProfiles, templateInterfaceName)
+			return testutils.ExpectHostendpoint(c, expectedTemplateHepName, expectedTemplateHepLabels, nil, expectedTemplateIPs, autoHepProfiles, templateInterfaceName)
 		}, time.Second*15, 500*time.Millisecond).Should(BeNil())
 	})
 
@@ -670,7 +724,7 @@ var _ = Describe("Auto Hostendpoint FV tests", Ordered, ContinueOnFailure, func(
 			"node1":                        "test-value",
 		}
 		Eventually(func() error {
-			return testutils.ExpectHostendpoint(c, expectedDefaultHepName1, expectedDefaultHepLabels1, expectedDefaultIPs1, autoHepProfiles, defaultInterfaceName)
+			return testutils.ExpectHostendpoint(c, expectedDefaultHepName1, expectedDefaultHepLabels1, nil, expectedDefaultIPs1, autoHepProfiles, defaultInterfaceName)
 		}, time.Second*15, 500*time.Millisecond).Should(BeNil())
 
 		// Expect a wildcard hostendpoint to be created for node 2.
@@ -681,7 +735,7 @@ var _ = Describe("Auto Hostendpoint FV tests", Ordered, ContinueOnFailure, func(
 			"projectcalico.org/created-by": "calico-kube-controllers",
 		}
 		Eventually(func() error {
-			return testutils.ExpectHostendpoint(c, expectedDefaultHepName2, expectedDefaultHepLabels2, expectedDefaultIPs2, autoHepProfiles, defaultInterfaceName)
+			return testutils.ExpectHostendpoint(c, expectedDefaultHepName2, expectedDefaultHepLabels2, nil, expectedDefaultIPs2, autoHepProfiles, defaultInterfaceName)
 		}, time.Second*15, 500*time.Millisecond).Should(BeNil())
 
 		// Expect a template hostendpoint to be created for node 1.
@@ -694,7 +748,7 @@ var _ = Describe("Auto Hostendpoint FV tests", Ordered, ContinueOnFailure, func(
 			"node1":                        "test-value",
 		}
 		Eventually(func() error {
-			return testutils.ExpectHostendpoint(c, expectedTemplateHepName1, expectedTemplateHepLabels1, expectedTemplateIPs1, autoHepProfiles, templateInterfaceName)
+			return testutils.ExpectHostendpoint(c, expectedTemplateHepName1, expectedTemplateHepLabels1, nil, expectedTemplateIPs1, autoHepProfiles, templateInterfaceName)
 		}, time.Second*15, 500*time.Millisecond).Should(BeNil())
 
 		// Expect a template hostendpoint to be created for node 2.
@@ -706,7 +760,7 @@ var _ = Describe("Auto Hostendpoint FV tests", Ordered, ContinueOnFailure, func(
 			"template-label":               "template-value",
 		}
 		Eventually(func() error {
-			return testutils.ExpectHostendpoint(c, expectedTemplateHepName2, expectedTemplateHepLabels2, expectedTemplateIPs2, autoHepProfiles, templateInterfaceName)
+			return testutils.ExpectHostendpoint(c, expectedTemplateHepName2, expectedTemplateHepLabels2, nil, expectedTemplateIPs2, autoHepProfiles, templateInterfaceName)
 		}, time.Second*15, 500*time.Millisecond).Should(BeNil())
 
 		// Restart the controller with updated template
@@ -732,10 +786,10 @@ var _ = Describe("Auto Hostendpoint FV tests", Ordered, ContinueOnFailure, func(
 
 		// Expect the default hostendpoints to be present
 		Eventually(func() error {
-			return testutils.ExpectHostendpoint(c, expectedDefaultHepName1, expectedDefaultHepLabels1, expectedDefaultIPs1, autoHepProfiles, defaultInterfaceName)
+			return testutils.ExpectHostendpoint(c, expectedDefaultHepName1, expectedDefaultHepLabels1, nil, expectedDefaultIPs1, autoHepProfiles, defaultInterfaceName)
 		}, time.Second*15, 500*time.Millisecond).Should(BeNil())
 		Eventually(func() error {
-			return testutils.ExpectHostendpoint(c, expectedDefaultHepName2, expectedDefaultHepLabels2, expectedDefaultIPs2, autoHepProfiles, defaultInterfaceName)
+			return testutils.ExpectHostendpoint(c, expectedDefaultHepName2, expectedDefaultHepLabels2, nil, expectedDefaultIPs2, autoHepProfiles, defaultInterfaceName)
 		}, time.Second*15, 500*time.Millisecond).Should(BeNil())
 
 		// Expect the template hostendpoint for node2 to be deleted
@@ -751,7 +805,7 @@ var _ = Describe("Auto Hostendpoint FV tests", Ordered, ContinueOnFailure, func(
 			"node1":                        "test-value",
 		}
 		Eventually(func() error {
-			return testutils.ExpectHostendpoint(c, expectedTemplateHepName1, expectedTemplateHepLabels1, expectedTemplateIPs1, autoHepProfiles, templateInterfaceName)
+			return testutils.ExpectHostendpoint(c, expectedTemplateHepName1, expectedTemplateHepLabels1, nil, expectedTemplateIPs1, autoHepProfiles, templateInterfaceName)
 		}, time.Second*15, 500*time.Millisecond).Should(BeNil())
 
 		// Expect a new template hostendpoint to be created for node 1.
@@ -763,7 +817,7 @@ var _ = Describe("Auto Hostendpoint FV tests", Ordered, ContinueOnFailure, func(
 			"node1":                        "test-value",
 		}
 		Eventually(func() error {
-			return testutils.ExpectHostendpoint(c, expectedTemplateHepName3, expectedTemplateHepLabels3, expectedTemplateIPs3, autoHepProfiles, templateInterfaceName)
+			return testutils.ExpectHostendpoint(c, expectedTemplateHepName3, expectedTemplateHepLabels3, nil, expectedTemplateIPs3, autoHepProfiles, templateInterfaceName)
 		}, time.Second*15, 500*time.Millisecond).Should(BeNil())
 
 		// Restart the controller with autoCreate Disabled, should clean up all created hostendpoints
@@ -805,7 +859,7 @@ var _ = Describe("Auto Hostendpoint FV tests", Ordered, ContinueOnFailure, func(
 			"projectcalico.org/created-by": "calico-kube-controllers",
 		}
 		Eventually(func() error {
-			return testutils.ExpectHostendpoint(c, expectedDefaultHepName, expectedDefaultHepLabels, expectedDefaultIPs, autoHepProfiles, defaultInterfaceName)
+			return testutils.ExpectHostendpoint(c, expectedDefaultHepName, expectedDefaultHepLabels, nil, expectedDefaultIPs, autoHepProfiles, defaultInterfaceName)
 		}, time.Second*15, 500*time.Millisecond).Should(BeNil())
 
 		// Expect a template hostendpoint to be created.
@@ -817,7 +871,7 @@ var _ = Describe("Auto Hostendpoint FV tests", Ordered, ContinueOnFailure, func(
 			"template-label":               "template-value",
 		}
 		Eventually(func() error {
-			return testutils.ExpectHostendpoint(c, expectedTemplateHepName, expectedTemplateHepLabels, expectedTemplateIPs, autoHepProfiles, templateInterfaceName)
+			return testutils.ExpectHostendpoint(c, expectedTemplateHepName, expectedTemplateHepLabels, nil, expectedTemplateIPs, autoHepProfiles, templateInterfaceName)
 		}, time.Second*15, 500*time.Millisecond).Should(BeNil())
 
 		// Update the default host endpoint
@@ -829,7 +883,7 @@ var _ = Describe("Auto Hostendpoint FV tests", Ordered, ContinueOnFailure, func(
 
 		// Expect the default host endpoint to be synced correctly after external update
 		Eventually(func() error {
-			return testutils.ExpectHostendpoint(c, expectedDefaultHepName, expectedDefaultHepLabels, expectedDefaultIPs, autoHepProfiles, defaultInterfaceName)
+			return testutils.ExpectHostendpoint(c, expectedDefaultHepName, expectedDefaultHepLabels, nil, expectedDefaultIPs, autoHepProfiles, defaultInterfaceName)
 		}, time.Second*15, 500*time.Millisecond).Should(BeNil())
 
 		// Update the template host endpoint
@@ -841,7 +895,7 @@ var _ = Describe("Auto Hostendpoint FV tests", Ordered, ContinueOnFailure, func(
 
 		// Expect the template host endpoint to be synced correctly after external update
 		Eventually(func() error {
-			return testutils.ExpectHostendpoint(c, expectedTemplateHepName, expectedTemplateHepLabels, expectedTemplateIPs, autoHepProfiles, templateInterfaceName)
+			return testutils.ExpectHostendpoint(c, expectedTemplateHepName, expectedTemplateHepLabels, nil, expectedTemplateIPs, autoHepProfiles, templateInterfaceName)
 		}, time.Second*15, 500*time.Millisecond).Should(BeNil())
 
 		// Manually delete the default host endpoint, kube-controller should recreate it
@@ -850,7 +904,7 @@ var _ = Describe("Auto Hostendpoint FV tests", Ordered, ContinueOnFailure, func(
 
 		// Expect the default host endpoint to be recreated when deleted manually
 		Eventually(func() error {
-			return testutils.ExpectHostendpoint(c, expectedDefaultHepName, expectedDefaultHepLabels, expectedDefaultIPs, autoHepProfiles, defaultInterfaceName)
+			return testutils.ExpectHostendpoint(c, expectedDefaultHepName, expectedDefaultHepLabels, nil, expectedDefaultIPs, autoHepProfiles, defaultInterfaceName)
 		}, time.Second*15, 500*time.Millisecond).Should(BeNil())
 
 		// Manually delete the template host endpoint, kube-controller should recreate it
@@ -859,7 +913,7 @@ var _ = Describe("Auto Hostendpoint FV tests", Ordered, ContinueOnFailure, func(
 
 		// Expect the template host endpoint to be recreated when deleted manually
 		Eventually(func() error {
-			return testutils.ExpectHostendpoint(c, expectedTemplateHepName, expectedTemplateHepLabels, expectedTemplateIPs, autoHepProfiles, templateInterfaceName)
+			return testutils.ExpectHostendpoint(c, expectedTemplateHepName, expectedTemplateHepLabels, nil, expectedTemplateIPs, autoHepProfiles, templateInterfaceName)
 		}, time.Second*15, 500*time.Millisecond).Should(BeNil())
 	})
 
@@ -887,7 +941,7 @@ var _ = Describe("Auto Hostendpoint FV tests", Ordered, ContinueOnFailure, func(
 			"projectcalico.org/created-by": "calico-kube-controllers",
 		}
 		Eventually(func() error {
-			return testutils.ExpectHostendpoint(c, expectedDefaultHepName, expectedDefaultHepLabels, expectedDefaultIPs, autoHepProfiles, defaultInterfaceName)
+			return testutils.ExpectHostendpoint(c, expectedDefaultHepName, expectedDefaultHepLabels, nil, expectedDefaultIPs, autoHepProfiles, defaultInterfaceName)
 		}, time.Second*15, 500*time.Millisecond).Should(BeNil())
 	})
 
@@ -909,7 +963,7 @@ var _ = Describe("Auto Hostendpoint FV tests", Ordered, ContinueOnFailure, func(
 			"template-label":               "template-value",
 		}
 		Eventually(func() error {
-			return testutils.ExpectHostendpoint(c, expectedTemplateHepName, expectedTemplateHepLabels, expectedTemplateIPs, autoHepProfiles, templateInterfaceName)
+			return testutils.ExpectHostendpoint(c, expectedTemplateHepName, expectedTemplateHepLabels, nil, expectedTemplateIPs, autoHepProfiles, templateInterfaceName)
 		}, time.Second*15, 500*time.Millisecond).Should(BeNil())
 
 		// Restart the controller with updated template name
@@ -930,7 +984,7 @@ var _ = Describe("Auto Hostendpoint FV tests", Ordered, ContinueOnFailure, func(
 		// Expect template hostendpoint to have new hashed name
 		expectedTemplateHepName = "2vhzifmgzoee1hgruafve8iewjr1cabezq3o51myej0-auto-hep"
 		Eventually(func() error {
-			return testutils.ExpectHostendpoint(c, expectedTemplateHepName, expectedTemplateHepLabels, expectedTemplateIPs, autoHepProfiles, templateInterfaceName)
+			return testutils.ExpectHostendpoint(c, expectedTemplateHepName, expectedTemplateHepLabels, nil, expectedTemplateIPs, autoHepProfiles, templateInterfaceName)
 		}, time.Second*15, 500*time.Millisecond).Should(BeNil())
 	})
 
@@ -969,7 +1023,7 @@ var _ = Describe("Auto Hostendpoint FV tests", Ordered, ContinueOnFailure, func(
 		}
 		expectedTemplateInterface := "eth0"
 		Eventually(func() error {
-			return testutils.ExpectHostendpoint(c, expectedTemplateHepName, expectedTemplateHepLabels, expectedTemplateIPs, autoHepProfiles, expectedTemplateInterface)
+			return testutils.ExpectHostendpoint(c, expectedTemplateHepName, expectedTemplateHepLabels, nil, expectedTemplateIPs, autoHepProfiles, expectedTemplateInterface)
 		}, time.Second*15, 500*time.Millisecond).Should(BeNil())
 
 		// Expect one hostendpoint to be created
@@ -994,7 +1048,7 @@ var _ = Describe("Auto Hostendpoint FV tests", Ordered, ContinueOnFailure, func(
 
 		// Expect the eth0 host endpoint to be unchanged
 		Eventually(func() error {
-			return testutils.ExpectHostendpoint(c, expectedTemplateHepName, expectedTemplateHepLabels, expectedTemplateIPs, autoHepProfiles, expectedTemplateInterface)
+			return testutils.ExpectHostendpoint(c, expectedTemplateHepName, expectedTemplateHepLabels, nil, expectedTemplateIPs, autoHepProfiles, expectedTemplateInterface)
 		}, time.Second*15, 500*time.Millisecond).Should(BeNil())
 
 		// Expect a hostendpoint to be created for eth1.
@@ -1006,7 +1060,7 @@ var _ = Describe("Auto Hostendpoint FV tests", Ordered, ContinueOnFailure, func(
 		}
 		expectedTemplateInterface2 := "eth1"
 		Eventually(func() error {
-			return testutils.ExpectHostendpoint(c, expectedTemplateHepName2, expectedTemplateHepLabels2, expectedTemplateIPs2, autoHepProfiles, expectedTemplateInterface2)
+			return testutils.ExpectHostendpoint(c, expectedTemplateHepName2, expectedTemplateHepLabels2, nil, expectedTemplateIPs2, autoHepProfiles, expectedTemplateInterface2)
 		}, time.Second*15, 500*time.Millisecond).Should(BeNil())
 
 		// Expect two host endpoints to be created
@@ -1032,12 +1086,12 @@ var _ = Describe("Auto Hostendpoint FV tests", Ordered, ContinueOnFailure, func(
 
 		expectedTemplateIPs = []string{"172.16.1.1", "5.5.5.5"}
 		Eventually(func() error {
-			return testutils.ExpectHostendpoint(c, expectedTemplateHepName, expectedTemplateHepLabels, expectedTemplateIPs, autoHepProfiles, expectedTemplateInterface)
+			return testutils.ExpectHostendpoint(c, expectedTemplateHepName, expectedTemplateHepLabels, nil, expectedTemplateIPs, autoHepProfiles, expectedTemplateInterface)
 		}, time.Second*15, 500*time.Millisecond).Should(BeNil())
 
 		expectedTemplateIPs2 = []string{"172.16.1.1", "6.6.6.6"}
 		Eventually(func() error {
-			return testutils.ExpectHostendpoint(c, expectedTemplateHepName2, expectedTemplateHepLabels2, expectedTemplateIPs2, autoHepProfiles, expectedTemplateInterface2)
+			return testutils.ExpectHostendpoint(c, expectedTemplateHepName2, expectedTemplateHepLabels2, nil, expectedTemplateIPs2, autoHepProfiles, expectedTemplateInterface2)
 		}, time.Second*15, 500*time.Millisecond).Should(BeNil())
 
 		// Expect two host endpoints to be created
@@ -1067,7 +1121,7 @@ var _ = Describe("Auto Hostendpoint FV tests", Ordered, ContinueOnFailure, func(
 		// Expect the eth1 host endpoint to be updated
 		expectedTemplateIPs2 = []string{"6.6.6.6"}
 		Eventually(func() error {
-			return testutils.ExpectHostendpoint(c, expectedTemplateHepName2, expectedTemplateHepLabels2, expectedTemplateIPs2, autoHepProfiles, expectedTemplateInterface2)
+			return testutils.ExpectHostendpoint(c, expectedTemplateHepName2, expectedTemplateHepLabels2, nil, expectedTemplateIPs2, autoHepProfiles, expectedTemplateInterface2)
 		}, time.Second*15, 500*time.Millisecond).Should(BeNil())
 
 		// Expect one host endpoint to be created

--- a/kube-controllers/pkg/controllers/node/hostendpoints.go
+++ b/kube-controllers/pkg/controllers/node/hostendpoints.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2025 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2026 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/kube-controllers/pkg/controllers/node/hostendpoints.go
+++ b/kube-controllers/pkg/controllers/node/hostendpoints.go
@@ -307,7 +307,7 @@ func (c *autoHostEndpointController) syncHostEndpointsForNode(nodeName string) {
 			logrus.WithError(err).Error("failed to generate host endpoint name")
 			return
 		}
-		expectedHostEndpoint := c.generateAutoHostEndpoint(node, nil, defaultHostEndpointName, c.getExpectedIPs(node), defaultHostEndpointInterface)
+		expectedHostEndpoint := c.generateAutoHostEndpoint(node, nil, nil, defaultHostEndpointName, c.getExpectedIPs(node), defaultHostEndpointInterface)
 		// Check if current default host endpoint is up to date. Create it if missing
 		c.createOrUpdateHostEndpoint(expectedHostEndpoint)
 
@@ -341,7 +341,7 @@ func (c *autoHostEndpointController) syncHostEndpointsForNode(nodeName string) {
 					logrus.WithError(err).Error("failed to generate host endpoint name")
 					return
 				}
-				expectedHostEndpoint := c.generateAutoHostEndpoint(node, template.Labels, hostEndpointName, expectedIPs, "")
+				expectedHostEndpoint := c.generateAutoHostEndpoint(node, template.Labels, template.Annotations, hostEndpointName, expectedIPs, "")
 				c.createOrUpdateHostEndpoint(expectedHostEndpoint)
 
 				hostEndpointsMatchingNode[hostEndpointName] = true
@@ -362,7 +362,7 @@ func (c *autoHostEndpointController) syncHostEndpointsForNode(nodeName string) {
 
 					// Update the expected IPs with IPs belonging to the matched interface, we do not need to check if it's empty as the generated host endpoint will contain interface name
 					expectedIPsWithInterfaceIPs := c.mergeExpectedIPsWithInterfaceIPs(expectedIPs, iface)
-					expectedHostEndpoint := c.generateAutoHostEndpoint(node, template.Labels, hostEndpointName, expectedIPsWithInterfaceIPs, iface.Name)
+					expectedHostEndpoint := c.generateAutoHostEndpoint(node, template.Labels, template.Annotations, hostEndpointName, expectedIPsWithInterfaceIPs, iface.Name)
 					c.createOrUpdateHostEndpoint(expectedHostEndpoint)
 
 					hostEndpointsMatchingNode[hostEndpointName] = true
@@ -569,7 +569,7 @@ func (c *autoHostEndpointController) getExpectedIPs(node *internalapi.Node) []st
 }
 
 // generateAutoHostEndpoint returns a HostEndpoint created based on the specific parameters
-func (c *autoHostEndpointController) generateAutoHostEndpoint(node *internalapi.Node, templateLabels map[string]string, hepName string, expectedIPs []string, interfaceName string) *api.HostEndpoint {
+func (c *autoHostEndpointController) generateAutoHostEndpoint(node *internalapi.Node, templateLabels, templateAnnotations map[string]string, hepName string, expectedIPs []string, interfaceName string) *api.HostEndpoint {
 	hepLabels := make(map[string]string)
 	maps.Copy(hepLabels, node.Labels)
 	for k, v := range templateLabels {
@@ -581,13 +581,21 @@ func (c *autoHostEndpointController) generateAutoHostEndpoint(node *internalapi.
 	}
 	hepLabels[hepCreatedLabelKey] = hepCreatedLabelValue
 
+	// Only template annotations are applied to the HostEndpoint; Node annotations
+	// are intentionally not copied.
+	var hepAnnotations map[string]string
+	if len(templateAnnotations) > 0 {
+		hepAnnotations = maps.Clone(templateAnnotations)
+	}
+
 	hostEndpoint := &api.HostEndpoint{
 		TypeMeta: metav1.TypeMeta{
 			Kind: api.KindHostEndpoint,
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   hepName,
-			Labels: hepLabels,
+			Name:        hepName,
+			Labels:      hepLabels,
+			Annotations: hepAnnotations,
 		},
 		Spec: api.HostEndpointSpec{
 			Node:          node.Name,
@@ -606,6 +614,10 @@ func (c *autoHostEndpointController) hostEndpointNeedsUpdate(current *api.HostEn
 	logrus.Debugf("checking if hostendpoint needs update\ncurrent: %#v\nexpected: %#v", current, expected)
 	if !reflect.DeepEqual(current.Labels, expected.Labels) {
 		logrus.WithField("hep.Name", current.Name).Debug("hostendpoint needs update because of labels")
+		return true
+	}
+	if !reflect.DeepEqual(current.Annotations, expected.Annotations) {
+		logrus.WithField("hep.Name", current.Name).Debug("hostendpoint needs update because of annotations")
 		return true
 	}
 	if !reflect.DeepEqual(current.Spec.ExpectedIPs, expected.Spec.ExpectedIPs) {

--- a/kube-controllers/tests/testutils/node_controller_utils.go
+++ b/kube-controllers/tests/testutils/node_controller_utils.go
@@ -96,7 +96,7 @@ func ExpectNodeLabels(c client.Interface, labels map[string]string, node string)
 	return nil
 }
 
-func ExpectHostendpoint(c client.Interface, hepName string, expectedLabels map[string]string, expectedIPs, expectedProfiles []string, interfaceName string) error {
+func ExpectHostendpoint(c client.Interface, hepName string, expectedLabels, expectedAnnotations map[string]string, expectedIPs, expectedProfiles []string, interfaceName string) error {
 	hep, err := c.HostEndpoints().Get(context.Background(), hepName, options.GetOptions{})
 	if err != nil {
 		return err
@@ -111,6 +111,12 @@ func ExpectHostendpoint(c client.Interface, hepName string, expectedLabels map[s
 
 	if !reflect.DeepEqual(hep.Labels, expectedLabels) {
 		s := fmt.Sprintf("labels do not match.\n\nExpected: %#v\n  Actual: %#v\n", expectedLabels, hep.Labels)
+		logrus.Warn(s)
+		return errors.New(s)
+	}
+
+	if !reflect.DeepEqual(hep.Annotations, expectedAnnotations) {
+		s := fmt.Sprintf("annotations do not match.\n\nExpected: %#v\n  Actual: %#v\n", expectedAnnotations, hep.Annotations)
 		logrus.Warn(s)
 		return errors.New(s)
 	}

--- a/libcalico-go/config/crd/crd.projectcalico.org_kubecontrollersconfigurations.yaml
+++ b/libcalico-go/config/crd/crd.projectcalico.org_kubecontrollersconfigurations.yaml
@@ -112,6 +112,13 @@ spec:
                                 AutoHostEndpoints
                               items:
                                 properties:
+                                  annotations:
+                                    additionalProperties:
+                                      type: string
+                                    description:
+                                      Annotations adds the specified annotations
+                                      to the generated AutoHostEndpoint.
+                                    type: object
                                   generateName:
                                     description:
                                       GenerateName is appended to the end
@@ -341,6 +348,13 @@ spec:
                                     AutoHostEndpoints
                                   items:
                                     properties:
+                                      annotations:
+                                        additionalProperties:
+                                          type: string
+                                        description:
+                                          Annotations adds the specified
+                                          annotations to the generated AutoHostEndpoint.
+                                        type: object
                                       generateName:
                                         description:
                                           GenerateName is appended to the

--- a/libcalico-go/lib/validator/v3/validator.go
+++ b/libcalico-go/lib/validator/v3/validator.go
@@ -249,6 +249,7 @@ func init() {
 	registerStructValidator(validate, validateGlobalNetworkSet, api.GlobalNetworkSet{})
 	registerStructValidator(validate, validateNetworkSet, api.NetworkSet{})
 	registerStructValidator(validate, validateRuleMetadata, api.RuleMetadata{})
+	registerStructValidator(validate, validateTemplate, api.Template{})
 	registerStructValidator(validate, validateRouteTableIDRange, api.RouteTableIDRange{})
 	registerStructValidator(validate, validateRouteTableRange, api.RouteTableRange{})
 	registerStructValidator(validate, validateBGPConfigurationSpec, api.BGPConfigurationSpec{})
@@ -481,6 +482,11 @@ func validateLabels(fl validator.FieldLevel) bool {
 		}
 	}
 	return true
+}
+
+func validateTemplate(structLevel validator.StructLevel) {
+	template := structLevel.Current().Interface().(api.Template)
+	validateObjectMetaAnnotations(structLevel, template.Annotations)
 }
 
 func validateProtocol(structLevel validator.StructLevel) {

--- a/libcalico-go/lib/validator/v3/validator_test.go
+++ b/libcalico-go/lib/validator/v3/validator_test.go
@@ -4192,6 +4192,29 @@ func init() {
 				Annotations: map[string]string{"not a valid key": "value"},
 			}, false,
 		),
+		// Templates are nested in a slice on AutoHostEndpointConfig; verify that
+		// per-template validation is actually reached (i.e. the slice dives).
+		Entry("should accept a nested template with valid annotations",
+			api.KubeControllersConfigurationSpec{Controllers: api.ControllersConfig{
+				Node: &api.NodeControllerConfig{HostEndpoint: &api.AutoHostEndpointConfig{
+					Templates: []api.Template{{Annotations: map[string]string{"projectcalico.org/note": "ok"}}},
+				}},
+			}}, true,
+		),
+		Entry("should reject a nested template with an invalid annotation key",
+			api.KubeControllersConfigurationSpec{Controllers: api.ControllersConfig{
+				Node: &api.NodeControllerConfig{HostEndpoint: &api.AutoHostEndpointConfig{
+					Templates: []api.Template{{Annotations: map[string]string{"not a valid key": "value"}}},
+				}},
+			}}, false,
+		),
+		Entry("should reject a nested template with an invalid generateName",
+			api.KubeControllersConfigurationSpec{Controllers: api.ControllersConfig{
+				Node: &api.NodeControllerConfig{HostEndpoint: &api.AutoHostEndpointConfig{
+					Templates: []api.Template{{GenerateName: "test$set"}},
+				}},
+			}}, false,
+		),
 
 		// BGP Communities validation in BGPConfigurationSpec
 		Entry("should not accept community when PrefixAdvertisement is empty", &api.BGPConfiguration{

--- a/libcalico-go/lib/validator/v3/validator_test.go
+++ b/libcalico-go/lib/validator/v3/validator_test.go
@@ -4182,6 +4182,16 @@ func init() {
 				InterfaceCIDRs: []string{"not a real cidr"},
 			}, false,
 		),
+		Entry("should allow valid template annotations, including values not valid as label values",
+			api.Template{
+				Annotations: map[string]string{"projectcalico.org/note": "any value, including spaces & symbols!"},
+			}, true,
+		),
+		Entry("should reject template annotations with an invalid key",
+			api.Template{
+				Annotations: map[string]string{"not a valid key": "value"},
+			}, false,
+		),
 
 		// BGP Communities validation in BGPConfigurationSpec
 		Entry("should not accept community when PrefixAdvertisement is empty", &api.BGPConfiguration{

--- a/manifests/calico-bpf.yaml
+++ b/manifests/calico-bpf.yaml
@@ -5714,6 +5714,13 @@ spec:
                                 AutoHostEndpoints
                               items:
                                 properties:
+                                  annotations:
+                                    additionalProperties:
+                                      type: string
+                                    description:
+                                      Annotations adds the specified annotations
+                                      to the generated AutoHostEndpoint.
+                                    type: object
                                   generateName:
                                     description:
                                       GenerateName is appended to the end
@@ -5943,6 +5950,13 @@ spec:
                                     AutoHostEndpoints
                                   items:
                                     properties:
+                                      annotations:
+                                        additionalProperties:
+                                          type: string
+                                        description:
+                                          Annotations adds the specified
+                                          annotations to the generated AutoHostEndpoint.
+                                        type: object
                                       generateName:
                                         description:
                                           GenerateName is appended to the

--- a/manifests/calico-policy-only.yaml
+++ b/manifests/calico-policy-only.yaml
@@ -5724,6 +5724,13 @@ spec:
                                 AutoHostEndpoints
                               items:
                                 properties:
+                                  annotations:
+                                    additionalProperties:
+                                      type: string
+                                    description:
+                                      Annotations adds the specified annotations
+                                      to the generated AutoHostEndpoint.
+                                    type: object
                                   generateName:
                                     description:
                                       GenerateName is appended to the end
@@ -5953,6 +5960,13 @@ spec:
                                     AutoHostEndpoints
                                   items:
                                     properties:
+                                      annotations:
+                                        additionalProperties:
+                                          type: string
+                                        description:
+                                          Annotations adds the specified
+                                          annotations to the generated AutoHostEndpoint.
+                                        type: object
                                       generateName:
                                         description:
                                           GenerateName is appended to the

--- a/manifests/calico-typha.yaml
+++ b/manifests/calico-typha.yaml
@@ -5725,6 +5725,13 @@ spec:
                                 AutoHostEndpoints
                               items:
                                 properties:
+                                  annotations:
+                                    additionalProperties:
+                                      type: string
+                                    description:
+                                      Annotations adds the specified annotations
+                                      to the generated AutoHostEndpoint.
+                                    type: object
                                   generateName:
                                     description:
                                       GenerateName is appended to the end
@@ -5954,6 +5961,13 @@ spec:
                                     AutoHostEndpoints
                                   items:
                                     properties:
+                                      annotations:
+                                        additionalProperties:
+                                          type: string
+                                        description:
+                                          Annotations adds the specified
+                                          annotations to the generated AutoHostEndpoint.
+                                        type: object
                                       generateName:
                                         description:
                                           GenerateName is appended to the

--- a/manifests/calico-v3-crds.yaml
+++ b/manifests/calico-v3-crds.yaml
@@ -5987,6 +5987,13 @@ spec:
                                 AutoHostEndpoints
                               items:
                                 properties:
+                                  annotations:
+                                    additionalProperties:
+                                      type: string
+                                    description:
+                                      Annotations adds the specified annotations
+                                      to the generated AutoHostEndpoint.
+                                    type: object
                                   generateName:
                                     description:
                                       GenerateName is appended to the end
@@ -6216,6 +6223,13 @@ spec:
                                     AutoHostEndpoints
                                   items:
                                     properties:
+                                      annotations:
+                                        additionalProperties:
+                                          type: string
+                                        description:
+                                          Annotations adds the specified
+                                          annotations to the generated AutoHostEndpoint.
+                                        type: object
                                       generateName:
                                         description:
                                           GenerateName is appended to the

--- a/manifests/calico-vxlan.yaml
+++ b/manifests/calico-vxlan.yaml
@@ -5709,6 +5709,13 @@ spec:
                                 AutoHostEndpoints
                               items:
                                 properties:
+                                  annotations:
+                                    additionalProperties:
+                                      type: string
+                                    description:
+                                      Annotations adds the specified annotations
+                                      to the generated AutoHostEndpoint.
+                                    type: object
                                   generateName:
                                     description:
                                       GenerateName is appended to the end
@@ -5938,6 +5945,13 @@ spec:
                                     AutoHostEndpoints
                                   items:
                                     properties:
+                                      annotations:
+                                        additionalProperties:
+                                          type: string
+                                        description:
+                                          Annotations adds the specified
+                                          annotations to the generated AutoHostEndpoint.
+                                        type: object
                                       generateName:
                                         description:
                                           GenerateName is appended to the

--- a/manifests/calico.yaml
+++ b/manifests/calico.yaml
@@ -5709,6 +5709,13 @@ spec:
                                 AutoHostEndpoints
                               items:
                                 properties:
+                                  annotations:
+                                    additionalProperties:
+                                      type: string
+                                    description:
+                                      Annotations adds the specified annotations
+                                      to the generated AutoHostEndpoint.
+                                    type: object
                                   generateName:
                                     description:
                                       GenerateName is appended to the end
@@ -5938,6 +5945,13 @@ spec:
                                     AutoHostEndpoints
                                   items:
                                     properties:
+                                      annotations:
+                                        additionalProperties:
+                                          type: string
+                                        description:
+                                          Annotations adds the specified
+                                          annotations to the generated AutoHostEndpoint.
+                                        type: object
                                       generateName:
                                         description:
                                           GenerateName is appended to the

--- a/manifests/canal.yaml
+++ b/manifests/canal.yaml
@@ -5726,6 +5726,13 @@ spec:
                                 AutoHostEndpoints
                               items:
                                 properties:
+                                  annotations:
+                                    additionalProperties:
+                                      type: string
+                                    description:
+                                      Annotations adds the specified annotations
+                                      to the generated AutoHostEndpoint.
+                                    type: object
                                   generateName:
                                     description:
                                       GenerateName is appended to the end
@@ -5955,6 +5962,13 @@ spec:
                                     AutoHostEndpoints
                                   items:
                                     properties:
+                                      annotations:
+                                        additionalProperties:
+                                          type: string
+                                        description:
+                                          Annotations adds the specified
+                                          annotations to the generated AutoHostEndpoint.
+                                        type: object
                                       generateName:
                                         description:
                                           GenerateName is appended to the

--- a/manifests/crds.yaml
+++ b/manifests/crds.yaml
@@ -5623,6 +5623,13 @@ spec:
                                 AutoHostEndpoints
                               items:
                                 properties:
+                                  annotations:
+                                    additionalProperties:
+                                      type: string
+                                    description:
+                                      Annotations adds the specified annotations
+                                      to the generated AutoHostEndpoint.
+                                    type: object
                                   generateName:
                                     description:
                                       GenerateName is appended to the end
@@ -5852,6 +5859,13 @@ spec:
                                     AutoHostEndpoints
                                   items:
                                     properties:
+                                      annotations:
+                                        additionalProperties:
+                                          type: string
+                                        description:
+                                          Annotations adds the specified
+                                          annotations to the generated AutoHostEndpoint.
+                                        type: object
                                       generateName:
                                         description:
                                           GenerateName is appended to the

--- a/manifests/flannel-migration/calico.yaml
+++ b/manifests/flannel-migration/calico.yaml
@@ -5709,6 +5709,13 @@ spec:
                                 AutoHostEndpoints
                               items:
                                 properties:
+                                  annotations:
+                                    additionalProperties:
+                                      type: string
+                                    description:
+                                      Annotations adds the specified annotations
+                                      to the generated AutoHostEndpoint.
+                                    type: object
                                   generateName:
                                     description:
                                       GenerateName is appended to the end
@@ -5938,6 +5945,13 @@ spec:
                                     AutoHostEndpoints
                                   items:
                                     properties:
+                                      annotations:
+                                        additionalProperties:
+                                          type: string
+                                        description:
+                                          Annotations adds the specified
+                                          annotations to the generated AutoHostEndpoint.
+                                        type: object
                                       generateName:
                                         description:
                                           GenerateName is appended to the

--- a/manifests/operator-crds.yaml
+++ b/manifests/operator-crds.yaml
@@ -40567,6 +40567,13 @@ spec:
                                 AutoHostEndpoints
                               items:
                                 properties:
+                                  annotations:
+                                    additionalProperties:
+                                      type: string
+                                    description:
+                                      Annotations adds the specified annotations
+                                      to the generated AutoHostEndpoint.
+                                    type: object
                                   generateName:
                                     description:
                                       GenerateName is appended to the end
@@ -40796,6 +40803,13 @@ spec:
                                     AutoHostEndpoints
                                   items:
                                     properties:
+                                      annotations:
+                                        additionalProperties:
+                                          type: string
+                                        description:
+                                          Annotations adds the specified
+                                          annotations to the generated AutoHostEndpoint.
+                                        type: object
                                       generateName:
                                         description:
                                           GenerateName is appended to the

--- a/manifests/v1_crd_projectcalico_org.yaml
+++ b/manifests/v1_crd_projectcalico_org.yaml
@@ -40567,6 +40567,13 @@ spec:
                                 AutoHostEndpoints
                               items:
                                 properties:
+                                  annotations:
+                                    additionalProperties:
+                                      type: string
+                                    description:
+                                      Annotations adds the specified annotations
+                                      to the generated AutoHostEndpoint.
+                                    type: object
                                   generateName:
                                     description:
                                       GenerateName is appended to the end
@@ -40796,6 +40803,13 @@ spec:
                                     AutoHostEndpoints
                                   items:
                                     properties:
+                                      annotations:
+                                        additionalProperties:
+                                          type: string
+                                        description:
+                                          Annotations adds the specified
+                                          annotations to the generated AutoHostEndpoint.
+                                        type: object
                                       generateName:
                                         description:
                                           GenerateName is appended to the

--- a/manifests/v3_projectcalico_org.yaml
+++ b/manifests/v3_projectcalico_org.yaml
@@ -40838,6 +40838,13 @@ spec:
                                 AutoHostEndpoints
                               items:
                                 properties:
+                                  annotations:
+                                    additionalProperties:
+                                      type: string
+                                    description:
+                                      Annotations adds the specified annotations
+                                      to the generated AutoHostEndpoint.
+                                    type: object
                                   generateName:
                                     description:
                                       GenerateName is appended to the end
@@ -41067,6 +41074,13 @@ spec:
                                     AutoHostEndpoints
                                   items:
                                     properties:
+                                      annotations:
+                                        additionalProperties:
+                                          type: string
+                                        description:
+                                          Annotations adds the specified
+                                          annotations to the generated AutoHostEndpoint.
+                                        type: object
                                       generateName:
                                         description:
                                           GenerateName is appended to the


### PR DESCRIPTION
<!-- Describe your changes, including the type of change (bug fix, feature, etc.),
why it should be merged, testing done, and links to related issues. -->
Add an `annotations` field to the KubeControllersConfiguration auto-HEP Template, mirroring `labels`: annotations set on a template are applied to the host endpoints it generates and kept in sync.

<!-- For any user-visible change, replace TBD with a one-line description. -->
**Release note:**
```release-note
 kube-controllers can now set annotations on automatically-created host endpoints via the annotations field of the KubeControllersConfiguration auto host endpoint template. Generated host endpoints are fully managed, so any annotation added directly to a generated host endpoint (outside the template) is removed on the next reconcile — set custom annotations on the template's annotations field instead.
```
