### PR TITLE
ci: diagnose and tolerate slow VM host-key publication

### DIFF
--- a/.semaphore/vms/configure-test-vm
+++ b/.semaphore/vms/configure-test-vm
@@ -23,17 +23,21 @@ zone=${ZONE:-europe-west3-c}
 project=${GCP_PROJECT:-unique-caldron-775}
 
 vm_pub_key=""
-for attempt in $(seq 1 20); do
+# The host key is published to guest attributes by GCP's guest agent early in
+# boot.  Wait up to ~2min: a cold-booting VM occasionally takes longer than the
+# old ~40s budget to get that far, especially now that VMs are spread across the
+# region's zones (see run-tests-on-vms).
+for attempt in $(seq 1 30); do
   echo "Getting VM ssh key (attempt $attempt)..."
   vm_pub_key=$(gcloud compute instances get-guest-attributes "${vm_name}" --zone="${zone}" --query-path="hostkeys/ssh-ed25519" --format='value(value)') || {
     echo "Failed to get VM ssh key, retrying..."
-    sleep 1
+    sleep 3
     continue
   }
   echo "VM SSH host key: $vm_pub_key"
   if [[ -z "$vm_pub_key" ]]; then
     echo "Empty key, retrying..."
-    sleep 1
+    sleep 3
     continue
   fi
 
@@ -42,6 +46,10 @@ done
 
 if [[ -z "$vm_pub_key" ]]; then
   echo "Failed to get VM ssh key after multiple attempts, exiting."
+  # The guest agent never published the host key, so the VM likely never
+  # finished booting.  Grab the serial console so the failure is diagnosable.
+  echo "Fetching serial console output for debugging:"
+  gcloud compute --project="$project" instances get-serial-port-output "$vm_name" --zone="$zone" --port=1 || true
   exit 22
 fi
 


### PR DESCRIPTION
## Description

CI test-VM setup (`configure-test-vm`) reads the VM's SSH host key from GCP
guest attributes, which the guest agent publishes early in boot. On a slow cold
boot the key occasionally does not appear within the old budget (20 tries, 1s
apart, ~40s), so setup gives up with `exit 22`. This became more likely once VMs
were spread across the region's zones (#13038, which can land a VM in a
slower-booting zone).

A recent 26.04 UT run hit this on its single VM; the host key never appeared and
the job failed at configuration. The concurrent 26.04 jitharden job (same image,
17 VMs) passed, which points to a transient per-VM boot flake rather than an
image problem.

Two changes to `configure-test-vm`:

- **Extend the wait to ~2min** (30 tries, 3s apart) to ride out a slow cold boot.
- **Capture the serial console on timeout.** Previously only the
  startup-script-timeout path (`exit 23`) fetched serial output; the
  host-key-timeout path (`exit 22`) exited blind, so we couldn't tell *why* the
  key never appeared. Now both paths dump the console.

No product code changes; CI scripting only.

## Release Note

```release-note
None
```