### PR TITLE
calicoctl cluster diags: collect --previous logs per container

### DIFF
--- a/calicoctl/calicoctl/commands/cluster/diags.go
+++ b/calicoctl/calicoctl/commands/cluster/diags.go
@@ -718,30 +718,38 @@ func diagsCmdsForPod(dir, linkDir string, opts *diagOpts, nodeName, namespace st
 			SymLink:  fmt.Sprintf("%s/%s/%s.txt", linkDir, namespace, pod.Name),
 		},
 	}
-	// If any container has restarted, also grab the previous incarnation's
-	// logs — those are usually the ones that explain the restart.
-	if hasPreviousLogs(pod) {
+	// For each container that has restarted, also grab the previous
+	// incarnation's logs — those are usually the ones that explain the
+	// restart. We collect them per-container rather than with a single
+	// --all-containers invocation: `kubectl logs --previous --all-containers`
+	// fails outright if any one container in the pod has no previous
+	// incarnation, which would lose the crashed container's logs — exactly
+	// the ones we came for. Requesting only the containers that actually have
+	// a prior incarnation, one command each, sidesteps that.
+	for _, container := range containersWithPreviousLogs(pod) {
 		cmds = append(cmds, common.Cmd{
-			Info:     fmt.Sprintf("Collect previous logs for pod %s", pod.Name),
-			CmdStr:   fmt.Sprintf("kubectl logs --previous --since=%s -n %s %s --all-containers", opts.Since, namespace, pod.Name),
-			FilePath: fmt.Sprintf("%s/%s.previous.log", namespaceDir, pod.Name),
-			SymLink:  fmt.Sprintf("%s/%s/%s.previous.log", linkDir, namespace, pod.Name),
+			Info:     fmt.Sprintf("Collect previous logs for container %s in pod %s", container, pod.Name),
+			CmdStr:   fmt.Sprintf("kubectl logs --previous --since=%s -n %s %s -c %s", opts.Since, namespace, pod.Name, container),
+			FilePath: fmt.Sprintf("%s/%s.%s.previous.log", namespaceDir, pod.Name, container),
+			SymLink:  fmt.Sprintf("%s/%s/%s.%s.previous.log", linkDir, namespace, pod.Name, container),
 		})
 	}
 	return cmds
 }
 
-// hasPreviousLogs reports whether any container in the pod has a prior
-// incarnation worth fetching logs from.
-func hasPreviousLogs(pod *apiv1.Pod) bool {
+// containersWithPreviousLogs returns the names of the pod's containers (both
+// regular and init) that have a prior incarnation worth fetching logs from,
+// i.e. the container has restarted or has a previously terminated state.
+func containersWithPreviousLogs(pod *apiv1.Pod) []string {
 	statuses := append([]apiv1.ContainerStatus{}, pod.Status.ContainerStatuses...)
 	statuses = append(statuses, pod.Status.InitContainerStatuses...)
+	var names []string
 	for _, cs := range statuses {
 		if cs.RestartCount > 0 || cs.LastTerminationState.Terminated != nil {
-			return true
+			names = append(names, cs.Name)
 		}
 	}
-	return false
+	return names
 }
 
 // bpfJSONCmd builds a diagnostic command that dumps calico-bpf state as JSON,

--- a/calicoctl/calicoctl/commands/cluster/diags_test.go
+++ b/calicoctl/calicoctl/commands/cluster/diags_test.go
@@ -185,26 +185,50 @@ func TestDiagsCmdsForPod_Previous(t *testing.T) {
 	// A pod with no restarts gets only the current-log and describe commands.
 	steady := &apiv1.Pod{}
 	steady.Name = "calico-typha-0"
-	steady.Status.ContainerStatuses = []apiv1.ContainerStatus{{RestartCount: 0}}
+	steady.Status.ContainerStatuses = []apiv1.ContainerStatus{{Name: "calico-typha", RestartCount: 0}}
 	cmds := diagsCmdsForPod("/dir", "/links", opts, "nodeA", "calico-system", steady)
 	Expect(cmdStrs(cmds)).NotTo(ContainElement(ContainSubstring("--previous")))
 
 	// A pod whose container has restarted picks up an extra previous-log
-	// command alongside the usual current-log + describe.
+	// command, scoped to that specific container (not --all-containers), so a
+	// crashed container's logs survive even when sibling containers have no
+	// previous incarnation.
 	restarted := &apiv1.Pod{}
 	restarted.Name = "calico-apiserver-0"
-	restarted.Status.ContainerStatuses = []apiv1.ContainerStatus{{RestartCount: 2}}
+	restarted.Status.ContainerStatuses = []apiv1.ContainerStatus{
+		{Name: "calico-apiserver", RestartCount: 2},
+		{Name: "calico-apiserver-sidecar", RestartCount: 0},
+	}
 	cmds = diagsCmdsForPod("/dir", "/links", opts, "nodeA", "calico-apiserver", restarted)
-	Expect(cmdStrs(cmds)).To(ContainElement(ContainSubstring("kubectl logs --previous")))
+	prev := filterStrs(cmdStrs(cmds), "--previous")
+	// Only the restarted container is fetched, and it is scoped with -c.
+	Expect(prev).To(HaveLen(1))
+	Expect(prev[0]).To(ContainSubstring("kubectl logs --previous"))
+	Expect(prev[0]).To(ContainSubstring("-c calico-apiserver"))
+	Expect(prev[0]).NotTo(ContainSubstring("--all-containers"))
 
-	// An init container that previously terminated also flips the flag.
+	// An init container that previously terminated also gets its previous logs.
 	initTerminated := &apiv1.Pod{}
 	initTerminated.Name = "calico-node-xyz"
 	initTerminated.Status.InitContainerStatuses = []apiv1.ContainerStatus{{
+		Name:                 "install-cni",
 		LastTerminationState: apiv1.ContainerState{Terminated: &apiv1.ContainerStateTerminated{ExitCode: 1}},
 	}}
 	cmds = diagsCmdsForPod("/dir", "/links", opts, "nodeA", "calico-system", initTerminated)
-	Expect(cmdStrs(cmds)).To(ContainElement(ContainSubstring("kubectl logs --previous")))
+	Expect(cmdStrs(cmds)).To(ContainElement(And(
+		ContainSubstring("kubectl logs --previous"),
+		ContainSubstring("-c install-cni"),
+	)))
+}
+
+func filterStrs(strs []string, substr string) []string {
+	var out []string
+	for _, s := range strs {
+		if strings.Contains(s, substr) {
+			out = append(out, s)
+		}
+	}
+	return out
 }
 
 func cmdStrs(cmds []common.Cmd) []string {


### PR DESCRIPTION
### Description

`calicoctl cluster diags` already collects previous-incarnation ("`--previous`") logs for pods whose containers have restarted, but it did so with a single `kubectl logs --previous --all-containers` invocation per pod. That combined command fails outright if **any** container in the pod has no previous incarnation — so a pod where one container crashed but its siblings are healthy loses the crashed container's previous logs entirely, which are exactly the logs the bundle needs to explain the restart.

This change collects previous logs **per container** instead:

- One `kubectl logs --previous ... -c <container>` command is emitted only for the containers (regular or init) that actually have a prior incarnation (`RestartCount > 0` or a previous terminated state).
- Each container's previous logs land in their own `<pod>.<container>.previous.log` file (and matching symlink).
- `hasPreviousLogs` is replaced by `containersWithPreviousLogs`, which returns the relevant container names.

Because we now target only containers that have a prior incarnation, we also avoid the harmless-but-noisy error output that `--all-containers --previous` produced for pods with a mix of restarted and never-restarted containers.

### Type of change

Enhancement to existing diagnostics behavior.

### Testing

- `go test ./calicoctl/calicoctl/commands/cluster/...` passes. `TestDiagsCmdsForPod_Previous` is extended to assert that a restarted container is fetched with `-c <container>` (not `--all-containers`), that a healthy sibling container is **not** fetched, and that a previously-terminated init container is fetched by name.
- `go vet` and `go build` clean; `gofmt` clean.

**Release note:**
```release-note
calicoctl cluster diags now collects previous-container logs per container, so a crashed container's previous logs are captured even when other containers in the same pod have no previous incarnation.
```
