### PR TITLE
[v3.32] felix: gate FIB-lookup ext-to-service mark on EXT_LOCAL flag

### DIFF
--- a/.semaphore/vms/configure-test-vm
+++ b/.semaphore/vms/configure-test-vm
@@ -23,7 +23,10 @@ zone=${ZONE:-europe-west3-c}
 project=${GCP_PROJECT:-unique-caldron-775}
 
 vm_pub_key=""
-for attempt in $(seq 1 20); do
+# The guest agent publishes the host key to guest attributes only once it is up,
+# which can take well over 20s on newer Ubuntu images (e.g. 26.04), so poll
+# generously before giving up.
+for attempt in $(seq 1 60); do
   echo "Getting VM ssh key (attempt $attempt)..."
   vm_pub_key=$(gcloud compute instances get-guest-attributes "${vm_name}" --zone="${zone}" --query-path="hostkeys/ssh-ed25519" --format='value(value)') || {
     echo "Failed to get VM ssh key, retrying..."

--- a/felix/bpf-gpl/fib_co_re.h
+++ b/felix/bpf-gpl/fib_co_re.h
@@ -203,8 +203,17 @@ skip_redir_ifindex:
 				.l4_protocol = state->ip_proto,
 			};
 
+			/* Only reply traffic of an external client hitting a local
+			 * service must carry EXT_TO_SVC_MARK into the FIB lookup so
+			 * the RPDB routes it back the way the request arrived. For
+			 * ordinary pod-originated egress the mark must stay 0 so a
+			 * host source-based routing rule (e.g. AWS VPC CNI's per-pod
+			 * rule) selects the pod's own interface. */
 			if (bpf_core_field_exists(((struct bpf_fib_lookup *)0)->mark)) {
-				fib_params(ctx)->mark = EXT_TO_SVC_MARK;
+				if (CALI_F_FROM_WEP && EXT_TO_SVC_MARK &&
+						(state->ct_result.flags & CALI_CT_FLAG_EXT_LOCAL)) {
+					fib_params(ctx)->mark = EXT_TO_SVC_MARK;
+				}
 			}
 
 #ifdef IPVER6
@@ -365,9 +374,15 @@ try_fib_external:
 			.l4_protocol = state->ip_proto,
 		};
 
+		/* See the note above the matching guard in the local-dest path:
+		 * only external-client-to-local-service reply traffic gets the
+		 * mark; ordinary pod egress leaves it 0 for host source routing. */
 		if (bpf_core_field_exists(((struct bpf_fib_lookup *)0)->mark)) {
-			fib_params(ctx)->mark = EXT_TO_SVC_MARK;
-			CALI_DEBUG("FIB mark=0x%d", fib_params(ctx)->mark);
+			if (CALI_F_FROM_WEP && EXT_TO_SVC_MARK &&
+					(state->ct_result.flags & CALI_CT_FLAG_EXT_LOCAL)) {
+				fib_params(ctx)->mark = EXT_TO_SVC_MARK;
+				CALI_DEBUG("FIB mark=0x%x", fib_params(ctx)->mark);
+			}
 		}
 
 		if (state->ip_proto != IPPROTO_ICMP_46) {

--- a/felix/fv/bpf_multi_home_test.go
+++ b/felix/fv/bpf_multi_home_test.go
@@ -234,5 +234,59 @@ func describeBPFMultiHomedTests() bool {
 			Eventually(dump30.MatchCountFn("eth30-ingress"), "5s", "330ms").Should(BeNumerically("==", 1))
 			Eventually(dump20.MatchCountFn("eth20-egress"), "5s", "330ms").Should(BeNumerically("==", 1))
 		})
+
+		It("should not stamp the ext-to-service connmark on ordinary pod egress", func() {
+			// A node using source-based routing (e.g. AWS VPC CNI) gives
+			// each pod a source rule that selects the interface owning the
+			// pod's IP, and a higher-priority fwmark rule that sends traffic
+			// marked with the ext-to-service connmark out of the primary
+			// interface. Ordinary pod-originated egress must not carry that
+			// mark, otherwise the fwmark rule hijacks it onto the wrong
+			// interface. Here eth20 owns the pod's IP and eth30 stands in for
+			// the primary interface; the packet must leave via eth20.
+			var err error
+
+			Felix.Exec("ip", "addr", "add", "192.168.20.20/24", "dev", "eth20")
+			Felix.Exec("ip", "addr", "add", "192.168.30.30/24", "dev", "eth30")
+
+			Felix.Exec("bash", "-c", "echo 200 pod_eni >> /etc/iproute2/rt_tables")
+			Felix.Exec("bash", "-c", "echo 201 primary_eni >> /etc/iproute2/rt_tables")
+
+			// Pod's own interface, selected by the pod's source IP.
+			Felix.Exec("ip", "route", "add", "10.65.1.0/24", "dev", "eth20", "table", "pod_eni")
+			Felix.Exec("ip", "rule", "add", "from", w.IP, "table", "pod_eni", "priority", "1536")
+
+			// Primary interface, selected by the ext-to-service connmark and
+			// at a higher priority than the pod source rule.
+			Felix.Exec("ip", "route", "add", "10.65.1.0/24", "dev", "eth30", "table", "primary_eni")
+			Felix.Exec("ip", "rule", "add", "fwmark", "0x80/0x80", "table", "primary_eni", "priority", "1024")
+
+			Felix.Exec("ip", "route", "flush", "cache")
+			Felix.Exec("ip", "neigh", "add", "10.65.1.3", "lladdr", "ee:ee:ee:ee:ee:ee", "dev", "eth20")
+			Felix.Exec("ip", "neigh", "add", "10.65.1.3", "lladdr", "ee:ee:ee:ee:ee:ee", "dev", "eth30")
+
+			dump20 := Felix.AttachTCPDump("eth20")
+			dump20.SetLogEnabled(true)
+			dump20.AddMatcher("eth20-egress", regexp.MustCompile("10.65.0.2.30444 > 10.65.1.3.30444: UDP"))
+			dump20.Start(infra, "-v", "udp", "and", "dst", "host", "10.65.1.3")
+
+			dump30 := Felix.AttachTCPDump("eth30")
+			dump30.SetLogEnabled(true)
+			dump30.AddMatcher("eth30-egress", regexp.MustCompile("10.65.0.2.30444 > 10.65.1.3.30444: UDP"))
+			dump30.Start(infra, "-v", "udp", "and", "dst", "host", "10.65.1.3")
+
+			By("Sending packets from the workload")
+			_, err = w.RunCmd("pktgen", w.IP, "10.65.1.3", "udp", "--ip-id", "1",
+				"--port-src", "30444", "--port-dst", "30444")
+			Expect(err).NotTo(HaveOccurred())
+			_, err = w.RunCmd("pktgen", w.IP, "10.65.1.3", "udp", "--ip-id", "2",
+				"--port-src", "30444", "--port-dst", "30444")
+			Expect(err).NotTo(HaveOccurred())
+
+			// The pod source rule must win: traffic leaves via eth20 and
+			// never via the fwmark-selected eth30.
+			Eventually(dump20.MatchCountFn("eth20-egress"), "5s", "330ms").Should(BeNumerically("==", 2))
+			Consistently(dump30.MatchCountFn("eth30-egress"), "1s", "330ms").Should(BeNumerically("==", 0))
+		})
 	})
 }


### PR DESCRIPTION
Cherry-pick of #13256 into release-v3.32.

v3.32 is the only affected OSS release branch: it carries #11665 ("use mark in fib lookup"), which introduced the regression; v3.31 and earlier branched before #11665 and do not have the offending code.

### Description

The BPF dataplane passes `EXT_TO_SVC_MARK` to `bpf_fib_lookup` via `BPF_FIB_LOOKUP_MARK` (kernel 6.10+) so reply traffic of an external client hitting a local service is routed back the way the request arrived. That mark was being set unconditionally for all non-egress-gw pod egress, not only for external-to-local-service replies.

On a node that uses source-based routing (e.g. AWS VPC CNI), each pod gets a source rule that selects the interface owning the pod's IP, plus a higher-priority rule that sends traffic carrying the ext-to-service connmark out of the primary interface. With the mark stamped on ordinary pod egress, that higher-priority rule hijacked the packet onto the wrong interface, which the cloud fabric then dropped because the source IP did not belong to that interface. Cross-node UDP (notably DNS to the kube-dns ClusterIP) from pods whose IP lived on a secondary interface timed out.

The fix gates the FIB-lookup mark on `CALI_F_FROM_WEP` and `CALI_CT_FLAG_EXT_LOCAL`, matching the skb-mark path and the pre-6.10 fallback.

Fixes CI-2022.

### Cherry-pick history

- master: #13256 (commit 86f6ac5cda)

### Release Note

```release-note
Fixed a regression in the eBPF dataplane where ordinary pod egress carried the ext-to-service connmark into the FIB lookup, breaking cross-node connectivity (including DNS) on nodes that use source-based routing such as AWS VPC CNI.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)