### PR TITLE
Reduce size of felix UT JUnit reports so CI can publish them

### DIFF
--- a/felix/aws/ec2_suite_test.go
+++ b/felix/aws/ec2_suite_test.go
@@ -30,6 +30,6 @@ func init() {
 func TestUpdateEC2Instance(t *testing.T) {
 	gomega.RegisterFailHandler(ginkgo.Fail)
 	suiteConfig, reporterConfig := ginkgo.GinkgoConfiguration()
-	reporterConfig.JUnitReport = "../report/felix_aws_suite.xml"
+	testutils.RegisterJUnitReporter("felix_aws_suite.xml")
 	ginkgo.RunSpecs(t, "UT: felix/aws", suiteConfig, reporterConfig)
 }

--- a/felix/bpf/conntrack/conntrack_suite_test.go
+++ b/felix/bpf/conntrack/conntrack_suite_test.go
@@ -30,6 +30,6 @@ func init() {
 func TestBPFConntrack(t *testing.T) {
 	gomega.RegisterFailHandler(ginkgo.Fail)
 	suiteConfig, reporterConfig := ginkgo.GinkgoConfiguration()
-	reporterConfig.JUnitReport = "../../report/felix_bpf_conntrack_suite.xml"
+	testutils.RegisterJUnitReporter("felix_bpf_conntrack_suite.xml")
 	ginkgo.RunSpecs(t, "UT: felix/bpf/conntrack", suiteConfig, reporterConfig)
 }

--- a/felix/bpf/consistenthash/consistenthash_suite_test.go
+++ b/felix/bpf/consistenthash/consistenthash_suite_test.go
@@ -16,6 +16,6 @@ func init() {
 func TestConsistentHash(t *testing.T) {
 	gomega.RegisterFailHandler(ginkgo.Fail)
 	suiteConfig, reporterConfig := ginkgo.GinkgoConfiguration()
-	reporterConfig.JUnitReport = "../../report/felix_bpf_consistenthash_suite.xml"
+	testutils.RegisterJUnitReporter("felix_bpf_consistenthash_suite.xml")
 	ginkgo.RunSpecs(t, "UT: felix/bpf/consistenthash", suiteConfig, reporterConfig)
 }

--- a/felix/bpf/events/events_suite_test.go
+++ b/felix/bpf/events/events_suite_test.go
@@ -27,6 +27,6 @@ func TestEvents(t *testing.T) {
 	testutils.HookLogrusForGinkgo()
 	gomega.RegisterFailHandler(ginkgo.Fail)
 	suiteConfig, reporterConfig := ginkgo.GinkgoConfiguration()
-	reporterConfig.JUnitReport = "../../report/felix_bpf_events_suite.xml"
+	testutils.RegisterJUnitReporter("felix_bpf_events_suite.xml")
 	ginkgo.RunSpecs(t, "UT: felix/bpf/events", suiteConfig, reporterConfig)
 }

--- a/felix/bpf/proxy/proxy_suite_test.go
+++ b/felix/bpf/proxy/proxy_suite_test.go
@@ -19,11 +19,13 @@ import (
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
+
+	"github.com/projectcalico/calico/libcalico-go/lib/testutils"
 )
 
 func TestProxy(t *testing.T) {
 	gomega.RegisterFailHandler(ginkgo.Fail)
 	suiteConfig, reporterConfig := ginkgo.GinkgoConfiguration()
-	reporterConfig.JUnitReport = "../../report/felix_bpf_proxy_suite.xml"
+	testutils.RegisterJUnitReporter("felix_bpf_proxy_suite.xml")
 	ginkgo.RunSpecs(t, "UT: felix/bpf/proxy", suiteConfig, reporterConfig)
 }

--- a/felix/bpf/proxy/proxy_suite_test.go
+++ b/felix/bpf/proxy/proxy_suite_test.go
@@ -23,6 +23,10 @@ import (
 	"github.com/projectcalico/calico/libcalico-go/lib/testutils"
 )
 
+func init() {
+	testutils.HookLogrusForGinkgo()
+}
+
 func TestProxy(t *testing.T) {
 	gomega.RegisterFailHandler(ginkgo.Fail)
 	suiteConfig, reporterConfig := ginkgo.GinkgoConfiguration()

--- a/felix/calc/calc_suite_test.go
+++ b/felix/calc/calc_suite_test.go
@@ -30,6 +30,6 @@ func init() {
 func TestCalculationGraph(t *testing.T) {
 	gomega.RegisterFailHandler(ginkgo.Fail)
 	suiteConfig, reporterConfig := ginkgo.GinkgoConfiguration()
-	reporterConfig.JUnitReport = "../report/felix_calc_suite.xml"
+	testutils.RegisterJUnitReporter("felix_calc_suite.xml")
 	ginkgo.RunSpecs(t, "UT: felix/calc", suiteConfig, reporterConfig)
 }

--- a/felix/collector/collector_suite_test.go
+++ b/felix/collector/collector_suite_test.go
@@ -27,6 +27,6 @@ func TestCollector(t *testing.T) {
 	testutils.HookLogrusForGinkgo()
 	gomega.RegisterFailHandler(ginkgo.Fail)
 	suiteConfig, reporterConfig := ginkgo.GinkgoConfiguration()
-	reporterConfig.JUnitReport = "../report/felix_collector_suite.xml"
+	testutils.RegisterJUnitReporter("felix_collector_suite.xml")
 	ginkgo.RunSpecs(t, "UT: felix/collector", suiteConfig, reporterConfig)
 }

--- a/felix/collector/flowlog/flowlogs_suite_test.go
+++ b/felix/collector/flowlog/flowlogs_suite_test.go
@@ -34,6 +34,6 @@ func init() {
 func TestFlowlogs(t *testing.T) {
 	gomega.RegisterFailHandler(ginkgo.Fail)
 	suiteConfig, reporterConfig := ginkgo.GinkgoConfiguration()
-	reporterConfig.JUnitReport = "../../report/felix_collector_flowlog_suite.xml"
+	testutils.RegisterJUnitReporter("felix_collector_flowlog_suite.xml")
 	ginkgo.RunSpecs(t, "UT: felix/collector/flowlog", suiteConfig, reporterConfig)
 }

--- a/felix/collector/types/counter/counter_suite_test.go
+++ b/felix/collector/types/counter/counter_suite_test.go
@@ -32,6 +32,6 @@ func init() {
 func TestCounter(t *testing.T) {
 	gomega.RegisterFailHandler(ginkgo.Fail)
 	suiteConfig, reporterConfig := ginkgo.GinkgoConfiguration()
-	reporterConfig.JUnitReport = "../../../report/felix_collector_counter_suite.xml"
+	testutils.RegisterJUnitReporter("felix_collector_counter_suite.xml")
 	ginkgo.RunSpecs(t, "UT: felix/collector/counter", suiteConfig, reporterConfig)
 }

--- a/felix/collector/types/tuple/tuple_suite_test.go
+++ b/felix/collector/types/tuple/tuple_suite_test.go
@@ -32,6 +32,6 @@ func init() {
 func TestTuple(t *testing.T) {
 	gomega.RegisterFailHandler(ginkgo.Fail)
 	suiteConfig, reporterConfig := ginkgo.GinkgoConfiguration()
-	reporterConfig.JUnitReport = "../../../report/felix_collector_tuple_suite.xml"
+	testutils.RegisterJUnitReporter("felix_collector_tuple_suite.xml")
 	ginkgo.RunSpecs(t, "UT: felix/collector/tuple", suiteConfig, reporterConfig)
 }

--- a/felix/config/config_suite_test.go
+++ b/felix/config/config_suite_test.go
@@ -30,6 +30,6 @@ func init() {
 func TestConfig(t *testing.T) {
 	gomega.RegisterFailHandler(ginkgo.Fail)
 	suiteConfig, reporterConfig := ginkgo.GinkgoConfiguration()
-	reporterConfig.JUnitReport = "../report/felix_config_suite.xml"
+	testutils.RegisterJUnitReporter("felix_config_suite.xml")
 	ginkgo.RunSpecs(t, "UT: felix/config", suiteConfig, reporterConfig)
 }

--- a/felix/conntrack/conntrack_suite_test.go
+++ b/felix/conntrack/conntrack_suite_test.go
@@ -30,6 +30,6 @@ func init() {
 func TestConntrack(t *testing.T) {
 	gomega.RegisterFailHandler(ginkgo.Fail)
 	suiteConfig, reporterConfig := ginkgo.GinkgoConfiguration()
-	reporterConfig.JUnitReport = "../report/felix_conntrack_suite.xml"
+	testutils.RegisterJUnitReporter("felix_conntrack_suite.xml")
 	ginkgo.RunSpecs(t, "UT: felix/conntrack", suiteConfig, reporterConfig)
 }

--- a/felix/daemon/daemon_suite_test.go
+++ b/felix/daemon/daemon_suite_test.go
@@ -30,6 +30,6 @@ func init() {
 func TestConfig(t *testing.T) {
 	gomega.RegisterFailHandler(ginkgo.Fail)
 	suiteConfig, reporterConfig := ginkgo.GinkgoConfiguration()
-	reporterConfig.JUnitReport = "../report/felix_daemon_suite.xml"
+	testutils.RegisterJUnitReporter("felix_daemon_suite.xml")
 	ginkgo.RunSpecs(t, "UT: felix/daemon", suiteConfig, reporterConfig)
 }

--- a/felix/dataplane/ipsets/ipsets_mgr_ut_suite_test.go
+++ b/felix/dataplane/ipsets/ipsets_mgr_ut_suite_test.go
@@ -30,6 +30,6 @@ func init() {
 func TestIPSetMgr(t *testing.T) {
 	gomega.RegisterFailHandler(ginkgo.Fail)
 	suiteConfig, reporterConfig := ginkgo.GinkgoConfiguration()
-	reporterConfig.JUnitReport = "../../report/felix_dataplane_ipsets_suite.xml"
+	testutils.RegisterJUnitReporter("felix_dataplane_ipsets_suite.xml")
 	ginkgo.RunSpecs(t, "UT: felix/dataplane/ipsets", suiteConfig, reporterConfig)
 }

--- a/felix/dataplane/linux/intdataplane_ut_suite_test.go
+++ b/felix/dataplane/linux/intdataplane_ut_suite_test.go
@@ -30,6 +30,6 @@ func init() {
 func TestIntdataplane(t *testing.T) {
 	gomega.RegisterFailHandler(ginkgo.Fail)
 	suiteConfig, reporterConfig := ginkgo.GinkgoConfiguration()
-	reporterConfig.JUnitReport = "../../report/felix_dataplane_linux_suite.xml"
+	testutils.RegisterJUnitReporter("felix_dataplane_linux_suite.xml")
 	ginkgo.RunSpecs(t, "UT: felix/dataplane/linux", suiteConfig, reporterConfig)
 }

--- a/felix/dataplane/windows/windataplane_ut_suite_test.go
+++ b/felix/dataplane/windows/windataplane_ut_suite_test.go
@@ -30,6 +30,6 @@ func init() {
 func TestWindataplane(t *testing.T) {
 	gomega.RegisterFailHandler(ginkgo.Fail)
 	suiteConfig, reporterConfig := ginkgo.GinkgoConfiguration()
-	reporterConfig.JUnitReport = "../../report/felix_dataplane_windows_suite.xml"
+	testutils.RegisterJUnitReporter("felix_dataplane_windows_suite.xml")
 	ginkgo.RunSpecs(t, "UT: felix/dataplane/windows", suiteConfig, reporterConfig)
 }

--- a/felix/felix_suite_test.go
+++ b/felix/felix_suite_test.go
@@ -16,6 +16,6 @@ func init() {
 func TestFelix(t *testing.T) {
 	gomega.RegisterFailHandler(ginkgo.Fail)
 	suiteConfig, reporterConfig := ginkgo.GinkgoConfiguration()
-	reporterConfig.JUnitReport = "./report/felix_suite.xml"
+	testutils.RegisterJUnitReporter("felix_suite.xml")
 	ginkgo.RunSpecs(t, "UT: felix", suiteConfig, reporterConfig)
 }

--- a/felix/idalloc/idalloc_suite_test.go
+++ b/felix/idalloc/idalloc_suite_test.go
@@ -30,6 +30,6 @@ func init() {
 func TestCalculationGraph(t *testing.T) {
 	gomega.RegisterFailHandler(ginkgo.Fail)
 	suiteConfig, reporterConfig := ginkgo.GinkgoConfiguration()
-	reporterConfig.JUnitReport = "../report/felix_idalloc_suite.xml"
+	testutils.RegisterJUnitReporter("felix_idalloc_suite.xml")
 	ginkgo.RunSpecs(t, "UT: felix/idalloc", suiteConfig, reporterConfig)
 }

--- a/felix/ifacemonitor/ifacemonitor_suite_test.go
+++ b/felix/ifacemonitor/ifacemonitor_suite_test.go
@@ -30,6 +30,6 @@ func init() {
 func TestIfacemonitor(t *testing.T) {
 	gomega.RegisterFailHandler(ginkgo.Fail)
 	suiteConfig, reporterConfig := ginkgo.GinkgoConfiguration()
-	reporterConfig.JUnitReport = "../report/felix_ifacemonitor_suite.xml"
+	testutils.RegisterJUnitReporter("felix_ifacemonitor_suite.xml")
 	ginkgo.RunSpecs(t, "UT: felix/ifacemonitor", suiteConfig, reporterConfig)
 }

--- a/felix/ip/ip_suite_test.go
+++ b/felix/ip/ip_suite_test.go
@@ -26,7 +26,7 @@ import (
 func TestIp(t *testing.T) {
 	gomega.RegisterFailHandler(ginkgo.Fail)
 	suiteConfig, reporterConfig := ginkgo.GinkgoConfiguration()
-	reporterConfig.JUnitReport = "../report/felix_ip_suite.xml"
+	testutils.RegisterJUnitReporter("felix_ip_suite.xml")
 	ginkgo.RunSpecs(t, "UT: felix/ip", suiteConfig, reporterConfig)
 }
 

--- a/felix/ipsets/ipsets_suite_test.go
+++ b/felix/ipsets/ipsets_suite_test.go
@@ -30,6 +30,6 @@ func init() {
 func TestIPSets(t *testing.T) {
 	gomega.RegisterFailHandler(ginkgo.Fail)
 	suiteConfig, reporterConfig := ginkgo.GinkgoConfiguration()
-	reporterConfig.JUnitReport = "../report/felix_ipsets_suite.xml"
+	testutils.RegisterJUnitReporter("felix_ipsets_suite.xml")
 	ginkgo.RunSpecs(t, "UT: felix/ipsets", suiteConfig, reporterConfig)
 }

--- a/felix/iptables/iptables_ut_suite_test.go
+++ b/felix/iptables/iptables_ut_suite_test.go
@@ -30,6 +30,6 @@ func init() {
 func TestIptablesUT(t *testing.T) {
 	gomega.RegisterFailHandler(ginkgo.Fail)
 	suiteConfig, reporterConfig := ginkgo.GinkgoConfiguration()
-	reporterConfig.JUnitReport = "../report/felix_iptables_suite.xml"
+	testutils.RegisterJUnitReporter("felix_iptables_suite.xml")
 	ginkgo.RunSpecs(t, "UT: felix/iptables", suiteConfig, reporterConfig)
 }

--- a/felix/jitter/jitter_suite_test.go
+++ b/felix/jitter/jitter_suite_test.go
@@ -30,6 +30,6 @@ func init() {
 func TestJitter(t *testing.T) {
 	gomega.RegisterFailHandler(ginkgo.Fail)
 	suiteConfig, reporterConfig := ginkgo.GinkgoConfiguration()
-	reporterConfig.JUnitReport = "../report/felix_jitter_suite.xml"
+	testutils.RegisterJUnitReporter("felix_jitter_suite.xml")
 	ginkgo.RunSpecs(t, "UT: felix/jitter", suiteConfig, reporterConfig)
 }

--- a/felix/labelindex/labelindex_suite_test.go
+++ b/felix/labelindex/labelindex_suite_test.go
@@ -30,6 +30,6 @@ func init() {
 func TestLabels(t *testing.T) {
 	gomega.RegisterFailHandler(ginkgo.Fail)
 	suiteConfig, reporterConfig := ginkgo.GinkgoConfiguration()
-	reporterConfig.JUnitReport = "../report/felix_labelindex_suite.xml"
+	testutils.RegisterJUnitReporter("felix_labelindex_suite.xml")
 	ginkgo.RunSpecs(t, "UT: felix/labelindex", suiteConfig, reporterConfig)
 }

--- a/felix/markbits/markbits_suite_test.go
+++ b/felix/markbits/markbits_suite_test.go
@@ -30,6 +30,6 @@ func init() {
 func TestConfig(t *testing.T) {
 	gomega.RegisterFailHandler(ginkgo.Fail)
 	suiteConfig, reporterConfig := ginkgo.GinkgoConfiguration()
-	reporterConfig.JUnitReport = "../report/felix_markbits_suite.xml"
+	testutils.RegisterJUnitReporter("felix_markbits_suite.xml")
 	ginkgo.RunSpecs(t, "UT: felix/markbits", suiteConfig, reporterConfig)
 }

--- a/felix/multidict/multidict_suite_test.go
+++ b/felix/multidict/multidict_suite_test.go
@@ -30,6 +30,6 @@ func init() {
 func TestMultidict(t *testing.T) {
 	gomega.RegisterFailHandler(ginkgo.Fail)
 	suiteConfig, reporterConfig := ginkgo.GinkgoConfiguration()
-	reporterConfig.JUnitReport = "../report/felix_multidict_suite.xml"
+	testutils.RegisterJUnitReporter("felix_multidict_suite.xml")
 	ginkgo.RunSpecs(t, "UT: felix/multidict", suiteConfig, reporterConfig)
 }

--- a/felix/nfnetlink/nfnetlink_suite_test.go
+++ b/felix/nfnetlink/nfnetlink_suite_test.go
@@ -30,6 +30,6 @@ func init() {
 func TestNfnetlink(t *testing.T) {
 	gomega.RegisterFailHandler(ginkgo.Fail)
 	suiteConfig, reporterConfig := ginkgo.GinkgoConfiguration()
-	reporterConfig.JUnitReport = "../report/felix_nfnetlink_suite.xml"
+	testutils.RegisterJUnitReporter("felix_nfnetlink_suite.xml")
 	ginkgo.RunSpecs(t, "UT: felix/nfnetlink", suiteConfig, reporterConfig)
 }

--- a/felix/nftables/nftables_ut_suite_test.go
+++ b/felix/nftables/nftables_ut_suite_test.go
@@ -30,6 +30,6 @@ func init() {
 func TestNftablesUT(t *testing.T) {
 	gomega.RegisterFailHandler(ginkgo.Fail)
 	suiteConfig, reporterConfig := ginkgo.GinkgoConfiguration()
-	reporterConfig.JUnitReport = "../report/felix_nftables_suite.xml"
+	testutils.RegisterJUnitReporter("felix_nftables_suite.xml")
 	ginkgo.RunSpecs(t, "UT: felix/nftables", suiteConfig, reporterConfig)
 }

--- a/felix/policysync/policysync_suite_test.go
+++ b/felix/policysync/policysync_suite_test.go
@@ -30,6 +30,6 @@ func init() {
 func TestPolicysync(t *testing.T) {
 	gomega.RegisterFailHandler(ginkgo.Fail)
 	suiteConfig, reporterConfig := ginkgo.GinkgoConfiguration()
-	reporterConfig.JUnitReport = "../report/felix_policysync_suite.xml"
+	testutils.RegisterJUnitReporter("felix_policysync_suite.xml")
 	ginkgo.RunSpecs(t, "UT: felix/policysync", suiteConfig, reporterConfig)
 }

--- a/felix/routerule/routerule_suite_test.go
+++ b/felix/routerule/routerule_suite_test.go
@@ -30,6 +30,6 @@ func init() {
 func TestRules(t *testing.T) {
 	gomega.RegisterFailHandler(ginkgo.Fail)
 	suiteConfig, reporterConfig := ginkgo.GinkgoConfiguration()
-	reporterConfig.JUnitReport = "../report/felix_routerule_suite.xml"
+	testutils.RegisterJUnitReporter("felix_routerule_suite.xml")
 	ginkgo.RunSpecs(t, "UT: felix/routerule", suiteConfig, reporterConfig)
 }

--- a/felix/routetable/routetable_suite_test.go
+++ b/felix/routetable/routetable_suite_test.go
@@ -30,6 +30,6 @@ func init() {
 func TestRules(t *testing.T) {
 	gomega.RegisterFailHandler(ginkgo.Fail)
 	suiteConfig, reporterConfig := ginkgo.GinkgoConfiguration()
-	reporterConfig.JUnitReport = "../report/felix_routetable_suite.xml"
+	testutils.RegisterJUnitReporter("felix_routetable_suite.xml")
 	ginkgo.RunSpecs(t, "UT: felix/routetable", suiteConfig, reporterConfig)
 }

--- a/felix/rules/rules_suite_test.go
+++ b/felix/rules/rules_suite_test.go
@@ -30,6 +30,6 @@ func init() {
 func TestRules(t *testing.T) {
 	gomega.RegisterFailHandler(ginkgo.Fail)
 	suiteConfig, reporterConfig := ginkgo.GinkgoConfiguration()
-	reporterConfig.JUnitReport = "../report/felix_rules_suite.xml"
+	testutils.RegisterJUnitReporter("felix_rules_suite.xml")
 	ginkgo.RunSpecs(t, "UT: felix/rules", suiteConfig, reporterConfig)
 }

--- a/felix/serviceindex/serviceindex_suite_test.go
+++ b/felix/serviceindex/serviceindex_suite_test.go
@@ -30,6 +30,6 @@ func init() {
 func TestLabels(t *testing.T) {
 	gomega.RegisterFailHandler(ginkgo.Fail)
 	suiteConfig, reporterConfig := ginkgo.GinkgoConfiguration()
-	reporterConfig.JUnitReport = "../report/felix_serviceindex_suite.xml"
+	testutils.RegisterJUnitReporter("felix_serviceindex_suite.xml")
 	ginkgo.RunSpecs(t, "UT: felix/serviceindex", suiteConfig, reporterConfig)
 }

--- a/felix/statusrep/statusrep_suite_test.go
+++ b/felix/statusrep/statusrep_suite_test.go
@@ -30,6 +30,6 @@ func init() {
 func TestStatusrep(t *testing.T) {
 	gomega.RegisterFailHandler(ginkgo.Fail)
 	suiteConfig, reporterConfig := ginkgo.GinkgoConfiguration()
-	reporterConfig.JUnitReport = "../report/felix_statusrep_suite.xml"
+	testutils.RegisterJUnitReporter("felix_statusrep_suite.xml")
 	ginkgo.RunSpecs(t, "UT: felix/statusrep", suiteConfig, reporterConfig)
 }

--- a/felix/stringutils/stringutils_suite_test.go
+++ b/felix/stringutils/stringutils_suite_test.go
@@ -30,6 +30,6 @@ func init() {
 func TestStringutils(t *testing.T) {
 	gomega.RegisterFailHandler(ginkgo.Fail)
 	suiteConfig, reporterConfig := ginkgo.GinkgoConfiguration()
-	reporterConfig.JUnitReport = "../report/felix_stringutils_suite.xml"
+	testutils.RegisterJUnitReporter("felix_stringutils_suite.xml")
 	ginkgo.RunSpecs(t, "UT: felix/stringutils", suiteConfig, reporterConfig)
 }

--- a/felix/throttle/throttle_suite_test.go
+++ b/felix/throttle/throttle_suite_test.go
@@ -30,6 +30,6 @@ func init() {
 func TestJitter(t *testing.T) {
 	gomega.RegisterFailHandler(ginkgo.Fail)
 	suiteConfig, reporterConfig := ginkgo.GinkgoConfiguration()
-	reporterConfig.JUnitReport = "../report/felix_throttle_suite.xml"
+	testutils.RegisterJUnitReporter("felix_throttle_suite.xml")
 	ginkgo.RunSpecs(t, "UT: felix/throttle", suiteConfig, reporterConfig)
 }

--- a/felix/usagerep/usagerep_suite_test.go
+++ b/felix/usagerep/usagerep_suite_test.go
@@ -30,6 +30,6 @@ func init() {
 func TestUsagerep(t *testing.T) {
 	gomega.RegisterFailHandler(ginkgo.Fail)
 	suiteConfig, reporterConfig := ginkgo.GinkgoConfiguration()
-	reporterConfig.JUnitReport = "../report/felix_usagerep_suite.xml"
+	testutils.RegisterJUnitReporter("felix_usagerep_suite.xml")
 	ginkgo.RunSpecs(t, "UT: felix/usagerep", suiteConfig, reporterConfig)
 }

--- a/felix/wireguard/wireguard_suite_test.go
+++ b/felix/wireguard/wireguard_suite_test.go
@@ -30,6 +30,6 @@ func init() {
 func TestRules(t *testing.T) {
 	gomega.RegisterFailHandler(ginkgo.Fail)
 	suiteConfig, reporterConfig := ginkgo.GinkgoConfiguration()
-	reporterConfig.JUnitReport = "../report/felix_wireguard_suite.xml"
+	testutils.RegisterJUnitReporter("felix_wireguard_suite.xml")
 	ginkgo.RunSpecs(t, "UT: felix/wireguard", suiteConfig, reporterConfig)
 }

--- a/libcalico-go/lib/testutils/junitreport.go
+++ b/libcalico-go/lib/testutils/junitreport.go
@@ -86,12 +86,9 @@ func reportPath(filename string) (path string, err error) {
 		return "", err
 	}
 	component := strings.Split(rel, string(filepath.Separator))[0]
-	switch component {
-	case "..":
-		return "", fmt.Errorf("working directory %s is outside repo root %s", cwd, root)
-	case ".":
+	if component == "." {
+		// Working directory is the repo root itself.
 		return filepath.Join(root, "report", filename), nil
-	default:
-		return filepath.Join(root, component, "report", filename), nil
 	}
+	return filepath.Join(root, component, "report", filename), nil
 }

--- a/libcalico-go/lib/testutils/junitreport.go
+++ b/libcalico-go/lib/testutils/junitreport.go
@@ -1,0 +1,97 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testutils
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/ginkgo/v2/reporters"
+	"github.com/onsi/ginkgo/v2/types"
+)
+
+// RegisterJUnitReporter registers a ReportAfterSuite node that writes a JUnit
+// report named filename to the report/ directory of the component containing
+// the suite (e.g. felix/report/), located by walking up from the test
+// binary's working directory to the repo root.  Call it before RunSpecs.
+//
+// Unlike ginkgo's --junit-report flag (or reporterConfig.JUnitReport), the
+// generated report omits the captured log output of passing specs.  That
+// output dominates report size — log-heavy suites produce reports of tens of
+// MB or more — and CI's "test-results publish" parser is OOM-killed trying to
+// parse them, so none of the suite results reach the CI test dashboard.
+// Failing specs keep their timelines (including GinkgoWriter/logrus output).
+//
+// To see the full output of every spec locally, run the suite in verbose
+// mode, which streams captured output to the console:
+//
+//	go test ./felix/calc/ -ginkgo.v -ginkgo.focus="<spec name>"
+//
+// or pass -ginkgo.junit-report=<path> to also write a full-detail JUnit
+// report alongside the slim one.
+//
+// Don't combine this with reporterConfig.JUnitReport, which would write a
+// second, full-fat report.
+func RegisterJUnitReporter(filename string) {
+	ginkgo.ReportAfterSuite("JUnit report", func(report ginkgo.Report) {
+		path, err := reportPath(filename)
+		if err == nil {
+			err = reporters.GenerateJUnitReportWithConfig(report, path, reporters.JunitReportConfig{
+				OmitTimelinesForSpecState: types.SpecStatePassed | types.SpecStateSkipped | types.SpecStatePending,
+				OmitCapturedStdOutErr:     true,
+			})
+		}
+		if err != nil {
+			// Matching ginkgo's own behaviour for a failed report write:
+			// warn, don't fail the suite.
+			fmt.Fprintf(os.Stderr, "Failed to write JUnit report %s: %v\n", filename, err)
+		}
+	})
+}
+
+// reportPath resolves filename into the report/ directory of the component
+// whose tests are running: go test runs each test binary with the package
+// directory as its working directory, and the component is the first path
+// element under the repo root (CI publishes <component>/report/*.xml).
+func reportPath(filename string) (path string, err error) {
+	// FindRepoRoot panics when the root can't be located; a missing report
+	// must not take the suite down with it.
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("%v", r)
+		}
+	}()
+	root := FindRepoRoot()
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	rel, err := filepath.Rel(root, cwd)
+	if err != nil {
+		return "", err
+	}
+	component := strings.Split(rel, string(filepath.Separator))[0]
+	switch component {
+	case "..":
+		return "", fmt.Errorf("working directory %s is outside repo root %s", cwd, root)
+	case ".":
+		return filepath.Join(root, "report", filename), nil
+	default:
+		return filepath.Join(root, component, "report", filename), nil
+	}
+}

--- a/libcalico-go/lib/testutils/junitreport_internal_test.go
+++ b/libcalico-go/lib/testutils/junitreport_internal_test.go
@@ -1,0 +1,88 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testutils
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestReportPath(t *testing.T) {
+	root := fakeRepoRoot(t, "felix/bpf/proxy")
+	tests := []struct {
+		name    string
+		giveDir string // working directory, relative to the repo root
+		want    string // expected report path, relative to the repo root
+	}{
+		{
+			name:    "component directory",
+			giveDir: "felix",
+			want:    "felix/report/x.xml",
+		},
+		{
+			name:    "nested package directory",
+			giveDir: "felix/bpf/proxy",
+			want:    "felix/report/x.xml",
+		},
+		{
+			name:    "repo root",
+			giveDir: ".",
+			want:    "report/x.xml",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Chdir(filepath.Join(root, tt.giveDir))
+			got, err := reportPath("x.xml")
+			if err != nil {
+				t.Fatalf("reportPath: %v", err)
+			}
+			if want := filepath.Join(root, filepath.FromSlash(tt.want)); got != want {
+				t.Errorf("reportPath = %q, want %q", got, want)
+			}
+		})
+	}
+}
+
+func TestReportPathOutsideRepo(t *testing.T) {
+	t.Chdir(t.TempDir())
+	if path, err := reportPath("x.xml"); err == nil {
+		t.Errorf("reportPath = %q, want error when working directory is outside the repo", path)
+	}
+}
+
+// fakeRepoRoot creates a directory tree that FindRepoRoot recognises as the
+// calico repo root, plus the given subdirectories.  It returns the
+// symlink-resolved root path so expectations match os.Getwd, which resolves
+// symlinks (t.TempDir may sit behind one, e.g. /tmp on macOS).
+func fakeRepoRoot(t *testing.T, subdirs ...string) string {
+	t.Helper()
+	root := t.TempDir()
+	err := os.WriteFile(filepath.Join(root, "go.mod"), []byte("module github.com/projectcalico/calico\n"), 0o644)
+	if err != nil {
+		t.Fatalf("write go.mod: %v", err)
+	}
+	for _, dir := range subdirs {
+		if err := os.MkdirAll(filepath.Join(root, filepath.FromSlash(dir)), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+	root, err = filepath.EvalSymlinks(root)
+	if err != nil {
+		t.Fatalf("resolve symlinks: %v", err)
+	}
+	return root
+}


### PR DESCRIPTION
Felix UT suites write JUnit reports containing the full captured log output of every spec.  The biggest suites produce reports of tens of MB, and the "test-results publish" epilogue in the "Felix: UT" CI job is OOM-killed parsing them, so no felix UT results ever reach Semaphore's Tests dashboard.

Replace the per-suite reporterConfig.JUnitReport setting with a shared testutils.RegisterJUnitReporter helper that omits captured output for passing/skipped/pending specs; failing specs keep their failure message and log timeline.  

When runnlng locally, you can still get the full logs with:

```bash
go test ./felix/calc/ -ginkgo.v -ginkgo.focus="<spec name>"
```

<!-- For any user-visible change, replace TBD with a one-line description. -->
**Release note:**
```release-note
TBD
```
