### PR TITLE
felix: don't drop tunnel-only nodes' host IP in dataplane_passthru

### DIFF
--- a/felix/calc/dataplane_passthru.go
+++ b/felix/calc/dataplane_passthru.go
@@ -15,6 +15,8 @@
 package calc
 
 import (
+	"reflect"
+
 	v3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
 	"github.com/sirupsen/logrus"
 	kapiv1 "k8s.io/api/core/v1"
@@ -116,12 +118,20 @@ func (h *DataplanePassthru) processKindNode(key model.ResourceKey, update api.Up
 	node, _ := update.Value.(*internalapi.Node)
 	logrus.WithField("update", update).Debug("Passing-through Node update")
 
-	// An explicitly-empty BGP spec (`BGP: &NodeBGPSpec{}`) is treated as if the
-	// Node had been deleted — there is no useful metadata to pass through. A nil
-	// BGP, by contrast, leaves the Node entry alive (with empty IPs) since other
-	// Node info such as labels may still be relevant.
+	// A BGP spec that is entirely zero (`BGP: &NodeBGPSpec{}`) is treated as if
+	// the Node had been deleted — there is no useful metadata to pass through.
+	// We compare against the zero value rather than checking
+	// IPv4Address/IPv6Address/ASNumber individually: a spec whose only populated
+	// field is a tunnel address (e.g. IPv4IPIPTunnelAddr, which IPAM assigns even
+	// on clusters that have no BGP node IP, such as GKE) is NOT empty and must
+	// not be dropped here — doing so skips the InternalIP fallback below and
+	// starves the dataplane of the host IP. This mirrors the same
+	// reflect.DeepEqual emptiness test libcalico's K8sNodeToCalico uses to decide
+	// whether Spec.BGP is populated at all. A nil BGP, by contrast, leaves the
+	// Node entry alive (with empty IPs) since other Node info such as labels may
+	// still be relevant.
 	bgpSpec := node.Spec.BGP
-	if bgpSpec != nil && bgpSpec.IPv4Address == "" && bgpSpec.IPv6Address == "" && bgpSpec.ASNumber == nil {
+	if bgpSpec != nil && reflect.DeepEqual(*bgpSpec, internalapi.NodeBGPSpec{}) {
 		delete(h.nodeInfo, hostname)
 		if before != nil {
 			h.callbacks.OnHostMetadataRemove(hostname)

--- a/felix/calc/dataplane_passthru_test.go
+++ b/felix/calc/dataplane_passthru_test.go
@@ -260,6 +260,27 @@ var _ = Describe("DataplanePassthru host metadata sourcing", func() {
 		Expect(recorder.removes).To(Equal([]string{host}))
 	})
 
+	It("does not treat a tunnel-address-only BGP spec as a delete; falls back to InternalIP", func() {
+		// On clusters with no Calico BGP node IP (e.g. GKE), IPAM still assigns an
+		// IPIP tunnel address, so libcalico produces a non-nil BGP spec whose only
+		// populated field is IPv4IPIPTunnelAddr. This must NOT be mistaken for an
+		// empty/deleted node: the InternalIP fallback still has to supply the host
+		// IP, otherwise the BPF dataplane never learns it and calico-node stays
+		// NotReady (BPFHostIP "Host IP not yet known"). Regression test.
+		passthru.OnUpdate(nodeUpdate(host, &internalapi.Node{
+			ObjectMeta: metav1.ObjectMeta{Name: host},
+			Spec: internalapi.NodeSpec{
+				BGP: &internalapi.NodeBGPSpec{IPv4IPIPTunnelAddr: "10.96.2.1"},
+				Addresses: []internalapi.NodeAddress{
+					{Address: "10.95.141.117", Type: internalapi.InternalIP},
+				},
+			},
+		}))
+		Expect(recorder.removes).To(BeEmpty())
+		Expect(recorder.updates).To(HaveLen(1))
+		Expect(recorder.updates[0].ip4Addr).To(Equal("10.95.141.117/32"))
+	})
+
 	It("propagates BGP ASN even when no IP is supplied (using fallback for IPv4)", func() {
 		asn, err := numorstring.ASNumberFromString("65000")
 		Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
Bug fix for the BPF dataplane.

### Problem

On clusters where nodes have an IPIP/VXLAN tunnel address but **no** BGP node IP — the
normal state on GKE, where Calico BGP is not used — `calico-node` comes up and stays
`NotReady` under the BPF dataplane. Felix's `bpf_ep_mgr` never learns the node's host IP,
so the `BPFHostIP` health reporter is stuck non-ready (`Host IP not yet known`).

### Root cause

`bpf_ep_mgr`'s host IP is sourced from `HostMetadataUpdate`, produced by
`DataplanePassthru.processKindNode`. That function short-circuits, treating an "empty" BGP
spec as a node deletion, when `IPv4Address`, `IPv6Address` and `ASNumber` are all unset:

```go
if bgpSpec != nil && bgpSpec.IPv4Address == "" && bgpSpec.IPv6Address == "" && bgpSpec.ASNumber == nil {
    ... OnHostMetadataRemove ...; return   // skips the InternalIP fallback below
}
```

But `K8sNodeToCalico` sets `Spec.BGP` to a **non-nil** spec whenever *any* BGP field is
populated — including `IPv4IPIPTunnelAddr`, which IPAM assigns on every node regardless of
BGP. A node whose only BGP field is the tunnel address therefore has a non-nil spec with
empty IP/ASN fields, matches this condition, and is dropped as "deleted" — so
`extractNodeAddress`'s InternalIP fallback never runs, no `HostMetadataUpdate` is emitted,
and the dataplane never learns the host IP.

The producer (`K8sNodeToCalico`) and this consumer disagreed on what "empty BGP" means:
libcalico uses `reflect.DeepEqual(*bgpSpec, NodeBGPSpec{})` over the whole struct; this
check looked at only three fields.

### Fix

Compare the whole BGP spec against its zero value, matching the emptiness test
`K8sNodeToCalico` already uses. A tunnel-only spec is no longer misclassified, the
InternalIP fallback runs, and the host IP is programmed. A genuinely-empty spec
(`BGP: &NodeBGPSpec{}`) is still treated as a delete.

### Testing

- New unit test in `felix/calc/dataplane_passthru_test.go`: a tunnel-address-only BGP spec
  must not be treated as a delete and must fall back to `InternalIP`. Verified it fails
  against the old code and passes with the fix.
- Existing "empty BGP spec as a delete" test still passes.

**Release note:**
```release-note
NONE
```
