### PR TITLE
Add --nobest to node image package upgrades

### DIFF
--- a/node/Dockerfile
+++ b/node/Dockerfile
@@ -36,7 +36,9 @@ FROM almalinux:9 AS almalinux
 
 ARG RUNIT_VER
 
-RUN dnf upgrade -y && dnf install -y epel-release
+# --nobest: don't fail the build when the newest package can't be cleanly
+# installed (e.g. a mid-sync mirror offering glibc but not its lockstep siblings).
+RUN dnf upgrade -y --nobest && dnf install -y epel-release
 
 RUN dnf --enablerepo=crb install -y \
     iptables-legacy \
@@ -65,7 +67,8 @@ ARG RUNIT_VER
 
 # Update base packages to pick up security updates - must do this before adding the AlmaLinux repo,
 # and install the necessary packages from ubi repos.
-RUN microdnf upgrade -y
+# --nobest so a mid-sync mirror (newest glibc without its lockstep siblings) doesn't fail the build.
+RUN microdnf upgrade -y --nobest
 RUN microdnf install -y \
     # Don't install copious docs.
     --setopt=tsflags=nodocs \


### PR DESCRIPTION
The arm64 node image build intermittently fails when a UBI/AlmaLinux mirror is mid-sync and offers a newer glibc without its lockstep siblings (glibc-common, glibc-minimal-langpack). `microdnf upgrade` / `dnf upgrade` then can't install the newest candidate and aborts the whole transaction, so the build fails with a depsolve error.

`--nobest` lets the resolver keep the installed version when the newest can't be cleanly installed, instead of failing the build. The next build picks up the upgrade once the mirror is consistent. Verified the flag is accepted and exits cleanly in both base images (ubi9/ubi-minimal, almalinux:9).

```release-note
None
```
