### PR TITLE
felix/bpf-gpl: fix always-true log guard in forward_or_drop epilogue

### DIFF
--- a/felix/bpf-gpl/fib_co_re.h
+++ b/felix/bpf-gpl/fib_co_re.h
@@ -581,7 +581,11 @@ deny:
 	rc = TC_ACT_SHOT;
 
 allow:
-	if (CALI_LOG_LEVEL_INFO >= CALI_LOG_LEVEL_INFO || PROFILING) {
+	if (CALI_F_VXLAN && CALI_F_TO_HOST && rc != TC_ACT_SHOT) {
+		bpf_skb_change_type(ctx->skb, PACKET_HOST);
+	}
+
+	if (CALI_LOG_LEVEL >= CALI_LOG_LEVEL_INFO || PROFILING) {
 		__u64 prog_end_time = bpf_ktime_get_ns();
 
 		if (PROFILING) {
@@ -595,9 +599,6 @@ allow:
 			CALI_INFO("Final result=DENY (%d). Program execution time: %lluns",
 					ctx->state->fwd.reason, prog_end_time-state->prog_start_time);
 		} else {
-			if (CALI_F_VXLAN && CALI_F_TO_HOST) {
-				bpf_skb_change_type(ctx->skb, PACKET_HOST);
-			}
 			CALI_INFO("Final result=ALLOW rc %d. Program execution time: %lluns",
 					rc, prog_end_time-state->prog_start_time);
 		}


### PR DESCRIPTION
### Description

The epilogue of `forward_or_drop` guarded its timing/diagnostics block with
`CALI_LOG_LEVEL_INFO >= CALI_LOG_LEVEL_INFO`, which is always true. As a result
production (`no_log`) builds executed a `bpf_ktime_get_ns()` helper call at
every program exit even with profiling disabled — per-packet work on the fast
path that serves no purpose when logging and profiling are off.

Fix the comparison to `CALI_LOG_LEVEL >= CALI_LOG_LEVEL_INFO`, and hoist the
functional `bpf_skb_change_type(PACKET_HOST)` call for VXLAN-to-host packets
out of the diagnostics block so it keeps running regardless of log level or
profiling (it is dataplane behaviour, not diagnostics).

```release-note
eBPF dataplane: remove an unnecessary per-packet timestamp lookup on the
forwarding fast path in non-debug builds.
```
