### PR TITLE
Upload the kind e2e diagnostics bundle from collect-kind-diags

### DIFF
--- a/.semaphore/collect-kind-diags
+++ b/.semaphore/collect-kind-diags
@@ -14,10 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Collect diagnostics from a kind-based e2e cluster into artifacts/ so that
-# .semaphore/publish-artifacts uploads them for inspection. Drives
-# `calico ctl cluster diags`, which packages logs, descriptions, TLS state,
-# and Calico resources into a single tarball.
+# Collect diagnostics from a kind-based e2e cluster and upload them as a job
+# artifact for inspection. Drives `calico ctl cluster diags`, which packages
+# logs, descriptions, TLS state, and Calico resources into a single tarball.
 #
 # Intended to be called from the e2e job epilogue. Best-effort: missing
 # kubeconfig, missing image, or a torn-down cluster is not an error.
@@ -77,11 +76,11 @@ chmod +x "$calico_bin"
 mkdir -p "$artifacts_dir"
 
 # `calico ctl cluster diags` writes a calico-diagnostics-<timestamp>.tar.gz
-# into the working directory. Run it in artifacts/ so publish-artifacts picks
-# it up. The default --config points at /etc/calico/calicoctl.cfg, which
-# doesn't exist on the CI host — calicoctl tolerates that and falls back to
-# DATASTORE_TYPE / KUBECONFIG. Up max-logs from the default 5 so we don't
-# miss restarted pods on busier kind runs.
+# into the working directory, so run it from artifacts/. The default --config
+# points at /etc/calico/calicoctl.cfg, which doesn't exist on the CI host —
+# calicoctl tolerates that and falls back to DATASTORE_TYPE / KUBECONFIG. Up
+# max-logs from the default 5 so we don't miss restarted pods on busier kind
+# runs.
 cd "$artifacts_dir"
 PATH="$(dirname "$kubectl_bin"):$PATH" \
 DATASTORE_TYPE=kubernetes \
@@ -90,5 +89,19 @@ KUBECONFIG="$kubeconfig" \
     --max-logs=100 \
     --allow-version-mismatch \
   || echo "collect-kind-diags: cluster diags exited non-zero (continuing)"
+
+# Upload the bundle here rather than leaving it for .semaphore/publish-artifacts.
+# publish-artifacts runs in the global job epilogue, which executes *before* this
+# on_fail step, so by the time it runs the bundle doesn't exist yet and is never
+# uploaded. Pushing it directly makes the diags actually retrievable.
+if command -v artifact >/dev/null 2>&1; then
+  for bundle in calico-diagnostics-*.tar.gz; do
+    [ -e "$bundle" ] || continue
+    artifact push job "$bundle" -d "diags/$bundle" \
+      || echo "collect-kind-diags: failed to push $bundle (continuing)"
+  done
+else
+  echo "collect-kind-diags: 'artifact' CLI not found; bundle left in $artifacts_dir"
+fi
 
 exit 0


### PR DESCRIPTION
## Description

`collect-kind-diags` builds a `calico-diagnostics-*.tar.gz` in `artifacts/` and relied on `.semaphore/publish-artifacts` to upload it. But `publish-artifacts` runs in the **global** job epilogue, which executes *before* the block's `on_fail` epilogue where `collect-kind-diags` runs. So the bundle is created **after** the only upload step and is never published — confirmed from a failed run's console: `publish-artifacts` starts, then `collect-kind-diags` starts and writes the tarball as the last line of the job, with nothing pushing it afterward.

Every kind e2e job that uses `collect-kind-diags` (the KinD e2e block, kubevirt live-migration, scheduled builds) has silently discarded its diagnostics — which is why kind e2e failures never had kube-controllers/typha logs to debug from.

Fix: push the bundle directly from `collect-kind-diags` so it no longer depends on epilogue ordering. The push is guarded on the `artifact` CLI and is non-fatal, so local/manual runs and the script's best-effort contract are unaffected.

## Release Note

```release-note
None
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
