### PR TITLE
felix: fix "asm/types.h file not found" in BPF build on multiarch hosts

### DIFF
--- a/felix/Makefile
+++ b/felix/Makefile
@@ -218,8 +218,12 @@ $(BPF_GPL_O_FILES) $(BPF_GPL_UT_O_FILES) &: $(shell find bpf-gpl -name '*.[ch]')
 	$(DOCKER_GO_BUILD) make -j$$(nproc) -C bpf-gpl ARCH=$(ARCH) all ut-objs map-objs
 	touch -c $@
 
+# This is the only bpf-gpl make that runs on the host rather than in the
+# go-build container.  Generating a stub source file needs no C auto-deps, so
+# skip the *.d includes; they bake the container's system-header paths and
+# would fail to regenerate on the host (see SKIP_DEP_INCLUDES in bpf-gpl/Makefile).
 bpf-gpl/%_map_stub.c: bpf-gpl/Makefile
-	$(MAKE) -C bpf-gpl $(@F)
+	$(MAKE) -C bpf-gpl SKIP_DEP_INCLUDES=1 $(@F)
 
 clean-bpf:
 	rm -rf bpf-gpl/*.d bpf-apache/*.d bin/bpf

--- a/felix/bpf-gpl/Makefile
+++ b/felix/bpf-gpl/Makefile
@@ -369,10 +369,21 @@ COMPILE_DEPS=set -e; rm -f $@; \
 		sed 's,\($*\)\.o[ :]*,\1.o $@ : ,g' < $@.$$$$ > $@; \
 		rm -f $@.$$$$
 
+# The *.d auto-dependency files bake absolute system-header paths (e.g.
+# /usr/include/asm/types.h) from the environment that generated them — the
+# containerized go-build image.  Those paths do not exist on a typical
+# multiarch host (where asm/ lives under /usr/include/<triple>/), so a make
+# running on the host that includes a container-generated *.d sees a missing
+# prerequisite, tries to regenerate the *.d with host clang, and fails with
+# "asm/types.h file not found".  SKIP_DEP_INCLUDES lets a host-side caller that
+# only needs to generate source (e.g. the *_map_stub.c rule in felix/Makefile)
+# opt out of the includes it never needs.
+ifndef SKIP_DEP_INCLUDES
 ifneq ($(MAKECMDGOALS),clean)
   ifneq ($(MAKECMDGOALS), libbpf)
     include $(wildcard *.d)
   endif
+endif
 endif
 
 clean:


### PR DESCRIPTION
### Description

The BPF `*.d` auto-dependency files are generated inside the `go-build`
container, where they bake absolute system-header paths such as
`/usr/include/asm/types.h`. On a typical Debian/Ubuntu multiarch **host**,
those paths don't exist — `asm/` lives under `/usr/include/<triple>/` (e.g.
`/usr/include/x86_64-linux-gnu/asm/types.h`).

`felix/Makefile`'s `bpf-gpl/%_map_stub.c` rule is the one `bpf-gpl` make that
runs on the host rather than in the container. When it `include`s a
container-generated `*.d`, make sees a prerequisite path that is missing on the
host and — because a missing prerequisite always forces its dependents to be
remade — tries to regenerate the `*.d` with host `clang`. That regeneration
compiles the BPF source with `-target bpf`, which cannot resolve
`<asm/types.h>`, so the build fails with:

```
/usr/include/linux/types.h: fatal error: 'asm/types.h' file not found
```

The failure surfaces on the **second of two consecutive builds**: the first
build has no `*.d` yet when the host-side rule runs, and the container step then
writes them; the second build's host-side rule reads those container `*.d` and
blows up. Neither the `-MP` phony targets nor the `/usr/include/%.h` catch-all
rule prevent it, since both still let make treat the missing header as freshly
rebuilt and regenerate the dependent `*.d`. The long-standing workaround has
been `rm -f felix/bpf-gpl/*.d`.

### Fix

Generating a stub source file needs no C auto-dependency information at all. Add
a `SKIP_DEP_INCLUDES` switch to `felix/bpf-gpl/Makefile` that suppresses
`include $(wildcard *.d)`, and have the host-side stub rule pass it, so the host
never parses or regenerates the container-built `*.d`. The containerized object
build does not set the switch, so in-container incremental dependency tracking
is unchanged.

Verified by reproducing the exact `asm/types.h` failure with real
container-generated `*.d` files, then confirming the guarded host-side path
generates the stub and exits 0 with those same `*.d` present.

### Release Note

```release-note
None
```
