### PR TITLE
Use bapi.BackendAccessor instead of ad-hoc accessor interfaces

### DIFF
--- a/apiserver/pkg/apiserver/apiserver.go
+++ b/apiserver/pkg/apiserver/apiserver.go
@@ -114,7 +114,7 @@ func (c completedConfig) New() (*ProjectCalicoServer, error) {
 	calicostore := calicorest.RESTStorageProvider{StorageType: "calico"}
 
 	// Create a backend Calico v3 clientset.
-	cc := calico.CreateClientFromConfig().(backendClient).Backend()
+	cc := calico.CreateClientFromConfig().(api.BackendAccessor).Backend()
 
 	// Create the various lister and getters required by the RBAC calculator. Note that we use an informer/cache for the
 	// k8s resources to minimize the number of queries underpinning a single request. For the Calico resources we
@@ -291,10 +291,6 @@ func (t *calicoResourceLister) OnUpdates(updates []api.Update) {
 			}
 		}
 	}
-}
-
-type backendClient interface {
-	Backend() api.Client
 }
 
 // install registers the API group and adds types to a scheme

--- a/calicoctl/calicoctl/commands/clientmgr/client.go
+++ b/calicoctl/calicoctl/commands/clientmgr/client.go
@@ -85,10 +85,7 @@ func GetClients(cf string) (kubeClient kubernetes.Interface, calicoClient client
 	}
 
 	// Get the backend client.
-	type accessor interface {
-		Backend() bapi.Client
-	}
-	bc = calicoClient.(accessor).Backend()
+	bc = calicoClient.(bapi.BackendAccessor).Backend()
 
 	// Get a kube-client. If this is a kdd cluster, we can pull this from the backend.
 	// Otherwise, we need to build one ourselves.

--- a/calicoctl/calicoctl/commands/datastore/migrate/migrateipam.go
+++ b/calicoctl/calicoctl/commands/datastore/migrate/migrateipam.go
@@ -77,10 +77,7 @@ type ipamResults struct {
 }
 
 func NewMigrateIPAM(c client.Interface) *migrateIPAM {
-	type accessor interface {
-		Backend() bapi.Client
-	}
-	bc := c.(accessor).Backend()
+	bc := c.(bapi.BackendAccessor).Backend()
 	return &migrateIPAM{
 		client: bc,
 	}

--- a/calicoctl/calicoctl/commands/ipam/check.go
+++ b/calicoctl/calicoctl/commands/ipam/check.go
@@ -94,10 +94,7 @@ Description:
 	}
 
 	// Get the backend client.
-	type accessor interface {
-		Backend() bapi.Client
-	}
-	bc := client.(accessor).Backend()
+	bc := client.(bapi.BackendAccessor).Backend()
 
 	// Get a kube-client. If this is a kdd cluster, we can pull this from the backend.
 	// Otherwise, we need to build one ourselves.

--- a/calicoctl/calicoctl/commands/ipam/release.go
+++ b/calicoctl/calicoctl/commands/ipam/release.go
@@ -282,11 +282,8 @@ func releaseHandles(notInUseHandles map[string]HandleInfo, c clientv3.Interface)
 	fmt.Printf("Deleting %d handles...\n", len(notInUseHandles))
 	fmt.Println("Key: '.' = Deleted OK; 'x' = skip, handle missing/changed.")
 	// Get the backend client.
-	type accessor interface {
-		Backend() bapi.Client
-	}
 	var numReleased, numConflict, numErrors int
-	bc := c.(accessor).Backend()
+	bc := c.(bapi.BackendAccessor).Backend()
 
 	type result struct {
 		Handle HandleInfo

--- a/calicoctl/calicoctl/commands/ipam/show.go
+++ b/calicoctl/calicoctl/commands/ipam/show.go
@@ -325,10 +325,7 @@ Description:
 	ippoolClient := client.IPPools()
 
 	// Get the backend client.
-	type accessor interface {
-		Backend() bapi.Client
-	}
-	bc := client.(accessor).Backend()
+	bc := client.(bapi.BackendAccessor).Backend()
 
 	passedIP := parsedArgs["--ip"]
 	showBlocks := parsedArgs["--show-blocks"].(bool)

--- a/calicoctl/calicoctl/commands/ipam_command.go
+++ b/calicoctl/calicoctl/commands/ipam_command.go
@@ -71,10 +71,7 @@ func newIPAMCheckCommand() *cobra.Command {
 				return err
 			}
 
-			type accessor interface {
-				Backend() bapi.Client
-			}
-			bc := client.(accessor).Backend()
+			bc := client.(bapi.BackendAccessor).Backend()
 
 			var kubeClient kubernetes.Interface
 			if kc, ok := bc.(*k8s.KubeClient); ok {
@@ -198,10 +195,7 @@ func newIPAMShowCommand() *cobra.Command {
 			ipamClient := client.IPAM()
 			ippoolClient := client.IPPools()
 
-			type accessor interface {
-				Backend() bapi.Client
-			}
-			bc := client.(accessor).Backend()
+			bc := client.(bapi.BackendAccessor).Backend()
 
 			if ip != "" {
 				return ipam.ShowIP(ctx, ipamClient, ip)

--- a/calicoctl/tests/fv/ipam_test.go
+++ b/calicoctl/tests/fv/ipam_test.go
@@ -240,10 +240,7 @@ func TestIPAMCleanup(t *testing.T) {
 		Expect(err).NotTo(HaveOccurred())
 
 		// Make a raw, leaked handle for IPAM check to find.
-		type accessor interface {
-			Backend() bapi.Client
-		}
-		bc := client.(accessor).Backend()
+		bc := client.(bapi.BackendAccessor).Backend()
 		createLeakedHandle := func() *model.KVPair {
 			kv, err := bc.Create(ctx, &model.KVPair{
 				Key: model.IPAMHandleKey{
@@ -317,10 +314,7 @@ func TestIPAMCleanup(t *testing.T) {
 }
 
 func createNodeForLocalhost(t *testing.T, ctx context.Context, client clientv3.Interface) (cleanup func()) {
-	type accessor interface {
-		Backend() bapi.Client
-	}
-	bc := client.(accessor).Backend()
+	bc := client.(bapi.BackendAccessor).Backend()
 	nodeName, err := os.Hostname()
 	if k8sClient, ok := bc.(*k8s.KubeClient); ok {
 		t.Log("Creating Kubernetes Node")

--- a/calicoctl/tests/fv/utils/datastore.go
+++ b/calicoctl/tests/fv/utils/datastore.go
@@ -35,9 +35,7 @@ func RunDatastoreTest(t *testing.T, testFn func(t *testing.T, kdd bool, client c
 		client, err := clientv3.New(*config)
 		Expect(err).NotTo(HaveOccurred())
 		defer func() {
-			err := client.(interface {
-				Backend() bapi.Client
-			}).Backend().Clean()
+			err := client.(bapi.BackendAccessor).Backend().Clean()
 			Expect(err).NotTo(HaveOccurred())
 		}()
 		testFn(t, false, client)
@@ -58,9 +56,7 @@ func RunDatastoreTest(t *testing.T, testFn func(t *testing.T, kdd bool, client c
 		client, err := clientv3.New(*config)
 		Expect(err).NotTo(HaveOccurred())
 		defer func() {
-			err := client.(interface {
-				Backend() bapi.Client
-			}).Backend().Clean()
+			err := client.(bapi.BackendAccessor).Backend().Clean()
 			Expect(err).NotTo(HaveOccurred())
 		}()
 		testFn(t, true, client)

--- a/cni-plugin/pkg/upgrade/migrate.go
+++ b/cni-plugin/pkg/upgrade/migrate.go
@@ -48,13 +48,9 @@ var binariesToDisable = []string{
 	"/host/opt/cni/bin/host-local",
 }
 
-type accessor interface {
-	Backend() bapi.Client
-}
-
 func Migrate(ctxt context.Context, c client.Interface, nodename string) error {
 	// k8sClient directly calls the k8s apiserver.
-	k8sClient := c.(accessor).Backend().(*k8s.KubeClient).ClientSet
+	k8sClient := c.(bapi.BackendAccessor).Backend().(*k8s.KubeClient).ClientSet
 
 	// Check to see if the system is still using host-local
 	// by checking the existence of the path.

--- a/confd/pkg/backends/calico/client.go
+++ b/confd/pkg/backends/calico/client.go
@@ -75,11 +75,6 @@ var (
 	largeCommunity          = regexp.MustCompile(`^(\d+):(\d+):(\d+)$`)
 )
 
-// backendClientAccessor is an interface to access the backend client from the main v2 client.
-type backendClientAccessor interface {
-	Backend() api.Client
-}
-
 func NewRouteIndex() *RouteIndex {
 	return &RouteIndex{
 		programmedRoutes:       make(map[string]bool),
@@ -114,7 +109,7 @@ func NewCalicoClient(cc clientv3.Interface, k8sClient kubernetes.Interface, data
 	}
 
 	// Extract the backend client from the v3 client.
-	bc := cc.(backendClientAccessor).Backend()
+	bc := cc.(api.BackendAccessor).Backend()
 
 	// The node label manager tracks node labels for components to use when calculating
 	// node selectors, etc.

--- a/confd/tests/helpers_test.go
+++ b/confd/tests/helpers_test.go
@@ -658,10 +658,7 @@ func createBlockAffinities(t *testing.T, be *datastoreBackend) func() {
 	if be.datastoreType == apiconfig.EtcdV3 {
 		// In etcd mode, write raw v2 IPAM block entries that the confd syncer watches.
 		// These match the format in mock_data/etcd/block.
-		type backendAccessor interface {
-			Backend() backendapi.Client
-		}
-		bc := be.calicoClient.(backendAccessor).Backend()
+		bc := be.calicoClient.(backendapi.BackendAccessor).Backend()
 		for _, a := range standardBlockAffinities {
 			_, err := bc.Apply(ctx, &model.KVPair{
 				Key: model.BlockAffinityKey{

--- a/felix/daemon/daemon.go
+++ b/felix/daemon/daemon.go
@@ -222,7 +222,7 @@ configRetry:
 		}
 		log.Info("Created datastore client")
 		numClientsCreated++
-		backendClient = v3Client.(interface{ Backend() bapi.Client }).Backend()
+		backendClient = v3Client.(bapi.BackendAccessor).Backend()
 		for {
 			globalConfig, selectorConfig, hostConfig, err := loadConfigFromDatastore(
 				ctx, backendClient, datastoreConfig, configParams.FelixHostname)

--- a/felix/fv/infrastructure/infra_k8s.go
+++ b/felix/fv/infrastructure/infra_k8s.go
@@ -689,7 +689,7 @@ func (kds *K8sDatastoreInfra) CleanUp() {
 
 func cleanupIPAM(clientset *kubernetes.Clientset, calicoClient client.Interface) {
 	log.Info("Cleaning up IPAM")
-	c := calicoClient.(interface{ Backend() bapi.Client }).Backend()
+	c := calicoClient.(bapi.BackendAccessor).Backend()
 	for _, li := range []model.ListInterface{
 		model.BlockListOptions{},
 		model.BlockAffinityListOptions{},

--- a/felix/fv/status_report_test.go
+++ b/felix/fv/status_report_test.go
@@ -69,7 +69,7 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ openstack status-reporting"
 			By(fmt.Sprintf("listing workload endpoint statuses {%+v}", wlListOpts))
 
 			c := infra.GetCalicoClient()
-			backendClient := c.(interface{ Backend() bapi.Client }).Backend()
+			backendClient := c.(bapi.BackendAccessor).Backend()
 			statuses, err := backendClient.List(context.Background(), wlListOpts, "")
 			Expect(err).NotTo(HaveOccurred(), "Couldn't list workload endpoint statuses")
 

--- a/kube-controllers/pkg/controllers/flannelmigration/flannel_migration_fv_test.go
+++ b/kube-controllers/pkg/controllers/flannelmigration/flannel_migration_fv_test.go
@@ -110,11 +110,8 @@ var _ = Describe("flannel-migration-controller FV test", Ordered, ContinueOnFail
 		testutils.ApplyCRDs(apiserver)
 
 		// Make a Calico client and backend client.
-		type accessor interface {
-			Backend() backend.Client
-		}
 		calicoClient = testutils.GetCalicoClient(apiconfig.Kubernetes, "", kconfigfile)
-		bc = calicoClient.(accessor).Backend()
+		bc = calicoClient.(backend.BackendAccessor).Backend()
 
 		// Run controller manager.
 		controllerManager = testutils.RunK8sControllerManager(apiserver.IP)

--- a/kube-controllers/pkg/controllers/networkpolicy/policy_name_migrator_test.go
+++ b/kube-controllers/pkg/controllers/networkpolicy/policy_name_migrator_test.go
@@ -52,11 +52,6 @@ var _ = Describe("policy name migration tests (etcd mode)", func() {
 		err               error
 	)
 
-	// Define an interface to access the backend client from the Calico client.
-	type accessor interface {
-		Backend() bapi.Client
-	}
-
 	BeforeEach(func() {
 		// Run etcd.
 		etcd = testutils.RunEtcd()
@@ -74,7 +69,7 @@ var _ = Describe("policy name migration tests (etcd mode)", func() {
 		cli = testutils.GetCalicoClient(mode, etcd.IP, kubeconfig)
 		k8sClient, err = testutils.GetK8sClient(kubeconfig)
 		Expect(err).NotTo(HaveOccurred())
-		bcli = cli.(accessor).Backend()
+		bcli = cli.(bapi.BackendAccessor).Backend()
 
 		// Wait for the apiserver to be available.
 		Eventually(func() error {

--- a/kube-controllers/pkg/controllers/node/kdd_ipam_gc_fv_test.go
+++ b/kube-controllers/pkg/controllers/node/kdd_ipam_gc_fv_test.go
@@ -87,11 +87,8 @@ var _ = Describe("IPAM garbage collection FV tests with short leak grace period"
 		testutils.ApplyCRDs(apiserver)
 
 		// Make a Calico client and backend client.
-		type accessor interface {
-			Backend() backend.Client
-		}
 		calicoClient = testutils.GetCalicoClient(apiconfig.Kubernetes, "", kconfigfile)
-		bc = calicoClient.(accessor).Backend()
+		bc = calicoClient.(backend.BackendAccessor).Backend()
 
 		// Run controller manager.
 		controllerManager = testutils.RunK8sControllerManager(apiserver.IP)
@@ -618,11 +615,8 @@ var _ = Describe("IPAM garbage collection FV tests with long leak grace period",
 		testutils.ApplyCRDs(apiserver)
 
 		// Make a Calico client and backend client.
-		type accessor interface {
-			Backend() backend.Client
-		}
 		calicoClient = testutils.GetCalicoClient(apiconfig.Kubernetes, "", kconfigfile)
-		bc = calicoClient.(accessor).Backend()
+		bc = calicoClient.(backend.BackendAccessor).Backend()
 
 		// Run controller manager.
 		controllerManager = testutils.RunK8sControllerManager(apiserver.IP)

--- a/kube-controllers/pkg/controllers/node/metrics_fv_test.go
+++ b/kube-controllers/pkg/controllers/node/metrics_fv_test.go
@@ -121,11 +121,8 @@ var _ = Describe("kube-controllers metrics FV tests", Ordered, ContinueOnFailure
 		}, 15*time.Second, 3*time.Second).ShouldNot(HaveOccurred())
 
 		// Make a Calico client and backend client.
-		type accessor interface {
-			Backend() backend.Client
-		}
 		calicoClient = testutils.GetCalicoClient(apiconfig.Kubernetes, "", kconfigfile)
-		bc = calicoClient.(accessor).Backend()
+		bc = calicoClient.(backend.BackendAccessor).Backend()
 
 		// Shorten the leak grace period for testing, allowing reclamations to happen quickly.
 		kcc := api.NewKubeControllersConfiguration()

--- a/kube-controllers/pkg/controllers/node/node_controller_fv_test.go
+++ b/kube-controllers/pkg/controllers/node/node_controller_fv_test.go
@@ -85,11 +85,8 @@ var _ = Describe("Calico node controller FV tests (KDD mode)", Ordered, Continue
 		testutils.ApplyCRDs(apiserver)
 
 		// Make a Calico client and backend client.
-		type accessor interface {
-			Backend() backend.Client
-		}
 		calicoClient = testutils.GetCalicoClient(apiconfig.Kubernetes, "", kconfigfile)
-		bc = calicoClient.(accessor).Backend()
+		bc = calicoClient.(backend.BackendAccessor).Backend()
 
 		// In KDD mode, we only support the node controller right now.
 		kubeControllers = testutils.RunKubeControllers(apiconfig.Kubernetes, "", kconfigfile, "node")

--- a/kube-controllers/pkg/controllers/utils/syncer.go
+++ b/kube-controllers/pkg/controllers/utils/syncer.go
@@ -69,16 +69,12 @@ func NewDataFeed(c client.Interface, dataStore string) *DataFeed {
 			ListInterface: model.ResourceListOptions{Kind: apiv3.KindStagedGlobalNetworkPolicy},
 		},
 	}
-	type accessor interface {
-		Backend() bapi.Client
-	}
-
 	d := &DataFeed{
 		registrations:       map[any][]UpdateHandler{},
 		statusRegistrations: []StatusHandler{},
 		dataStore:           dataStore,
 	}
-	d.syncer = watchersyncer.New(c.(accessor).Backend(), resourceTypes, d)
+	d.syncer = watchersyncer.New(c.(bapi.BackendAccessor).Backend(), resourceTypes, d)
 	return d
 }
 

--- a/libcalico-go/lib/clientv3/ippool_e2e_test.go
+++ b/libcalico-go/lib/clientv3/ippool_e2e_test.go
@@ -348,10 +348,7 @@ var _ = testutils.E2eDatastoreDescribe("IPPool tests", testutils.DatastoreAll, f
 			By("Adding an IPPool with empty string for IPIPMode and VXLANMode and expecting it to be defaulted to 'Never'")
 
 			// Get the Calico backend client.
-			type accessor interface {
-				Backend() backendapi.Client
-			}
-			bc := c.(accessor).Backend()
+			bc := c.(backendapi.BackendAccessor).Backend()
 
 			// Add the IPPool through the backend so it skips setting default values
 			kvp := &model.KVPair{

--- a/libcalico-go/lib/ipam/ipam_block_reader_writer_test.go
+++ b/libcalico-go/lib/ipam/ipam_block_reader_writer_test.go
@@ -157,11 +157,6 @@ func (c *fakeClient) Watch(ctx context.Context, list model.ListInterface, option
 	panic("should not be called")
 }
 
-// backendClientAccessor is an interface used to access the backend client from the main clientv3.
-type backendClientAccessor interface {
-	Backend() api.Client
-}
-
 var _ = testutils.E2eDatastoreDescribe("IPAM affine block allocation tests", testutils.DatastoreAll, func(config apiconfig.CalicoAPIConfig) {
 	log.SetLevel(log.DebugLevel)
 

--- a/node/pkg/allocateip/allocateip.go
+++ b/node/pkg/allocateip/allocateip.go
@@ -107,7 +107,7 @@ func run(
 		log.Debug("Using typha syncclient")
 	} else {
 		log.Debug("Using local syncer")
-		syncer := tunnelipsyncer.New(c.(backendClientAccessor).Backend(), r, nodename)
+		syncer := tunnelipsyncer.New(c.(bapi.BackendAccessor).Backend(), r, nodename)
 		syncer.Start()
 	}
 
@@ -783,11 +783,6 @@ func getLogger(attrType string) *log.Entry {
 		return log.WithField("type", "wireguardV6TunnelAddress")
 	}
 	return nil
-}
-
-// backendClientAccessor is an interface to access the backend client from the main v2 client.
-type backendClientAccessor interface {
-	Backend() bapi.Client
 }
 
 // loadFelixEnvConfig loads the felix configuration from environment. It does not perform a hierarchical load across

--- a/node/pkg/status/nodestatus.go
+++ b/node/pkg/status/nodestatus.go
@@ -59,7 +59,7 @@ func RunWithContext(ctx context.Context) error {
 		log.Debug("Using typha syncclient")
 	} else {
 		log.Debug("Using local syncer")
-		syncer := nodestatussyncer.New(c.(backendClientAccessor).Backend(), r)
+		syncer := nodestatussyncer.New(c.(bapi.BackendAccessor).Backend(), r)
 		syncer.Start()
 	}
 
@@ -292,9 +292,4 @@ func (r *NodeStatusReporter) processPendingUpdates() {
 		}
 		delete(r.pendingUpdates, name)
 	}
-}
-
-// backendClientAccessor is an interface to access the backend client from the main v2 client.
-type backendClientAccessor interface {
-	Backend() bapi.Client
 }

--- a/typha/pkg/daemon/daemon.go
+++ b/typha/pkg/daemon/daemon.go
@@ -473,7 +473,7 @@ type DatastoreClient interface {
 	NodeStatusSyncerByIface(callbacks bapi.SyncerCallbacks) bapi.Syncer
 }
 
-// RealClientV3 is the real API of the V3 client, including the semi-private API that we use to get the backend.
+// RealClientV3 is the real API of the V3 client, plus the BackendAccessor we use to get the backend.
 type RealClientV3 interface {
 	clientv3.Interface
 	bapi.BackendAccessor

--- a/typha/pkg/daemon/daemon.go
+++ b/typha/pkg/daemon/daemon.go
@@ -476,7 +476,7 @@ type DatastoreClient interface {
 // RealClientV3 is the real API of the V3 client, including the semi-private API that we use to get the backend.
 type RealClientV3 interface {
 	clientv3.Interface
-	Backend() bapi.Client
+	bapi.BackendAccessor
 }
 
 // TODO Typha: Share with Felix.


### PR DESCRIPTION
libcalico-go exposes a public `bapi.BackendAccessor` interface for getting at the backend client from a v3 client (added specifically to replace the ad-hoc `accessor` / `backendClientAccessor` interfaces that had accreted across the tree). This swaps every one of those local interfaces over to it, and drops a couple that were dead.

No behavior change - a mechanical cleanup across calicoctl, kube-controllers, felix, typha, node, cni-plugin, apiserver, and confd.

```release-note
None
```
