### PR TITLE
[v3.32] ci: widen VM SSH host-key poll window for slow-booting images

### DIFF
--- a/.semaphore/vms/configure-test-vm
+++ b/.semaphore/vms/configure-test-vm
@@ -23,7 +23,10 @@ zone=${ZONE:-europe-west3-c}
 project=${GCP_PROJECT:-unique-caldron-775}
 
 vm_pub_key=""
-for attempt in $(seq 1 20); do
+# The guest agent publishes the host key to guest attributes only once it is up,
+# which can take well over 20s on newer Ubuntu images (e.g. 26.04), so poll
+# generously before giving up.
+for attempt in $(seq 1 60); do
   echo "Getting VM ssh key (attempt $attempt)..."
   vm_pub_key=$(gcloud compute instances get-guest-attributes "${vm_name}" --zone="${zone}" --query-path="hostkeys/ssh-ed25519" --format='value(value)') || {
     echo "Failed to get VM ssh key, retrying..."


### PR DESCRIPTION
Backport of #13261 onto release-v3.32.

### Description

The on-VM test setup (`.semaphore/vms/configure-test-vm`) reads each VM's SSH host key from the GCP guest attribute `hostkeys/ssh-ed25519`, published by the guest agent only once the VM is up. On `ubuntu-2604-lts-amd64` (the Felix BPF tier) that happens much later in boot than on 24.04 (attempt ~10–20 vs 3–5), overrunning the 20-attempt poll window. The single-VM `Felix: BPF program-loading check` job starts polling immediately and fails deterministically with `Failed to get VM ssh key after multiple attempts, exiting. exit 22` before the test runs.

Widen the poll window to 60 attempts. Ports the EE-side follow-on fix (tigera/calico-private#12720) to OSS release-v3.32.

### Cherry-pick history

- master: #13261

### Release Note

```release-note
None
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)