### PR TITLE
build(envoy-gateway): bump bundled Envoy Gateway to v1.8.2

### DIFF
--- a/third_party/envoy-gateway/Makefile
+++ b/third_party/envoy-gateway/Makefile
@@ -7,7 +7,7 @@ BUILD_IMAGES ?= $(ENVOY_GATEWAY_IMAGE)
 
 # For updating this version please see
 # https://github.com/tigera/operator/blob/master/docs/common_tasks.md#updating-the-bundled-version-of-envoy-gateway
-ENVOY_GATEWAY_VERSION=v1.8.0
+ENVOY_GATEWAY_VERSION=v1.8.2
 
 ##############################################################################
 # Include lib.Makefile before anything else

--- a/third_party/envoy-gateway/patches/0001-CVE-dependency-fixes.patch
+++ b/third_party/envoy-gateway/patches/0001-CVE-dependency-fixes.patch
@@ -1,142 +1,97 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tigera <noreply@tigera.io>
-Date: Tue, 17 Jun 2026 09:00:00 -0700
+Date: Mon, 21 Jul 2026 09:00:00 -0700
 Subject: [PATCH] Update dependencies for CVE fixes
 
 Applied on top of the pinned envoyproxy/gateway release
-(ENVOY_GATEWAY_VERSION). Advances the golang.org/x modules to the
-versions used by the calico module, keeping the bundled image in lockstep
-with the rest of the tree and clearing CVE-2026-33814 (HTTP/2 SETTINGS
-infinite loop, fixed in golang.org/x/net v0.53.0):
+(ENVOY_GATEWAY_VERSION). Advances two golang.org/x modules to clear CVEs
+in the bundled image:
 
-  golang.org/x/net   v0.53.0 -> v0.56.0
-  golang.org/x/crypto v0.50.0 -> v0.53.0
-  golang.org/x/sys   v0.43.0 -> v0.46.0
-  golang.org/x/text  v0.36.0 -> v0.38.0
-  golang.org/x/term  v0.42.0 -> v0.44.0
-  golang.org/x/sync  v0.20.0 -> v0.21.0
-  golang.org/x/mod   v0.35.0 -> v0.36.0
-  golang.org/x/tools v0.44.0 -> v0.45.0
+  golang.org/x/net  v0.55.0 -> v0.56.0
+  golang.org/x/text v0.38.0 -> v0.39.0
 
-Regenerated via `go get golang.org/x/net@v0.56.0 && go mod tidy` against
-the pinned upstream ref; the only churn is the golang.org/x modules. The
-module's `go` directive is unchanged at 1.26.3 (the build supplies a
-newer toolchain via GOTOOLCHAIN).
+- x/net clears GO-2026-5942 (panic parsing an invalid SVCB or HTTPS DNS
+  RR in golang.org/x/net/dns/dnsmessage), still at v0.55.0 in v1.8.2.
+- x/text clears CVE-2026-56852 / GO-2026-5970 (infinite loop in norm.Iter
+  on invalid UTF-8), reachable from the gateway-api schema validation
+  path. Bumping x/text also advances x/mod v0.37.0 and x/tools v0.47.0,
+  which its go.mod requires.
 
-The CVE fixes that v1.7.x carried as separate per-dependency patches
-(grpc, otel-sdk, go-jose, spdystream) are already satisfied by v1.8.0
-upstream, so those patches are dropped.
+As of Envoy Gateway v1.8.2 the other dependencies this patch used to
+advance are already at safe versions upstream (the rest of golang.org/x,
+docker/cli v29.6.0). The earlier CVE-2026-33814 (x/net v0.53.0) is
+already in the v1.8.2 baseline.
+
+Regenerated via `go get golang.org/x/net@v0.56.0 golang.org/x/text@v0.39.0
+&& go mod tidy` against the pinned upstream ref. The go directive is
+unchanged (the build supplies a newer toolchain via GOTOOLCHAIN).
 ---
 diff --git a/go.mod b/go.mod
-index 6a7d481..3b17407 100644
 --- a/go.mod
 +++ b/go.mod
-@@ -55,7 +55,7 @@ require (
- 	go.opentelemetry.io/proto/otlp v1.10.0
- 	go.uber.org/zap v1.28.0
- 	golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f
--	golang.org/x/sync v0.20.0
-+	golang.org/x/sync v0.21.0
- 	gomodules.xyz/jsonpatch/v2 v2.5.0
- 	google.golang.org/genproto/googleapis/api v0.0.0-20260401024825-9d38bb4040a9
- 	google.golang.org/grpc v1.80.0
-@@ -282,15 +282,15 @@ require (
- 	go.uber.org/multierr v1.11.0 // indirect
+@@ -263,14 +263,14 @@
  	go.yaml.in/yaml/v2 v2.4.4 // indirect
  	go.yaml.in/yaml/v3 v3.0.4 // indirect
--	golang.org/x/crypto v0.50.0 // indirect
--	golang.org/x/mod v0.35.0 // indirect
--	golang.org/x/net v0.53.0 // indirect
-+	golang.org/x/crypto v0.53.0 // indirect
-+	golang.org/x/mod v0.36.0 // indirect
+ 	golang.org/x/crypto v0.53.0 // indirect
+-	golang.org/x/mod v0.36.0 // indirect
+-	golang.org/x/net v0.55.0 // indirect
++	golang.org/x/mod v0.37.0 // indirect
 +	golang.org/x/net v0.56.0 // indirect
  	golang.org/x/oauth2 v0.36.0 // indirect
--	golang.org/x/sys v0.43.0 // indirect
--	golang.org/x/term v0.42.0 // indirect
--	golang.org/x/text v0.36.0 // indirect
-+	golang.org/x/sys v0.46.0 // indirect
-+	golang.org/x/term v0.44.0 // indirect
-+	golang.org/x/text v0.38.0 // indirect
+ 	golang.org/x/sys v0.46.0 // indirect
+ 	golang.org/x/term v0.44.0 // indirect
+-	golang.org/x/text v0.38.0 // indirect
++	golang.org/x/text v0.39.0 // indirect
  	golang.org/x/time v0.15.0 // indirect
--	golang.org/x/tools v0.44.0 // indirect
-+	golang.org/x/tools v0.45.0 // indirect
- 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260401024825-9d38bb4040a9 // indirect
+-	golang.org/x/tools v0.45.0 // indirect
++	golang.org/x/tools v0.47.0 // indirect
+ 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa // indirect
  	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
  	gopkg.in/inf.v0 v0.9.1 // indirect
 diff --git a/go.sum b/go.sum
-index 1409188..2f24667 100644
 --- a/go.sum
 +++ b/go.sum
-@@ -709,14 +709,14 @@ golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnf
- golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
- golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
- golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
--golang.org/x/crypto v0.50.0 h1:zO47/JPrL6vsNkINmLoo/PH1gcxpls50DNogFvB5ZGI=
--golang.org/x/crypto v0.50.0/go.mod h1:3muZ7vA7PBCE6xgPX7nkzzjiUq87kRItoJQM1Yo8S+Q=
-+golang.org/x/crypto v0.53.0 h1:QZ4Muo8THX6CizN2vPPd5fBGHyogrdK9fG4wLPFUsto=
-+golang.org/x/crypto v0.53.0/go.mod h1:DNLU434OwVakk9PzuwV8w62mAJpRJL3vsgcfp4Qnsio=
- golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f h1:W3F4c+6OLc6H2lb//N1q4WpJkhzJCK5J6kUi1NTVXfM=
+@@ -687,8 +687,8 @@
  golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f/go.mod h1:J1xhfL/vlindoeF/aINzNzt2Bket5bjo9sdOYzOsU80=
  golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
  golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
--golang.org/x/mod v0.35.0 h1:Ww1D637e6Pg+Zb2KrWfHQUnH2dQRLBQyAtpr/haaJeM=
--golang.org/x/mod v0.35.0/go.mod h1:+GwiRhIInF8wPm+4AoT6L0FA1QWAad3OMdTRx4tFYlU=
-+golang.org/x/mod v0.36.0 h1:JJjpVx6myfUsUdAzZuOSTTmRE0PfZeNWzzvKrP7amb4=
-+golang.org/x/mod v0.36.0/go.mod h1:moc6ELqsWcOw5Ef3xVprK5ul/MvtVvkIXLziUOICjUQ=
+-golang.org/x/mod v0.36.0 h1:JJjpVx6myfUsUdAzZuOSTTmRE0PfZeNWzzvKrP7amb4=
+-golang.org/x/mod v0.36.0/go.mod h1:moc6ELqsWcOw5Ef3xVprK5ul/MvtVvkIXLziUOICjUQ=
++golang.org/x/mod v0.37.0 h1:vF1DjpVEshcIqoEaauuHebaLk1O1forxjxBaVn884JQ=
++golang.org/x/mod v0.37.0/go.mod h1:m8S8VeM9r4dzDwjrKO0a1sZP3YjeMamRRlD+fmR2Q/0=
  golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
  golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
  golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
-@@ -724,16 +724,16 @@ golang.org/x/net v0.0.0-20190923162816-aa69164e4478/go.mod h1:z5CRVTTTmAJ677TzLL
- golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+@@ -697,8 +697,8 @@
  golang.org/x/net v0.0.0-20200520004742-59133d7f0dd7/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
  golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
--golang.org/x/net v0.53.0 h1:d+qAbo5L0orcWAr0a9JweQpjXF19LMXJE8Ey7hwOdUA=
--golang.org/x/net v0.53.0/go.mod h1:JvMuJH7rrdiCfbeHoo3fCQU24Lf5JJwT9W3sJFulfgs=
+ golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+-golang.org/x/net v0.55.0 h1:bcvxaJn3e1U6InsFWt1JUq1aSjnRxLzT2rtD2KfkDF8=
+-golang.org/x/net v0.55.0/go.mod h1:L5U2KuzuOe1lY7Z+aWVIKK6qEeJXnXV9yzGA+WCHJww=
 +golang.org/x/net v0.56.0 h1:Rw8j/hFzGvJUZwNBXnAtf5sVDVt+65SK2C7IxCxZt5o=
 +golang.org/x/net v0.56.0/go.mod h1:D3Ku6r+V6JROoZK144D2XfMHFcMq/0zSfLelVTCFKec=
  golang.org/x/oauth2 v0.36.0 h1:peZ/1z27fi9hUOFCAZaHyrpWG5lwe0RJEEEeH0ThlIs=
  golang.org/x/oauth2 v0.36.0/go.mod h1:YDBUJMTkDnJS+A4BP4eZBjCqtokkg1hODuPjwiGPO7Q=
  golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
- golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
- golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
- golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
--golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
--golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
-+golang.org/x/sync v0.21.0 h1:HLII4xRRTtCRkxYp4HNFF0Js/Og6q2i++KXbg0gHCwM=
-+golang.org/x/sync v0.21.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
- golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
- golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
- golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
-@@ -752,15 +752,15 @@ golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBc
- golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
- golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
- golang.org/x/sys v0.10.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
--golang.org/x/sys v0.43.0 h1:Rlag2XtaFTxp19wS8MXlJwTvoh8ArU6ezoyFsMyCTNI=
--golang.org/x/sys v0.43.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
--golang.org/x/term v0.42.0 h1:UiKe+zDFmJobeJ5ggPwOshJIVt6/Ft0rcfrXZDLWAWY=
--golang.org/x/term v0.42.0/go.mod h1:Dq/D+snpsbazcBG5+F9Q1n2rXV8Ma+71xEjTRufARgY=
-+golang.org/x/sys v0.46.0 h1:noSf2Fq6F8DBgS+LysIkx7rIExoNHJsxOAtPp4rthXw=
-+golang.org/x/sys v0.46.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
-+golang.org/x/term v0.44.0 h1:0rLvDRCtNj0gZkyIXhCyOb2OAzEhLVqc4B+hrsBhrmc=
-+golang.org/x/term v0.44.0/go.mod h1:7ze4MdzUzLXpSAoFP1H0bOI9aXDqveSvatT5vKcFh2Y=
- golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
- golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
+@@ -739,8 +739,8 @@
  golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
--golang.org/x/text v0.36.0 h1:JfKh3XmcRPqZPKevfXVpI1wXPTqbkE5f7JA92a55Yxg=
--golang.org/x/text v0.36.0/go.mod h1:NIdBknypM8iqVmPiuco0Dh6P5Jcdk8lJL0CUebqK164=
-+golang.org/x/text v0.38.0 h1:sXmwo9DwP3OK9EZ7PqAdaooSGozfl/3a6/xJcbzPRhE=
-+golang.org/x/text v0.38.0/go.mod h1:YXZt3QhHUKYT53r2lLKFIVi6Ao1jdzrTR/KQ09qyxF4=
+ golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+ golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
+-golang.org/x/text v0.38.0 h1:sXmwo9DwP3OK9EZ7PqAdaooSGozfl/3a6/xJcbzPRhE=
+-golang.org/x/text v0.38.0/go.mod h1:YXZt3QhHUKYT53r2lLKFIVi6Ao1jdzrTR/KQ09qyxF4=
++golang.org/x/text v0.39.0 h1:UbZz4pLOvn600D6Oh6GGEI6VAmndrEBLv8/6BEXzyus=
++golang.org/x/text v0.39.0/go.mod h1:3UwRclnC2g0TU9x8PZiyfOajCd1zaUNHF9cvqcQZ+ZM=
  golang.org/x/time v0.15.0 h1:bbrp8t3bGUeFOx08pvsMYRTCVSMk89u4tKbNOZbp88U=
  golang.org/x/time v0.15.0/go.mod h1:Y4YMaQmXwGQZoFaVFk4YpCt4FLQMYKZe9oeV/f4MSno=
  golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
-@@ -768,8 +768,8 @@ golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtn
+@@ -748,8 +748,8 @@
  golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
  golang.org/x/tools v0.0.0-20201224043029-2b0845dc783e/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
  golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
--golang.org/x/tools v0.44.0 h1:UP4ajHPIcuMjT1GqzDWRlalUEoY+uzoZKnhOjbIPD2c=
--golang.org/x/tools v0.44.0/go.mod h1:KA0AfVErSdxRZIsOVipbv3rQhVXTnlU6UhKxHd1seDI=
-+golang.org/x/tools v0.45.0 h1:18qN3FAooORvApf5XjCXgsuayZOEtXf6JK18I3+ONa8=
-+golang.org/x/tools v0.45.0/go.mod h1:LuUGqqaXcXMEFEruIVJVm5mgDD8vww/z/SR1gQ4uE/0=
+-golang.org/x/tools v0.45.0 h1:18qN3FAooORvApf5XjCXgsuayZOEtXf6JK18I3+ONa8=
+-golang.org/x/tools v0.45.0/go.mod h1:LuUGqqaXcXMEFEruIVJVm5mgDD8vww/z/SR1gQ4uE/0=
++golang.org/x/tools v0.47.0 h1:7Kn5x/d1svx/PzryTsqeoZN4TZwqeH5pGWjefhLi/1Q=
++golang.org/x/tools v0.47.0/go.mod h1:dFHnyTvFWY212G+h7ZY4Vsp/K3U4/7W9TyVaAul8uCA=
  golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
  golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
  golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=


### PR DESCRIPTION
## Description

This bumps the bundled Envoy Gateway build from v1.8.0 to v1.8.2. That's the newest stable patch on the 1.8 line. gateway-api stays at v1.5.1, so there are no CRD or API changes.

I also rebuilt the CVE dependency patch. v1.8.2 already ships all the golang.org/x bumps the old patch used to add, so the only one left is x/net. Upstream still pins x/net at v0.55.0, which has GO-2026-5942, a panic when parsing a bad SVCB or HTTPS DNS record. The patch now moves x/net to v0.56.0 to clear it. The older CVE-2026-33814 fix is already in the v1.8.2 base.

The proxy and ratelimit pins don't change.

## Test Plan

- Confirmed v1.8.2 is the newest stable Envoy Gateway release. v1.9.0 is still an rc.
- The rebuilt patch applies cleanly to the v1.8.2 source, no fuzz.
- CI builds the bundled Envoy Gateway image from v1.8.2.

## Release Note

```release-note
Update the bundled Envoy Gateway to v1.8.2. Please review the Envoy Gateway v1.8.2 release notes for upstream changes: https://github.com/envoyproxy/gateway/blob/v1.8.2/release-notes/v1.8.2.yaml
```

## Companion PRs

- calico-private: https://github.com/tigera/calico-private/pull/12813
- operator: https://github.com/tigera/operator/pull/5077

