### PR TITLE
e2e: poll for schedulable nodes instead of asserting once

### DIFF
--- a/e2e/pkg/tests/ipam/ipam_strict_affinity.go
+++ b/e2e/pkg/tests/ipam/ipam_strict_affinity.go
@@ -30,7 +30,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kubernetes/test/e2e/framework"
-	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
 	"k8s.io/utils/ptr"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -67,11 +66,7 @@ var _ = describe.CalicoDescribe(
 
 			// Require at least 2 schedulable worker nodes so the deployment can
 			// spread replicas across nodes.
-			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-			defer cancel()
-			nodes, err := e2enode.GetBoundedReadySchedulableNodes(ctx, f.ClientSet, 3)
-			Expect(err).NotTo(HaveOccurred(), "failed to list schedulable nodes")
-			Expect(len(nodes.Items)).To(BeNumerically(">=", 2), "need at least 2 schedulable nodes for StrictAffinity test")
+			utils.AwaitReadySchedulableNodesInfo(f, 2, false)
 		})
 
 		// Verifies that toggling IPAMConfiguration.StrictAffinity affects real pod

--- a/e2e/pkg/tests/networking/hep_datapath.go
+++ b/e2e/pkg/tests/networking/hep_datapath.go
@@ -216,8 +216,11 @@ var _ = describe.CalicoDescribe(
 
 			nodesInfo := utils.AwaitReadySchedulableNodesInfo(f, 2, false)
 			allNames := nodesInfo.GetNames()
+			allIPs := nodesInfo.GetIPv4s()
+			Expect(len(allIPs)).To(BeNumerically(">=", 2),
+				"HEP datapath tests require at least 2 nodes with IPv4 addresses, found %d", len(allIPs))
 			nodeNames = allNames[:2]
-			nodeIPs = nodesInfo.GetIPv4s()[:2]
+			nodeIPs = allIPs[:2]
 			calicoNames = nodesInfo.GetCalicoNames()[:2]
 			logrus.Infof("HEP nodes: %v IPs: %v calico: %v", nodeNames, nodeIPs, calicoNames)
 

--- a/e2e/pkg/tests/networking/hep_datapath.go
+++ b/e2e/pkg/tests/networking/hep_datapath.go
@@ -30,7 +30,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kubernetes/test/e2e/framework"
-	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
 	"k8s.io/utils/ptr"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -215,14 +214,8 @@ var _ = describe.CalicoDescribe(
 			cli, err = client.New(f.ClientConfig())
 			Expect(err).NotTo(HaveOccurred())
 
-			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-			defer cancel()
-			nodes, err := e2enode.GetBoundedReadySchedulableNodes(ctx, f.ClientSet, 6)
-			Expect(err).NotTo(HaveOccurred())
-			nodesInfo := utils.GetNodesInfo(f, nodes, false)
+			nodesInfo := utils.AwaitReadySchedulableNodesInfo(f, 2, false)
 			allNames := nodesInfo.GetNames()
-			Expect(len(allNames)).To(BeNumerically(">=", 2),
-				"HEP datapath tests require at least 2 schedulable worker nodes, found %d", len(allNames))
 			nodeNames = allNames[:2]
 			nodeIPs = nodesInfo.GetIPv4s()[:2]
 			calicoNames = nodesInfo.GetCalicoNames()[:2]

--- a/e2e/pkg/tests/networking/packet_size.go
+++ b/e2e/pkg/tests/networking/packet_size.go
@@ -15,7 +15,6 @@
 package networking
 
 import (
-	"context"
 	"fmt"
 	"strconv"
 	"strings"
@@ -27,7 +26,6 @@ import (
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/kubernetes/test/e2e/framework"
-	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
 
 	"github.com/projectcalico/calico/e2e/pkg/describe"
 	"github.com/projectcalico/calico/e2e/pkg/utils"
@@ -111,15 +109,9 @@ var _ = describe.CalicoDescribe(
 		f := utils.NewDefaultFramework("packet-size")
 
 		runPacketTest := func(clientType, targetType int, sameNode bool) {
-			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-			defer cancel()
-			nodes, err := e2enode.GetBoundedReadySchedulableNodes(ctx, f.ClientSet, 6)
-			Expect(err).NotTo(HaveOccurred())
-			nodesInfo := utils.GetNodesInfo(f, nodes, false)
+			nodesInfo := utils.AwaitReadySchedulableNodesInfo(f, 2, false)
 			nodeNames := nodesInfo.GetNames()
 			nodeIPs := nodesInfo.GetIPv4s()
-			Expect(len(nodeNames)).To(BeNumerically(">=", 2),
-				"packet size tests require at least 2 schedulable worker nodes")
 
 			// Sample packet sizes densely around the cluster's effective pod MTU.
 			// The MTU is derived from the Installation status so the test tracks

--- a/e2e/pkg/tests/networking/packet_size.go
+++ b/e2e/pkg/tests/networking/packet_size.go
@@ -112,6 +112,8 @@ var _ = describe.CalicoDescribe(
 			nodesInfo := utils.AwaitReadySchedulableNodesInfo(f, 2, false)
 			nodeNames := nodesInfo.GetNames()
 			nodeIPs := nodesInfo.GetIPv4s()
+			Expect(nodeIPs).NotTo(BeEmpty(),
+				"packet size tests require a node with an IPv4 address")
 
 			// Sample packet sizes densely around the cluster's effective pod MTU.
 			// The MTU is derived from the Installation status so the test tracks

--- a/e2e/pkg/tests/networking/qos.go
+++ b/e2e/pkg/tests/networking/qos.go
@@ -15,16 +15,13 @@
 package networking
 
 import (
-	"context"
 	"time"
-
 	//nolint:staticcheck // Ignore ST1001: should not use dot imports
 	. "github.com/onsi/ginkgo/v2"
 	//nolint:staticcheck // Ignore ST1001: should not use dot imports
 	. "github.com/onsi/gomega"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
-	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
 
 	"github.com/projectcalico/calico/e2e/pkg/describe"
 	"github.com/projectcalico/calico/e2e/pkg/utils"
@@ -47,16 +44,9 @@ var _ = describe.CalicoDescribe(
 		// limits via pod annotations and verify the actual throughput matches the
 		// configured limits within a tolerance.
 		It("should limit bandwidth with QoS annotations", func() {
-			ctx := context.Background()
-
 			By("Getting cluster node names")
-			nodeCtx, nodeCancel := context.WithTimeout(ctx, 30*time.Second)
-			defer nodeCancel()
-			nodes, err := e2enode.GetBoundedReadySchedulableNodes(nodeCtx, f.ClientSet, 3)
-			Expect(err).NotTo(HaveOccurred(), "failed to list schedulable nodes")
-			nodesInfo := utils.GetNodesInfo(f, nodes, true)
+			nodesInfo := utils.AwaitReadySchedulableNodesInfo(f, 2, true)
 			nodeNames := nodesInfo.GetNames()
-			Expect(len(nodeNames)).To(BeNumerically(">=", 2), "QoS test requires at least 2 nodes")
 			serverNode := nodeNames[0]
 			clientNode := nodeNames[1]
 
@@ -162,16 +152,9 @@ var _ = describe.CalicoDescribe(
 
 		// Verifies that Calico's QoS packet rate annotations limit actual throughput.
 		It("should limit packet rate with QoS annotations", func() {
-			ctx := context.Background()
-
 			By("Getting cluster node names")
-			nodeCtx, nodeCancel := context.WithTimeout(ctx, 30*time.Second)
-			defer nodeCancel()
-			nodes, err := e2enode.GetBoundedReadySchedulableNodes(nodeCtx, f.ClientSet, 3)
-			Expect(err).NotTo(HaveOccurred(), "failed to list schedulable nodes")
-			nodesInfo := utils.GetNodesInfo(f, nodes, true)
+			nodesInfo := utils.AwaitReadySchedulableNodesInfo(f, 2, true)
 			nodeNames := nodesInfo.GetNames()
-			Expect(len(nodeNames)).To(BeNumerically(">=", 2), "QoS test requires at least 2 nodes")
 			serverNode := nodeNames[0]
 			clientNode := nodeNames[1]
 

--- a/e2e/pkg/tests/networking/workload_egress.go
+++ b/e2e/pkg/tests/networking/workload_egress.go
@@ -87,6 +87,8 @@ var _ = describe.CalicoDescribe(
 			nodesInfo := utils.AwaitReadySchedulableNodesInfo(f, 2, false)
 			allNames := nodesInfo.GetNames()
 			allIPs := nodesInfo.GetIPv4s()
+			Expect(len(allIPs)).To(BeNumerically(">=", 2),
+				"workload egress tests require at least 2 nodes with IPv4 addresses, found %d", len(allIPs))
 			nodeNames = allNames[:2]
 			nodeIPs = allIPs[:2]
 			logrus.Infof("Nodes: %v IPs: %v", nodeNames, nodeIPs)

--- a/e2e/pkg/tests/networking/workload_egress.go
+++ b/e2e/pkg/tests/networking/workload_egress.go
@@ -28,7 +28,6 @@ import (
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kubernetes/test/e2e/framework"
-	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
 
 	"github.com/projectcalico/calico/e2e/pkg/describe"
 	"github.com/projectcalico/calico/e2e/pkg/utils"
@@ -85,20 +84,9 @@ var _ = describe.CalicoDescribe(
 			cli, err := client.New(f.ClientConfig())
 			Expect(err).NotTo(HaveOccurred())
 
-			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-			defer cancel()
-			nodes, err := e2enode.GetBoundedReadySchedulableNodes(ctx, f.ClientSet, 3)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(len(nodes.Items)).To(BeNumerically(">=", 2),
-				"workload egress tests require at least 2 schedulable nodes")
-
-			nodesInfo := utils.GetNodesInfo(f, nodes, false)
+			nodesInfo := utils.AwaitReadySchedulableNodesInfo(f, 2, false)
 			allNames := nodesInfo.GetNames()
 			allIPs := nodesInfo.GetIPv4s()
-			Expect(len(allNames)).To(BeNumerically(">=", 2),
-				"workload egress tests require at least 2 non-master nodes with names")
-			Expect(len(allIPs)).To(BeNumerically(">=", 2),
-				"workload egress tests require at least 2 non-master nodes with IPv4 addresses")
 			nodeNames = allNames[:2]
 			nodeIPs = allIPs[:2]
 			logrus.Infof("Nodes: %v IPs: %v", nodeNames, nodeIPs)

--- a/e2e/pkg/tests/networking/workload_ingress.go
+++ b/e2e/pkg/tests/networking/workload_ingress.go
@@ -29,7 +29,6 @@ import (
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kubernetes/test/e2e/framework"
-	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
 
 	"github.com/projectcalico/calico/e2e/pkg/describe"
 	"github.com/projectcalico/calico/e2e/pkg/utils"
@@ -281,19 +280,10 @@ var _ = describe.CalicoDescribe(
 			cli, err := client.New(f.ClientConfig())
 			Expect(err).NotTo(HaveOccurred())
 
-			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-			defer cancel()
-
-			// Request more nodes than we need so we can filter out the control
-			// plane and still have 3 workers.
-			nodes, err := e2enode.GetBoundedReadySchedulableNodes(ctx, f.ClientSet, 6)
-			Expect(err).NotTo(HaveOccurred())
-			nodesInfo := utils.GetNodesInfo(f, nodes, false)
+			nodesInfo := utils.AwaitReadySchedulableNodesInfo(f, 3, false)
 			allNames := nodesInfo.GetNames()
 			allIPs := nodesInfo.GetIPv4s()
 			allTunnelIPs := nodesInfo.GetTunnelIPs()
-			Expect(len(allNames)).To(BeNumerically(">=", 3),
-				"workload ingress tests require at least 3 schedulable worker nodes, found %d", len(allNames))
 			nodeNames = allNames[:3]
 			nodeIPs = allIPs[:3]
 			tunnelIPs = allTunnelIPs[:3]

--- a/e2e/pkg/tests/networking/workload_ingress.go
+++ b/e2e/pkg/tests/networking/workload_ingress.go
@@ -284,6 +284,8 @@ var _ = describe.CalicoDescribe(
 			allNames := nodesInfo.GetNames()
 			allIPs := nodesInfo.GetIPv4s()
 			allTunnelIPs := nodesInfo.GetTunnelIPs()
+			Expect(len(allIPs)).To(BeNumerically(">=", 3),
+				"workload ingress tests require at least 3 nodes with IPv4 addresses, found %d", len(allIPs))
 			nodeNames = allNames[:3]
 			nodeIPs = allIPs[:3]
 			tunnelIPs = allTunnelIPs[:3]

--- a/e2e/pkg/utils/nodes.go
+++ b/e2e/pkg/utils/nodes.go
@@ -25,6 +25,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
 )
 
 const (
@@ -131,6 +132,33 @@ func GetNodesInfo(f *framework.Framework, nodes *corev1.NodeList, masterOK bool)
 		calicoNodeNames: calicoNodeNames,
 		tunnelIPs:       tunnelIPs,
 	}
+}
+
+// AwaitReadySchedulableNodesInfo polls until at least minCount ready and
+// schedulable nodes are available, then returns their NodesInfo. masterOK
+// controls whether the control-plane node is eligible (see GetNodesInfo).
+//
+// It retries rather than asserting once because a node can be *transiently*
+// unschedulable. For example, a HostEndpoint datapath test reprogramming the
+// BPF dataplane on a host interface briefly flaps calico-node readiness, which
+// re-adds the node.kubernetes.io/network-unavailable:NoSchedule taint; a
+// GetBoundedReadySchedulableNodes call landing in that window then reports too
+// few nodes. A one-shot node-count precondition races that recovery and fails
+// spuriously — use this helper for any multi-node requirement instead.
+func AwaitReadySchedulableNodesInfo(f *framework.Framework, minCount int, masterOK bool) NodesInfoGetter {
+	var info NodesInfoGetter
+	gomega.EventuallyWithOffset(1, func(g gomega.Gomega) {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		// Bound generously so we still clear minCount after any master node is
+		// filtered out.
+		nodes, err := e2enode.GetBoundedReadySchedulableNodes(ctx, f.ClientSet, minCount+4)
+		g.Expect(err).NotTo(gomega.HaveOccurred(), "failed to list schedulable nodes")
+		info = GetNodesInfo(f, nodes, masterOK)
+		g.Expect(len(info.GetNames())).To(gomega.BeNumerically(">=", minCount),
+			"require at least %d ready schedulable nodes, found %d", minCount, len(info.GetNames()))
+	}).WithTimeout(60 * time.Second).WithPolling(5 * time.Second).Should(gomega.Succeed())
+	return info
 }
 
 func getNodeTunnelIP(node *corev1.Node) string {

--- a/e2e/pkg/utils/nodes.go
+++ b/e2e/pkg/utils/nodes.go
@@ -148,7 +148,9 @@ func GetNodesInfo(f *framework.Framework, nodes *corev1.NodeList, masterOK bool)
 func AwaitReadySchedulableNodesInfo(f *framework.Framework, minCount int, masterOK bool) NodesInfoGetter {
 	var info NodesInfoGetter
 	gomega.EventuallyWithOffset(1, func(g gomega.Gomega) {
-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		// Keep the per-attempt timeout well under the polling interval so a slow
+		// or erroring List doesn't eat the whole Eventually budget in one attempt.
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
 		// Bound generously so we still clear minCount after any master node is
 		// filtered out.


### PR DESCRIPTION
The multi-node preconditions in the e2e suite listed schedulable nodes once and immediately asserted the count. This races transient unschedulability: creating/deleting a `HostEndpoint` makes Felix reattach the BPF programs on host interfaces, and while that reprogramming settles, `calico-node` readiness dips and the `node.kubernetes.io/network-unavailable:NoSchedule` taint is re-added for a few seconds. A node list landing in that window reports too few nodes and the `BeforeEach` fails before the test body runs.

Observed on master (BPF e2e), `HEP datapath egress-1N2`/`egress-1C2`:

```
[FAILED] HEP datapath tests require at least 2 schedulable worker nodes, found 1
Expected <int>: 1 to be >= <int>: 2
```

The two immediately-preceding specs from the same `Host Endpoint Datapath` suite — sharing the identical node-count check — passed, and the next serial spec's own `>=2` gate passed seconds later, so the cluster was healthy again almost immediately. Classic transient-window flake.

### Fix

Add `utils.AwaitReadySchedulableNodesInfo`, which wraps the list + master-filter + count check in an `Eventually` (60s / 5s poll), and route every multi-node precondition through it:

- `hep_datapath.go` (≥2)
- `workload_ingress.go` (≥3)
- `workload_egress.go` (≥2)
- `packet_size.go` (≥2)
- `qos.go` (≥2, ×2)
- `ipam_strict_affinity.go` (≥2)

The helper fails loudly if the nodes never recover, so it absorbs the transient window without hiding a genuine outage. Single-node (`>0` / non-empty) gates in `maglev.go`, `ipam_gc.go`, and `auto_hostendpoints.go` are left as-is — they would only flake if every worker went unschedulable at once.
