### PR TITLE
CI: move Felix BPF Ubuntu 25.10 tier to 26.04 LTS (25.10 image family removed at EOL)

### DIFF
--- a/.claude/skills/ci-reproduce-on-gcp-vm/SKILL.md
+++ b/.claude/skills/ci-reproduce-on-gcp-vm/SKILL.md
@@ -20,7 +20,7 @@ Check `felix/.semaphore/fv-prologue` to find the image family for the failing CI
 |---|---|---|
 | `22.04` | `ubuntu-2204-lts` | 22.04 Jammy |
 | `24.04` | `ubuntu-2404-lts-amd64` | 24.04 Noble |
-| `25.10` | `ubuntu-2510-amd64` | 25.10 Plucky |
+| `26.04` | `ubuntu-2604-lts-amd64` | 26.04 |
 
 For example, the `bpf-24.04-ipt-with-ut` test group uses `ubuntu-2404-lts-amd64`.
 

--- a/.semaphore/semaphore-scheduled-builds.yml
+++ b/.semaphore/semaphore-scheduled-builds.yml
@@ -1299,12 +1299,12 @@ blocks:
             - export FV_FOCUS='_BPF_.*ct=true'
             - export NUM_FV_BATCHES=10
             - .semaphore/vms/run-tests-on-vms ${VM_PREFIX}
-        - name: "Felix: BPF tests on Ubuntu 25.10 with netkit (nftables)"
+        - name: "Felix: BPF tests on Ubuntu 26.04 with netkit (nftables)"
           execution_time_limit:
             minutes: 60
           env_vars:
             - name: FELIX_TEST_GROUP
-              value: "bpf-25.10-nft-no-fv-with-ut"
+              value: "bpf-26.04-nft-no-fv-with-ut"
             - name: FELIX_FV_BPFATTACHTYPE
               value: "tc"
             - name: JOB_TIMEOUT_MINUTES
@@ -1315,14 +1315,14 @@ blocks:
             - source felix/.semaphore/fv-prologue
             - export NUM_FV_BATCHES=60
             - .semaphore/vms/run-tests-on-vms ${VM_PREFIX}
-        - name: "Felix: BPF tests on Ubuntu 25.10 with jitharden=2 (nftables)"
+        - name: "Felix: BPF tests on Ubuntu 26.04 with jitharden=2 (nftables)"
           execution_time_limit:
             minutes: 60
           env_vars:
             - name: JOB_TIMEOUT_MINUTES
               value: "60"
             - name: FELIX_TEST_GROUP
-              value: "bpf-25.10-nft-with-ut-jitharden"
+              value: "bpf-26.04-nft-with-ut-jitharden"
             - name: FELIX_FV_BPFATTACHTYPE
               value: "tc"
           commands:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -4101,12 +4101,12 @@ blocks:
             - export FV_FOCUS='_BPF_.*ct=true'
             - export NUM_FV_BATCHES=10
             - .semaphore/vms/run-tests-on-vms ${VM_PREFIX}
-        - name: "Felix: BPF tests on Ubuntu 25.10 with netkit (nftables)"
+        - name: "Felix: BPF tests on Ubuntu 26.04 with netkit (nftables)"
           execution_time_limit:
             minutes: 60
           env_vars:
             - name: FELIX_TEST_GROUP
-              value: "bpf-25.10-nft-no-fv-with-ut"
+              value: "bpf-26.04-nft-no-fv-with-ut"
             - name: FELIX_FV_BPFATTACHTYPE
               value: "tc"
             - name: JOB_TIMEOUT_MINUTES
@@ -4117,14 +4117,14 @@ blocks:
             - source felix/.semaphore/fv-prologue
             - export NUM_FV_BATCHES=60
             - .semaphore/vms/run-tests-on-vms ${VM_PREFIX}
-        - name: "Felix: BPF tests on Ubuntu 25.10 with jitharden=2 (nftables)"
+        - name: "Felix: BPF tests on Ubuntu 26.04 with jitharden=2 (nftables)"
           execution_time_limit:
             minutes: 60
           env_vars:
             - name: JOB_TIMEOUT_MINUTES
               value: "60"
             - name: FELIX_TEST_GROUP
-              value: "bpf-25.10-nft-with-ut-jitharden"
+              value: "bpf-26.04-nft-with-ut-jitharden"
             - name: FELIX_FV_BPFATTACHTYPE
               value: "tc"
           commands:

--- a/.semaphore/semaphore.yml.d/blocks/20-felix.yml
+++ b/.semaphore/semaphore.yml.d/blocks/20-felix.yml
@@ -272,12 +272,12 @@
           - export FV_FOCUS='_BPF_.*ct=true'
           - export NUM_FV_BATCHES=10
           - .semaphore/vms/run-tests-on-vms ${VM_PREFIX}
-      - name: "Felix: BPF tests on Ubuntu 25.10 with netkit (nftables)"
+      - name: "Felix: BPF tests on Ubuntu 26.04 with netkit (nftables)"
         execution_time_limit:
           minutes: 60
         env_vars:
           - name: FELIX_TEST_GROUP
-            value: "bpf-25.10-nft-no-fv-with-ut"
+            value: "bpf-26.04-nft-no-fv-with-ut"
           - name: FELIX_FV_BPFATTACHTYPE
             value: "tc"
           - name: JOB_TIMEOUT_MINUTES
@@ -288,14 +288,14 @@
           - source felix/.semaphore/fv-prologue
           - export NUM_FV_BATCHES=60
           - .semaphore/vms/run-tests-on-vms ${VM_PREFIX}
-      - name: "Felix: BPF tests on Ubuntu 25.10 with jitharden=2 (nftables)"
+      - name: "Felix: BPF tests on Ubuntu 26.04 with jitharden=2 (nftables)"
         execution_time_limit:
           minutes: 60
         env_vars:
           - name: JOB_TIMEOUT_MINUTES
             value: "60"
           - name: FELIX_TEST_GROUP
-            value: "bpf-25.10-nft-with-ut-jitharden"
+            value: "bpf-26.04-nft-with-ut-jitharden"
           - name: FELIX_FV_BPFATTACHTYPE
             value: "tc"
         commands:

--- a/felix/.semaphore/fv-prologue
+++ b/felix/.semaphore/fv-prologue
@@ -41,10 +41,10 @@ elif [[ $FELIX_TEST_GROUP =~ 24.04 ]]; then
   export IMAGE_FAMILY=ubuntu-2404-lts-amd64
   JOB_TAG+="2404"
   TEST_REPORT_NAME+="Ubuntu-24.04/"
-elif [[ $FELIX_TEST_GROUP =~ 25.10 ]]; then
-  export IMAGE_FAMILY=ubuntu-2510-amd64
-  JOB_TAG+="2510"
-  TEST_REPORT_NAME+="Ubuntu-25.10/"
+elif [[ $FELIX_TEST_GROUP =~ 26.04 ]]; then
+  export IMAGE_FAMILY=ubuntu-2604-lts-amd64
+  JOB_TAG+="2604"
+  TEST_REPORT_NAME+="Ubuntu-26.04/"
 else
   echo "Unknown OS version in FELIX_TEST_GROUP: $FELIX_TEST_GROUP"
   exit 1


### PR DESCRIPTION
### Description

Ubuntu 25.10 (Questing) is a non-LTS interim release and has reached end-of-life, so Canonical removed its image family from the `ubuntu-os-cloud` GCP project. The Felix FV-on-VMs jobs pinned to `ubuntu-2510-amd64` now fail at VM creation:

```
ERROR: (gcloud.compute.instances.bulk.create) Could not fetch resource:
 - The resource 'projects/ubuntu-os-cloud/global/images/family/ubuntu-2510-amd64' was not found
```

This breaks every build that runs those jobs, not just one PR.

This moves the tier to `ubuntu-2604-lts-amd64`. An LTS release keeps a recent kernel for the BPF tests and will not be pulled again after nine months the way an interim release is. It renames the two Felix BPF test groups (`bpf-25.10-*` → `bpf-26.04-*`) and the `fv-prologue` mapping, regenerates the Semaphore pipelines, and refreshes the `ci-reproduce-on-gcp-vm` skill table (also fixing a stale codename label).

### Release Note

```release-note
None
```