### PR TITLE
Raise webhook client QPS and burst to avoid throttling

### DIFF
--- a/webhooks/pkg/webhook/command.go
+++ b/webhooks/pkg/webhook/command.go
@@ -108,6 +108,13 @@ func serveWebhookTLS(cmd *cobra.Command, args []string) {
 	if err != nil {
 		logrus.WithError(err).Fatal("Failed to create in-cluster config")
 	}
+
+	// The client-go defaults (QPS 5 / burst 10) throttle the webhook under bursts of policy writes,
+	// since every admission review issues a SubjectAccessReview. Match kube-controllers' higher
+	// limits so a large batch of concurrent writes doesn't queue behind client-side rate limiting.
+	rc.QPS = 100
+	rc.Burst = 200
+
 	cs, err := kubernetes.NewForConfig(rc)
 	if err != nil {
 		logrus.WithError(err).Fatal("Failed to create Kubernetes clientset")


### PR DESCRIPTION
The Calico webhooks server issues a SubjectAccessReview for every admission review, so under bursts of policy writes the client-go default rate limits (QPS 5, burst 10) throttle it, delaying admission and slowing down tools that apply many policies at once (e.g. Flux syncs). This raises the webhook's Kubernetes client to QPS 100 / burst 200, matching kube-controllers.

Part of the fixes for #13244.

**Release note:**
```release-note
Raises the Calico webhooks server's Kubernetes client rate limits so that bursts of policy changes are no longer delayed by client-side throttling.
```
