### PR TITLE
[v3.32] felix: make periodic IP set resync incremental

### DIFF
--- a/.semaphore/cleanup.yml
+++ b/.semaphore/cleanup.yml
@@ -17,7 +17,8 @@ blocks:
           - checkout
           - export GOOGLE_APPLICATION_CREDENTIALS=$HOME/secrets/secret.google-service-account-key.json
           - export SHORT_WORKFLOW_ID=$(echo ${SEMAPHORE_WORKFLOW_ID} | sha256sum | cut -c -8)
-          - export ZONE=europe-west3-c
+          # clean-up-vms is zone-agnostic (it discovers each VM's zone), so no
+          # ZONE is needed here.
           - export VM_PREFIX=sem-${SEMAPHORE_PROJECT_NAME}-${SHORT_WORKFLOW_ID}-
           - echo VM_PREFIX=${VM_PREFIX}
       jobs:

--- a/.semaphore/semaphore-scheduled-builds.yml
+++ b/.semaphore/semaphore-scheduled-builds.yml
@@ -1460,7 +1460,9 @@ blocks:
           - gcloud config set project unique-caldron-775
           - cd node
           - export SHORT_WORKFLOW_ID=$(echo ${SEMAPHORE_WORKFLOW_ID} | sha256sum | cut -c -8)
-          - export ZONE=europe-west3-c
+          # Spread the test VMs across the zones of this region (by available
+          # capacity); see .semaphore/vms/run-tests-on-vms.
+          - export REGION=europe-west3
           - export VM_PREFIX=sem-${SEMAPHORE_PROJECT_NAME}-${SHORT_WORKFLOW_ID}-kind-
           - echo VM_PREFIX=${VM_PREFIX}
           - export COMPONENT=node

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -1460,7 +1460,9 @@ blocks:
           - gcloud config set project unique-caldron-775
           - cd node
           - export SHORT_WORKFLOW_ID=$(echo ${SEMAPHORE_WORKFLOW_ID} | sha256sum | cut -c -8)
-          - export ZONE=europe-west3-c
+          # Spread the test VMs across the zones of this region (by available
+          # capacity); see .semaphore/vms/run-tests-on-vms.
+          - export REGION=europe-west3
           - export VM_PREFIX=sem-${SEMAPHORE_PROJECT_NAME}-${SHORT_WORKFLOW_ID}-kind-
           - echo VM_PREFIX=${VM_PREFIX}
           - export COMPONENT=node

--- a/.semaphore/semaphore.yml.d/blocks/20-node.yml
+++ b/.semaphore/semaphore.yml.d/blocks/20-node.yml
@@ -99,7 +99,9 @@
         - gcloud config set project unique-caldron-775
         - cd node
         - export SHORT_WORKFLOW_ID=$(echo ${SEMAPHORE_WORKFLOW_ID} | sha256sum | cut -c -8)
-        - export ZONE=europe-west3-c
+        # Spread the test VMs across the zones of this region (by available
+        # capacity); see .semaphore/vms/run-tests-on-vms.
+        - export REGION=europe-west3
         - export VM_PREFIX=sem-${SEMAPHORE_PROJECT_NAME}-${SHORT_WORKFLOW_ID}-kind-
         - echo VM_PREFIX=${VM_PREFIX}
         - export COMPONENT=node

--- a/.semaphore/vms/clean-up-vms
+++ b/.semaphore/vms/clean-up-vms
@@ -28,17 +28,37 @@ gcp_secret_key=${GCP_SECRET_KEY:-$HOME/secrets/secret.google-service-account-key
 gcloud config set project $project
 gcloud auth activate-service-account --key-file=$gcp_secret_key
 
+# The test VMs are spread across the zones of a region (see run-tests-on-vms),
+# so we list project-wide by name prefix and delete each instance in whichever
+# zone it ended up in.  This is zone-agnostic, so it also reclaims any leaked
+# VMs regardless of where they landed.
 while true; do
   gcloud --quiet compute instances list \
         "--filter=name~'${vm_prefix}.*'" \
-        --zones=${ZONE} \
-        --format='table[no-heading](name)' > instance-list
-  instances="$(cat instance-list)"
-  if [ "${instances}" = "" ]; then
+        --format='csv[no-heading](name,zone.basename())' > instance-list
+  if [ ! -s instance-list ]; then
     echo "All instances deleted"
     break
   fi
-  echo "Instances to delete: $instances"
-  gcloud --quiet beta compute instances delete ${instances} --zone=${ZONE} --no-graceful-shutdown
+  echo "Instances to delete:"
+  cat instance-list
+
+  # Group the instances by zone so we can delete each zone's VMs in a single
+  # 'gcloud delete' call.  A single delete with multiple names tears them down
+  # in parallel, which is much faster than one call per VM -- but gcloud
+  # requires every name in a call to share a --zone, hence the per-zone grouping.
+  declare -A zone_names=()
+  while IFS=, read -r name zone; do
+    [ -n "$name" ] || continue
+    zone_names["$zone"]+=" $name"
+  done < instance-list
+
+  for zone in "${!zone_names[@]}"; do
+    # Best-effort: don't let one failed delete (an instance vanished between list
+    # and delete, or a transient API error) abort the whole sweep under 'set -e'
+    # and leak the rest.  Anything still present is retried on the next pass.
+    gcloud --quiet beta compute instances delete ${zone_names[$zone]} --zone="$zone" --no-graceful-shutdown \
+      || echo "WARNING: failed to delete one or more instances in $zone; will retry."
+  done
   sleep 1
 done

--- a/.semaphore/vms/run-tests-on-vms
+++ b/.semaphore/vms/run-tests-on-vms
@@ -22,7 +22,11 @@ my_dir="$(dirname $0)"
 repo_dir="$my_dir/../.."
 vm_name_prefix=$1
 artifacts_dir="$repo_dir/artifacts"
-zone=${ZONE:-europe-west3-c}
+# We bulk-create the VMs across all the zones in a region (based on available
+# capacity) rather than pinning a single zone, so a single zone running out of
+# capacity no longer blocks the job.  REGION selects the region; the zone each
+# VM actually lands in is discovered after creation (see below).
+region=${REGION:-europe-west3}
 : "${VM_MACHINE_TYPE:=n4-standard-4}"
 : "${IMAGE_FAMILY:=ubuntu-minimal-2204-lts}"
 : "${MAX_RUN_DURATION:=4h}"
@@ -74,12 +78,17 @@ else
 fi
 
 # Do a bulk create; this is faster and it saves API quota.
-echo "Creating test VMs in bulk..."
+#
+# We pass --region (not --zone) with --target-distribution-shape=any so that
+# GCP spreads the VMs across the zones of the region according to available
+# capacity.  This avoids a single zone filling up and failing the whole job.
+echo "Creating test VMs in bulk across region ${region}..."
 gcloud --quiet compute instances bulk create \
        --service-account="semaphore-v2-gcr@unique-caldron-775.iam.gserviceaccount.com" \
        --scopes="https://www.googleapis.com/auth/cloud-platform" \
        --predefined-names="$names" \
-       --zone=${zone} \
+       --region=${region} \
+       --target-distribution-shape=any \
        --machine-type=${VM_MACHINE_TYPE} \
        --image-family=${IMAGE_FAMILY} \
        --image-project=ubuntu-os-cloud \
@@ -90,6 +99,31 @@ gcloud --quiet compute instances bulk create \
        --labels="${labels}" \
        --metadata-from-file startup-script="$my_dir/vm-bootstrap.sh" \
        --metadata block-project-ssh-keys=TRUE,ssh-keys="ubuntu:$(ssh-keygen -y -f $HOME/.ssh/id_rsa)",enable-guest-attributes=TRUE
+
+# Since the VMs are spread across the region's zones, we can no longer assume a
+# single zone for the downstream describe/ssh/delete commands.  Build a
+# name->zone map by listing the instances we just created, filtered by our
+# workflow-unique name prefix.  bulk create is synchronous, so the instances
+# already exist by the time it returns.
+echo "Discovering which zone each VM landed in..."
+declare -A vm_zone
+while IFS=, read -r name vm_z; do
+  [ -n "$name" ] || continue
+  vm_zone["$name"]="$vm_z"
+  echo "  $name -> $vm_z"
+done < <(gcloud --quiet compute instances list \
+              --filter="name~'^${vm_name_prefix}'" \
+              --format='csv[no-heading](name,zone.basename())')
+
+# Fail fast if any expected VM is missing from the map; the rest of the script
+# relies on knowing every VM's zone.
+for batch in "${batches[@]}"; do
+  vm_name="$vm_name_prefix$batch"
+  if [ -z "${vm_zone[$vm_name]:-}" ]; then
+    echo "ERROR: could not determine the zone of VM $vm_name after bulk create." 1>&2
+    exit 1
+  fi
+done
 
 ###### Configure VMs, run tests and shut them down ######
 
@@ -138,6 +172,16 @@ format_batch_for_log() {
 
 for batch in "${batches[@]}"; do
   vm_name="$vm_name_prefix$batch"
+  # Each VM may be in a different zone; look up the one it landed in.  Every
+  # downstream command in this iteration (vm-ip, on-test-vm, configure-test-vm,
+  # the delete, and the watchdog's serial/snapshot capture) uses $zone.  We also
+  # export ZONE: run_batch (sourced from batches.sh) shells out to
+  # 'gcloud get-serial-port-output --zone="${ZONE}"' to grab the serial console
+  # when a VM wedges, and it reads ZONE from the environment.  The backgrounded
+  # per-batch subshell below captures this value at fork time, so each batch
+  # sees its own VM's zone.
+  zone="${vm_zone[$vm_name]}"
+  export ZONE="$zone"
   vm_ip="$(env VM_NAME="$vm_name" ZONE="$zone" "$my_dir/vm-ip")"
   batch_formatted="$(format_batch_for_log "$batch")"
   log_file="$artifacts_dir/test-$batch_formatted.log"
@@ -153,7 +197,7 @@ for batch in "${batches[@]}"; do
 
     conf_log_file="$artifacts_dir/configure-vm-$batch_formatted.log"
     echo "$prefix Configuring test VM $vm_name. Redirecting log to $conf_log_file."
-    if "${my_dir}/configure-test-vm" "$vm_name" >& "$conf_log_file"; then
+    if env ZONE="$zone" "${my_dir}/configure-test-vm" "$vm_name" >& "$conf_log_file"; then
       echo "$prefix Configuration of VM $vm_name SUCCEEDED."
     else
       echo "$prefix Configuration of VM $vm_name FAILED.  Log file will be uploaded as artifact $conf_log_file. "

--- a/felix/.semaphore/fv-prologue
+++ b/felix/.semaphore/fv-prologue
@@ -6,7 +6,9 @@ gcloud auth activate-service-account --key-file="$GOOGLE_APPLICATION_CREDENTIALS
 gcloud config set project unique-caldron-775
 
 export COMPONENT=felix
-export ZONE=europe-west3-c
+# Spread the test VMs across the zones of this region (by available capacity)
+# rather than pinning a single zone; see .semaphore/vms/run-tests-on-vms.
+export REGION=europe-west3
 
 # 4 vCPUs seems to be the minimum for stable tests.  8 vCPUs doesn't seem to
 # help performance very much.

--- a/felix/dataplane/ipsets/ipsets_mgr.go
+++ b/felix/dataplane/ipsets/ipsets_mgr.go
@@ -30,6 +30,11 @@ type IPSetsDataplane interface {
 	GetIPFamily() ipsets.IPFamily
 	GetTypeOf(setID string) (ipsets.IPSetType, error)
 	GetDesiredMembers(setID string) (set.Set[string], error)
+	// QueueResync requests a resync with the dataplane to catch drift Felix
+	// wasn't told about.  An implementation may satisfy it incrementally over
+	// subsequent ApplyUpdates calls, using the ApplyDeletions reschedule signal
+	// to ask for more loops; the resync need not complete within a single
+	// ApplyUpdates.
 	QueueResync()
 	ApplyUpdates(listener UpdateListener)
 	ApplyDeletions() (reschedule bool)

--- a/felix/fv/ipsets_test.go
+++ b/felix/fv/ipsets_test.go
@@ -125,6 +125,121 @@ var _ = infrastructure.DatastoreDescribe("_IPSets_ Tests for IPset rendering", [
 	})
 })
 
+var _ = infrastructure.DatastoreDescribe("_IPSets_ periodic resync repairs dataplane drift",
+	[]apiconfig.DatastoreType{apiconfig.EtcdV3}, func(getInfra infrastructure.InfraFactory) {
+		// A short refresh interval so the periodic resync fires promptly; the
+		// assertions below still allow many multiples of it to avoid flakes.
+		const refreshInterval = 5 * time.Second
+		// Two distinctive set sizes so we can pick our sets out of the full
+		// 'ipset list' by member count, including default Calico sets.
+		const setASize = 41
+		const setBSize = 53
+		const bogusMember = "10.123.123.123"
+
+		var (
+			tc    infrastructure.TopologyContainers
+			felix *infrastructure.Felix
+			c     client.Interface
+			infra infrastructure.DatastoreInfra
+			w     *workload.Workload
+		)
+
+		BeforeEach(func() {
+			if NFTMode() || BPFMode() {
+				// The incremental periodic resync being exercised here belongs
+				// to the legacy (iptables) ipsets driver.  nftables has its own
+				// resync path and the BPF dataplane doesn't program these IP
+				// sets.
+				Skip("legacy (iptables) ipsets driver only")
+			}
+			topologyOptions := infrastructure.DefaultTopologyOptions()
+			topologyOptions.FelixLogSeverity = "Info"
+			topologyOptions.EnableIPv6 = false
+			topologyOptions.ExtraEnvVars = map[string]string{
+				"FELIX_IPSETSREFRESHINTERVAL": fmt.Sprintf("%d", int(refreshInterval.Seconds())),
+			}
+			logrus.SetLevel(logrus.InfoLevel)
+			infra = getInfra()
+			tc, c = infrastructure.StartSingleNodeTopology(topologyOptions, infra)
+			felix = tc.Felixes[0]
+			w = workload.Run(felix, "w", "default", "10.65.0.2", "8085", "tcp")
+		})
+
+		AfterEach(func() {
+			if infra == nil {
+				// Skipped before the topology started.
+				return
+			}
+			w.Stop()
+			tc.Stop()
+			infra.Stop()
+		})
+
+		It("should repair externally-modified IP sets on the next periodic resync", func() {
+			// Program two network sets of distinct, identifiable sizes and a
+			// policy that references both and applies to our workload, so both
+			// IP sets get rendered into the dataplane.
+			makeNetSet := func(name string, size int) {
+				ns := api.NewGlobalNetworkSet()
+				ns.Name = name
+				ns.Labels = map[string]string{"netset": name}
+				ns.Spec.Nets = generateIPv4s(size)
+				_, err := c.GlobalNetworkSets().Create(context.TODO(), ns, options.SetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+			}
+			makeNetSet("netset-a", setASize)
+			makeNetSet("netset-b", setBSize)
+
+			pol := api.NewGlobalNetworkPolicy()
+			pol.Name = "pol-repair"
+			pol.Spec.Selector = "all()"
+			pol.Spec.Ingress = []api.Rule{
+				{Action: "Allow", Source: api.EntityRule{Selector: "netset == 'netset-a'"}},
+				{Action: "Allow", Source: api.EntityRule{Selector: "netset == 'netset-b'"}},
+			}
+			pol.Spec.Egress = []api.Rule{{Action: "Allow"}}
+			order := 1000.0
+			pol.Spec.Order = &order
+			_, err := c.GlobalNetworkPolicies().Create(context.TODO(), pol, options.SetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			w.ConfigureInInfra(infra)
+
+			By("Waiting for both IP sets to be programmed")
+			// Identify our sets by their (unique) member counts.
+			findSetOfSize := func(size int) string {
+				for name, sz := range felix.IPSetSizes() {
+					if sz == size {
+						return name
+					}
+				}
+				return ""
+			}
+			Eventually(func() string { return findSetOfSize(setASize) }, "60s", "1s").ShouldNot(BeEmpty())
+			Eventually(func() string { return findSetOfSize(setBSize) }, "60s", "1s").ShouldNot(BeEmpty())
+			setA := findSetOfSize(setASize)
+			setB := findSetOfSize(setBSize)
+			Expect(setA).NotTo(Equal(setB))
+
+			By("Corrupting the IP sets behind Felix's back")
+			// Add a bogus member to one set (Felix should remove it) and flush
+			// the other (Felix should re-add its members).  We deliberately do
+			// not destroy a set: an in-use set can't be destroyed, and the
+			// whole-set-missing path is covered by the unit tests.
+			// Exec fails the test if the commands themselves fail; we don't
+			// assert on the corrupted sizes because the refresh timer may
+			// repair them before we could read them back.
+			felix.Exec("ipset", "add", setA, bogusMember)
+			felix.Exec("ipset", "flush", setB)
+
+			By("Waiting for the periodic resync to repair both sets")
+			Eventually(func() map[string]int {
+				sizes := felix.IPSetSizes()
+				return map[string]int{"a": sizes[setA], "b": sizes[setB]}
+			}, "60s", "1s").Should(Equal(map[string]int{"a": setASize, "b": setBSize}))
+		})
+	})
+
 func createNetworkSetPolicies(c client.Interface, numPols, numRulesPerPol int) {
 	By("Creating network sets")
 	sizes := []int{1, 1, 1, 2, 3, 4, 5, 5, 5, 5, 5, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 100, 200, 1000}

--- a/felix/ipsets/ipsets.go
+++ b/felix/ipsets/ipsets.go
@@ -17,6 +17,7 @@ package ipsets
 import (
 	"bufio"
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -37,7 +38,17 @@ import (
 const (
 	MaxIPSetDeletionsPerIteration = 1
 	MaxRetryAttempt               = 10
+	// BackgroundResyncTimeBudget caps the wall-clock time spent re-listing IP
+	// sets during a background (periodic) resync in a single ApplyUpdates call.
+	// Listing a set is a fork/exec per set, so a fleet of sets is re-checked a
+	// batch at a time across successive apply loops rather than stalling one.
+	BackgroundResyncTimeBudget = 100 * time.Millisecond
 )
+
+// ErrIPSetNotFound is returned by runIPSetList when the kernel reports that the
+// set does not exist.  During a resync this is an expected, recoverable state
+// (the set was deleted out from under us), not a failure.
+var ErrIPSetNotFound = errors.New("IP set not found in dataplane")
 
 type dataplaneMetadata struct {
 	Type         IPSetType
@@ -75,14 +86,23 @@ type IPSets struct {
 	nextTempIPSetIdx       uint
 	ipSetsWithDirtyMembers set.Set[string]
 
-	ipSetsRequiringResync set.Typed[string]
-	fullResyncRequired    bool
+	// resyncQueue holds the names of IP sets whose contents we need to
+	// re-check against the dataplane, split into a "must" tier (drained before
+	// we trust the dataplane) and a "background" tier (drained a time-boxed
+	// batch per apply).  fullResyncRequired, set at start of day and on
+	// persistent update failures, forces a from-scratch resync of everything.
+	resyncQueue        *resyncQueue
+	bgResyncRequested  bool
+	fullResyncRequired bool
 
 	// Factory for command objects; shimmed for UT mocking.
 	newCmd cmdFactory
 
 	// Shim for time.Sleep()
 	sleep func(time.Duration)
+
+	// Shim for time.Now(), used to time-box the background resync drain.
+	timeNow func() time.Time
 
 	gaugeNumIpsets prometheus.Gauge
 
@@ -111,6 +131,7 @@ func NewIPSets(ipVersionConfig *IPVersionConfig, recorder logutils.OpRecorder) *
 		recorder,
 		newRealCmd,
 		time.Sleep,
+		time.Now,
 	)
 }
 
@@ -120,6 +141,7 @@ func NewIPSetsWithShims(
 	recorder logutils.OpRecorder,
 	cmdFactory cmdFactory,
 	sleep func(time.Duration),
+	timeNow func() time.Time,
 ) *IPSets {
 	familyStr := string(ipVersionConfig.Family)
 	return &IPSets{
@@ -137,11 +159,12 @@ func NewIPSetsWithShims(
 		mainSetNameToMembers: map[string]*deltatracker.SetDeltaTracker[IPSetMember]{},
 
 		ipSetsWithDirtyMembers: set.New[string](),
-		ipSetsRequiringResync:  set.New[string](),
+		resyncQueue:            newResyncQueue(),
 		fullResyncRequired:     true,
 
-		newCmd: cmdFactory,
-		sleep:  sleep,
+		newCmd:  cmdFactory,
+		sleep:   sleep,
+		timeNow: timeNow,
 
 		gaugeNumIpsets: gaugeVecNumCalicoIpsets.WithLabelValues(familyStr),
 
@@ -279,11 +302,15 @@ func (s *IPSets) RemoveMembers(setID string, removedMembers []string) {
 	s.updateDirtiness(setName)
 }
 
-// QueueResync forces a resync with the dataplane on the next ApplyUpdates() call.
+// QueueResync requests a resync with the dataplane.  The resync is satisfied
+// incrementally, spread over the next several ApplyUpdates() calls: the set
+// names are listed and any sets that vanished or appeared unexpectedly are
+// reconciled immediately, then the contents of the surviving sets are
+// re-checked a time-boxed batch at a time.  This differs from the start-of-day
+// and error-triggered resyncs, which run in full before we trust the dataplane.
 func (s *IPSets) QueueResync() {
 	s.logCxt.Debug("Asked to resync with the dataplane on next update.")
-	s.fullResyncRequired = true
-	s.ipSetsRequiringResync.Clear()
+	s.bgResyncRequested = true
 }
 
 func (s *IPSets) GetIPFamily() IPFamily {
@@ -352,19 +379,27 @@ func (s *IPSets) ApplyUpdates(listener UpdateListener) {
 		retryDelay *= 2
 	}
 
+	// Background resync work is time-boxed by a single budget shared across all
+	// retry attempts of this call, so that retries don't burn extra background
+	// work on top of the fresh work each ApplyUpdates is expected to do.
+	bgBudget := BackgroundResyncTimeBudget
+
 	var resyncErr, updateErr error
 	for attempt := range MaxRetryAttempt {
 		if attempt > 0 {
 			s.logCxt.Info("Retrying after an ipsets update failure...")
 		}
 		treatFailureAsTransient := attempt < MaxRetryAttempt/2
-		if s.fullResyncRequired || s.ipSetsRequiringResync.Len() > 0 {
+		if s.fullResyncRequired || s.bgResyncRequested || s.resyncQueue.Len() > 0 {
 			// Compare our in-memory state against the dataplane and queue up
 			// modifications to fix any inconsistencies.
-			s.logCxt.Debug("Resyncing ipsets with dataplane.")
-			s.opReporter.RecordOperation(fmt.Sprint("resync-ipsets-v", s.IPVersionConfig.Family.Version()))
+			s.logCxt.WithFields(log.Fields{
+				"full":     s.fullResyncRequired,
+				"bg":       bgBudget,
+				"queueLen": s.resyncQueue.Len(),
+			}).Debug("Resyncing ipsets with dataplane.")
 
-			if resyncErr = s.tryResync(); resyncErr != nil {
+			if resyncErr = s.tryResync(&bgBudget); resyncErr != nil {
 				s.logCxt.WithError(resyncErr).Warning("Failed to resync with dataplane")
 
 				// After a few attempts, most likely, we are dealing with a persistent failure.
@@ -394,7 +429,7 @@ func (s *IPSets) ApplyUpdates(listener UpdateListener) {
 				// Persistent failures, try a full resync.
 				s.logCxt.WithError(updateErr).WithField("attempt", attempt).Warning(
 					"Persistently failed to update IP sets. Will do full resync.")
-				s.QueueResync()
+				s.fullResyncRequired = true
 			}
 			countNumIPSetErrors.Inc()
 		}
@@ -415,9 +450,13 @@ func (s *IPSets) ApplyUpdates(listener UpdateListener) {
 	gaugeNumTotalIpsets.Set(float64(s.setNameToProgrammedMetadata.Dataplane().Len()))
 }
 
-// tryResync attempts to bring our state into sync with the dataplane.  It scans the contents of the
-// IP sets in the dataplane and queues up updates to any IP sets that are out-of-sync.
-func (s *IPSets) tryResync() (err error) {
+// tryResync brings our state into sync with the dataplane.  A full resync
+// (start of day, or after a persistent update failure) re-lists everything and
+// drains it synchronously; a background resync lists the names, repairs any
+// that vanished or appeared unexpectedly, then re-checks the surviving sets'
+// contents a time-boxed batch at a time.  bgBudget is the remaining background
+// time budget for the enclosing ApplyUpdates call and is decremented in place.
+func (s *IPSets) tryResync(bgBudget *time.Duration) (err error) {
 	// Log the time spent as we exit the function.
 	resyncStart := time.Now()
 	defer func() {
@@ -426,99 +465,162 @@ func (s *IPSets) tryResync() (err error) {
 			"ipSetsWithDirtyMembers":   s.ipSetsWithDirtyMembers.Len(),
 			"ipSetsToCreateOrRecreate": s.setNameToProgrammedMetadata.PendingUpdates().Len(),
 			"ipSetsToDelete":           s.setNameToProgrammedMetadata.PendingDeletions().Len(),
+			"resyncQueueLength":        s.resyncQueue.Len(),
 		}).Debug("Finished IPSets resync")
 	}()
 
-	// Figure out if debug logging is enabled so we can disable some expensive-to-calculate logs
-	// in the tight loop below if they're not going to be emitted.  This speeds up the loop
-	// by a factor of 3-4x!
-	debug := log.GetLevel() >= log.DebugLevel
-
-	// Clear out the dataplane metadata for any IP sets that we're about to
-	// resync.  We'll then repopulate it as we go.  If we don't see the IP set
-	// then it won't get repopulated, which will trigger it to be re-created
-	// later.
-	if s.fullResyncRequired {
-		s.setNameToProgrammedMetadata.Dataplane().DeleteAll()
-	} else {
-		for name := range s.ipSetsRequiringResync.All() {
-			s.setNameToProgrammedMetadata.Dataplane().Delete(name)
+	switch {
+	case s.fullResyncRequired:
+		s.opReporter.RecordOperation(fmt.Sprint("resync-ipsets-v", s.IPVersionConfig.Family.Version()))
+		if err = s.beginFullResync(); err != nil {
+			return err
 		}
+	case s.bgResyncRequested:
+		s.opReporter.RecordOperation(fmt.Sprint("resync-ipsets-bg-start-v", s.IPVersionConfig.Family.Version()))
+		if err = s.beginBackgroundResync(); err != nil {
+			return err
+		}
+	default:
+		// No new resync requested; we're just draining the queue from a
+		// previous one over successive apply loops.
+		s.opReporter.RecordOperation(fmt.Sprint("resync-ipsets-bg-v", s.IPVersionConfig.Family.Version()))
 	}
 
-	// Even if we're doing a partial resync, we still list all IP set names.
-	// this is because resyncIPSet() should only be called with IP sets that
-	// are known to exist.
-	ipSets, err := s.CalicoIPSets()
+	return s.drainResyncQueue(bgBudget)
+}
+
+// beginFullResync discards our whole view of the dataplane and re-lists it from
+// scratch, queueing every owned set at "must" priority so drainResyncQueue
+// re-checks all of them before we trust the dataplane.
+func (s *IPSets) beginFullResync() error {
+	s.logCxt.Debug("Doing full resync of IP sets.")
+	s.resyncQueue.Clear()
+	s.setNameToProgrammedMetadata.Dataplane().DeleteAll()
+
+	listed, err := s.listCalicoIPSets()
 	if err != nil {
-		s.logCxt.WithError(err).Error("Failed to get the list of Calico ipsets")
-		return
+		return err
 	}
-	if debug {
-		s.logCxt.Debugf("List of calico ipsets: %v", ipSets)
+	for name := range listed.All() {
+		s.resyncQueue.Add(name, resyncPriMust)
 	}
+	s.sweepIPSetsMissingFromDataplane(listed)
+	// The full resync subsumes any pending background resync: we just did the
+	// listing and sweep, and every set is queued at "must".
+	s.bgResyncRequested = false
+	return nil
+}
 
-	ipSetPartOfSync := func(name string) bool {
-		return s.fullResyncRequired || s.ipSetsRequiringResync.Contains(name)
+// beginBackgroundResync lists the owned set names, immediately repairs any set
+// we expected but that is now missing (recreated in the same apply by
+// tryUpdates), and queues the surviving sets at "background" priority for their
+// contents to be re-checked over subsequent apply loops.
+func (s *IPSets) beginBackgroundResync() error {
+	s.logCxt.Debug("Doing background resync of IP sets.")
+	listed, err := s.listCalicoIPSets()
+	if err != nil {
+		// Keep bgResyncRequested set so we retry the listing next time.
+		return err
 	}
+	s.sweepIPSetsMissingFromDataplane(listed)
+	for name := range listed.All() {
+		// Add keeps an existing "must" position, so a set promoted by an
+		// earlier failure is still re-checked ahead of the background batch.
+		s.resyncQueue.Add(name, resyncPriBackground)
+	}
+	s.bgResyncRequested = false
+	return nil
+}
 
+// drainResyncQueue re-lists queued IP sets.  The must tier is drained fully;
+// the background tier is drained until the shared time budget runs out, making
+// at least one set of progress per ApplyUpdates call (a retry attempt may find
+// the budget already spent and skip background work).  A failure to re-list a *desired*
+// set is aggregated into the returned error and the set is re-queued at "must"
+// so the retry loop re-checks it before writing; failures for undesired sets
+// are logged only, since their recreation or deletion is already queued.
+func (s *IPSets) drainResyncQueue(bgBudget *time.Duration) error {
 	var failedIPSets []string
-	for _, name := range ipSets {
-		if !ipSetPartOfSync(name) {
-			// Skipping this IP set on this pass.
-			continue
-		}
-		if debug {
-			s.logCxt.Debugf("Parsing IP set %v.", name)
-		}
-		if err = s.resyncIPSet(name); err != nil {
-			// Ignore failures of IP sets not in desired state, as those will be cleaned up later.
+	resync := func(name string) {
+		if err := s.resyncIPSet(name); err != nil {
 			if _, desired := s.setNameToProgrammedMetadata.Desired().Get(name); desired {
 				failedIPSets = append(failedIPSets, name)
+				s.resyncQueue.Add(name, resyncPriMust)
 				s.logCxt.WithError(err).WithField("name", name).
 					Warn("Failed to parse required Calico-owned ipset that is needed, will try recreating it.")
 			} else {
 				s.logCxt.WithError(err).WithField("name", name).
 					Warn("Failed to parse Calico-owned ipset that is no longer needed, will queue it for deletion.")
 			}
-		} else {
-			// Successful resync of this IP set, clear any pending partial resync.
-			s.ipSetsRequiringResync.Discard(name)
+		}
+	}
+
+	for name := range s.resyncQueue.PopAllMust() {
+		resync(name)
+	}
+
+	// A pending full resync will re-list everything anyway, so don't spend the
+	// budget on background work that it would redo.
+	if !s.fullResyncRequired {
+		lastTime := s.timeNow()
+		for *bgBudget > 0 {
+			name, ok := s.resyncQueue.PopBackground()
+			if !ok {
+				break
+			}
+			resync(name)
+			now := s.timeNow()
+			*bgBudget -= now.Sub(lastTime)
+			lastTime = now
 		}
 	}
 
 	if len(failedIPSets) > 0 {
 		return fmt.Errorf("failed to parse IPSets %v", strings.Join(failedIPSets, ","))
 	}
+	return nil
+}
 
-	// Mark any IP sets that we didn't see as empty.
-	for name, members := range s.mainSetNameToMembers {
-		if !ipSetPartOfSync(name) {
-			// Skipping this IP set on this pass.
-			continue
-		}
-		if _, ok := s.setNameToProgrammedMetadata.Dataplane().Get(name); ok {
-			// In the dataplane, we should have updated its members above.
-			continue
-		}
-		if _, ok := s.setNameToAllMetadata[name]; !ok {
-			// Defensive: this IP set is not in the dataplane, and it's not
-			// one we are tracking, clean up its member tracker.
-			log.WithField("name", name).Warn(
-				"Cleaning up leaked(?) IP set member tracker.")
-			delete(s.mainSetNameToMembers, name)
-			continue
-		}
-		// We're tracking this IP set, but we didn't find it in the dataplane;
-		// reset the members set to empty.
-		members.Dataplane().DeleteAll()
+// sweepIPSetsMissingFromDataplane reconciles every set we are tracking that is
+// absent from the given listing of live set names, repairing it in place so
+// that tryUpdates recreates a desired set in the same apply.
+func (s *IPSets) sweepIPSetsMissingFromDataplane(listed set.Set[string]) {
+	candidates := set.New[string]()
+	for name := range s.mainSetNameToMembers {
+		candidates.Add(name)
 	}
+	s.setNameToProgrammedMetadata.Dataplane().Iter(func(name string, _ dataplaneMetadata) {
+		candidates.Add(name)
+	})
+	s.setNameToProgrammedMetadata.Desired().Iter(func(name string, _ dataplaneMetadata) {
+		candidates.Add(name)
+	})
+	for name := range candidates.All() {
+		if listed.Contains(name) {
+			continue
+		}
+		s.onIPSetMissingFromDataplane(name)
+	}
+}
 
-	// At this point, the partial resync set can only contain IP sets that
-	// don't exist in the dataplane, and we just handled those above.
-	s.ipSetsRequiringResync.Clear()
-
-	return
+// onIPSetMissingFromDataplane records that a set we were tracking is not in the
+// dataplane: it drops our dataplane view (so a desired set becomes a pending
+// create) and cancels any queued resync of it.
+func (s *IPSets) onIPSetMissingFromDataplane(name string) {
+	s.setNameToProgrammedMetadata.Dataplane().Delete(name)
+	if members, ok := s.mainSetNameToMembers[name]; ok {
+		if _, tracked := s.setNameToAllMetadata[name]; !tracked {
+			// Defensive: not one we're tracking, clean up its member tracker.
+			s.logCxt.WithField("name", name).Warn("Cleaning up leaked(?) IP set member tracker.")
+			delete(s.mainSetNameToMembers, name)
+		} else {
+			// We're tracking this IP set, but it's gone from the dataplane;
+			// reset the members set to empty so it gets recreated.
+			members.Dataplane().DeleteAll()
+		}
+	}
+	s.updateDirtiness(name)
+	s.resyncQueue.Remove(name)
 }
 
 func (s *IPSets) CalicoIPSets() ([]string, error) {
@@ -548,6 +650,18 @@ func (s *IPSets) CalicoIPSets() ([]string, error) {
 		return nil, err
 	}
 	return ipSets, nil
+}
+
+// listCalicoIPSets returns the set of owned IP set names currently in the
+// dataplane.  It wraps CalicoIPSets for the resync paths that need set-membership
+// lookups.
+func (s *IPSets) listCalicoIPSets() (set.Set[string], error) {
+	names, err := s.CalicoIPSets()
+	if err != nil {
+		s.logCxt.WithError(err).Error("Failed to get the list of Calico ipsets")
+		return nil, err
+	}
+	return set.FromArray(names), nil
 }
 
 func (s *IPSets) resyncIPSet(ipSetName string) error {
@@ -697,6 +811,13 @@ func (s *IPSets) resyncIPSet(ipSetName string) error {
 		}
 		return scanner.Err()
 	})
+	if errors.Is(err, ErrIPSetNotFound) {
+		// The set was deleted out from under us (e.g. between listing the
+		// names and getting here).  Repair our view directly rather than
+		// recording metadata for a set that doesn't exist.
+		s.onIPSetMissingFromDataplane(ipSetName)
+		return nil
+	}
 	if err != nil {
 		// This can occur if we have version skew with the version of IP set
 		// used to create the IP set. Mark the metadata as invalid in order
@@ -748,6 +869,13 @@ func (s *IPSets) runIPSetList(arg string, parsingFunc func(*bufio.Scanner) error
 		return err
 	}
 	if err != nil {
+		// Match on ipset's userspace error message (stable for many years).
+		// If it ever changes we fall back to returning the raw error, which
+		// degrades to the ListFailed/recreate path rather than misbehaving.
+		if strings.Contains(stderr.String(), "The set with the given name does not exist") {
+			logCxt.WithError(err).Debugf("IP set does not exist for '%v'.", cmdStr)
+			return ErrIPSetNotFound
+		}
 		logCxt.WithError(err).Errorf("Bad return code from '%v'.", cmdStr)
 		return err
 	}
@@ -863,7 +991,7 @@ func (s *IPSets) tryUpdates(dirtyIPSets []string, listener UpdateListener) (err 
 			"input":      s.restoreInCopy.String(),
 		}).Warning("Failed to complete ipset restore, IP sets may be out-of-sync.")
 		for _, setName := range touchedIPSets {
-			s.ipSetsRequiringResync.Add(setName)
+			s.resyncQueue.Add(setName, resyncPriMust)
 		}
 		return fmt.Errorf("failed to write one or more IP set: %v", err)
 	}
@@ -1060,6 +1188,7 @@ func (s *IPSets) ApplyDeletions() bool {
 			return deltatracker.IterActionNoOp
 		}
 		numDeletions++
+		s.resyncQueue.Remove(setName)
 		if _, ok := s.setNameToAllMetadata[setName]; !ok {
 			// IP set is not just filtered out, clean up the members cache.
 			logCxt.Debug("IP set now gone from dataplane, removing from members tracker.")
@@ -1079,6 +1208,11 @@ func (s *IPSets) ApplyDeletions() bool {
 	s.gaugeNumIpsets.Set(float64(s.setNameToProgrammedMetadata.Dataplane().Len()))
 
 	// Determine if we need to be rescheduled.
+	if s.resyncQueue.Len() > 0 {
+		// The background resync still has sets to re-check.  Ask to be
+		// rescheduled so the reschedule timer paces the queue drain.
+		return true
+	}
 	numDeletionsPending := s.setNameToProgrammedMetadata.PendingDeletions().Len()
 	if numDeletions == 0 {
 		// We had nothing to delete, or we only encountered errors, don't
@@ -1113,6 +1247,7 @@ func (s *IPSets) tryTempIPSetDeletions() {
 			return deltatracker.IterActionNoOp
 		}
 		numDeletions++
+		s.resyncQueue.Remove(setName)
 		return deltatracker.IterActionUpdateDataplane
 	})
 }

--- a/felix/ipsets/ipsets_test.go
+++ b/felix/ipsets/ipsets_test.go
@@ -262,6 +262,22 @@ var _ = Describe("IP sets dataplane", func() {
 		apply()
 	}
 
+	// resyncAndApplyUntilDrained queues a resync then applies repeatedly until
+	// the background resync queue is fully drained (signalled by the
+	// reschedule flag going false).  Multi-set resyncs spread their per-set
+	// re-listing over successive applies, so tests that resync more than one
+	// set need to pump the loop.
+	resyncAndApplyUntilDrained := func() {
+		ipsets.QueueResync()
+		for i := 0; ; i++ {
+			ExpectWithOffset(1, i).To(BeNumerically("<", 100), "resync drain did not terminate")
+			apply()
+			if !reschedRequested {
+				break
+			}
+		}
+	}
+
 	BeforeEach(func() {
 		listener = nil
 		dataplane = newMockDataplane()
@@ -270,6 +286,7 @@ var _ = Describe("IP sets dataplane", func() {
 			logutils.NewSummarizer("test loop"),
 			dataplane.newCmd,
 			dataplane.sleep,
+			dataplane.timeNow,
 		)
 	})
 
@@ -500,6 +517,39 @@ var _ = Describe("IP sets dataplane", func() {
 			// v4MainIPSetName2 should be destroyed since it's not in the desired state.
 			v4MainIPSetName3: []string{"10.0.0.5", "10.0.0.6"}, // This IPSet should not be touched.
 		})
+	})
+
+	It("should not spin the resync loop when a desired set cannot be re-listed", func() {
+		// Regression test: a desired set stuck at an unsupported revision fails
+		// every per-set re-list until tryUpdates recreates it.  The resync must
+		// re-list it only a bounded number of times per apply, not re-pop and
+		// re-list it in a tight loop — which previously ballooned memory by
+		// forking 'ipset list' commands without limit.
+		dataplane.IPSetMetadata = map[string]setMetadata{
+			v4MainIPSetName: {
+				Name:     v4MainIPSetName,
+				Family:   "inet",
+				Type:     IPSetTypeHashIP,
+				MaxSize:  1234,
+				Revision: supportedMockRevision + 1,
+			},
+		}
+		dataplane.IPSetMembers[v4MainIPSetName] = set.From("10.0.0.1", "10.0.0.9")
+		ipsets.AddOrReplaceIPSet(meta, []string{"10.0.0.1", "10.0.0.2"})
+
+		apply()
+
+		dataplane.ExpectMembers(map[string][]string{
+			v4MainIPSetName: {"10.0.0.1", "10.0.0.2"},
+		})
+		listCalls := 0
+		for _, name := range dataplane.CmdNames {
+			if name == "list" {
+				listCalls++
+			}
+		}
+		Expect(listCalls).To(BeNumerically("<", 40),
+			"the stuck set should be re-listed a bounded number of times, not in a spin")
 	})
 
 	Describe("with many left-over IP sets in place", func() {
@@ -785,7 +835,7 @@ var _ = Describe("IP sets dataplane", func() {
 				})
 
 				It("should be detected and fixed by a resync", func() {
-					resyncAndApply()
+					resyncAndApplyUntilDrained()
 					dataplane.ExpectMembers(map[string][]string{
 						v4MainIPSetName:  {"10.0.0.1", "10.0.0.2"},
 						v4MainIPSetName2: {"10.0.0.1", "10.0.0.3"},
@@ -802,7 +852,7 @@ var _ = Describe("IP sets dataplane", func() {
 				})
 
 				It("should be detected and fixed by a resync", func() {
-					resyncAndApply()
+					resyncAndApplyUntilDrained()
 					dataplane.ExpectMembers(map[string][]string{
 						v4MainIPSetName:  {"10.0.0.1", "10.0.0.2"},
 						v4MainIPSetName2: {"10.0.0.1", "10.0.0.3"},
@@ -824,7 +874,7 @@ var _ = Describe("IP sets dataplane", func() {
 					})
 
 					// But the next timer-triggered resync should catch it.
-					resyncAndApply()
+					resyncAndApplyUntilDrained()
 					dataplane.ExpectMembers(map[string][]string{
 						v4MainIPSetName:  {"10.0.0.1", "10.0.0.2"},
 						v4MainIPSetName2: {"10.0.0.1", "10.0.0.3", "10.0.0.4"},
@@ -1069,7 +1119,7 @@ var _ = Describe("IP sets dataplane", func() {
 		dataplane.IPSetMembers["cali4tunknown"] = staleSet
 		ipsets.AddOrReplaceIPSet(meta, v4Members1And2)
 
-		resyncAndApply()
+		resyncAndApplyUntilDrained()
 
 		dataplane.ExpectMembers(map[string][]string{v4MainIPSetName: v4Members1And2})
 	})
@@ -1086,7 +1136,7 @@ var _ = Describe("IP sets dataplane", func() {
 
 		// Recreate its temporary set, then resync.
 		dataplane.IPSetMembers[v4TempIPSetName1] = set.From("10.0.0.1")
-		resyncAndApply()
+		resyncAndApplyUntilDrained()
 
 		// Should be cleaned up.
 		dataplane.ExpectMembers(map[string][]string{v4MainIPSetName: v4Members1And2})
@@ -1108,6 +1158,210 @@ var _ = Describe("IP sets dataplane", func() {
 		ipsets, err := ipsets.CalicoIPSets()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ipsets).Should(Equal([]string{v4MainIPSetName}))
+	})
+
+	Describe("incremental background resync", func() {
+		countListsOf := func(name string) int {
+			n := 0
+			for _, listed := range dataplane.ListedNames {
+				if listed == name {
+					n++
+				}
+			}
+			return n
+		}
+
+		Describe("with two IP sets programmed", func() {
+			BeforeEach(func() {
+				ipsets.AddOrReplaceIPSet(meta, []string{"10.0.0.1"})
+				ipsets.AddOrReplaceIPSet(meta2, []string{"10.0.0.2"})
+				apply()
+			})
+
+			It("should drain the background queue one set per apply", func() {
+				// Corrupt both sets behind our back.
+				dataplane.IPSetMembers[v4MainIPSetName].Add("10.0.0.99")
+				dataplane.IPSetMembers[v4MainIPSetName2].Add("10.0.0.99")
+
+				ipsets.QueueResync()
+
+				apply()
+				Expect(reschedRequested).To(BeTrue(),
+					"should reschedule while the background queue is draining")
+
+				apply()
+				Expect(reschedRequested).To(BeFalse(), "queue should be drained")
+
+				dataplane.ExpectMembers(map[string][]string{
+					v4MainIPSetName:  {"10.0.0.1"},
+					v4MainIPSetName2: {"10.0.0.2"},
+				})
+			})
+
+			It("should list the names once per background resync", func() {
+				// Duplicate QueueResync calls collapse into one background resync.
+				ipsets.QueueResync()
+				ipsets.QueueResync()
+				dataplane.NumListNamesCalls = 0
+				apply()
+				Expect(dataplane.NumListNamesCalls).To(Equal(1))
+			})
+
+			It("should subsume a mid-drain background resync into an escalated full resync", func() {
+				// Corrupt both sets and start a background resync; the first
+				// apply repairs only one set, leaving the other mid-queue.
+				dataplane.IPSetMembers[v4MainIPSetName].Add("10.0.0.99")
+				dataplane.IPSetMembers[v4MainIPSetName2].Add("10.0.0.99")
+				ipsets.QueueResync()
+				apply()
+				Expect(reschedRequested).To(BeTrue(), "one set should still be queued")
+
+				// Escalate to a full resync via persistent update failures.
+				dataplane.RestoreOpFailures = slices.Repeat([]string{"write-ip"}, (MaxRetryAttempt/2)+1)
+				ipsets.AddMembers(ipSetID, []string{"10.0.0.3"})
+				apply()
+
+				// The full resync clears the queue and re-checks everything at
+				// "must" priority, so the still-queued corruption is repaired
+				// within the same apply and nothing is left queued.
+				dataplane.ExpectMembers(map[string][]string{
+					v4MainIPSetName:  {"10.0.0.1", "10.0.0.3"},
+					v4MainIPSetName2: {"10.0.0.2"},
+				})
+				Expect(reschedRequested).To(BeFalse(), "full resync should leave the queue drained")
+			})
+		})
+
+		Describe("after creating an IP set", func() {
+			BeforeEach(func() {
+				ipsets.AddOrReplaceIPSet(meta, []string{"10.0.0.1", "10.0.0.2"})
+				apply()
+				dataplane.ListedNames = nil
+			})
+
+			It("should recreate a set deleted between listing names and re-listing it", func() {
+				// The set is present when we enumerate names but gone by the
+				// time we re-list its contents: the classic resync race.
+				dataplane.PostListNamesHooks = []func(*mockDataplane){
+					func(d *mockDataplane) { delete(d.IPSetMembers, v4MainIPSetName) },
+				}
+				sleepBefore := dataplane.CumulativeSleep
+
+				resyncAndApply()
+
+				dataplane.ExpectMembers(map[string][]string{
+					v4MainIPSetName: {"10.0.0.1", "10.0.0.2"},
+				})
+				Expect(dataplane.CumulativeSleep).To(Equal(sleepBefore),
+					"missing set is not a failure, should not back off")
+				Expect(dataplane.LinesExecuted).To(ContainElement(HavePrefix("create " + v4MainIPSetName)))
+				Expect(dataplane.LinesExecuted).NotTo(ContainElement(HavePrefix("swap ")),
+					"recreation should be a plain create, not a temp-set swap")
+			})
+
+			It("should repair a desired set missing from the name listing without re-listing it", func() {
+				// The set is already gone before we enumerate names, so the
+				// name sweep must repair it directly, with no 'ipset list <set>'.
+				delete(dataplane.IPSetMembers, v4MainIPSetName)
+
+				resyncAndApply()
+
+				dataplane.ExpectMembers(map[string][]string{
+					v4MainIPSetName: {"10.0.0.1", "10.0.0.2"},
+				})
+				Expect(countListsOf(v4MainIPSetName)).To(Equal(0),
+					"a set missing from the listing should not be individually listed")
+			})
+
+			It("should re-check a desired set at must priority after a failed background list", func() {
+				// Corrupt the set, then fail the first re-list of its contents.
+				dataplane.IPSetMembers[v4MainIPSetName].Add("10.0.0.99")
+				dataplane.PostListNamesHooks = []func(*mockDataplane){
+					func(d *mockDataplane) { d.ListOpFailures = []string{"rc"} },
+				}
+
+				resyncAndApply()
+
+				Expect(dataplane.ListOpFailures).To(BeEmpty(), "the failure should be consumed")
+				Expect(dataplane.CumulativeSleep).To(BeNumerically(">", 0),
+					"a failed desired-set list should back off")
+				dataplane.ExpectMembers(map[string][]string{
+					v4MainIPSetName: {"10.0.0.1", "10.0.0.2"},
+				})
+			})
+
+			It("should not re-list a set that was removed while queued", func() {
+				// Queue several sets for background resync, then remove them all
+				// so ApplyDeletions destroys them a batch at a time.  A set that
+				// is destroyed while still queued must be dropped from the queue,
+				// so it is never individually re-listed afterwards.
+				for i, m := range []IPSetMetadata{meta2, meta3, meta4, meta5} {
+					ipsets.AddOrReplaceIPSet(m, []string{fmt.Sprintf("10.1.0.%d", i)})
+				}
+				apply()
+
+				ipsets.QueueResync()
+				apply() // Enumerate names + enqueue; pops one, leaves the rest queued.
+
+				dataplane.ListedNames = nil
+				ipsets.RemoveIPSet(ipSetID)
+				ipsets.RemoveIPSet(ipSetID2)
+				ipsets.RemoveIPSet(ipSetID3)
+				ipsets.RemoveIPSet(ipSetID4)
+				ipsets.RemoveIPSet(ipSetID5)
+
+				for i := 0; ; i++ {
+					Expect(i).To(BeNumerically("<", 100), "drain did not terminate")
+					apply()
+					if !reschedRequested {
+						break
+					}
+				}
+
+				dataplane.ExpectMembers(map[string][]string{})
+				Expect(dataplane.TriedToDeleteNonExistent).To(BeFalse())
+				for name, count := range listCounts(dataplane.ListedNames) {
+					Expect(count).To(BeNumerically("<=", 1),
+						"set %s was individually listed more than once during teardown", name)
+				}
+			})
+		})
+
+		Describe("with a fake clock that makes each resync cheap", func() {
+			BeforeEach(func() {
+				// Program several sets and let them settle.
+				for i, m := range []IPSetMetadata{meta, meta2, meta3, meta4, meta5} {
+					ipsets.AddOrReplaceIPSet(m, []string{fmt.Sprintf("10.2.0.%d", i)})
+				}
+				apply()
+			})
+
+			It("should re-list many sets in one apply while the budget lasts", func() {
+				// Each resync advances the clock by a fifth of the budget, so
+				// the drain can afford five sets in a single apply.
+				dataplane.autoAdvance = BackgroundResyncTimeBudget / 5
+				dataplane.ListedNames = nil
+
+				resyncAndApply()
+
+				Expect(reschedRequested).To(BeFalse(), "the budget should cover all five sets")
+				Expect(len(dataplane.ListedNames)).To(Equal(5))
+			})
+
+			It("should stop the drain when the budget is exhausted", func() {
+				// Each resync costs half the budget, so only a couple of sets
+				// are re-listed before the drain stops for this apply.
+				dataplane.autoAdvance = BackgroundResyncTimeBudget / 2
+				dataplane.ListedNames = nil
+
+				ipsets.QueueResync()
+				apply()
+
+				Expect(reschedRequested).To(BeTrue(), "budget exhausted, more work pending")
+				Expect(len(dataplane.ListedNames)).To(BeNumerically("<", 5),
+					"the drain should stop before re-listing every set")
+			})
+		})
 	})
 })
 
@@ -1165,6 +1419,14 @@ var _ = DescribeTable("ParseRange tests",
 	Entry("FOO-1", "FOO-1", 0, 0, true),
 	Entry("FOO", "FOO", 0, 0, true),
 )
+
+func listCounts(names []string) map[string]int {
+	counts := map[string]int{}
+	for _, name := range names {
+		counts[name]++
+	}
+	return counts
+}
 
 type mockListener struct {
 	SeenMembers set.Typed[string]

--- a/felix/ipsets/resync_queue.go
+++ b/felix/ipsets/resync_queue.go
@@ -1,0 +1,145 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ipsets
+
+import (
+	"container/list"
+	"iter"
+	"slices"
+)
+
+// resyncPri is the priority of a queued resync.  Higher-valued priorities are
+// drained first; the ordering matters for promotion (see resyncQueue.Add).
+type resyncPri int
+
+const (
+	// resyncPriBackground sets are re-checked opportunistically, a time-boxed
+	// batch per apply loop.
+	resyncPriBackground resyncPri = iota
+	// resyncPriMust sets are re-checked before we trust the dataplane: the
+	// start-of-day resync and error-forced single-set resyncs.
+	resyncPriMust
+)
+
+// resyncQueue is a FIFO of IP set names awaiting a dataplane resync, split into
+// a "must" tier and a "background" tier.  A name appears in at most one tier at
+// a time.  Re-adding a name that is already queued keeps its original position
+// so that, even if we never fully drain between refreshes, every set still
+// reaches the front eventually; the exception is promotion, which moves a
+// background entry to the back of the must tier.
+type resyncQueue struct {
+	must       *list.List
+	background *list.List
+	entries    map[string]resyncEntry
+}
+
+type resyncEntry struct {
+	pri     resyncPri
+	element *list.Element
+}
+
+func newResyncQueue() *resyncQueue {
+	return &resyncQueue{
+		must:       list.New(),
+		background: list.New(),
+		entries:    map[string]resyncEntry{},
+	}
+}
+
+// Add queues name at the given priority.  If name is already queued at the same
+// or a higher priority its position is left unchanged.  A background entry that
+// is re-added at "must" is promoted to the back of the must tier; there is no
+// demotion.
+func (q *resyncQueue) Add(name string, pri resyncPri) {
+	existing, ok := q.entries[name]
+	if !ok {
+		q.push(name, pri)
+		return
+	}
+	if pri <= existing.pri {
+		return
+	}
+	q.listFor(existing.pri).Remove(existing.element)
+	q.push(name, pri)
+}
+
+func (q *resyncQueue) push(name string, pri resyncPri) {
+	q.entries[name] = resyncEntry{
+		pri:     pri,
+		element: q.listFor(pri).PushBack(name),
+	}
+}
+
+func (q *resyncQueue) Remove(name string) {
+	e, ok := q.entries[name]
+	if !ok {
+		return
+	}
+	q.listFor(e.pri).Remove(e.element)
+	delete(q.entries, name)
+}
+
+func (q *resyncQueue) PopMust() (string, bool) {
+	return q.pop(q.must)
+}
+
+func (q *resyncQueue) PopBackground() (string, bool) {
+	return q.pop(q.background)
+}
+
+// PopAllMust pops all the "must" items and returns an iterator over them.
+func (q *resyncQueue) PopAllMust() iter.Seq[string] {
+	var names []string
+	for {
+		name, ok := q.PopMust()
+		if !ok {
+			break
+		}
+		names = append(names, name)
+	}
+	return slices.Values(names)
+}
+
+func (q *resyncQueue) pop(l *list.List) (string, bool) {
+	front := l.Front()
+	if front == nil {
+		return "", false
+	}
+	name := front.Value.(string)
+	l.Remove(front)
+	delete(q.entries, name)
+	return name, true
+}
+
+func (q *resyncQueue) Len() int {
+	return len(q.entries)
+}
+
+func (q *resyncQueue) MustLen() int {
+	return q.must.Len()
+}
+
+func (q *resyncQueue) Clear() {
+	q.must.Init()
+	q.background.Init()
+	clear(q.entries)
+}
+
+func (q *resyncQueue) listFor(pri resyncPri) *list.List {
+	if pri == resyncPriMust {
+		return q.must
+	}
+	return q.background
+}

--- a/felix/ipsets/resync_queue_test.go
+++ b/felix/ipsets/resync_queue_test.go
@@ -1,0 +1,152 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ipsets
+
+import "testing"
+
+// drainMust pops the whole must tier into a slice, preserving pop order.
+func (q *resyncQueue) drainMust() []string {
+	var out []string
+	for {
+		name, ok := q.PopMust()
+		if !ok {
+			return out
+		}
+		out = append(out, name)
+	}
+}
+
+// drainBackground pops the whole background tier into a slice, preserving pop order.
+func (q *resyncQueue) drainBackground() []string {
+	var out []string
+	for {
+		name, ok := q.PopBackground()
+		if !ok {
+			return out
+		}
+		out = append(out, name)
+	}
+}
+
+func TestResyncQueue_FIFOPerTier(t *testing.T) {
+	q := newResyncQueue()
+	q.Add("a", resyncPriBackground)
+	q.Add("b", resyncPriBackground)
+	q.Add("c", resyncPriMust)
+	q.Add("d", resyncPriMust)
+
+	if got, want := q.Len(), 4; got != want {
+		t.Fatalf("Len() = %d, want %d", got, want)
+	}
+	if got, want := q.MustLen(), 2; got != want {
+		t.Fatalf("MustLen() = %d, want %d", got, want)
+	}
+
+	assertOrder(t, "must", q.drainMust(), "c", "d")
+	assertOrder(t, "background", q.drainBackground(), "a", "b")
+}
+
+func TestResyncQueue_DedupeKeepsPosition(t *testing.T) {
+	q := newResyncQueue()
+	q.Add("a", resyncPriBackground)
+	q.Add("b", resyncPriBackground)
+	// Re-adding a at the same priority must not move it behind b.
+	q.Add("a", resyncPriBackground)
+
+	if got, want := q.Len(), 2; got != want {
+		t.Fatalf("Len() = %d, want %d", got, want)
+	}
+	assertOrder(t, "background", q.drainBackground(), "a", "b")
+}
+
+func TestResyncQueue_PromotionMovesToMustTail(t *testing.T) {
+	q := newResyncQueue()
+	q.Add("a", resyncPriBackground)
+	q.Add("b", resyncPriBackground)
+	q.Add("x", resyncPriMust)
+	// Promote a: it should leave the background tier and land at the must tail,
+	// behind the already-queued x.
+	q.Add("a", resyncPriMust)
+
+	assertOrder(t, "must", q.drainMust(), "x", "a")
+	assertOrder(t, "background", q.drainBackground(), "b")
+}
+
+func TestResyncQueue_NoDemotion(t *testing.T) {
+	q := newResyncQueue()
+	q.Add("a", resyncPriMust)
+	// A background add of a must-tier entry is ignored.
+	q.Add("a", resyncPriBackground)
+
+	if got := q.drainBackground(); len(got) != 0 {
+		t.Fatalf("background tier = %v, want empty", got)
+	}
+	assertOrder(t, "must", q.drainMust(), "a")
+}
+
+func TestResyncQueue_Remove(t *testing.T) {
+	q := newResyncQueue()
+	q.Add("a", resyncPriBackground)
+	q.Add("b", resyncPriMust)
+	q.Remove("a")
+	q.Remove("b")
+	q.Remove("missing") // no-op
+
+	if got, want := q.Len(), 0; got != want {
+		t.Fatalf("Len() = %d, want %d", got, want)
+	}
+	if _, ok := q.PopMust(); ok {
+		t.Fatal("PopMust() returned an entry after Remove")
+	}
+	if _, ok := q.PopBackground(); ok {
+		t.Fatal("PopBackground() returned an entry after Remove")
+	}
+}
+
+func TestResyncQueue_PopOnEmpty(t *testing.T) {
+	q := newResyncQueue()
+	if name, ok := q.PopMust(); ok || name != "" {
+		t.Fatalf("PopMust() on empty = (%q, %v), want (\"\", false)", name, ok)
+	}
+	if name, ok := q.PopBackground(); ok || name != "" {
+		t.Fatalf("PopBackground() on empty = (%q, %v), want (\"\", false)", name, ok)
+	}
+}
+
+func TestResyncQueue_Clear(t *testing.T) {
+	q := newResyncQueue()
+	q.Add("a", resyncPriBackground)
+	q.Add("b", resyncPriMust)
+	q.Clear()
+
+	if got, want := q.Len(), 0; got != want {
+		t.Fatalf("Len() after Clear = %d, want %d", got, want)
+	}
+	// The queue must still be usable after a Clear.
+	q.Add("c", resyncPriMust)
+	assertOrder(t, "must", q.drainMust(), "c")
+}
+
+func assertOrder(t *testing.T, tier string, got []string, want ...string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("%s tier = %v, want %v", tier, got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("%s tier = %v, want %v", tier, got, want)
+		}
+	}
+}

--- a/felix/ipsets/utils_for_test.go
+++ b/felix/ipsets/utils_for_test.go
@@ -50,6 +50,12 @@ func newMockDataplane() *mockDataplane {
 		IPSetMembers:     make(map[string]set.Set[string]),
 		IPSetMetadata:    make(map[string]setMetadata),
 		FailDestroyNames: set.New[string](),
+		now:              time.Now(),
+		// By default, make each background resync consume the whole budget, so
+		// the background drain does exactly one set per apply.  This exercises
+		// the incremental machinery in the existing tests; budget-specific
+		// tests override autoAdvance.
+		autoAdvance: BackgroundResyncTimeBudget,
 	}
 }
 
@@ -72,8 +78,31 @@ type mockDataplane struct {
 	LinesExecuted     []string
 	AttemptedDestroys []string
 
+	// ListedNames records the set name passed to each 'ipset list <name>' call
+	// (not the 'ipset list -name' enumeration).  NumListNamesCalls counts the
+	// 'ipset list -name' enumerations.
+	ListedNames       []string
+	NumListNamesCalls int
+
+	// PostListNamesHooks are invoked (and then cleared) after an
+	// 'ipset list -name' emits its names, letting a test simulate a set being
+	// deleted in the window between listing the names and re-listing a set.
+	PostListNamesHooks []func(*mockDataplane)
+
 	CumulativeSleep time.Duration
 	numRestoreCalls int
+
+	// now and autoAdvance drive the mockable clock.  Each call to timeNow()
+	// returns the current time and advances it by autoAdvance, so a test can
+	// make each background resync "cost" a fixed, deterministic duration.
+	now         time.Time
+	autoAdvance time.Duration
+}
+
+func (d *mockDataplane) timeNow() time.Time {
+	t := d.now
+	d.now = d.now.Add(d.autoAdvance)
+	return t
 }
 
 func (d *mockDataplane) ExpectMembers(expected map[string][]string) {
@@ -533,6 +562,7 @@ type listCmd struct {
 	SetName   string
 	allIpSets bool
 	Stdout    *io.PipeWriter
+	Stderr    io.Writer
 	resultC   chan error
 }
 
@@ -540,8 +570,8 @@ func (c *listCmd) SetStdin(_ io.Reader) {
 	Fail("listNamesCmd expects no input")
 }
 
-func (c *listCmd) SetStderr(r io.Writer) {
-
+func (c *listCmd) SetStderr(w io.Writer) {
+	c.Stderr = w
 }
 
 func (c *listCmd) SetStdout(r io.Writer) {
@@ -720,15 +750,27 @@ func (c *listCmd) main() {
 	}
 
 	if c.allIpSets {
+		c.Dataplane.NumListNamesCalls++
 		for setName := range c.Dataplane.IPSetMembers {
 			fmt.Fprintf(c.Stdout, "%s\n", setName)
+		}
+		hooks := c.Dataplane.PostListNamesHooks
+		c.Dataplane.PostListNamesHooks = nil
+		for _, hook := range hooks {
+			hook(c.Dataplane)
 		}
 		return
 	}
 
+	c.Dataplane.ListedNames = append(c.Dataplane.ListedNames, c.SetName)
 	members, exists := c.Dataplane.IPSetMembers[c.SetName]
 	if !exists {
-		result = fmt.Errorf("ipset %v does not exists", c.SetName)
+		// Emit the real message the kernel produces so the production code
+		// exercises its ErrIPSetNotFound detection path.
+		if c.Stderr != nil {
+			_, _ = c.Stderr.Write([]byte("ipset v7.11: The set with the given name does not exist"))
+		}
+		result = errors.New("exit status 1")
 		return
 	}
 	meta, ok := c.Dataplane.IPSetMetadata[c.SetName]


### PR DESCRIPTION
**Cherry-pick history**
- Pick onto **release-v3.32**: projectcalico/calico#13245

Since the move from one `ipset list` dump to per-set `ipset list <name>` calls (needed for an ipset compatibility issue), the periodic IP set resync re-listed every set in a single apply loop. On nodes with many IP sets that stalls the dataplane 10x+ longer than the old whole-table dump.

This PR makes the periodic resync incremental:

- Incluides pick of #13038 to get CI working.
- When the refresh timer pops, Felix lists only the IP set **names** (one cheap exec). Sets that vanished behind Felix's back are repaired in the *same* apply (their dataplane view is cleared, so the normal create path recreates them); unexpected sets are queued for discovery and deletion.
- The surviving sets' contents are re-checked from a new two-tier dedup queue, drained a time-boxed batch (100ms) per apply loop, paced by the same ≤100ms reschedule already used for rate-limited deletions.
- **Must** entries (start-of-day resync, sets implicated in a failed write) are drained fully before Felix trusts the dataplane — start-of-day behaviour is unchanged. **Background** entries (timer-driven) spread over apply loops. Re-adding a queued set keeps its position, so every set eventually reaches the front even if the queue never fully drains between refreshes; a failed write promotes a background entry to must.
- `resyncIPSet` now tolerates the set being deleted between the name listing and the per-set list (kernel's "set does not exist" is detected and treated as "repair via create"). Previously this recorded `ListFailed` metadata for a nonexistent set, triggering a doomed temp-set-swap retry loop.

No change to the `IPSetsDataplane` interface; nftables, BPF and Windows implementations are untouched. `felix/design/dataplane.md` is updated with the new semantics and review invariants.

CORE-11437
CORE-13157

Testing:
- New unit tests: queue semantics (dedupe/promotion/removal), incremental drain across applies, time-budget behaviour, missing-set races, and a regression test for a resync-loop spin found during development.
- New FV: `_IPSets_ periodic resync repairs dataplane drift` — externally corrupts programmed IP sets (`ipset add` / `ipset flush`) and asserts the periodic resync repairs them. Passed locally, along with the existing "thousands of IP sets flapping" FV.

**Release note:**
```release-note
Felix: periodic IP set resyncs are now incremental, avoiding dataplane stalls on nodes with many IP sets.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

