### PR TITLE
calicoctl: make node diags work without docker

### DIFF
--- a/calicoctl/calicoctl/commands/node/diags.go
+++ b/calicoctl/calicoctl/commands/node/diags.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2017 Tigera, Inc. All rights reserved.
+// Copyright (c) 2016-2026 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -35,6 +35,11 @@ type diagCmd struct {
 	filename string
 }
 
+// containerRuntimes is the preference order for tooling that can run or inspect
+// containers on a node. Modern Kubernetes nodes typically only have crictl
+// (containerd/CRI-O); docker-based installs still have docker.
+var containerRuntimes = []string{"docker", "nerdctl", "crictl"}
+
 // Diags gathers diagnostic information and logs from a Calico node, reading
 // logs from logDir.
 func Diags(logDir string) error {
@@ -56,7 +61,6 @@ func runDiags(logDir string) error {
 		{"Dumping iptables (IPv4)", "iptables-save -c", "ipv4_tables"},
 		{"Dumping iptables (IPv6)", "ip6tables-save -c", "ipv6_tables"},
 		{"Dumping ipsets", "ipset list", "ipsets"},
-		{"Dumping ipsets (container)", "docker run --rm --privileged --net=host calico/node ipset list", "ipset_container"},
 		{"Copying journal for calico-node.service", "journalctl -u calico-node.service --no-pager", "journalctl_calico_node"},
 		{"Dumping felix stats", "pkill -SIGUSR1 felix", ""},
 	}
@@ -104,6 +108,15 @@ func runDiags(logDir string) error {
 		cmds = append(cmds, ssCmd)
 	}
 
+	// Prefer host `ipset list`, then also try via a container runtime so the
+	// dump still works when the host lacks the ipset binary (common on k8s
+	// nodes that only have containerd/CRI-O tooling).
+	if ipsetCmd, err := containerIpsetCmd(); err == nil {
+		cmds = append(cmds, diagCmd{"Dumping ipsets (container)", ipsetCmd, "ipset_container"})
+	} else {
+		fmt.Printf("Skipping container ipset dump: %v\n", err)
+	}
+
 	for _, v := range cmds {
 		_ = writeDiags(v, diagsTmpDir)
 	}
@@ -145,6 +158,62 @@ func runDiags(logDir string) error {
 	return nil
 }
 
+// findContainerRuntime returns the first supported container CLI found in PATH.
+// lookPath is injected so unit tests can simulate different environments.
+func findContainerRuntime(lookPath func(string) (string, error)) string {
+	if lookPath == nil {
+		lookPath = exec.LookPath
+	}
+	for _, name := range containerRuntimes {
+		if _, err := lookPath(name); err == nil {
+			return name
+		}
+	}
+	return ""
+}
+
+// containerIpsetCmd builds a command that runs `ipset list` in a privileged
+// calico/node context. Docker and nerdctl start an ephemeral container; crictl
+// execs into the already-running calico-node (which is privileged + host net).
+func containerIpsetCmd() (string, error) {
+	return containerIpsetCmdFor(findContainerRuntime(nil), crictlFindContainer)
+}
+
+// containerIpsetCmdFor is the testable core of containerIpsetCmd.
+func containerIpsetCmdFor(runtime string, findCrictlContainer func(name string) (string, error)) (string, error) {
+	switch runtime {
+	case "docker", "nerdctl":
+		return runtime + " run --rm --privileged --net=host calico/node ipset list", nil
+	case "crictl":
+		id, err := findCrictlContainer("calico-node")
+		if err != nil {
+			return "", fmt.Errorf("crictl: %w", err)
+		}
+		return "crictl exec " + id + " ipset list", nil
+	default:
+		return "", fmt.Errorf("no supported container runtime found in PATH (tried %s)", strings.Join(containerRuntimes, ", "))
+	}
+}
+
+// crictlFindContainer returns the first container ID whose name matches name.
+func crictlFindContainer(name string) (string, error) {
+	// Prefer running containers, then fall back to -a.
+	for _, args := range [][]string{
+		{"ps", "--name", name, "-q"},
+		{"ps", "-a", "--name", name, "-q"},
+	} {
+		out, err := exec.Command("crictl", args...).CombinedOutput()
+		if err != nil {
+			return "", fmt.Errorf("crictl %s failed: %v: %s", strings.Join(args, " "), err, strings.TrimSpace(string(out)))
+		}
+		ids := strings.Fields(string(out))
+		if len(ids) > 0 {
+			return ids[0], nil
+		}
+	}
+	return "", fmt.Errorf("no container matching %q found", name)
+}
+
 // getNodeContainerLogs will attempt to grab logs for any "calico" named containers for hosted installs.
 func getNodeContainerLogs(logDir string) {
 	err := os.MkdirAll(logDir, os.ModeDir)
@@ -153,10 +222,23 @@ func getNodeContainerLogs(logDir string) {
 		return
 	}
 
+	runtime := findContainerRuntime(nil)
+	switch runtime {
+	case "docker", "nerdctl":
+		getDockerStyleContainerLogs(runtime, logDir)
+	case "crictl":
+		getCrictlContainerLogs(logDir)
+	default:
+		fmt.Printf("Could not collect container logs: no container runtime found (tried %s)\n", strings.Join(containerRuntimes, ", "))
+	}
+}
+
+// getDockerStyleContainerLogs copies logs using docker or nerdctl (compatible CLIs).
+func getDockerStyleContainerLogs(cli, logDir string) {
 	// Get a list of Calico containers running on this Node.
-	result, err := exec.Command("docker", "ps", "-a", "--filter", "name=calico", "--format", "{{.Names}}: {{.CreatedAt}}").CombinedOutput()
+	result, err := exec.Command(cli, "ps", "-a", "--filter", "name=calico", "--format", "{{.Names}}: {{.CreatedAt}}").CombinedOutput()
 	if err != nil {
-		fmt.Printf("Could not run docker command: %s\n", string(result))
+		fmt.Printf("Could not run %s command: %s\n", cli, string(result))
 		return
 	}
 
@@ -170,10 +252,10 @@ func getNodeContainerLogs(logDir string) {
 	re := regexp.MustCompile("(?m)[\r\n]+^.*k8s_POD.*$")
 	containers := re.ReplaceAllString(string(result), "")
 
-	fmt.Println("Copying logs from Calico containers")
+	fmt.Printf("Copying logs from Calico containers (%s)\n", cli)
 	err = os.WriteFile(logDir+"/"+"container_creation_time", []byte(containers), 0o666)
 	if err != nil {
-		fmt.Printf("Could not save output of `docker ps` command to container_creation_time: %s\n", err)
+		fmt.Printf("Could not save output of `%s ps` command to container_creation_time: %s\n", cli, err)
 	}
 
 	// Grab the log for each container and write it as <containerName>.log.
@@ -181,7 +263,7 @@ func getNodeContainerLogs(logDir string) {
 	for scanner.Scan() {
 		name := strings.Split(scanner.Text(), ":")[0]
 		log.Debugf("Getting logs for container %s", name)
-		cLog, err := exec.Command("docker", "logs", name).CombinedOutput()
+		cLog, err := exec.Command(cli, "logs", name).CombinedOutput()
 		if err != nil {
 			fmt.Printf("Could not pull log for container %s: %s\n", name, err)
 			continue
@@ -189,6 +271,38 @@ func getNodeContainerLogs(logDir string) {
 		err = os.WriteFile(logDir+"/"+name+".log", cLog, 0o666)
 		if err != nil {
 			fmt.Printf("Failed to write log for container %s to file: %s\n", name, err)
+		}
+	}
+}
+
+// getCrictlContainerLogs copies logs for calico containers via crictl (containerd/CRI-O).
+func getCrictlContainerLogs(logDir string) {
+	// --name does a substring match on the container name (e.g. calico-node).
+	idsOut, err := exec.Command("crictl", "ps", "-a", "--name", "calico", "-q").CombinedOutput()
+	if err != nil {
+		fmt.Printf("Could not run crictl command: %s\n", strings.TrimSpace(string(idsOut)))
+		return
+	}
+	ids := strings.Fields(string(idsOut))
+	if len(ids) == 0 {
+		log.Debug("Did not find any Calico containers via crictl")
+		return
+	}
+
+	fmt.Println("Copying logs from Calico containers (crictl)")
+	if err := os.WriteFile(logDir+"/container_creation_time", []byte(strings.Join(ids, "\n")+"\n"), 0o666); err != nil {
+		fmt.Printf("Could not save container list to container_creation_time: %s\n", err)
+	}
+
+	for _, id := range ids {
+		log.Debugf("Getting logs for container %s", id)
+		cLog, err := exec.Command("crictl", "logs", id).CombinedOutput()
+		if err != nil {
+			fmt.Printf("Could not pull log for container %s: %s\n", id, err)
+			continue
+		}
+		if err := os.WriteFile(logDir+"/"+id+".log", cLog, 0o666); err != nil {
+			fmt.Printf("Failed to write log for container %s to file: %s\n", id, err)
 		}
 	}
 }

--- a/calicoctl/calicoctl/commands/node/diags_test.go
+++ b/calicoctl/calicoctl/commands/node/diags_test.go
@@ -1,0 +1,78 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package node
+
+import (
+	"errors"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("container runtime detection for node diags", func() {
+	DescribeTable("findContainerRuntime",
+		func(available []string, want string) {
+			lookPath := func(name string) (string, error) {
+				for _, a := range available {
+					if a == name {
+						return "/usr/bin/" + name, nil
+					}
+				}
+				return "", errors.New("not found")
+			}
+			Expect(findContainerRuntime(lookPath)).To(Equal(want))
+		},
+		Entry("prefers docker when present", []string{"docker", "nerdctl", "crictl"}, "docker"),
+		Entry("uses nerdctl when docker missing", []string{"nerdctl", "crictl"}, "nerdctl"),
+		Entry("uses crictl on containerd-only nodes", []string{"crictl"}, "crictl"),
+		Entry("empty when nothing available", []string{}, ""),
+		Entry("ignores unrelated binaries", []string{"kubectl", "ctr"}, ""),
+	)
+
+	DescribeTable("containerIpsetCmdFor",
+		func(runtime string, findErr error, wantCmd string, wantErrSubstr string) {
+			find := func(name string) (string, error) {
+				Expect(name).To(Equal("calico-node"))
+				if findErr != nil {
+					return "", findErr
+				}
+				return "abc123def", nil
+			}
+			cmd, err := containerIpsetCmdFor(runtime, find)
+			if wantErrSubstr != "" {
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring(wantErrSubstr))
+				Expect(cmd).To(Equal(""))
+				return
+			}
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cmd).To(Equal(wantCmd))
+		},
+		Entry("docker run", "docker", nil,
+			"docker run --rm --privileged --net=host calico/node ipset list", ""),
+		Entry("nerdctl run", "nerdctl", nil,
+			"nerdctl run --rm --privileged --net=host calico/node ipset list", ""),
+		Entry("crictl exec into calico-node", "crictl", nil,
+			"crictl exec abc123def ipset list", ""),
+		Entry("crictl missing container", "crictl", errors.New("no container matching \"calico-node\" found"),
+			"", "crictl"),
+		Entry("no runtime", "", nil,
+			"", "no supported container runtime"),
+	)
+
+	It("containerRuntimes preference order is docker, nerdctl, crictl", func() {
+		Expect(containerRuntimes).To(Equal([]string{"docker", "nerdctl", "crictl"}))
+	})
+})


### PR DESCRIPTION
## Description

`calicoctl node diags` previously hard-coded `docker run` / `docker logs` for the container ipset dump and hosted-install log collection. On modern Kubernetes nodes (containerd/CRI-O) docker is usually not installed, so those steps always failed (see #5637).

This change detects a supported container CLI in PATH, in order:

1. **docker** – existing behaviour for docker-based installs
2. **nerdctl** – docker-compatible CLI for containerd
3. **crictl** – typical on kubeadm/k8s nodes; runs `ipset list` via `crictl exec` into the already-privileged `calico-node` container, and collects logs with `crictl logs`

If none of those tools are present, the container steps are skipped with a clear message instead of a hard docker failure.

## Related issues

Fixes #5637

## Release note

```release-note
calicoctl node diags now works on containerd/CRI-O nodes via crictl/nerdctl when docker is not installed
```

## Testing

- Unit tests for runtime detection and command construction: `go test ./calicoctl/calicoctl/commands/node/`