### PR TITLE
ci: widen VM SSH host-key poll window for slow-booting images

### DIFF
--- a/.semaphore/vms/configure-test-vm
+++ b/.semaphore/vms/configure-test-vm
@@ -23,7 +23,10 @@ zone=${ZONE:-europe-west3-c}
 project=${GCP_PROJECT:-unique-caldron-775}
 
 vm_pub_key=""
-for attempt in $(seq 1 20); do
+# The guest agent publishes the host key to guest attributes only once it is up,
+# which can take well over 20s on newer Ubuntu images (e.g. 26.04), so poll
+# generously before giving up.
+for attempt in $(seq 1 60); do
   echo "Getting VM ssh key (attempt $attempt)..."
   vm_pub_key=$(gcloud compute instances get-guest-attributes "${vm_name}" --zone="${zone}" --query-path="hostkeys/ssh-ed25519" --format='value(value)') || {
     echo "Failed to get VM ssh key, retrying..."


### PR DESCRIPTION
### Description

The on-VM test setup (`.semaphore/vms/configure-test-vm`) reads each VM's SSH host key from the GCP guest attribute `hostkeys/ssh-ed25519`, which the guest agent publishes only once the VM is up. On newer Ubuntu images (e.g. `ubuntu-2604-lts-amd64`, which the Felix BPF tier now uses) that happens much later in boot than on 24.04 — the host key is observed around attempt 10–20 rather than 3–5 — overrunning the 20-attempt poll window.

Multi-VM jobs are cushioned by bulk-create time, but the single-VM `Felix: BPF program-loading check` job starts polling almost immediately and fails deterministically with `Failed to get VM ssh key after multiple attempts, exiting. exit 22` before the test ever runs (empty `test-ut.log`).

Widen the poll window to 60 attempts, which covers 26.04 and is harmless for faster images.

This ports the follow-on fix already applied on the EE side (tigera/calico-private#12720) to the OSS branches, which still had the 20-attempt window.

### Release Note

```release-note
None
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)