### PR TITLE
felix: gate FIB-lookup ext-to-service mark on EXT_LOCAL flag

### DIFF
--- a/felix/bpf-gpl/fib_co_re.h
+++ b/felix/bpf-gpl/fib_co_re.h
@@ -211,8 +211,17 @@ skip_redir_ifindex:
 				.l4_protocol = state->ip_proto,
 			};
 
+			/* Only reply traffic of an external client hitting a local
+			 * service must carry EXT_TO_SVC_MARK into the FIB lookup so
+			 * the RPDB routes it back the way the request arrived. For
+			 * ordinary pod-originated egress the mark must stay 0 so a
+			 * host source-based routing rule (e.g. AWS VPC CNI's per-pod
+			 * rule) selects the pod's own interface. */
 			if (bpf_core_field_exists(((struct bpf_fib_lookup *)0)->mark)) {
-				fib_params(ctx)->mark = EXT_TO_SVC_MARK;
+				if (CALI_F_FROM_WEP && EXT_TO_SVC_MARK &&
+						(state->ct_result.flags & CALI_CT_FLAG_EXT_LOCAL)) {
+					fib_params(ctx)->mark = EXT_TO_SVC_MARK;
+				}
 			}
 
 #ifdef IPVER6
@@ -383,9 +392,15 @@ try_fib_external:
 			.l4_protocol = state->ip_proto,
 		};
 
+		/* See the note above the matching guard in the local-dest path:
+		 * only external-client-to-local-service reply traffic gets the
+		 * mark; ordinary pod egress leaves it 0 for host source routing. */
 		if (bpf_core_field_exists(((struct bpf_fib_lookup *)0)->mark)) {
-			fib_params(ctx)->mark = EXT_TO_SVC_MARK;
-			CALI_DEBUG("FIB mark=0x%d", fib_params(ctx)->mark);
+			if (CALI_F_FROM_WEP && EXT_TO_SVC_MARK &&
+					(state->ct_result.flags & CALI_CT_FLAG_EXT_LOCAL)) {
+				fib_params(ctx)->mark = EXT_TO_SVC_MARK;
+				CALI_DEBUG("FIB mark=0x%x", fib_params(ctx)->mark);
+			}
 		}
 
 		if (state->ip_proto != IPPROTO_ICMP_46) {

--- a/felix/fv/bpf_multi_home_test.go
+++ b/felix/fv/bpf_multi_home_test.go
@@ -234,5 +234,59 @@ func describeBPFMultiHomedTests() bool {
 			Eventually(dump30.MatchCountFn("eth30-ingress"), "5s", "330ms").Should(BeNumerically("==", 1))
 			Eventually(dump20.MatchCountFn("eth20-egress"), "5s", "330ms").Should(BeNumerically("==", 1))
 		})
+
+		It("should not stamp the ext-to-service connmark on ordinary pod egress", func() {
+			// A node using source-based routing (e.g. AWS VPC CNI) gives
+			// each pod a source rule that selects the interface owning the
+			// pod's IP, and a higher-priority fwmark rule that sends traffic
+			// marked with the ext-to-service connmark out of the primary
+			// interface. Ordinary pod-originated egress must not carry that
+			// mark, otherwise the fwmark rule hijacks it onto the wrong
+			// interface. Here eth20 owns the pod's IP and eth30 stands in for
+			// the primary interface; the packet must leave via eth20.
+			var err error
+
+			Felix.Exec("ip", "addr", "add", "192.168.20.20/24", "dev", "eth20")
+			Felix.Exec("ip", "addr", "add", "192.168.30.30/24", "dev", "eth30")
+
+			Felix.Exec("bash", "-c", "echo 200 pod_eni >> /etc/iproute2/rt_tables")
+			Felix.Exec("bash", "-c", "echo 201 primary_eni >> /etc/iproute2/rt_tables")
+
+			// Pod's own interface, selected by the pod's source IP.
+			Felix.Exec("ip", "route", "add", "10.65.1.0/24", "dev", "eth20", "table", "pod_eni")
+			Felix.Exec("ip", "rule", "add", "from", w.IP, "table", "pod_eni", "priority", "1536")
+
+			// Primary interface, selected by the ext-to-service connmark and
+			// at a higher priority than the pod source rule.
+			Felix.Exec("ip", "route", "add", "10.65.1.0/24", "dev", "eth30", "table", "primary_eni")
+			Felix.Exec("ip", "rule", "add", "fwmark", "0x80/0x80", "table", "primary_eni", "priority", "1024")
+
+			Felix.Exec("ip", "route", "flush", "cache")
+			Felix.Exec("ip", "neigh", "add", "10.65.1.3", "lladdr", "ee:ee:ee:ee:ee:ee", "dev", "eth20")
+			Felix.Exec("ip", "neigh", "add", "10.65.1.3", "lladdr", "ee:ee:ee:ee:ee:ee", "dev", "eth30")
+
+			dump20 := Felix.AttachTCPDump("eth20")
+			dump20.SetLogEnabled(true)
+			dump20.AddMatcher("eth20-egress", regexp.MustCompile("10.65.0.2.30444 > 10.65.1.3.30444: UDP"))
+			dump20.Start(infra, "-v", "udp", "and", "dst", "host", "10.65.1.3")
+
+			dump30 := Felix.AttachTCPDump("eth30")
+			dump30.SetLogEnabled(true)
+			dump30.AddMatcher("eth30-egress", regexp.MustCompile("10.65.0.2.30444 > 10.65.1.3.30444: UDP"))
+			dump30.Start(infra, "-v", "udp", "and", "dst", "host", "10.65.1.3")
+
+			By("Sending packets from the workload")
+			_, err = w.RunCmd("pktgen", w.IP, "10.65.1.3", "udp", "--ip-id", "1",
+				"--port-src", "30444", "--port-dst", "30444")
+			Expect(err).NotTo(HaveOccurred())
+			_, err = w.RunCmd("pktgen", w.IP, "10.65.1.3", "udp", "--ip-id", "2",
+				"--port-src", "30444", "--port-dst", "30444")
+			Expect(err).NotTo(HaveOccurred())
+
+			// The pod source rule must win: traffic leaves via eth20 and
+			// never via the fwmark-selected eth30.
+			Eventually(dump20.MatchCountFn("eth20-egress"), "5s", "330ms").Should(BeNumerically("==", 2))
+			Consistently(dump30.MatchCountFn("eth30-egress"), "1s", "330ms").Should(BeNumerically("==", 0))
+		})
 	})
 }


### PR DESCRIPTION
## Description

The BPF dataplane passes `EXT_TO_SVC_MARK` (the ext-to-service connmark, `bpfExtToServiceConnmark`, default `0x80`) to `bpf_fib_lookup` via `BPF_FIB_LOOKUP_MARK` on kernel 6.10+, so that reply traffic of an *external client hitting a local service* is routed back the way the request arrived. Since #11665 that mark was set **unconditionally** for all non-egress-gateway pod egress, not only for external-to-local-service replies.

On a node that uses source-based routing (e.g. AWS VPC CNI), each pod gets a source rule that selects the interface owning the pod's IP, plus a *higher-priority* rule that sends traffic carrying the ext-to-service connmark out of the primary interface:

```
1024:  from all fwmark 0x80/0x80 lookup <primary-eni-table>
1536:  from <podIP>          lookup <pod-eni-table>
```

With the mark stamped on ordinary pod egress, the higher-priority `fwmark` rule (1024) outranks the per-pod source rule (1536), so a pod whose IP lives on a secondary interface egresses the *primary* interface. The cloud fabric then drops the packet because the source IP does not belong to that interface. Cross-node UDP — notably DNS to the kube-dns ClusterIP — from such pods times out. This did not happen before #11665 because the FIB lookup carried no mark, so the source rule won.

## Fix

Gate the FIB-lookup mark on `CALI_F_FROM_WEP && EXT_TO_SVC_MARK && CALI_CT_FLAG_EXT_LOCAL` at both lookup sites in `fib_co_re.h`, matching the already-correct skb-mark path and the pre-6.10 `skip_fib` fallback. Ordinary pod egress now leaves the mark at 0 and the pod's own source rule selects its interface. The legitimate external-client-to-local-service reply path still carries the mark.

## Test

New FV in the BPF multi-homed suite (`felix/fv/bpf_multi_home_test.go`): with a pod source rule and a higher-priority ext-to-service `fwmark` rule pointing at different interfaces, ordinary pod egress must leave via the pod's own interface. Verified it **fails on the pre-fix code** (egress hijacked to the wrong interface, count 0) and **passes with the fix**; the existing "route external traffic marked with connmark correctly" test (the legitimate mark path) still passes. `TestPrecompiledBinariesAreLoadable` verifier gate passes.

Regression from #11665.

## Release Note

```release-note
Fixed a regression in the eBPF dataplane where pod-originated egress could be routed out the wrong interface on nodes using source-based routing (e.g. AWS VPC CNI), because the ext-to-service connmark was applied to the FIB lookup for all pod egress instead of only external-client-to-local-service reply traffic.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)