### PR TITLE
[v3.31] Felix: fix rare start-of-day deadlock on restart-requiring config change; Fix EnsureBlock IPv6 branch using IPv4 pool selector; felix BPF: drop in-loop IPv6 ext-header debug logs

### DIFF
--- a/felix/bpf-gpl/parsing6.h
+++ b/felix/bpf-gpl/parsing6.h
@@ -125,13 +125,13 @@ static CALI_BPF_INLINE void tc_state_fill_from_iphdr_v6_offset(struct cali_tc_ct
 	for (i = 0; i < 8; i++) {
 		struct ipv6_opt_hdr opt;
 
-		CALI_DEBUG("loading extension at offset %d", ipoff + len);
 		if (bpf_load_bytes(ctx, ipoff + len, &opt, sizeof(opt))) {
 			CALI_DEBUG("Too short");
 			goto deny;
 		}
 
-		CALI_DEBUG("ext nexthdr %d hdrlen %d", opt.nexthdr, opt.hdrlen);
+		// We used to log out the offsets and lengths here, but that causes a
+		// combinatorial explosion in the verifier.
 
 		switch(hdr) {
 		case NEXTHDR_FRAGMENT:

--- a/felix/daemon/daemon.go
+++ b/felix/daemon/daemon.go
@@ -436,15 +436,29 @@ configRetry:
 	var dpDriverCmd *exec.Cmd
 
 	failureReportChan := make(chan string)
+	// These callbacks run on dataplane goroutines and report a shutdown
+	// reason to the shutdown monitor.  The send is on the unbuffered
+	// failureReportChan; time it out with a panic backstop so a stuck send
+	// can't hang the goroutine forever with the backstop unreachable.
 	configChangedRestartCallback := func() {
-		failureReportChan <- reasonConfigChanged
-		time.Sleep(gracefulShutdownTimeout)
+		timeout := time.After(gracefulShutdownTimeout)
+		select {
+		case failureReportChan <- reasonConfigChanged:
+		case <-timeout:
+			log.Panic("Graceful shutdown failed: timed out reporting config change")
+		}
+		<-timeout
 		log.Panic("Graceful shutdown took too long")
 	}
 	fatalErrorCallback := func(err error) {
 		log.WithError(err).Error("Shutting down due to fatal error")
-		failureReportChan <- reasonFatalError
-		time.Sleep(gracefulShutdownTimeout)
+		timeout := time.After(gracefulShutdownTimeout)
+		select {
+		case failureReportChan <- reasonFatalError:
+		case <-timeout:
+			log.Panic("Graceful shutdown failed: timed out reporting fatal error")
+		}
+		<-timeout
 		log.Panic("Graceful shutdown took too long")
 	}
 
@@ -678,9 +692,6 @@ configRetry:
 	// calculation graph.
 	validator := calc.NewValidationFilter(asyncCalcGraph, configParams)
 
-	go syncerToValidator.SendToSinkForever(validator)
-	asyncCalcGraph.Start()
-	log.Infof("Started the processing graph")
 	var stopSignalChans []chan<- *sync.WaitGroup
 	if configParams.EndpointReportingEnabled {
 		delay := configParams.EndpointReportingDelaySecs
@@ -725,8 +736,16 @@ configRetry:
 	}
 
 	// Send the opening message to the dataplane driver, giving it its
-	// config.
+	// config.  Do this before starting the calculation graph so that we
+	// don't race with it to send the first message.  We used to start calc
+	// graph first but that could result in blocking or even deadlocking
+	// here.
 	dpConnector.ToDataplane <- configParams.ToConfigUpdate()
+
+	// Now the dataplane driver has its config, start the calculation graph.
+	go syncerToValidator.SendToSinkForever(validator)
+	asyncCalcGraph.Start()
+	log.Infof("Started the processing graph")
 
 	if configParams.PrometheusMetricsEnabled {
 		log.Info("Prometheus metrics enabled.  Starting server.")
@@ -1060,6 +1079,11 @@ type DataplaneConnector struct {
 	datastore         bapi.Client
 	datastorev3       client.Interface
 
+	// shutdownReportTimeout bounds how long shutDownProcess waits to hand
+	// its failure reason to the shutdown monitor before panicking as a
+	// backstop.  Overridable in tests.
+	shutdownReportTimeout time.Duration
+
 	firstStatusReportSent bool
 
 	wireguardStatUpdateFromDataplane chan *proto.WireguardStatusUpdate
@@ -1086,6 +1110,7 @@ func newConnector(configParams *config.Config,
 		statusUpdatesFromDataplaneConsumers: nil,
 		failureReportChan:                   failureReportChan,
 		dataplane:                           dataplane,
+		shutdownReportTimeout:               gracefulShutdownTimeout,
 		wireguardStatUpdateFromDataplane:    make(chan *proto.WireguardStatusUpdate, 1),
 	}
 
@@ -1342,13 +1367,28 @@ func (fc *DataplaneConnector) sendMessagesToDataplaneDriver() {
 	}
 }
 
+// shutDownProcess reports the given reason to the shutdown monitor
+// (monitorAndManageShutdown) and then blocks, expecting the monitor to tear
+// the process down.  It never returns; callers rely on that.
+//
+// Both steps have a panic backstop.  Reporting the reason is a blocking send
+// on the unbuffered failureReportChan, so we time it out: if the monitor
+// isn't reading (e.g. it hasn't started yet at start-of-day), we panic rather
+// than deadlock.  Once the reason is delivered we wait out the remainder of
+// the same timer and panic if the managed shutdown hasn't finished.
 func (fc *DataplaneConnector) shutDownProcess(reason string) {
-	// Send a failure report to the managed shutdown thread then give it
-	// a few seconds to do the shutdown.
-	fc.failureReportChan <- reason
-	time.Sleep(5 * time.Second)
-	// The graceful shutdown failed, terminate the process.
-	log.Panic("Managed shutdown failed. Panicking.")
+	timeout := time.After(fc.shutdownReportTimeout)
+	select {
+	case fc.failureReportChan <- reason:
+	case <-timeout:
+		log.WithField("reason", reason).Panic(
+			"Managed shutdown failed: timed out reporting shutdown reason. Panicking.")
+	}
+	// time.After fires only once; the send won the select above, so this
+	// receives the eventual tick, giving the monitor the full timeout to
+	// tear us down.
+	<-timeout
+	log.WithField("reason", reason).Panic("Managed shutdown failed. Panicking.")
 }
 
 // Start creates goroutines for:

--- a/felix/daemon/shutdown_test.go
+++ b/felix/daemon/shutdown_test.go
@@ -1,0 +1,68 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package daemon
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("shutDownProcess", func() {
+	// shutDownProcess never returns: it reports the reason to the shutdown
+	// monitor and then panics as a backstop.  Run it in a goroutine and
+	// recover so a stray panic can't outlive the spec.
+	runInBackground := func(fc *DataplaneConnector, reason string) <-chan any {
+		panicked := make(chan any, 1)
+		go func() {
+			defer func() { panicked <- recover() }()
+			fc.shutDownProcess(reason)
+		}()
+		return panicked
+	}
+
+	// Regression test for the start-of-day deadlock: if the shutdown monitor
+	// (the only reader of failureReportChan) hasn't started, the report send
+	// must not block forever.  Before the fix, the panic backstop sat after
+	// an unconditional blocking send, so this hung indefinitely.
+	It("panics instead of blocking when the shutdown monitor never reads", func() {
+		fc := &DataplaneConnector{
+			failureReportChan:     make(chan string), // Unbuffered, no reader.
+			shutdownReportTimeout: 100 * time.Millisecond,
+		}
+
+		panicked := runInBackground(fc, reasonConfigChanged)
+		Eventually(panicked, "5s").Should(Receive(Not(BeNil())))
+	})
+
+	It("delivers the reason to the monitor and then panics as a backstop", func() {
+		reportChan := make(chan string)
+		fc := &DataplaneConnector{
+			failureReportChan:     reportChan,
+			shutdownReportTimeout: 100 * time.Millisecond,
+		}
+
+		received := make(chan string, 1)
+		go func() { received <- <-reportChan }()
+
+		panicked := runInBackground(fc, reasonConfigChanged)
+
+		// The reason reaches the monitor: the send is not lost.
+		Eventually(received, "5s").Should(Receive(Equal(reasonConfigChanged)))
+		// The backstop still fires once the monitor fails to tear us down.
+		Eventually(panicked, "5s").Should(Receive(Not(BeNil())))
+	})
+})

--- a/felix/daemon/shutdown_test.go
+++ b/felix/daemon/shutdown_test.go
@@ -17,7 +17,7 @@ package daemon
 import (
 	"time"
 
-	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
 

--- a/libcalico-go/lib/ipam/ipam.go
+++ b/libcalico-go/lib/ipam/ipam.go
@@ -2248,7 +2248,7 @@ func (c ipamClient) EnsureBlock(ctx context.Context, args BlockArgs) (*net.IPNet
 				return nil, nil, fmt.Errorf("provided IPv6 IPPools list contains one or more IPv4 IPPools")
 			}
 		}
-		v6Net, err = c.ensureBlock(ctx, args.HostReservedAttrIPv6s, args.IPv4Pools, 6, affinityCfg)
+		v6Net, err = c.ensureBlock(ctx, args.HostReservedAttrIPv6s, args.IPv6Pools, 6, affinityCfg)
 		if err != nil {
 			log.Errorf("Error ensure IPv6 block: %v", err)
 			return nil, nil, err

--- a/libcalico-go/lib/ipam/ipam_test.go
+++ b/libcalico-go/lib/ipam/ipam_test.go
@@ -2557,6 +2557,25 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 			Expect(outErr).NotTo(HaveOccurred())
 			Expect(v4_again).To(Equal(v4))
 		})
+
+		It("should allocate an IPv6 block from IPv6Pools, not IPv4Pools", func() {
+			Expect(bc.Clean()).To(Succeed())
+			deleteAllPools()
+
+			applyNode(bc, kc, host, nil)
+			applyPool(pool1.String(), true, "")
+			applyPool(pool4_v6.String(), true, "")
+
+			args := BlockArgs{
+				Hostname:              host,
+				IPv4Pools:             []cnet.IPNet{pool1},
+				IPv6Pools:             []cnet.IPNet{pool4_v6},
+				HostReservedAttrIPv6s: rsvdAttrWindows,
+			}
+			_, v6, outErr := ic.EnsureBlock(context.Background(), args)
+			Expect(outErr).NotTo(HaveOccurred())
+			Expect(pool4_v6.Contains(v6.IP)).To(BeTrue())
+		})
 	})
 
 	Describe("IPAM findOrClaimBlock test", func() {


### PR DESCRIPTION
**Cherry-pick history**
- Pick onto **release-v3.31**: projectcalico/calico#13214
- Pick onto **release-v3.32**:
  - projectcalico/calico#13175
  - projectcalico/calico#13197
  - projectcalico/calico#13204

---
**Felix: fix rare start-of-day deadlock on restart-requiring config change** (projectcalico/calico#13175)
Bug fix for a rare but permanent start-of-day deadlock in Felix, seen as an FV flake ("Spoof tests ... should drop spoofed traffic" timing out waiting for felix to restart after `NodeIP`/`IpInIpTunnelAddr` were written during topology setup).

The deadlock is a three-way cycle in `daemon.Run()`:

1. The calc graph was started before the opening `ConfigUpdate` was sent to the dataplane connector. Its first flushed event is always a `ConfigUpdate` (`EventSequencer.Flush()` flushes config first), so it could win the race onto the unbuffered `ToDataplane` channel.
2. If that `ConfigUpdate` carried a restart-requiring change, the connector pump parked in `shutDownProcess()` on an unconditional send to the unbuffered `failureReportChan` — whose only reader, `monitorAndManageShutdown()`, had not started yet.
3. The main goroutine could never start it: it was parked sending the opening `ConfigUpdate` that the pump would never consume. The panic backstop in `shutDownProcess()` sat *after* the blocking send, so it never fired; felix hung forever instead of restarting.

Changes:

- **Reorder start of day**: start the calc graph only after the opening `ConfigUpdate` has been handed to the connector. This removes the deadlock's enabling condition structurally (at the handoff, main is the only sender and has no further blocking channel ops before the shutdown monitor starts) and restores the documented protocol ordering — the dataplane driver receives its config before the stream of calc-graph updates ("ConfigUpdate is sent at start of day", `felixbackend.proto`).
- **Make the shutdown backstops reachable** (defence in depth): `shutDownProcess()` and the config-changed/fatal-error callbacks now time out their failure-report send, so a stuck send panics (and restarts felix) rather than deadlocking. `shutDownProcess()`'s backstop is extended from 5s to `gracefulShutdownTimeout` (30s) so it cannot beat a legitimately slow external-driver shutdown (~7s worst case in the monitor's kill path).
- **Regression test**: `felix/daemon/shutdown_test.go` asserts `shutDownProcess()` panics rather than blocking forever when the shutdown monitor never reads (hangs on the old code), and that the reason is still delivered when a reader exists.

Testing: new UTs plus the existing `felix/daemon` suite pass; `go vet` clean. The reordered graceful-restart path is exercised by the existing FV restart tests; the original failure is timing-dependent and not reproducible on demand.

**Release note:**
```release-note
Fixed a rare start-of-day deadlock that could prevent Felix from restarting when a restart-requiring configuration change (e.g. the node IP being set) arrived while Felix was still starting up.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
**Fix EnsureBlock IPv6 branch using IPv4 pool selector** (projectcalico/calico#13197)
## Summary

`ipamClient.EnsureBlock`'s IPv6 branch validates `args.IPv6Pools` but then passes `args.IPv4Pools` into the underlying `ensureBlock` call for the v6 allocation. As a result, a caller that supplies an explicit `IPv6Pools` selector alongside `HostReservedAttrIPv6s` gets the block allocated against the wrong pool list — either landing in an unintended IPv6 pool, or failing outright if the IPv4 CIDR isn't a valid IPv6 pool.

The only caller passing explicit `HostReservedAttrIPv6s`/pools is the Windows host-local block-ensure path in `node/pkg/lifecycle/startup/startup_windows.go`, so this has been latent rather than actively triggering failures.

Fix: pass `args.IPv6Pools` instead of `args.IPv4Pools` in the v6 branch.

## Test plan

- [x] Added a regression test in `libcalico-go/lib/ipam/ipam_test.go` (`should allocate an IPv6 block from IPv6Pools, not IPv4Pools`) that calls `EnsureBlock` with distinct `IPv4Pools`/`IPv6Pools` and asserts the returned v6 block CIDR falls inside the requested `IPv6Pools`.
- [x] Verified the test fails against the pre-fix code (etcd backend errors with `the given pool (10.0.0.0/24) does not exist, or is not enabled`, since the v4 CIDR is looked up against the v6 pool table).
- [x] Verified the test passes with the fix, and the full `libcalico-go/lib/ipam` suite still passes against the etcdv3 backend.

**Release note:**
```release-note
Fixed a latent bug where EnsureBlock could allocate an IPv6 block from the wrong IP pool when an explicit IPv6 pool selector was provided (Windows host-local IPAM block reservation).
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
**felix BPF: drop in-loop IPv6 ext-header debug logs** (projectcalico/calico#13204)
The IPv6 extension-header parse loop in tc_state_fill_from_iphdr_v6_offset is unrolled 8x and feeds the whole of calico_tc_main. The two per-iteration CALI_DEBUG calls sit at that state-multiplying chokepoint: each is a bpf_trace_printk helper call that spills the loop-carried precise scalars across a verifier checkpoint, so states downstream of the loop stop merging and the verifier re-walks the large downstream once per surviving state.

Measured on the test_from_hep_debug_v6 object, calico_tc_main drops from 426,491 to 139,718 processed insns (-67%; total_states 22,564 -> 8,829) with no change to no_log builds.

**Release note:**
```release-note
eBPF: fix state explosion in the BPF verifier (resulting in programs not loading) caused by debug logs on a certain path.
```


