### PR TITLE
[release-v3.32] CORE-13107: avoid bpf_trace_printk dmesg spam under kernel lockdown=confidentiality (cherry-pick #13142, #13145)

### DIFF
--- a/charts/calico/templates/calico-node.yaml
+++ b/charts/calico/templates/calico-node.yaml
@@ -463,6 +463,13 @@ spec:
             # parent directory.
             - name: bpffs
               mountPath: /sys/fs/bpf
+            # Felix reads /sys/kernel/security/lockdown to detect kernel
+            # lockdown=confidentiality; under it, ftrace is disabled and Felix
+            # loads trace-printk-free BPF program variants. securityfs is a
+            # separate filesystem from /sys/fs, so it needs its own mount.
+            - name: sys-kernel-security
+              mountPath: /sys/kernel/security
+              readOnly: true
             - name: cni-log-dir
               mountPath: /var/log/calico/cni
               readOnly: true
@@ -607,6 +614,12 @@ spec:
           hostPath:
             path: /sys/fs/bpf
             type: Directory
+        # securityfs, read by Felix to detect kernel lockdown=confidentiality.
+        # No type set (like nodeproc below) so nodes without securityfs still
+        # start; Felix treats an unreadable lockdown file as "not locked down".
+        - name: sys-kernel-security
+          hostPath:
+            path: /sys/kernel/security
         # mount /proc at /nodeproc to be used by ebpf-bootstrap initContainer to mount root cgroup2 fs.
         - name: nodeproc
           hostPath:

--- a/felix/Makefile
+++ b/felix/Makefile
@@ -198,7 +198,9 @@ protobuf proto/felixbackend.pb.go: proto/felixbackend.proto
 # We pre-build lots of different variants of the TC programs, defer to the script.
 BPF_GPL_O_FILES:=$(addprefix bpf-gpl/,$(shell bpf-gpl/list-objs))
 BPF_GPL_O_FILES+=bpf-gpl/bin/tc_preamble_ingress.o bpf-gpl/bin/tc_preamble_egress.o \
-		 bpf-gpl/bin/xdp_preamble.o bpf-gpl/bin/policy_default_ingress.o  bpf-gpl/bin/policy_default_egress.o \
+		 bpf-gpl/bin/tc_preamble_ingress_notrace.o bpf-gpl/bin/tc_preamble_egress_notrace.o \
+		 bpf-gpl/bin/xdp_preamble.o bpf-gpl/bin/xdp_preamble_notrace.o \
+		 bpf-gpl/bin/policy_default_ingress.o  bpf-gpl/bin/policy_default_egress.o \
 		 bpf-gpl/bin/tcx_test.o
 BPF_GPL_MAP_STUB_O_FILES:=$(addprefix bpf-gpl/bin/,common_map_stub.o ipv4_map_stub.o ipv6_map_stub.o xdp_map_stub.o common_map_stub_ing.o)
 BPF_GPL_O_FILES+=$(BPF_GPL_MAP_STUB_O_FILES)

--- a/felix/bpf-gpl/Makefile
+++ b/felix/bpf-gpl/Makefile
@@ -112,8 +112,14 @@ bin/xdp_map_stub.o: bin/%.o: %.c %.d | bin
 OBJS:=$(shell ./list-objs)
 OBJS+=bin/tc_preamble_ingress.o
 OBJS+=bin/tc_preamble_egress.o
+# Trace-printk-free preamble variants, loaded on nodes running with kernel
+# lockdown=confidentiality (where ftrace is disabled and any program
+# referencing bpf_trace_printk spams the kernel log on every load).
+OBJS+=bin/tc_preamble_ingress_notrace.o
+OBJS+=bin/tc_preamble_egress_notrace.o
 OBJS+=bin/tcx_test.o
 OBJS+=bin/xdp_preamble.o
+OBJS+=bin/xdp_preamble_notrace.o
 OBJS+=bin/policy_default_ingress.o
 OBJS+=bin/policy_default_egress.o
 OBJS+=$(MAP_OBJS)
@@ -156,11 +162,19 @@ tc_preamble_ingress.ll: tc_preamble.c tc_preamble.d
 	$(COMPILE)
 tc_preamble_egress.ll: tc_preamble.c tc_preamble.d
 	$(COMPILE)
+tc_preamble_ingress_notrace.ll: tc_preamble.c tc_preamble.d
+	$(COMPILE)
+tc_preamble_ingress_notrace.ll: CFLAGS += -DCALI_NO_TRACE_PRINTK
+tc_preamble_egress_notrace.ll: tc_preamble.c tc_preamble.d
+	$(COMPILE)
+tc_preamble_egress_notrace.ll: CFLAGS += -DCALI_NO_TRACE_PRINTK
 tcx_test.ll: tcx_test.c tcx_test.d
 	$(CC) $(CFLAGS) -c $< -o $@
 
 xdp_preamble.ll: xdp_preamble.c xdp_preamble.d
 	$(CC) $(CFLAGS) -DCALI_COMPILE_FLAGS=64 -c $< -o $@
+xdp_preamble_notrace.ll: xdp_preamble.c xdp_preamble.d
+	$(CC) $(CFLAGS) -DCALI_COMPILE_FLAGS=64 -DCALI_NO_TRACE_PRINTK -c $< -o $@
 
 policy_default_ingress.ll: policy_default.c policy_default.d
 	$(COMPILE)
@@ -215,9 +229,15 @@ bin/tc_preamble_ingress.o: tc_preamble_ingress.ll | bin
 	$(LINK)
 bin/tc_preamble_egress.o: tc_preamble_egress.ll | bin
 	$(LINK)
+bin/tc_preamble_ingress_notrace.o: tc_preamble_ingress_notrace.ll | bin
+	$(LINK)
+bin/tc_preamble_egress_notrace.o: tc_preamble_egress_notrace.ll | bin
+	$(LINK)
 bin/tcx_test.o: tcx_test.ll | bin
 	$(LINK)
 bin/xdp_preamble.o: xdp_preamble.ll | bin
+	$(LINK)
+bin/xdp_preamble_notrace.o: xdp_preamble_notrace.ll | bin
 	$(LINK)
 bin/policy_default_ingress.o: policy_default_ingress.ll | bin
 	$(LINK)

--- a/felix/bpf-gpl/globals.h
+++ b/felix/bpf-gpl/globals.h
@@ -82,6 +82,27 @@ struct cali_xdp_preamble_globals {
 	struct cali_xdp_globals v6;
 };
 
+/* prog_flags holds per-program, load-time feature flags, distinct from the
+ * node-wide globals above: it lives in its own frozen read-only section so it
+ * does not disturb their layout, and Felix sets it per program at load. Because
+ * the section is frozen, the verifier folds each field to a constant and
+ * dead-code-eliminates the guarded branches (e.g. a program can load with no
+ * reference to the bpf_trace_printk helper at all). New per-program load-time
+ * flags belong here — append fields as needed.
+ */
+struct prog_flags {
+	/* no_trace_printk, when set, drops the code paths that call
+	 * bpf_trace_printk/bpf_trace_vprintk. Felix sets it on nodes running with
+	 * kernel lockdown=confidentiality, where ftrace is disabled and loading any
+	 * program that references the helper spams the kernel log on every load. */
+	__u8 no_trace_printk;
+};
+
+/* Instance lives in its own .rodata section; only objects that reference it get
+ * the map. Declared volatile const so the compiler emits real loads that the
+ * verifier can fold against the frozen map. */
+__attribute__((section(".rodata.prog_flags"))) volatile const struct prog_flags PROG_FLAGS;
+
 struct cali_ct_cleanup_globals {
     __u64 creation_grace;
 

--- a/felix/bpf-gpl/log.h
+++ b/felix/bpf-gpl/log.h
@@ -37,7 +37,16 @@
 #endif /* BPF_CORE_SUPPORTED */
 
 #ifndef CALI_LOG
+#ifdef CALI_NO_TRACE_PRINTK
+// Programs built with CALI_NO_TRACE_PRINTK must not reference the
+// bpf_trace_printk helper at all: on a kernel with lockdown=confidentiality
+// ftrace is disabled at boot, so loading any program that references the
+// helper makes the kernel emit "could not enable bpf_trace_printk events" on
+// every load. Compile the default log macro out entirely for those builds.
+#define CALI_LOG(fmt, ...) do {} while (0)
+#else
 #define CALI_LOG bpf_log
+#endif
 #endif
 
 #define CALI_INFO_NO_FLAG(fmt, ...)  CALI_LOG_IF(CALI_LOG_LEVEL_INFO, fmt, ## __VA_ARGS__)

--- a/felix/bpf-gpl/log.h
+++ b/felix/bpf-gpl/log.h
@@ -24,15 +24,24 @@
 #define IPVER_PFX	""
 #endif
 
+/* The no_trace_printk guard lets Felix strip every bpf_trace_printk reference
+ * from a program at load time (see struct prog_flags): the flag lives in
+ * frozen .rodata, so the verifier folds it and dead-code-eliminates the call.
+ * When the flag is clear (the normal case) the condition folds to always-true,
+ * so there is no runtime cost. */
 #ifdef BPF_CORE_SUPPORTED
 #define bpf_log(__fmt, ...) do { \
-		__attribute__((section(".rodata.cali_debug"))) static const char fmt[] = IPVER_PFX __fmt; \
-		bpf_trace_printk(fmt, sizeof(fmt), ## __VA_ARGS__); \
+		if (!PROG_FLAGS.no_trace_printk) { \
+			__attribute__((section(".rodata.cali_debug"))) static const char fmt[] = IPVER_PFX __fmt; \
+			bpf_trace_printk(fmt, sizeof(fmt), ## __VA_ARGS__); \
+		} \
 } while (0)
 #else
 #define bpf_log(__fmt, ...) do { \
-		char fmt[] = IPVER_PFX __fmt "\n"; \
-		bpf_trace_printk(fmt, sizeof(fmt), ## __VA_ARGS__); \
+		if (!PROG_FLAGS.no_trace_printk) { \
+			char fmt[] = IPVER_PFX __fmt "\n"; \
+			bpf_trace_printk(fmt, sizeof(fmt), ## __VA_ARGS__); \
+		} \
 } while (0)
 #endif /* BPF_CORE_SUPPORTED */
 

--- a/felix/bpf-gpl/skb.h
+++ b/felix/bpf-gpl/skb.h
@@ -210,6 +210,17 @@ static CALI_BPF_INLINE void skb_set_mark(struct __sk_buff *skb, __u32 mark)
 
 static CALI_BPF_INLINE void skb_log(struct cali_tc_ctx *ctx, bool accepted)
 {
+	/* skb_log's bpf_trace_vprintk/bpf_log calls are the only unconditional
+	 * reference to the trace-printk helpers in the main programs (they are gated
+	 * at runtime by CALI_ST_LOG_PACKET, not by CALI_LOG_LEVEL, so they survive
+	 * into the no_log builds). When Felix sets no_trace_printk (kernel
+	 * lockdown=confidentiality), this constant read folds and the verifier
+	 * dead-code-eliminates the rest of the function, so the loaded program
+	 * carries no trace-printk reference and its load does not spam the kernel
+	 * log. The policy Log action cannot work under that lockdown level anyway. */
+	if (PROG_FLAGS.no_trace_printk) {
+		return;
+	}
 	if (ctx->state->flags & CALI_ST_LOG_PACKET) {
 #ifdef BPF_CORE_SUPPORTED
 		if (bpf_core_enum_value_exists(enum bpf_func_id, BPF_FUNC_trace_vprintk)) {

--- a/felix/bpf/attach.go
+++ b/felix/bpf/attach.go
@@ -36,6 +36,10 @@ type AttachPoint struct {
 	LogLevel    string
 	Profiling   string
 	IfIndex     int
+	// NoTracePrintk selects the trace-printk-free preamble object variants,
+	// used on nodes running with kernel lockdown=confidentiality. See
+	// KernelLockdownConfidentiality.
+	NoTracePrintk bool
 }
 
 func (ap *AttachPoint) LogVal() string {

--- a/felix/bpf/bpf.go
+++ b/felix/bpf/bpf.go
@@ -2352,6 +2352,21 @@ func IterPerCpuMapCmdOutput(output []byte, f func(k, v []byte)) error {
 
 type ObjectConfigurator func(obj *libbpf.Obj) error
 
+// noTracePrintk, when true, makes loadObject set the no_trace_printk flag in
+// every loaded object's .rodata.prog_flags section, so the verifier eliminates
+// the bpf_trace_printk/bpf_trace_vprintk code paths at load time. Set once at
+// startup on nodes running with kernel lockdown=confidentiality, where loading
+// any program that references the helper spams the kernel log on every load.
+// See KernelLockdownConfidentiality.
+var noTracePrintk bool
+
+// SetNoTracePrintk configures whether subsequently loaded BPF programs have
+// their trace-printk code paths dead-code-eliminated at load time. It must be
+// called before any program is loaded.
+func SetNoTracePrintk(v bool) {
+	noTracePrintk = v
+}
+
 func LoadObject(file string, data libbpf.GlobalData, mapsToBePinned ...string) (*libbpf.Obj, error) {
 	return LoadObjectWithOptions(file, data, nil, mapsToBePinned...)
 }
@@ -2397,6 +2412,14 @@ func loadObject(obj *libbpf.Obj, data libbpf.GlobalData, mapsToBePinned ...strin
 		// userspace before the program is loaded.
 		mapName := m.Name()
 		if m.IsMapInternal() {
+			// Per-object load-time feature flags (see struct prog_flags).
+			// Its own section so it does not disturb the main globals .rodata.
+			if strings.HasSuffix(mapName, ".rodata.prog_flags") {
+				if err := m.SetProgFlags(noTracePrintk); err != nil {
+					return nil, fmt.Errorf("failed to set rodata flags on %s map %s: %w", obj.Filename(), mapName, err)
+				}
+				continue
+			}
 			if !strings.HasSuffix(mapName, ".rodata") {
 				continue
 			}

--- a/felix/bpf/libbpf/libbpf.go
+++ b/felix/bpf/libbpf/libbpf.go
@@ -684,6 +684,19 @@ func (c *CTLBGlobalData) Set(m *Map) error {
 	return err
 }
 
+// SetProgFlags writes the per-object load-time feature flags into the
+// program's .rodata.prog_flags section before load (see struct
+// prog_flags in globals.h).
+func (m *Map) SetProgFlags(noTracePrintk bool) error {
+	var noTrace C.uint8_t
+	if noTracePrintk {
+		noTrace = 1
+	}
+	_, err := C.bpf_set_prog_flags(m.bpfMap, noTrace)
+
+	return err
+}
+
 func (x *XDPGlobalData) Set(m *Map) error {
 	cName := C.CString(x.IfaceName)
 	defer C.free(unsafe.Pointer(cName))

--- a/felix/bpf/libbpf/libbpf_api.h
+++ b/felix/bpf/libbpf/libbpf_api.h
@@ -359,6 +359,18 @@ void bpf_ct_cleanup_set_globals(
 	set_errno(bpf_map__set_initial_value(map, (void*)(&data), sizeof(data)));
 }
 
+// bpf_set_prog_flags sets the per-object load-time feature flags in the
+// program's .rodata.prog_flags section (see struct prog_flags). Kept
+// separate from the main globals so it does not perturb their layout.
+void bpf_set_prog_flags(struct bpf_map *map, uint8_t no_trace_printk)
+{
+	struct prog_flags data = {
+		.no_trace_printk = no_trace_printk,
+	};
+
+	set_errno(bpf_map__set_initial_value(map, (void*)(&data), sizeof(data)));
+}
+
 int bpf_xdp_program_id(int ifIndex) {
 	__u32 prog_id = 0, flags = 0;
 	int err;

--- a/felix/bpf/libbpf/libbpf_stub.go
+++ b/felix/bpf/libbpf/libbpf_stub.go
@@ -250,6 +250,10 @@ func (t *CTLBGlobalData) Set(m *Map) error {
 	panic("LIBBPF syscall stub")
 }
 
+func (m *Map) SetProgFlags(noTracePrintk bool) error {
+	panic("LIBBPF syscall stub")
+}
+
 func ProgQueryTcx(ifindex int, ingress bool) ([64]uint32, [64]uint32, uint32, error) {
 	panic("LIBBPF syscall stub")
 }

--- a/felix/bpf/lockdown.go
+++ b/felix/bpf/lockdown.go
@@ -1,0 +1,61 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bpf
+
+import (
+	"os"
+	"strings"
+	"sync"
+)
+
+const lockdownPath = "/sys/kernel/security/lockdown"
+
+// KernelLockdownConfidentiality reports whether the kernel lockdown LSM is
+// active at "confidentiality" level. At that level the kernel disables ftrace
+// at boot (tracer_alloc_buffers returns -EPERM), so loading any BPF program
+// that references the bpf_trace_printk/bpf_trace_vprintk helper makes the
+// kernel log "could not enable bpf_trace_printk events" on every load. When
+// this returns true, Felix loads trace-printk-free variants of the preamble
+// programs to avoid that log spam.
+//
+// It returns false when lockdown is off, at a lower level, or the state cannot
+// be determined (securityfs not mounted, file absent) — i.e. it never turns on
+// the workaround speculatively.
+//
+// The state is read once and memoized: what matters is the lockdown level at
+// boot (that is when ftrace is enabled or disabled), and a single read
+// guarantees every caller makes the same decision even if the level is raised
+// at runtime.
+func KernelLockdownConfidentiality() bool {
+	lockdownOnce.Do(func() {
+		lockdownConfidentiality = kernelLockdownConfidentiality(lockdownPath)
+	})
+	return lockdownConfidentiality
+}
+
+var (
+	lockdownOnce            sync.Once
+	lockdownConfidentiality bool
+)
+
+func kernelLockdownConfidentiality(path string) bool {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+	// The file lists the available modes with the active one in brackets, e.g.
+	// "none integrity [confidentiality]".
+	return strings.Contains(string(data), "[confidentiality]")
+}

--- a/felix/bpf/lockdown_test.go
+++ b/felix/bpf/lockdown_test.go
@@ -1,0 +1,50 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bpf
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestKernelLockdownConfidentiality(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		content string
+		want    bool
+	}{
+		{"confidentiality active", "none integrity [confidentiality]\n", true},
+		{"integrity active", "none [integrity] confidentiality\n", false},
+		{"none active", "[none] integrity confidentiality\n", false},
+		{"empty", "", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "lockdown")
+			if err := os.WriteFile(path, []byte(tc.content), 0o644); err != nil {
+				t.Fatalf("failed to write test file: %v", err)
+			}
+			if got := kernelLockdownConfidentiality(path); got != tc.want {
+				t.Errorf("kernelLockdownConfidentiality(%q) = %v, want %v", tc.content, got, tc.want)
+			}
+		})
+	}
+
+	t.Run("missing file", func(t *testing.T) {
+		if kernelLockdownConfidentiality(filepath.Join(t.TempDir(), "does-not-exist")) {
+			t.Error("expected false when the lockdown file is absent")
+		}
+	})
+}

--- a/felix/bpf/tc/attach.go
+++ b/felix/bpf/tc/attach.go
@@ -154,7 +154,11 @@ func (ap *AttachPoint) AttachProgram() error {
 	// only need to load and configure the preamble that will pass the
 	// configuration further to the selected set of programs.
 
-	binaryToLoad := path.Join(bpfdefs.ObjectDir, fmt.Sprintf("tc_preamble_%s.o", ap.Hook))
+	preambleName := fmt.Sprintf("tc_preamble_%s", ap.Hook)
+	if ap.NoTracePrintk {
+		preambleName += "_notrace"
+	}
+	binaryToLoad := path.Join(bpfdefs.ObjectDir, preambleName+".o")
 	if ap.AttachType == apiv3.BPFAttachOptionTCX {
 		err := ap.attachTCXProgram(binaryToLoad)
 		if err != nil {

--- a/felix/bpf/ut/precompilation_test.go
+++ b/felix/bpf/ut/precompilation_test.go
@@ -20,7 +20,11 @@ import (
 	"fmt"
 	"math/rand"
 	"net"
+	"os"
+	"os/exec"
 	"path"
+	"regexp"
+	"strings"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -175,6 +179,76 @@ func helperCallIDs(file string) (map[int32]int, error) {
 		}
 	}
 	return calls, nil
+}
+
+// TestNoTracePrintkFlagStripsTraceHelper verifies the load-time dead-code
+// elimination: a main program carries skb_log's bpf_trace_printk/bpf_trace_vprintk
+// calls (the policy Log action) in its no_log build, but when Felix sets the
+// .rodata.prog_flags no_trace_printk flag before load, the verifier folds the
+// frozen constant and eliminates those code paths, so the loaded program
+// references no trace helper at all. That is what stops the "could not enable
+// bpf_trace_printk events" kernel-log spew under lockdown=confidentiality. With
+// the flag clear, the helper is still present.
+func TestNoTracePrintkFlagStripsTraceHelper(t *testing.T) {
+	RegisterTestingT(t)
+
+	bpffs, err := utils.MaybeMountBPFfs()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(bpffs).To(Equal("/sys/fs/bpf"))
+
+	// from_wep_no_log.o is a main program built at the "off" log level; it still
+	// carries skb_log's trace calls (gated at runtime, not by log level).
+	const obj = "from_wep_no_log.o"
+
+	// traceRe matches a trace-printk helper *call instruction*, whether bpftool
+	// renders the target by name (kallsyms/BTF available) or numerically by
+	// helper id (6 / 177). The leading "(85) call" (BPF_JMP|BPF_CALL opcode)
+	// distinguishes a real instruction from bpftool's interleaved source-line
+	// annotations (which start with ";" and mention the helper by name).
+	traceRe := regexp.MustCompile(`\(85\) call ((bpf_)?trace_v?printk|6\b|177\b)`)
+
+	loadedTraceHelperRefs := func(noTrace bool) int {
+		o, err := libbpf.OpenObject(path.Join(bpfdefs.ObjectDir, obj))
+		Expect(err).NotTo(HaveOccurred())
+		defer o.Close()
+
+		// Set the per-object flag before load so libbpf freezes it read-only and
+		// the verifier can fold it.
+		flagSet := false
+		for m, err := o.FirstMap(); m != nil && err == nil; m, err = m.NextMap() {
+			if strings.HasSuffix(m.Name(), ".rodata.prog_flags") {
+				Expect(m.SetProgFlags(noTrace)).NotTo(HaveOccurred())
+				flagSet = true
+			}
+		}
+		Expect(flagSet).To(BeTrue(), "object should carry a .rodata.prog_flags map")
+
+		Expect(o.Load()).NotTo(HaveOccurred())
+
+		pinDir := path.Join(bpffs, fmt.Sprintf("notrace-test-%x", rand.Uint32()))
+		Expect(os.MkdirAll(pinDir, 0o755)).NotTo(HaveOccurred())
+		defer os.RemoveAll(pinDir)
+		Expect(o.PinPrograms(pinDir)).NotTo(HaveOccurred())
+		defer func() { _ = o.UnpinPrograms(pinDir) }()
+
+		entries, err := os.ReadDir(pinDir)
+		Expect(err).NotTo(HaveOccurred())
+		refs := 0
+		for _, e := range entries {
+			out, err := exec.Command("bpftool", "prog", "dump", "xlated", "pinned",
+				path.Join(pinDir, e.Name())).CombinedOutput()
+			Expect(err).NotTo(HaveOccurred(), string(out))
+			refs += len(traceRe.FindAllString(string(out), -1))
+		}
+		return refs
+	}
+
+	// Baseline: without the flag the loaded program references the helper.
+	Expect(loadedTraceHelperRefs(false)).To(BeNumerically(">", 0),
+		"baseline: main program should reference a trace helper when no_trace_printk is clear")
+	// With the flag set, the verifier must have eliminated every trace helper.
+	Expect(loadedTraceHelperRefs(true)).To(BeZero(),
+		"with no_trace_printk set, the loaded program must reference no trace helper")
 }
 
 func createVeth() (string, netlink.Link) {

--- a/felix/bpf/ut/precompilation_test.go
+++ b/felix/bpf/ut/precompilation_test.go
@@ -15,6 +15,8 @@
 package ut_test
 
 import (
+	"debug/elf"
+	"encoding/binary"
 	"fmt"
 	"math/rand"
 	"net"
@@ -37,6 +39,14 @@ func checkBTFEnabled() []bool {
 	}
 	return []bool{false}
 }
+
+// BPF helper-function IDs (uapi/linux/bpf.h). Programs that reference either of
+// these carry the bpf_trace/bpf_trace_printk trace event, which the kernel tries
+// to enable on every program load.
+const (
+	bpfFuncTracePrintk  = 6
+	bpfFuncTraceVprintk = 177
+)
 
 func TestPrecompiledBinariesAreLoadable(t *testing.T) {
 	RegisterTestingT(t)
@@ -67,6 +77,9 @@ func TestPrecompiledBinariesAreLoadable(t *testing.T) {
 	objects["tc_preamble_ingress.o"] = struct{}{}
 	objects["tc_preamble_egress.o"] = struct{}{}
 	objects["xdp_preamble.o"] = struct{}{}
+	objects["tc_preamble_ingress_notrace.o"] = struct{}{}
+	objects["tc_preamble_egress_notrace.o"] = struct{}{}
+	objects["xdp_preamble_notrace.o"] = struct{}{}
 	objects["conntrack_cleanup_debug_co-re_v4.o"] = struct{}{}
 	objects["conntrack_cleanup_debug_co-re_v6.o"] = struct{}{}
 	objects["conntrack_cleanup_no_log_co-re_v4.o"] = struct{}{}
@@ -91,6 +104,77 @@ func TestPrecompiledBinariesAreLoadable(t *testing.T) {
 			testObject(path.Join(bpfdefs.ObjectDir, obj))
 		})
 	}
+}
+
+// TestPreambleNoTraceVariantsAreTracePrintkFree checks that the _notrace
+// preamble objects carry no bpf_trace_printk/bpf_trace_vprintk helper call.
+// These variants are loaded on nodes running with kernel lockdown=confidentiality,
+// where ftrace is disabled at boot and loading any program that references the
+// helper makes the kernel log "could not enable bpf_trace_printk events" on
+// every load.
+func TestPreambleNoTraceVariantsAreTracePrintkFree(t *testing.T) {
+	RegisterTestingT(t)
+
+	for _, obj := range []string{
+		"tc_preamble_ingress_notrace.o",
+		"tc_preamble_egress_notrace.o",
+		"xdp_preamble_notrace.o",
+	} {
+		t.Run(obj, func(t *testing.T) {
+			RegisterTestingT(t)
+			calls, err := helperCallIDs(path.Join(bpfdefs.ObjectDir, obj))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(calls).NotTo(HaveKey(int32(bpfFuncTracePrintk)),
+				"notrace preamble must not call bpf_trace_printk")
+			Expect(calls).NotTo(HaveKey(int32(bpfFuncTraceVprintk)),
+				"notrace preamble must not call bpf_trace_vprintk")
+		})
+	}
+
+	// Guard against the helper being stripped everywhere: the regular preambles
+	// are expected to still carry it, so the checks above genuinely exercise the
+	// _notrace build.
+	for _, obj := range []string{"tc_preamble_ingress.o", "tc_preamble_egress.o"} {
+		t.Run(obj+" (baseline)", func(t *testing.T) {
+			RegisterTestingT(t)
+			calls, err := helperCallIDs(path.Join(bpfdefs.ObjectDir, obj))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(calls).To(HaveKey(int32(bpfFuncTracePrintk)),
+				"regular preamble expected to call bpf_trace_printk")
+		})
+	}
+}
+
+// helperCallIDs returns the set of BPF helper-function IDs (with counts)
+// invoked by a precompiled object. A helper call is opcode 0x85
+// (BPF_JMP|BPF_CALL) with src register 0; its immediate is the helper ID.
+// (src register 1 is a bpf-to-bpf call, 2 is a kfunc call — not helpers.)
+// BPF instructions are 8-byte units; the second slot of a 16-byte wide load
+// has a zero opcode byte, so stepping by 8 never mistakes it for a call.
+func helperCallIDs(file string) (map[int32]int, error) {
+	f, err := elf.Open(file)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = f.Close() }()
+
+	calls := map[int32]int{}
+	for _, sec := range f.Sections {
+		if sec.Type != elf.SHT_PROGBITS || sec.Flags&elf.SHF_EXECINSTR == 0 {
+			continue
+		}
+		data, err := sec.Data()
+		if err != nil {
+			return nil, err
+		}
+		for off := 0; off+8 <= len(data); off += 8 {
+			if data[off] != 0x85 || data[off+1]>>4 != 0 {
+				continue
+			}
+			calls[int32(binary.LittleEndian.Uint32(data[off+4:off+8]))]++
+		}
+	}
+	return calls, nil
 }
 
 func createVeth() (string, netlink.Link) {

--- a/felix/bpf/xdp/attach.go
+++ b/felix/bpf/xdp/attach.go
@@ -124,7 +124,11 @@ func (ap *AttachPoint) AttachProgram() error {
 	// only need to load and configure the preamble that will pass the
 	// configuration further to the selected set of programs.
 
-	binaryToLoad := path.Join(bpfdefs.ObjectDir, "xdp_preamble.o")
+	preambleName := "xdp_preamble.o"
+	if ap.NoTracePrintk {
+		preambleName = "xdp_preamble_notrace.o"
+	}
+	binaryToLoad := path.Join(bpfdefs.ObjectDir, preambleName)
 	ap.Log().Infof("Continue with attaching BPF program %s", binaryToLoad)
 	obj, err := bpf.LoadObject(binaryToLoad, ap.Configuration())
 	if err != nil {

--- a/felix/dataplane/linux/bpf_ep_mgr.go
+++ b/felix/dataplane/linux/bpf_ep_mgr.go
@@ -301,8 +301,13 @@ type bpfEndpointManager struct {
 
 	dirtyIfaceNames set.Set[string]
 
-	logFilters              map[string]string
-	bpfLogLevel             string
+	logFilters  map[string]string
+	bpfLogLevel string
+	// bpfNoTracePrintk selects the trace-printk-free preamble variants; set
+	// when the kernel is running with lockdown=confidentiality (ftrace
+	// disabled), where loading a preamble that references bpf_trace_printk
+	// spams the kernel log on every attach.
+	bpfNoTracePrintk        bool
 	hostname                string
 	dataIfaceRegex          *regexp.Regexp
 	l3IfaceRegex            *regexp.Regexp
@@ -479,6 +484,21 @@ func NewBPFEndpointManager(
 		livenessCallback = func() {}
 	}
 
+	// Under kernel lockdown=confidentiality, ftrace is disabled at boot, so any
+	// BPF program that references bpf_trace_printk makes the kernel log "could
+	// not enable bpf_trace_printk events" on every load. Load the
+	// trace-printk-free preamble variants, and drop debug logging (which cannot
+	// work anyway) so the debug programs — which carry the helper — are not
+	// loaded either.
+	bpfLogLevel := strings.ToLower(config.BPFLogLevel)
+	bpfNoTracePrintk := bpf.KernelLockdownConfidentiality()
+	if bpfNoTracePrintk && bpfLogLevel == "debug" {
+		logrus.Warn("Kernel lockdown=confidentiality detected: BPF debug logging and the " +
+			"policy Log action are unavailable on this node (ftrace is disabled); " +
+			"forcing BPFLogLevel to off.")
+		bpfLogLevel = "off"
+	}
+
 	m := &bpfEndpointManager{
 		initUnknownIfaces:       set.New[string](),
 		dp:                      dp,
@@ -492,7 +512,8 @@ func NewBPFEndpointManager(
 		profilesToWorkloads:     map[types.ProfileID]set.Set[any]{},
 		dirtyIfaceNames:         set.New[string](),
 		hostIfaceTrees:          make(bpfIfaceTrees),
-		bpfLogLevel:             config.BPFLogLevel,
+		bpfLogLevel:             bpfLogLevel,
+		bpfNoTracePrintk:        bpfNoTracePrintk,
 		logFilters:              config.BPFLogFilters,
 		hostname:                config.Hostname,
 		l3IfaceRegex:            config.BPFL3IfacePattern,
@@ -2026,10 +2047,11 @@ func (m *bpfEndpointManager) doApplyPolicyToDataIface(iface, masterIface string,
 
 	xdpAttachPoint := &xdp.AttachPoint{
 		AttachPoint: bpf.AttachPoint{
-			IfIndex:  ifIndex,
-			Hook:     hook.XDP,
-			Iface:    iface,
-			LogLevel: m.bpfLogLevel,
+			IfIndex:       ifIndex,
+			Hook:          hook.XDP,
+			Iface:         iface,
+			LogLevel:      m.bpfLogLevel,
+			NoTracePrintk: m.bpfNoTracePrintk,
 		},
 		Modes: m.xdpModes,
 	}
@@ -3186,7 +3208,8 @@ func (m *bpfEndpointManager) getEndpointType(ifaceName string) tcdefs.EndpointTy
 func (m *bpfEndpointManager) calculateTCAttachPoint(ifaceName string) *tc.AttachPoint {
 	ap := &tc.AttachPoint{
 		AttachPoint: bpf.AttachPoint{
-			Iface: ifaceName,
+			Iface:         ifaceName,
+			NoTracePrintk: m.bpfNoTracePrintk,
 		},
 		MaglevLUTSize: uint32(m.maglevLUTSize),
 	}

--- a/felix/dataplane/linux/int_dataplane.go
+++ b/felix/dataplane/linux/int_dataplane.go
@@ -975,6 +975,11 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 			log.Warn("Kernel lockdown=confidentiality detected: forcing BPF conntrack cleanup " +
 				"log level to off (ftrace is disabled, debug logging cannot work).")
 		}
+		// Make every BPF program loaded from here on drop its trace-printk code
+		// paths at load time (via the .rodata.prog_flags no_trace_printk flag),
+		// so their load does not spam the kernel log under confidentiality
+		// lockdown. Must be set before any program is loaded.
+		bpf.SetNoTracePrintk(kernelLockdownConfidentiality)
 
 		// Start IPv4 BPF dataplane components
 		conntrackScannerV4, workloadRemoveChanV4 = startBPFDataplaneComponents(proto.IPVersion_IPV4, bpfMaps.V4, ipSetIDAllocatorV4, &config, ipsetsManager, dp, kernelLockdownConfidentiality)

--- a/felix/dataplane/linux/int_dataplane.go
+++ b/felix/dataplane/linux/int_dataplane.go
@@ -964,15 +964,27 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 			ipSetIDAllocatorV4.ReserveWellKnownID(rules.IPSetIDAllIstioWEPs, bpfipsets.AllIstioWEPsID)
 		}
 
+		// Under kernel lockdown=confidentiality ftrace is disabled at boot, so
+		// loading any BPF program that references bpf_trace_printk makes the
+		// kernel log "could not enable bpf_trace_printk events" on every load.
+		// The conntrack cleanup program carries the helper in its debug build,
+		// so downgrade it to the no-log build on such nodes (mirrors the
+		// endpoint manager forcing BPFLogLevel off).
+		kernelLockdownConfidentiality := bpf.KernelLockdownConfidentiality()
+		if kernelLockdownConfidentiality && strings.EqualFold(config.BPFConntrackLogLevel, "debug") {
+			log.Warn("Kernel lockdown=confidentiality detected: forcing BPF conntrack cleanup " +
+				"log level to off (ftrace is disabled, debug logging cannot work).")
+		}
+
 		// Start IPv4 BPF dataplane components
-		conntrackScannerV4, workloadRemoveChanV4 = startBPFDataplaneComponents(proto.IPVersion_IPV4, bpfMaps.V4, ipSetIDAllocatorV4, &config, ipsetsManager, dp)
+		conntrackScannerV4, workloadRemoveChanV4 = startBPFDataplaneComponents(proto.IPVersion_IPV4, bpfMaps.V4, ipSetIDAllocatorV4, &config, ipsetsManager, dp, kernelLockdownConfidentiality)
 		if config.BPFIpv6Enabled {
 			// Start IPv6 BPF dataplane components
 			ipSetIDAllocatorV6 = idalloc.New()
 			if config.RulesConfig.IstioAmbientModeEnabled {
 				ipSetIDAllocatorV6.ReserveWellKnownID(rules.IPSetIDAllIstioWEPs, bpfipsets.AllIstioWEPsID)
 			}
-			conntrackScannerV6, workloadRemoveChanV6 = startBPFDataplaneComponents(proto.IPVersion_IPV6, bpfMaps.V6, ipSetIDAllocatorV6, &config, ipsetsManagerV6, dp)
+			conntrackScannerV6, workloadRemoveChanV6 = startBPFDataplaneComponents(proto.IPVersion_IPV6, bpfMaps.V6, ipSetIDAllocatorV6, &config, ipsetsManagerV6, dp, kernelLockdownConfidentiality)
 		}
 
 		workloadIfaceRegex := regexp.MustCompile(strings.Join(interfaceRegexes, "|"))
@@ -2979,6 +2991,7 @@ func startBPFDataplaneComponents(
 	config *Config,
 	ipSetsMgr *dpsets.IPSetsManager,
 	dp *InternalDataplane,
+	kernelLockdownConfidentiality bool,
 ) (*bpfconntrack.Scanner, chan string) {
 	ipSetConfig := config.RulesConfig.IPSetConfigV4
 	ipSetEntry := bpfipsets.IPSetEntryFromBytes
@@ -3067,7 +3080,9 @@ func startBPFDataplaneComponents(
 
 	livenessScanner := bpfconntrack.NewLivenessScanner(config.BPFConntrackTimeouts, config.BPFNodePortDSREnabled)
 	ctLogLevel := bpfconntrack.BPFLogLevelNone
-	if config.BPFConntrackLogLevel == "debug" {
+	// The debug cleanup program references bpf_trace_printk; skip it under
+	// lockdown=confidentiality where that would spam the kernel log on load.
+	if strings.EqualFold(config.BPFConntrackLogLevel, "debug") && !kernelLockdownConfidentiality {
 		ctLogLevel = bpfconntrack.BPFLogLevelDebug
 	}
 

--- a/manifests/calico-bpf.yaml
+++ b/manifests/calico-bpf.yaml
@@ -7736,6 +7736,13 @@ spec:
             # parent directory.
             - name: bpffs
               mountPath: /sys/fs/bpf
+            # Felix reads /sys/kernel/security/lockdown to detect kernel
+            # lockdown=confidentiality; under it, ftrace is disabled and Felix
+            # loads trace-printk-free BPF program variants. securityfs is a
+            # separate filesystem from /sys/fs, so it needs its own mount.
+            - name: sys-kernel-security
+              mountPath: /sys/kernel/security
+              readOnly: true
             - name: cni-log-dir
               mountPath: /var/log/calico/cni
               readOnly: true
@@ -7764,6 +7771,12 @@ spec:
           hostPath:
             path: /sys/fs/bpf
             type: Directory
+        # securityfs, read by Felix to detect kernel lockdown=confidentiality.
+        # No type set (like nodeproc below) so nodes without securityfs still
+        # start; Felix treats an unreadable lockdown file as "not locked down".
+        - name: sys-kernel-security
+          hostPath:
+            path: /sys/kernel/security
         # mount /proc at /nodeproc to be used by ebpf-bootstrap initContainer to mount root cgroup2 fs.
         - name: nodeproc
           hostPath:

--- a/manifests/calico-etcd.yaml
+++ b/manifests/calico-etcd.yaml
@@ -584,6 +584,13 @@ spec:
             # parent directory.
             - name: bpffs
               mountPath: /sys/fs/bpf
+            # Felix reads /sys/kernel/security/lockdown to detect kernel
+            # lockdown=confidentiality; under it, ftrace is disabled and Felix
+            # loads trace-printk-free BPF program variants. securityfs is a
+            # separate filesystem from /sys/fs, so it needs its own mount.
+            - name: sys-kernel-security
+              mountPath: /sys/kernel/security
+              readOnly: true
             - name: cni-log-dir
               mountPath: /var/log/calico/cni
               readOnly: true
@@ -612,6 +619,12 @@ spec:
           hostPath:
             path: /sys/fs/bpf
             type: Directory
+        # securityfs, read by Felix to detect kernel lockdown=confidentiality.
+        # No type set (like nodeproc below) so nodes without securityfs still
+        # start; Felix treats an unreadable lockdown file as "not locked down".
+        - name: sys-kernel-security
+          hostPath:
+            path: /sys/kernel/security
         # mount /proc at /nodeproc to be used by ebpf-bootstrap initContainer to mount root cgroup2 fs.
         - name: nodeproc
           hostPath:

--- a/manifests/calico-policy-only.yaml
+++ b/manifests/calico-policy-only.yaml
@@ -7615,6 +7615,13 @@ spec:
             # parent directory.
             - name: bpffs
               mountPath: /sys/fs/bpf
+            # Felix reads /sys/kernel/security/lockdown to detect kernel
+            # lockdown=confidentiality; under it, ftrace is disabled and Felix
+            # loads trace-printk-free BPF program variants. securityfs is a
+            # separate filesystem from /sys/fs, so it needs its own mount.
+            - name: sys-kernel-security
+              mountPath: /sys/kernel/security
+              readOnly: true
             - name: cni-log-dir
               mountPath: /var/log/calico/cni
               readOnly: true
@@ -7643,6 +7650,12 @@ spec:
           hostPath:
             path: /sys/fs/bpf
             type: Directory
+        # securityfs, read by Felix to detect kernel lockdown=confidentiality.
+        # No type set (like nodeproc below) so nodes without securityfs still
+        # start; Felix treats an unreadable lockdown file as "not locked down".
+        - name: sys-kernel-security
+          hostPath:
+            path: /sys/kernel/security
         # mount /proc at /nodeproc to be used by ebpf-bootstrap initContainer to mount root cgroup2 fs.
         - name: nodeproc
           hostPath:

--- a/manifests/calico-typha.yaml
+++ b/manifests/calico-typha.yaml
@@ -7737,6 +7737,13 @@ spec:
             # parent directory.
             - name: bpffs
               mountPath: /sys/fs/bpf
+            # Felix reads /sys/kernel/security/lockdown to detect kernel
+            # lockdown=confidentiality; under it, ftrace is disabled and Felix
+            # loads trace-printk-free BPF program variants. securityfs is a
+            # separate filesystem from /sys/fs, so it needs its own mount.
+            - name: sys-kernel-security
+              mountPath: /sys/kernel/security
+              readOnly: true
             - name: cni-log-dir
               mountPath: /var/log/calico/cni
               readOnly: true
@@ -7765,6 +7772,12 @@ spec:
           hostPath:
             path: /sys/fs/bpf
             type: Directory
+        # securityfs, read by Felix to detect kernel lockdown=confidentiality.
+        # No type set (like nodeproc below) so nodes without securityfs still
+        # start; Felix treats an unreadable lockdown file as "not locked down".
+        - name: sys-kernel-security
+          hostPath:
+            path: /sys/kernel/security
         # mount /proc at /nodeproc to be used by ebpf-bootstrap initContainer to mount root cgroup2 fs.
         - name: nodeproc
           hostPath:

--- a/manifests/calico-v3-crds.yaml
+++ b/manifests/calico-v3-crds.yaml
@@ -7351,6 +7351,13 @@ spec:
             # parent directory.
             - name: bpffs
               mountPath: /sys/fs/bpf
+            # Felix reads /sys/kernel/security/lockdown to detect kernel
+            # lockdown=confidentiality; under it, ftrace is disabled and Felix
+            # loads trace-printk-free BPF program variants. securityfs is a
+            # separate filesystem from /sys/fs, so it needs its own mount.
+            - name: sys-kernel-security
+              mountPath: /sys/kernel/security
+              readOnly: true
             - name: cni-log-dir
               mountPath: /var/log/calico/cni
               readOnly: true
@@ -7379,6 +7386,12 @@ spec:
           hostPath:
             path: /sys/fs/bpf
             type: Directory
+        # securityfs, read by Felix to detect kernel lockdown=confidentiality.
+        # No type set (like nodeproc below) so nodes without securityfs still
+        # start; Felix treats an unreadable lockdown file as "not locked down".
+        - name: sys-kernel-security
+          hostPath:
+            path: /sys/kernel/security
         # mount /proc at /nodeproc to be used by ebpf-bootstrap initContainer to mount root cgroup2 fs.
         - name: nodeproc
           hostPath:

--- a/manifests/calico-vxlan.yaml
+++ b/manifests/calico-vxlan.yaml
@@ -7693,6 +7693,13 @@ spec:
             # parent directory.
             - name: bpffs
               mountPath: /sys/fs/bpf
+            # Felix reads /sys/kernel/security/lockdown to detect kernel
+            # lockdown=confidentiality; under it, ftrace is disabled and Felix
+            # loads trace-printk-free BPF program variants. securityfs is a
+            # separate filesystem from /sys/fs, so it needs its own mount.
+            - name: sys-kernel-security
+              mountPath: /sys/kernel/security
+              readOnly: true
             - name: cni-log-dir
               mountPath: /var/log/calico/cni
               readOnly: true
@@ -7721,6 +7728,12 @@ spec:
           hostPath:
             path: /sys/fs/bpf
             type: Directory
+        # securityfs, read by Felix to detect kernel lockdown=confidentiality.
+        # No type set (like nodeproc below) so nodes without securityfs still
+        # start; Felix treats an unreadable lockdown file as "not locked down".
+        - name: sys-kernel-security
+          hostPath:
+            path: /sys/kernel/security
         # mount /proc at /nodeproc to be used by ebpf-bootstrap initContainer to mount root cgroup2 fs.
         - name: nodeproc
           hostPath:

--- a/manifests/calico.yaml
+++ b/manifests/calico.yaml
@@ -7695,6 +7695,13 @@ spec:
             # parent directory.
             - name: bpffs
               mountPath: /sys/fs/bpf
+            # Felix reads /sys/kernel/security/lockdown to detect kernel
+            # lockdown=confidentiality; under it, ftrace is disabled and Felix
+            # loads trace-printk-free BPF program variants. securityfs is a
+            # separate filesystem from /sys/fs, so it needs its own mount.
+            - name: sys-kernel-security
+              mountPath: /sys/kernel/security
+              readOnly: true
             - name: cni-log-dir
               mountPath: /var/log/calico/cni
               readOnly: true
@@ -7723,6 +7730,12 @@ spec:
           hostPath:
             path: /sys/fs/bpf
             type: Directory
+        # securityfs, read by Felix to detect kernel lockdown=confidentiality.
+        # No type set (like nodeproc below) so nodes without securityfs still
+        # start; Felix treats an unreadable lockdown file as "not locked down".
+        - name: sys-kernel-security
+          hostPath:
+            path: /sys/kernel/security
         # mount /proc at /nodeproc to be used by ebpf-bootstrap initContainer to mount root cgroup2 fs.
         - name: nodeproc
           hostPath:

--- a/manifests/canal-etcd.yaml
+++ b/manifests/canal-etcd.yaml
@@ -669,6 +669,13 @@ spec:
             # parent directory.
             - name: bpffs
               mountPath: /sys/fs/bpf
+            # Felix reads /sys/kernel/security/lockdown to detect kernel
+            # lockdown=confidentiality; under it, ftrace is disabled and Felix
+            # loads trace-printk-free BPF program variants. securityfs is a
+            # separate filesystem from /sys/fs, so it needs its own mount.
+            - name: sys-kernel-security
+              mountPath: /sys/kernel/security
+              readOnly: true
             - name: cni-log-dir
               mountPath: /var/log/calico/cni
               readOnly: true
@@ -769,6 +776,12 @@ spec:
           hostPath:
             path: /sys/fs/bpf
             type: Directory
+        # securityfs, read by Felix to detect kernel lockdown=confidentiality.
+        # No type set (like nodeproc below) so nodes without securityfs still
+        # start; Felix treats an unreadable lockdown file as "not locked down".
+        - name: sys-kernel-security
+          hostPath:
+            path: /sys/kernel/security
         # mount /proc at /nodeproc to be used by ebpf-bootstrap initContainer to mount root cgroup2 fs.
         - name: nodeproc
           hostPath:

--- a/manifests/canal.yaml
+++ b/manifests/canal.yaml
@@ -7653,6 +7653,13 @@ spec:
             # parent directory.
             - name: bpffs
               mountPath: /sys/fs/bpf
+            # Felix reads /sys/kernel/security/lockdown to detect kernel
+            # lockdown=confidentiality; under it, ftrace is disabled and Felix
+            # loads trace-printk-free BPF program variants. securityfs is a
+            # separate filesystem from /sys/fs, so it needs its own mount.
+            - name: sys-kernel-security
+              mountPath: /sys/kernel/security
+              readOnly: true
             - name: cni-log-dir
               mountPath: /var/log/calico/cni
               readOnly: true
@@ -7714,6 +7721,12 @@ spec:
           hostPath:
             path: /sys/fs/bpf
             type: Directory
+        # securityfs, read by Felix to detect kernel lockdown=confidentiality.
+        # No type set (like nodeproc below) so nodes without securityfs still
+        # start; Felix treats an unreadable lockdown file as "not locked down".
+        - name: sys-kernel-security
+          hostPath:
+            path: /sys/kernel/security
         # mount /proc at /nodeproc to be used by ebpf-bootstrap initContainer to mount root cgroup2 fs.
         - name: nodeproc
           hostPath:

--- a/manifests/flannel-migration/calico.yaml
+++ b/manifests/flannel-migration/calico.yaml
@@ -7695,6 +7695,13 @@ spec:
             # parent directory.
             - name: bpffs
               mountPath: /sys/fs/bpf
+            # Felix reads /sys/kernel/security/lockdown to detect kernel
+            # lockdown=confidentiality; under it, ftrace is disabled and Felix
+            # loads trace-printk-free BPF program variants. securityfs is a
+            # separate filesystem from /sys/fs, so it needs its own mount.
+            - name: sys-kernel-security
+              mountPath: /sys/kernel/security
+              readOnly: true
             - name: cni-log-dir
               mountPath: /var/log/calico/cni
               readOnly: true
@@ -7723,6 +7730,12 @@ spec:
           hostPath:
             path: /sys/fs/bpf
             type: Directory
+        # securityfs, read by Felix to detect kernel lockdown=confidentiality.
+        # No type set (like nodeproc below) so nodes without securityfs still
+        # start; Felix treats an unreadable lockdown file as "not locked down".
+        - name: sys-kernel-security
+          hostPath:
+            path: /sys/kernel/security
         # mount /proc at /nodeproc to be used by ebpf-bootstrap initContainer to mount root cgroup2 fs.
         - name: nodeproc
           hostPath:


### PR DESCRIPTION
Cherry-pick of #13142 and #13145 to `release-v3.32` (CORE-13107).

Together these stop the `could not enable bpf_trace_printk events` kernel-log spew on eBPF nodes running with kernel `lockdown=confidentiality` (e.g. Talos):
- **#13142** — trace-printk-free `*_notrace.o` preamble variants loaded when Felix detects lockdown, securityfs mount so detection works, and `BPFLogLevel: Debug` forced off.
- **#13145** — `struct prog_flags` in a frozen `.rodata.prog_flags` section; Felix sets `no_trace_printk` at load so the verifier dead-code-eliminates the `bpf_log`/`skb_log` trace calls in the main programs (no program-matrix doubling).

Backport conflict notes (differences from master on this branch):
- Dropped the `felix/design/bpf-tc-programs.md` edits — that design file does not exist on `release-v3.32`.
- `felix/bpf/tc/attach.go` — kept the `_notrace` preamble selection; dropped the netkit branch (netkit attach is not on this branch).
- `felix/bpf-gpl/log.h` — this branch splits `bpf_log` by `BPF_CORE_SUPPORTED`; applied the `no_trace_printk` guard to both variants.
- `felix/bpf/ut/precompilation_test.go` — kept this branch's BTF/co-re object matrix; added the `_notrace` preamble entries and the notrace tests.

Verified locally on the branch: `make -C felix build-bpf` and `make -C felix build` both green.

### Release Note

```release-note
Fixed a kernel dmesg spew ("could not enable bpf_trace_printk events") on eBPF-dataplane nodes running with kernel lockdown=confidentiality (e.g. Talos).
```
