### PR TITLE
felix/fv: skip IPIP tunnel-address cleanup test in BPF mode

### DIFF
--- a/felix/fv/routing_test.go
+++ b/felix/fv/routing_test.go
@@ -195,6 +195,15 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ cluster routing using Felix
 				})
 
 				It("should clean up the IPIP tunnel address when IPIP is disabled", func() {
+					if BPFMode() {
+						// This topology forces FELIX_BPFOverlayHostSourceIP=HostAddress, under
+						// which the BPF dataplane deliberately does not program an IP onto tunl0
+						// (it handles encap/decap and source IP selection itself).  There is
+						// therefore no tunnel address to program or to clean up, so the premise
+						// of this test does not apply.
+						Skip("BPF mode with BPFOverlayHostSourceIP=HostAddress does not put an IP on tunl0")
+					}
+
 					// With IPIP enabled, Felix programs the node's tunnel address onto the
 					// tunl0 device.  Wait for that to happen on every node before we disable
 					// IPIP.

--- a/felix/fv/routing_test.go
+++ b/felix/fv/routing_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2025 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2026 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -196,11 +196,6 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ cluster routing using Felix
 
 				It("should clean up the IPIP tunnel address when IPIP is disabled", func() {
 					if BPFMode() {
-						// This topology forces FELIX_BPFOverlayHostSourceIP=HostAddress, under
-						// which the BPF dataplane deliberately does not program an IP onto tunl0
-						// (it handles encap/decap and source IP selection itself).  There is
-						// therefore no tunnel address to program or to clean up, so the premise
-						// of this test does not apply.
 						Skip("BPF mode with BPFOverlayHostSourceIP=HostAddress does not put an IP on tunl0")
 					}
 


### PR DESCRIPTION
### Description

The FV test `should clean up the IPIP tunnel address when IPIP is disabled`
lives in the `_BPF-SAFE_` "cluster routing using Felix programming routes"
Describe block, whose topology forces `FELIX_BPFOverlayHostSourceIP=HostAddress`
(see `ipipTopologyOptions` in `felix/fv/routing_test.go`).

Under `HostAddress`, `BPFOverlayIPOnDevice` is `false`, and the BPF dataplane
deliberately does **not** program an IP onto `tunl0` — it handles encap/decap
and source-IP selection itself (this is the behavior introduced in #11919):

```go
// felix/dataplane/linux/ipip_mgr.go
if m.dpConfig.BPFEnabled && !m.dpConfig.BPFOverlayIPOnDevice {
    // BPF dataplane handles encap/decap and source IP selection itself,
    // so it doesn't need an IP assigned to the tunnel device.
    return ipip, "", nil
}
```

As a result there is no tunnel address for Felix to program or clean up, and the
test fails at its precondition ("every node should have an IPIP tunnel address on
tunl0") in BPF mode, while passing under iptables/nftables.

This PR skips the test in BPF mode, where its premise does not apply.

### Related issues/PRs

Follow-up to #11919.

### Todos

- [x] Tested manually

### Release Note

```release-note
None
```

### Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.
- If this change requires user-facing documentation, please add label `docs-pr-required`. This label is used to track a follow-up PR for the docs.
- If this change does not require any documentation changes, please add label `docs-not-required`.
- If this change already has all the necessary documentation, please add label `docs-completed`.
