### PR TITLE
felix/bpf: add TestVerifierStats verifier-cost benchmark

### DIFF
--- a/felix/bpf/libbpf/libbpf.go
+++ b/felix/bpf/libbpf/libbpf.go
@@ -217,6 +217,38 @@ func (p *Program) Name() string {
 	return C.GoString(name)
 }
 
+// FD returns the file descriptor of the program. Only valid after the
+// containing object has been loaded; returns a negative value otherwise.
+func (p *Program) FD() int {
+	return int(C.bpf_program__fd(p.bpfProg))
+}
+
+// ProgInfo is a subset of the kernel's bpf_prog_info for a loaded program.
+// VerifiedInsns is the number of instructions the verifier processed; it
+// requires kernel >=5.16 and reads 0 on older kernels. XlatedProgLen and
+// JitedProgLen are the post-verifier and JITed image sizes in bytes.
+type ProgInfo struct {
+	ID            uint32
+	VerifiedInsns uint32
+	XlatedProgLen uint32
+	JitedProgLen  uint32
+}
+
+// GetProgInfo queries the kernel for information about a loaded program given
+// its file descriptor (see Program.FD).
+func GetProgInfo(fd int) (ProgInfo, error) {
+	info, err := C.bpf_get_prog_info(C.int(fd))
+	if err != nil {
+		return ProgInfo{}, fmt.Errorf("error getting program info: %w", err)
+	}
+	return ProgInfo{
+		ID:            uint32(info.id),
+		VerifiedInsns: uint32(info.verified_insns),
+		XlatedProgLen: uint32(info.xlated_prog_len),
+		JitedProgLen:  uint32(info.jited_prog_len),
+	}, nil
+}
+
 func (o *Obj) ProgramFD(secname string) (int, error) {
 	cSecName := C.CString(secname)
 	defer C.free(unsafe.Pointer(cSecName))

--- a/felix/bpf/libbpf/libbpf_api.h
+++ b/felix/bpf/libbpf/libbpf_api.h
@@ -101,6 +101,13 @@ void bpf_get_prog_name(uint prog_id, char *prog_name) {
 	close(prog_fd);
 }
 
+struct bpf_prog_info bpf_get_prog_info(int prog_fd) {
+	struct bpf_prog_info info = {};
+	__u32 len = sizeof(info);
+	set_errno(bpf_prog_get_info_by_fd(prog_fd, &info, &len));
+	return info;
+}
+
 struct bpf_link *bpf_link_open(char *path) {
 	struct bpf_link *link = bpf_link__open(path);
 	int err = libbpf_get_error(link);

--- a/felix/bpf/libbpf/libbpf_stub.go
+++ b/felix/bpf/libbpf/libbpf_stub.go
@@ -92,6 +92,21 @@ func (p *Program) Name() string {
 	panic("LIBBPF syscall stub")
 }
 
+func (p *Program) FD() int {
+	panic("LIBBPF syscall stub")
+}
+
+type ProgInfo struct {
+	ID            uint32
+	VerifiedInsns uint32
+	XlatedProgLen uint32
+	JitedProgLen  uint32
+}
+
+func GetProgInfo(fd int) (ProgInfo, error) {
+	panic("LIBBPF syscall stub")
+}
+
 func QueryClassifier(ifindex, handle, pref int, ingress bool) (int, error) {
 	panic("LIBBPF syscall stub")
 }

--- a/felix/bpf/ut/precompilation_test.go
+++ b/felix/bpf/ut/precompilation_test.go
@@ -21,6 +21,7 @@ import (
 	"math/rand"
 	"net"
 	"path"
+	"sort"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -41,22 +42,10 @@ const (
 	bpfFuncTraceVprintk = 177
 )
 
-func TestPrecompiledBinariesAreLoadable(t *testing.T) {
-	RegisterTestingT(t)
-
-	bpffs, err := utils.MaybeMountBPFfs()
-	Expect(err).NotTo(HaveOccurred())
-	Expect(bpffs).To(Equal("/sys/fs/bpf"))
-
-	testObject := func(file string) {
-		obj, err := libbpf.OpenObject(file)
-		defer func() { _ = obj.Close() }()
-		Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("failed to open object %s", file))
-		err = obj.Load()
-		Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("failed to load object %s", file))
-	}
-
-	// all unique objects
+// allProductionObjectFiles returns the base filenames of every BPF object that
+// ships in the product, deduplicated and sorted. TestPrecompiledBinariesAreLoadable
+// and TestVerifierStats both enumerate over it so their object sets cannot drift.
+func allProductionObjectFiles() []string {
 	objects := make(map[string]struct{})
 
 	for _, at := range hook.ListAttachTypes() {
@@ -75,12 +64,34 @@ func TestPrecompiledBinariesAreLoadable(t *testing.T) {
 	objects["conntrack_cleanup_no_log_v6.o"] = struct{}{}
 	for _, logLevel := range []string{"debug", "no_log"} {
 		for _, ipv := range []string{"v46", "v4", "v6"} {
-			filename := "connect_balancer_" + logLevel + "_" + ipv + ".o"
-			objects[filename] = struct{}{}
+			objects["connect_balancer_"+logLevel+"_"+ipv+".o"] = struct{}{}
 		}
 	}
 
+	files := make([]string, 0, len(objects))
 	for obj := range objects {
+		files = append(files, obj)
+	}
+	sort.Strings(files)
+	return files
+}
+
+func TestPrecompiledBinariesAreLoadable(t *testing.T) {
+	RegisterTestingT(t)
+
+	bpffs, err := utils.MaybeMountBPFfs()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(bpffs).To(Equal("/sys/fs/bpf"))
+
+	testObject := func(file string) {
+		obj, err := libbpf.OpenObject(file)
+		defer func() { _ = obj.Close() }()
+		Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("failed to open object %s", file))
+		err = obj.Load()
+		Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("failed to load object %s", file))
+	}
+
+	for _, obj := range allProductionObjectFiles() {
 		log.Debugf("Object %s", obj)
 		t.Run(obj, func(t *testing.T) {
 			RegisterTestingT(t)

--- a/felix/bpf/ut/verifier_stats_test.go
+++ b/felix/bpf/ut/verifier_stats_test.go
@@ -1,0 +1,191 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ut_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path"
+	"sort"
+	"strings"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"golang.org/x/sys/unix"
+
+	"github.com/projectcalico/calico/felix/bpf/bpfdefs"
+	"github.com/projectcalico/calico/felix/bpf/libbpf"
+	"github.com/projectcalico/calico/felix/bpf/utils"
+)
+
+// verifierStatsReportPath is relative to the test's working directory
+// (felix/bpf/ut inside the UT container), resolving to felix/report/ which the
+// ut-bpf make target creates and which persists via the repo mount.
+const verifierStatsReportPath = "../../report/bpf-verifier-stats.json"
+
+// TestVerifierStats loads every production BPF object and records per-program
+// verifier cost (verified_insns), post-verifier image size (xlated) and JITed
+// image size. It is informational: there is no committed baseline and no
+// threshold. verified_insns needs kernel >=5.16 and reads 0 on older kernels
+// (see felix/design/bpf-tests.md); the test tolerates zeros and never asserts
+// on counts, only on load success.
+func TestVerifierStats(t *testing.T) {
+	RegisterTestingT(t)
+
+	bpffs, err := utils.MaybeMountBPFfs()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(bpffs).To(Equal("/sys/fs/bpf"))
+
+	report := verifierStatsReport{Kernel: kernelRelease()}
+
+	// allProductionObjectFiles is sorted, so objects land in the report in
+	// name order, giving stable JSON diffs across runs.
+	for _, objFile := range allProductionObjectFiles() {
+		t.Run(objFile, func(t *testing.T) {
+			RegisterTestingT(t)
+			stat := collectObjectStats(t, path.Join(bpfdefs.ObjectDir, objFile), objFile)
+			report.Objects = append(report.Objects, stat)
+			report.TotalVerifiedInsns += stat.TotalVerifiedInsns
+		})
+	}
+
+	writeVerifierStatsReport(t, report)
+	logVerifierStatsTable(t, report)
+}
+
+// collectObjectStats opens and loads a single object then records stats for
+// each of its programs. A load failure fails the subtest, matching
+// TestPrecompiledBinariesAreLoadable.
+func collectObjectStats(t *testing.T, file, objName string) objectStat {
+	obj, err := libbpf.OpenObject(file)
+	Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("failed to open object %s", file))
+	defer func() { _ = obj.Close() }()
+
+	err = obj.Load()
+	Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("failed to load object %s", file))
+
+	stat := objectStat{Object: objName}
+	prog, err := obj.FirstProgram()
+	Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("failed to get first program of %s", file))
+	for prog != nil {
+		if fd := prog.FD(); fd < 0 {
+			// Program present in the ELF but not loaded (e.g. autoload
+			// disabled): no verifier stats to record. Loadability is the
+			// concern of TestPrecompiledBinariesAreLoadable, not this test.
+			t.Logf("skipping program %q in %s: not loaded", prog.Name(), objName)
+		} else {
+			info, err := libbpf.GetProgInfo(fd)
+			Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("failed to get info for program %q in %s", prog.Name(), file))
+			stat.Programs = append(stat.Programs, progStat{
+				Name:          prog.Name(),
+				VerifiedInsns: info.VerifiedInsns,
+				XlatedInsns:   info.XlatedProgLen / 8,
+				JitedBytes:    info.JitedProgLen,
+			})
+			stat.TotalVerifiedInsns += uint64(info.VerifiedInsns)
+		}
+
+		prog, err = prog.NextProgram()
+		Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("failed to iterate programs of %s", file))
+	}
+
+	sort.Slice(stat.Programs, func(i, j int) bool {
+		return stat.Programs[i].Name < stat.Programs[j].Name
+	})
+	return stat
+}
+
+func writeVerifierStatsReport(t *testing.T, report verifierStatsReport) {
+	data, err := json.MarshalIndent(report, "", "  ")
+	Expect(err).NotTo(HaveOccurred())
+	err = os.WriteFile(verifierStatsReportPath, data, 0o644)
+	Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("failed to write %s", verifierStatsReportPath))
+	t.Logf("Wrote verifier stats to %s", verifierStatsReportPath)
+}
+
+// logVerifierStatsTable prints a human-readable summary: top programs by
+// verified_insns, per-object totals, and the grand total.
+func logVerifierStatsTable(t *testing.T, report verifierStatsReport) {
+	type row struct {
+		object string
+		prog   progStat
+	}
+	var rows []row
+	for _, o := range report.Objects {
+		for _, p := range o.Programs {
+			rows = append(rows, row{object: o.Object, prog: p})
+		}
+	}
+	sort.Slice(rows, func(i, j int) bool {
+		return rows[i].prog.VerifiedInsns > rows[j].prog.VerifiedInsns
+	})
+
+	const topN = 40
+	var b strings.Builder
+	fmt.Fprintf(&b, "\nBPF verifier stats (kernel %s)\n", report.Kernel)
+	fmt.Fprintf(&b, "Top %d programs by verified_insns:\n", topN)
+	fmt.Fprintf(&b, "%12s %12s %12s  %s\n", "VERIFIED", "XLATED", "JITED_B", "PROGRAM (OBJECT)")
+	for i, r := range rows {
+		if i >= topN {
+			break
+		}
+		fmt.Fprintf(&b, "%12d %12d %12d  %s (%s)\n",
+			r.prog.VerifiedInsns, r.prog.XlatedInsns, r.prog.JitedBytes, r.prog.Name, r.object)
+	}
+
+	objByTotal := make([]objectStat, len(report.Objects))
+	copy(objByTotal, report.Objects)
+	sort.Slice(objByTotal, func(i, j int) bool {
+		return objByTotal[i].TotalVerifiedInsns > objByTotal[j].TotalVerifiedInsns
+	})
+	fmt.Fprintf(&b, "\nPer-object totals (verified_insns):\n")
+	for _, o := range objByTotal {
+		fmt.Fprintf(&b, "%12d  %s\n", o.TotalVerifiedInsns, o.Object)
+	}
+
+	fmt.Fprintf(&b, "\nGrand total verified_insns: %d across %d objects\n",
+		report.TotalVerifiedInsns, len(report.Objects))
+	t.Log(b.String())
+}
+
+func kernelRelease() string {
+	var uts unix.Utsname
+	if err := unix.Uname(&uts); err != nil {
+		return "unknown"
+	}
+	return unix.ByteSliceToString(uts.Release[:])
+}
+
+// verifierStatsReport is the on-disk schema. Slices (not maps) with sorted
+// contents keep JSON output deterministic for diffing between experiments.
+type verifierStatsReport struct {
+	Kernel             string       `json:"kernel"`
+	TotalVerifiedInsns uint64       `json:"totalVerifiedInsns"`
+	Objects            []objectStat `json:"objects"`
+}
+
+type objectStat struct {
+	Object             string     `json:"object"`
+	TotalVerifiedInsns uint64     `json:"totalVerifiedInsns"`
+	Programs           []progStat `json:"programs"`
+}
+
+type progStat struct {
+	Name          string `json:"name"`
+	VerifiedInsns uint32 `json:"verifiedInsns"`
+	XlatedInsns   uint32 `json:"xlatedInsns"`
+	JitedBytes    uint32 `json:"jitedBytes"`
+}

--- a/felix/design/bpf-tests.md
+++ b/felix/design/bpf-tests.md
@@ -71,6 +71,27 @@ differences — a change can pass `make build-bpf` (compilation)
 and still fail the verifier on a variant the developer didn't
 exercise. This test is the verifier gate every BPF PR has to pass.
 
+### Verifier cost: `TestVerifierStats`
+
+`TestVerifierStats` loads the same object set (both tests share
+`allProductionObjectFiles` so they cannot drift) and, per program,
+records `verified_insns` (verifier instructions processed),
+`xlated_insns` (post-verifier image), and `jited_bytes` (JITed
+image — the icache measure). It prints a table sorted by
+`verified_insns` and writes a stable-schema JSON report to
+`felix/report/bpf-verifier-stats.json` (uname, per-object and
+grand totals, per-program counts; keys and slices sorted for clean
+diffs).
+
+The test is **informational**: no committed baseline, no
+threshold — only load success is asserted. `verified_insns`
+requires kernel ≥5.16 (the `bpf_prog_info.verified_insns` field);
+on older kernels it reads 0, so the test tolerates zeros and never
+asserts on counts. Counts are not comparable across kernels or
+compiler versions — compare like-for-like on one host. It backs
+the BPF-modernization metric: shrink verifier cost and image size
+while every object stays loadable.
+
 ### Review notes for this section
 
 - A bug in BPF C is testable in the harness: the program is


### PR DESCRIPTION
### Description

Adds `TestVerifierStats`, a privileged BPF unit test that loads every
precompiled production BPF object and records, per program, the number of
instructions the verifier processed (`bpf_prog_info.verified_insns`) plus the
post-verifier (`xlated`) and JITed image sizes. It prints a table sorted by
verifier cost and writes a stable-schema JSON report to
`felix/report/bpf-verifier-stats.json` so the numbers can be diffed between
builds.

This is the measurement tool for ongoing work to reduce the eBPF programs'
verifier cost and code size. It shares its object enumeration with
`TestPrecompiledBinariesAreLoadable` (via a new `allProductionObjectFiles`
helper) so the two cannot drift.

Supporting changes:
- `felix/bpf/libbpf`: add `Program.FD()` and `GetProgInfo(fd)` bindings
  (plus their `!cgo` stubs) to read `bpf_prog_info` after load.
- `felix/design/bpf-tests.md`: document the new benchmark.

The test is informational only — no committed baseline, no threshold, asserts
only that every object loads. `verified_insns` needs kernel >=5.16 and reads 0
on older kernels; the test tolerates that. No production/runtime behaviour
changes.

```release-note
None
```
