### PR TITLE
build(envoy-proxy): bump bundled Envoy proxy to v1.38.3

### DIFF
--- a/third_party/envoy-proxy/Makefile
+++ b/third_party/envoy-proxy/Makefile
@@ -8,7 +8,7 @@ BUILD_IMAGES ?= $(ENVOY_PROXY_IMAGE)
 # For updating this version please see
 # https://github.com/tigera/operator/blob/master/docs/common_tasks.md#updating-the-bundled-version-of-envoy-gateway
 # See https://gateway.envoyproxy.io/news/releases/matrix/ for version compatibility.
-ENVOYBINARY_IMAGE ?= quay.io/tigera/envoybinary:v1.38.2-74b6da5880
+ENVOYBINARY_IMAGE ?= quay.io/tigera/envoybinary:v1.38.3-a1e8aefd3a
 
 # Only amd64 and arm64 are supported. `=` (not `?=`) so env-provided ARCHES
 # from the release manager doesn't override the allowlist.


### PR DESCRIPTION
## Description

Bumps the bundled Envoy binary in the `envoy-proxy` image from `v1.38.2-74b6da5880` to `v1.38.3-a1e8aefd3a`.

This is CVE parity. Envoy Gateway v1.8.2 bundles Envoy 1.38.3, which carries upstream Envoy CVE fixes. The `tigera/envoybinary` repo already built and published `quay.io/tigera/envoybinary:v1.38.3-a1e8aefd3a` (amd64 + arm64 + manifest) via tigera/envoybinary#25, and the enterprise fork is already on it. OSS was the last one behind, so this closes the gap.

The only change is the `ENVOYBINARY_IMAGE` pin in `third_party/envoy-proxy/Makefile`. The Dockerfile consumes that variable as a build arg, so there is a single source of truth.

## Test Plan

- CI builds the `envoy-proxy` image `FROM` the new `ENVOYBINARY_IMAGE` tag.
- The target tag `quay.io/tigera/envoybinary:v1.38.3-a1e8aefd3a` is already published on quay (amd64 + arm64 + manifest), so the build has an image to pull.

**Release note:**
```release-note
Update the bundled Envoy proxy to v1.38.3.
```
