### PR TITLE
e2e: add QoS connection-limit test

### DIFF
--- a/e2e/pkg/tests/networking/qos.go
+++ b/e2e/pkg/tests/networking/qos.go
@@ -294,8 +294,8 @@ var _ = describe.CalicoDescribe(
 					pod.Annotations["qos.projectcalico.org/ingressMaxConnections"] = strconv.Itoa(maxConns)
 					ctr := &pod.Spec.Containers[0]
 					ctr.Image = images.Netshoot
-					ctr.Args = nil
-					ctr.Command = []string{"socat", listenAddr, "EXEC:sleep 3600"}
+					ctr.Command = []string{"socat"}
+					ctr.Args = []string{listenAddr, "EXEC:sleep 3600"}
 					ctr.ReadinessProbe = nil
 				}),
 			)

--- a/e2e/pkg/tests/networking/qos.go
+++ b/e2e/pkg/tests/networking/qos.go
@@ -15,7 +15,12 @@
 package networking
 
 import (
+	"context"
+	"fmt"
+	"io"
+	"strconv"
 	"time"
+
 	//nolint:staticcheck // Ignore ST1001: should not use dot imports
 	. "github.com/onsi/ginkgo/v2"
 	//nolint:staticcheck // Ignore ST1001: should not use dot imports
@@ -25,6 +30,8 @@ import (
 
 	"github.com/projectcalico/calico/e2e/pkg/describe"
 	"github.com/projectcalico/calico/e2e/pkg/utils"
+	"github.com/projectcalico/calico/e2e/pkg/utils/conncheck"
+	"github.com/projectcalico/calico/e2e/pkg/utils/images"
 	"github.com/projectcalico/calico/e2e/pkg/utils/iperfcheck"
 )
 
@@ -231,6 +238,138 @@ var _ = describe.CalicoDescribe(
 			egressResult := measureWithRateRetry(tester, clientPeer, server, maxRate, udpOpts...)
 			logrus.Infof("Egress packet-rate-limited throughput (bps): %.0f", egressResult.AverageRate)
 			Expect(egressResult.AverageRate).To(BeNumerically("<=", maxRate), "egress packet rate limit not effective")
+		})
+
+		// Verifies that Calico's QoS connection-limit annotation
+		// (qos.projectcalico.org/ingressMaxConnections) caps the number of
+		// concurrent TCP connections a workload accepts, and that closing a
+		// connection frees a slot for a new one. This mirrors the FV case in
+		// felix/fv/qos_controls_test.go ("should limit connections correctly"):
+		// hold N connections open, confirm the (N+1)th is refused, then free
+		// one and confirm a new connection is admitted.
+		//
+		// The connlimit counter only manifests when N connections are held
+		// concurrently, which the conncheck ConnectionTester's one-shot
+		// Execute() model does not express on its own. We therefore hold the N
+		// connections open with ExecStream (the e2e analog of the FV's
+		// StartPersistentConnection) and use a TCPConnect target (the analog of
+		// CanConnectTo) for the one-shot (N+1)th probe. Egress limits use the
+		// identical counter and are covered at FV level, so this e2e exercises
+		// ingress only.
+		It("should limit concurrent connections with QoS annotations", func() {
+			const (
+				connLimitPort = 8080
+				maxConns      = 3
+			)
+
+			By("Getting cluster node names")
+			nodesInfo := utils.AwaitReadySchedulableNodesInfo(f, 2, true)
+			nodeNames := nodesInfo.GetNames()
+			serverNode := nodeNames[0]
+			clientNode := nodeNames[1]
+
+			checker := conncheck.NewConnectionTester(f)
+			defer checker.Stop()
+
+			// Server: a netshoot pod running a socat listener that accepts and
+			// holds many concurrent connections (fork spawns a child per
+			// connection; each child bridges to a `sleep` so the connection is
+			// never closed from the server side), annotated to cap ingress
+			// connections at maxConns. socat is used rather than netcat because
+			// netshoot's OpenBSD `nc -k` only accepts connections sequentially,
+			// whereas this test needs several held open at once. No Service is
+			// created — the client dials the pod IP directly, keeping the
+			// connlimit semantics clear of any kube-proxy/NAT interaction. socat
+			// is not an HTTP server, so the default HTTP readiness probe is
+			// dropped.
+			listenAddr := fmt.Sprintf("TCP-LISTEN:%d,fork,reuseaddr", connLimitPort)
+			server := conncheck.NewServer("qos-connlimit-server", f.Namespace,
+				conncheck.WithPorts(connLimitPort),
+				conncheck.WithAutoCreateService(false),
+				conncheck.WithServerPodCustomizer(conncheck.WithNodeName(serverNode)),
+				conncheck.WithServerPodCustomizer(func(pod *corev1.Pod) {
+					if pod.Annotations == nil {
+						pod.Annotations = map[string]string{}
+					}
+					pod.Annotations["qos.projectcalico.org/ingressMaxConnections"] = strconv.Itoa(maxConns)
+					ctr := &pod.Spec.Containers[0]
+					ctr.Image = images.Netshoot
+					ctr.Args = nil
+					ctr.Command = []string{"socat", listenAddr, "EXEC:sleep 3600"}
+					ctr.ReadinessProbe = nil
+				}),
+			)
+
+			// Client: a netshoot pod on a different node, so the test exercises
+			// the cross-node ingress path (from-hep/tunnel) rather than the
+			// same-node shortcut.
+			client := conncheck.NewClient("qos-connlimit-client", f.Namespace,
+				conncheck.WithClientCustomizer(conncheck.WithNodeName(clientNode)),
+				conncheck.WithClientCustomizer(func(pod *corev1.Pod) {
+					pod.Spec.Containers[0].Image = images.Netshoot
+				}),
+			)
+
+			checker.AddServer(server)
+			checker.AddClient(client)
+
+			By("Deploying the connlimit server and client pods")
+			checker.Deploy()
+
+			serverIP := server.Pod().Status.PodIP
+			Expect(serverIP).NotTo(BeEmpty(), "server pod has no IP after becoming ready")
+
+			probeTarget := conncheck.NewTCPConnectTarget(serverIP, connLimitPort)
+
+			// Confirm the server is reachable before saturating the limit. This
+			// also gives the pods a moment to settle; the meaningful assertions
+			// are the refusal and reuse steps below, which Execute() retries
+			// until the limit is programmed by Felix.
+			By("Verifying the server is reachable")
+			checker.ExpectSuccess(client, probeTarget)
+			checker.Execute()
+
+			// Hold maxConns connections open concurrently. Each holder is a
+			// socat that connects to the server and bridges to a `sleep`, so
+			// neither end ever closes the socket — it stays ESTABLISHED,
+			// occupying a connlimit slot until stopped. This is the e2e analog
+			// of the FV's StartPersistentConnection; ExecStream's stop() (the
+			// analog of pc.Stop()) terminates socat and closes the connection.
+			By(fmt.Sprintf("Holding %d concurrent connections open", maxConns))
+			connectAddr := fmt.Sprintf("TCP:%s:%d", serverIP, connLimitPort)
+			var holders []func() error
+			defer func() {
+				for _, stop := range holders {
+					_ = stop()
+				}
+			}()
+			for i := range maxConns {
+				stop, err := client.ExecStream(
+					context.Background(),
+					[]string{"socat", connectAddr, "EXEC:sleep 3600"},
+					io.Discard,
+				)
+				Expect(err).NotTo(HaveOccurred(), "failed to open held connection %d", i)
+				holders = append(holders, stop)
+			}
+
+			// With maxConns connections held, the (N+1)th must be refused.
+			// Execute() retries for up to 30s, which absorbs both the window
+			// where Felix is still programming the limit and the time for the
+			// held connections' handshakes to complete.
+			By("Verifying the (N+1)th connection is refused")
+			checker.ResetExpectations()
+			checker.ExpectFailure(client, probeTarget)
+			checker.Execute()
+
+			// Free one slot and confirm a new connection is admitted. This
+			// exercises the counter decrement on connection close.
+			By("Freeing one connection and verifying a new one is admitted")
+			Expect(holders[len(holders)-1]()).To(Succeed(), "failed to stop a held connection")
+			holders = holders[:len(holders)-1]
+			checker.ResetExpectations()
+			checker.ExpectSuccess(client, probeTarget)
+			checker.Execute()
 		})
 	})
 

--- a/e2e/pkg/tests/networking/qos.go
+++ b/e2e/pkg/tests/networking/qos.go
@@ -240,22 +240,9 @@ var _ = describe.CalicoDescribe(
 			Expect(egressResult.AverageRate).To(BeNumerically("<=", maxRate), "egress packet rate limit not effective")
 		})
 
-		// Verifies that Calico's QoS connection-limit annotation
-		// (qos.projectcalico.org/ingressMaxConnections) caps the number of
-		// concurrent TCP connections a workload accepts, and that closing a
-		// connection frees a slot for a new one. This mirrors the FV case in
-		// felix/fv/qos_controls_test.go ("should limit connections correctly"):
-		// hold N connections open, confirm the (N+1)th is refused, then free
-		// one and confirm a new connection is admitted.
-		//
-		// The connlimit counter only manifests when N connections are held
-		// concurrently, which the conncheck ConnectionTester's one-shot
-		// Execute() model does not express on its own. We therefore hold the N
-		// connections open with ExecStream (the e2e analog of the FV's
-		// StartPersistentConnection) and use a TCPConnect target (the analog of
-		// CanConnectTo) for the one-shot (N+1)th probe. Egress limits use the
-		// identical counter and are covered at FV level, so this e2e exercises
-		// ingress only.
+		// Verifies that the qos.projectcalico.org/ingressMaxConnections annotation
+		// caps concurrent TCP connections to a workload, and that closing one frees
+		// a slot. Egress uses the same counter and is covered by the FV suite.
 		It("should limit concurrent connections with QoS annotations", func() {
 			const (
 				connLimitPort = 8080
@@ -271,17 +258,8 @@ var _ = describe.CalicoDescribe(
 			checker := conncheck.NewConnectionTester(f)
 			defer checker.Stop()
 
-			// Server: a netshoot pod running a socat listener that accepts and
-			// holds many concurrent connections (fork spawns a child per
-			// connection; each child bridges to a `sleep` so the connection is
-			// never closed from the server side), annotated to cap ingress
-			// connections at maxConns. socat is used rather than netcat because
-			// netshoot's OpenBSD `nc -k` only accepts connections sequentially,
-			// whereas this test needs several held open at once. No Service is
-			// created — the client dials the pod IP directly, keeping the
-			// connlimit semantics clear of any kube-proxy/NAT interaction. socat
-			// is not an HTTP server, so the default HTTP readiness probe is
-			// dropped.
+			// socat rather than netcat: netshoot's OpenBSD `nc -k` accepts
+			// connections sequentially, and this test needs several held at once.
 			listenAddr := fmt.Sprintf("TCP-LISTEN:%d,fork,reuseaddr", connLimitPort)
 			server := conncheck.NewServer("qos-connlimit-server", f.Namespace,
 				conncheck.WithPorts(connLimitPort),
@@ -300,9 +278,6 @@ var _ = describe.CalicoDescribe(
 				}),
 			)
 
-			// Client: a netshoot pod on a different node, so the test exercises
-			// the cross-node ingress path (from-hep/tunnel) rather than the
-			// same-node shortcut.
 			client := conncheck.NewClient("qos-connlimit-client", f.Namespace,
 				conncheck.WithClientCustomizer(conncheck.WithNodeName(clientNode)),
 				conncheck.WithClientCustomizer(func(pod *corev1.Pod) {
@@ -321,20 +296,12 @@ var _ = describe.CalicoDescribe(
 
 			probeTarget := conncheck.NewTCPConnectTarget(serverIP, connLimitPort)
 
-			// Confirm the server is reachable before saturating the limit. This
-			// also gives the pods a moment to settle; the meaningful assertions
-			// are the refusal and reuse steps below, which Execute() retries
-			// until the limit is programmed by Felix.
 			By("Verifying the server is reachable")
 			checker.ExpectSuccess(client, probeTarget)
 			checker.Execute()
 
-			// Hold maxConns connections open concurrently. Each holder is a
-			// socat that connects to the server and bridges to a `sleep`, so
-			// neither end ever closes the socket — it stays ESTABLISHED,
-			// occupying a connlimit slot until stopped. This is the e2e analog
-			// of the FV's StartPersistentConnection; ExecStream's stop() (the
-			// analog of pc.Stop()) terminates socat and closes the connection.
+			// Each holder bridges to a sleep so neither end closes the socket; it
+			// stays ESTABLISHED, occupying a slot until stop() is called.
 			By(fmt.Sprintf("Holding %d concurrent connections open", maxConns))
 			connectAddr := fmt.Sprintf("TCP:%s:%d", serverIP, connLimitPort)
 			var holders []func() error
@@ -353,17 +320,11 @@ var _ = describe.CalicoDescribe(
 				holders = append(holders, stop)
 			}
 
-			// With maxConns connections held, the (N+1)th must be refused.
-			// Execute() retries for up to 30s, which absorbs both the window
-			// where Felix is still programming the limit and the time for the
-			// held connections' handshakes to complete.
 			By("Verifying the (N+1)th connection is refused")
 			checker.ResetExpectations()
 			checker.ExpectFailure(client, probeTarget)
 			checker.Execute()
 
-			// Free one slot and confirm a new connection is admitted. This
-			// exercises the counter decrement on connection close.
 			By("Freeing one connection and verifying a new one is admitted")
 			Expect(holders[len(holders)-1]()).To(Succeed(), "failed to stop a held connection")
 			holders = holders[:len(holders)-1]


### PR DESCRIPTION
The e2e QoS suite covered bandwidth and packet rate but had no coverage for connection limiting (qos.projectcalico.org/ingressMaxConnections), even though bandwidth and packet rate both have e2e tests. This closes that gap and exercises the annotation → libcalico-go → Felix → dataplane path on a real cluster (the lower layers are already covered by the FV suite in felix/fv/qos_controls_test.go).

The test mirrors the FV case ("should limit connections correctly"): hold N connections open concurrently, confirm the (N+1)th is refused, then free one and confirm a new connection is admitted (exercising the counter decrement on close). Server and client are pinned to separate nodes so the cross-node ingress path is exercised.

Because connection limiting only manifests with N connections held concurrently, the conncheck ConnectionTester's one-shot Execute() model does not express it alone. The N connections are held open with ExecStream (the e2e analog of the FV's StartPersistentConnection) and the (N+1)th is probed with a TCPConnect target (the analog of CanConnectTo). socat (with fork) is used for the listener and holders rather than netcat, since netshoot's OpenBSD `nc -k` only accepts connections sequentially and netshoot ships no ncat. Ingress only; egress uses the identical counter and is covered at FV level.

Verified against a BPF-dataplane cluster: 1 Passed, in around 10 seconds.

<!-- Describe your changes, including the type of change (bug fix, feature, etc.),
why it should be merged, testing done, and links to related issues. -->

<!-- For any user-visible change, replace TBD with a one-line description. -->
**Release note:**
```release-note
TBD
```
