### PR TITLE
e2e/kubevirt: skip tests when KubeVirt is not installed

### DIFF
--- a/e2e/pkg/tests/kubevirt/ip_persistence.go
+++ b/e2e/pkg/tests/kubevirt/ip_persistence.go
@@ -58,6 +58,9 @@ var _ = describe.CalicoDescribe(
 		var cli ctrlclient.Client
 
 		BeforeEach(func() {
+			if !isKubeVirtInstalled(f) {
+				Skip("KubeVirt is not installed in this cluster")
+			}
 			// Live migration needs at least 2 nodes to migrate between.
 			utils.RequireNodeCount(f, 2)
 

--- a/e2e/pkg/tests/kubevirt/live_migration.go
+++ b/e2e/pkg/tests/kubevirt/live_migration.go
@@ -65,6 +65,9 @@ var _ = describe.CalicoDescribe(
 		var cli ctrlclient.Client
 
 		BeforeEach(func() {
+			if !isKubeVirtInstalled(f) {
+				Skip("KubeVirt is not installed in this cluster")
+			}
 			// Live migration needs at least 2 nodes to migrate between.
 			utils.RequireNodeCount(f, 2)
 

--- a/e2e/pkg/tests/kubevirt/live_migration_mockvirt.go
+++ b/e2e/pkg/tests/kubevirt/live_migration_mockvirt.go
@@ -54,6 +54,9 @@ var _ = describe.CalicoDescribe(
 		var cli ctrlclient.Client
 
 		BeforeEach(func() {
+			if !isKubeVirtInstalled(f) {
+				Skip("KubeVirt is not installed in this cluster")
+			}
 			if !isMockVirtDeployed(f) {
 				Fail("KubeVirt-MockVirt tests selected but cluster does not have MockVirt deployed")
 			}

--- a/e2e/pkg/tests/kubevirt/utils.go
+++ b/e2e/pkg/tests/kubevirt/utils.go
@@ -35,6 +35,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/kubernetes/test/e2e/framework"
 	"k8s.io/utils/ptr"
@@ -50,6 +51,7 @@ import (
 	"github.com/projectcalico/calico/libcalico-go/lib/apiconfig"
 	"github.com/projectcalico/calico/libcalico-go/lib/clientv3"
 	cerrors "github.com/projectcalico/calico/libcalico-go/lib/errors"
+	libkubevirt "github.com/projectcalico/calico/libcalico-go/lib/kubevirt"
 	cnet "github.com/projectcalico/calico/libcalico-go/lib/net"
 	"github.com/projectcalico/calico/libcalico-go/lib/options"
 )
@@ -829,6 +831,20 @@ func pickThirdWorkerNode(ctx context.Context, f *framework.Framework, node1, nod
 	}
 	Fail(fmt.Sprintf("no third worker node found (node1=%s, node2=%s); need at least 3 schedulable workers for the double-migration eBGP test", node1, node2))
 	return ""
+}
+
+// isKubeVirtInstalled reports whether the kubevirt.io API group is served by
+// the cluster under test. Tests use this to Skip (rather than Fail) on clusters
+// that don't have KubeVirt installed — e.g. when the shared e2e suite runs on a
+// pipeline that doesn't provision KubeVirt. Delegates to libcalico-go's
+// IsKubeVirtInstalled so the detection logic has a single source of truth.
+func isKubeVirtInstalled(f *framework.Framework) bool {
+	GinkgoHelper()
+	disc, err := discovery.NewDiscoveryClientForConfig(f.ClientConfig())
+	Expect(err).NotTo(HaveOccurred(), "failed to create discovery client")
+	installed, err := libkubevirt.IsKubeVirtInstalled(disc)
+	Expect(err).NotTo(HaveOccurred(), "failed to check whether KubeVirt is installed")
+	return installed
 }
 
 // isMockVirtDeployed returns true if the cluster is running MockVirt (simulated


### PR DESCRIPTION
## Description

The KubeVirt e2e suites are tagged `[sig-calico]`, so the per-dataplane pipelines (`nftables`/`iptables`/`bpf`) that focus on `[sig-calico]` sweep them in **even on clusters that don't provision KubeVirt**. On those runs every KubeVirt case fails 100% in `BeforeEach` on API discovery (`kubevirt.io/v1: no matches` / `KubeVirt CR 404`) instead of being skipped — polluting release-readiness signal on `v3.30`/`v3.31`/`v3.32` (confirmed via Lens: all KubeVirt cases Failed on the release streams, Passed only on master's dedicated KubeVirt pipeline).

## Fix

Gate the suites on a **runtime capability check** that `Skip`s (rather than `Fail`s) when the `kubevirt.io` API group is absent. Because the check lives in the test code, it travels with the shared e2e image onto any branch/pipeline — no per-branch skip-regex maintenance.

## Release Note

```release-note
NONE
```