### PR TITLE
BPF: only preserve IPv6 link-local when clearing the overlay tunnel device IP

### DIFF
--- a/felix/dataplane/linux/ipip_mgr_test.go
+++ b/felix/dataplane/linux/ipip_mgr_test.go
@@ -128,6 +128,11 @@ var _ = Describe("IPIPManager", func() {
 		llAddr := &netlink.Addr{IPNet: &net.IPNet{IP: net.ParseIP("fe80::1"), Mask: net.CIDRMask(64, 128)}}
 		Expect(dataplane.AddrAdd(link, llAddr)).To(Succeed())
 
+		// Seed an IPv4 link-local (169.254.0.0/16) address too. Unlike the IPv6 link-local it is not
+		// kernel-managed on the tunnel device, so reconciling to "no address" must remove it.
+		v4llAddr := &netlink.Addr{IPNet: &net.IPNet{IP: net.ParseIP("169.254.1.1"), Mask: net.CIDRMask(32, 32)}}
+		Expect(dataplane.AddrAdd(link, v4llAddr)).To(Succeed())
+
 		dataplane.ResetDeltas()
 		err = ipipMgr.routeMgr.configureTunnelDevice(link, "", 1500, false)
 		Expect(err).NotTo(HaveOccurred())
@@ -136,12 +141,13 @@ var _ = Describe("IPIPManager", func() {
 		Expect(dataplane.NumLinkSetUpCalls).To(BeZero())
 		Expect(tunnelLink.LinkAttrs.MTU).To(Equal(1500))
 		Expect(tunnelLink.LinkAttrs.Flags).To(Equal(net.FlagUp))
-		// Empty addr means no Calico address is wanted: the existing global address is removed (clean
-		// break) so it can't linger and influence source-IP selection, while the link-local address
-		// is preserved.
+		// Empty addr means no Calico address is wanted: the existing global address and the IPv4
+		// link-local address are removed (clean break) so they can't linger and influence source-IP
+		// selection, while the kernel-managed IPv6 link-local address is preserved.
 		Expect(dataplane.AddedAddrs.Len()).To(BeZero())
 		Expect(dataplane.DeletedAddrs.Contains("192.168.0.1/32")).To(BeTrue())
-		Expect(dataplane.DeletedAddrs.Len()).To(Equal(1))
+		Expect(dataplane.DeletedAddrs.Contains("169.254.1.1/32")).To(BeTrue())
+		Expect(dataplane.DeletedAddrs.Len()).To(Equal(2))
 		Expect(tunnelLink.Addrs).To(HaveLen(1))
 		Expect(tunnelLink.Addrs[0].IP.String()).To(Equal("fe80::1"))
 	})

--- a/felix/dataplane/linux/route_mgr.go
+++ b/felix/dataplane/linux/route_mgr.go
@@ -681,15 +681,17 @@ func (m *routeManager) ensureAddressOnLink(ipStr string, link netlink.Link) erro
 		return err
 	}
 
-	// Remove any addresses which we don't want, but never strip the kernel-managed IPv6 link-local
-	// address.
+	// Remove any addresses which we don't want.
 	addrPresent := false
 	for _, existing := range existingAddrs {
 		if desired != nil && reflect.DeepEqual(existing.IPNet, desired.IPNet) {
 			addrPresent = true
 			continue
 		}
-		if existing.IP.IsLinkLocalUnicast() {
+		// Never strip the kernel-managed IPv6 link-local address. Guard on the address being IPv6
+		// (To4() == nil), since IsLinkLocalUnicast() also matches IPv4 169.254.0.0/16, which we do
+		// want to remove when reconciling to "no address".
+		if existing.IP.To4() == nil && existing.IP.IsLinkLocalUnicast() {
 			continue
 		}
 		m.logCtx.WithFields(logrus.Fields{

--- a/felix/netlinkshim/mocknetlink/netlink.go
+++ b/felix/netlinkshim/mocknetlink/netlink.go
@@ -628,7 +628,9 @@ func (d *MockNetlinkDataplane) AddrList(link netlink.Link, family int) ([]netlin
 		return nil, ErrSimulated
 	}
 	if link, ok := d.NameToLink[link.Attrs().Name]; ok {
-		return link.Addrs, nil
+		// Return a copy, matching the real netlink which allocates a fresh slice per call. This
+		// keeps a caller ranging over the result unaffected by concurrent AddrDel/AddrAdd calls.
+		return append([]netlink.Addr(nil), link.Addrs...), nil
 	}
 	return nil, ErrNotFound
 }


### PR DESCRIPTION
**Type:** bug fix (follow-up to #11919, on the still-unreleased `bpfOverlayHostSourceIP` feature).

When Felix clears the overlay tunnel device's IP in `bpfOverlayHostSourceIP: HostAddress`
mode, `ensureAddressOnLink` skips link-local addresses so the kernel-managed **IPv6**
link-local (`fe80::/10`) is not stripped. But `net.IP.IsLinkLocalUnicast()` also matches
**IPv4** `169.254.0.0/16`, so in IPv4 mode a stray link-local address would be preserved too,
defeating the "remove all non-desired addresses" invariant. This guards the skip on the
address being IPv6 (`To4() == nil`), so IPv4 link-local addresses are removed as intended while
the IPv6 link-local is still preserved.

Flagged by a Copilot review on the EE auto-pick (calico-private#12744).

It also fixes a latent inaccuracy in the **mock** netlink `AddrList`: it returned the live
address slice, whereas real netlink allocates a fresh slice per call. A caller ranging over the
result while calling `AddrDel` walked a slice mutated underneath it — only observable when more
than one address is removed in a single pass, which the new test exercises.

**Affected components:** Felix (`dataplane/linux` overlay tunnel device management).

### Testing

- Extended the IPIPManager "should configure tunnel properly" unit test: it now seeds both an
  IPv6 link-local (`fe80::1`) and an IPv4 link-local (`169.254.1.1`) on the tunnel device, then
  reconciles to "no address" and asserts the global address **and** the IPv4 link-local are
  removed while the IPv6 link-local is preserved.
- `felix/dataplane/linux` suite: unchanged pass/fail set vs. clean master (`950 Passed | 8
  Failed`, the 8 being pre-existing libbpf-CGO-stub panics under `CGO_ENABLED=0`; XDP specs
  gated on a build artifact excluded identically on both). `go vet` clean.

**Release note:**
```release-note
NONE
```
