### PR TITLE
calicoctl: fix node checksystem false negatives on modern distros

### DIFF
--- a/calicoctl/calicoctl/commands/node/checksystem.go
+++ b/calicoctl/calicoctl/commands/node/checksystem.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 Tigera, Inc. All rights reserved.
+// Copyright (c) 2016-2026 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -31,29 +32,60 @@ import (
 // namespaces and veth pairs.
 const minKernelVersion = "2.6.24"
 
-// Required kernel modules to run Calico are saved in a two dimensional map variable.
-// Keys are used to search in `lsmod` results or `modules.dep` and `modules.builtin` files.
-// Values are used to search the `kernel config` or `ip_tables_matches` file.
-var requiredModules = map[string]string{
-	"ip_set":               "CONFIG_IP_SET",
-	"ip6_tables":           "CONFIG_IP6_NF_IPTABLES",
-	"ip_tables":            "CONFIG_IP_NF_IPTABLES",
-	"ipt_ipvs":             "CONFIG_NETFILTER_XT_MATCH_IPVS",
-	"vfio-pci":             "CONFIG_VFIO",
-	"xt_bpf":               "CONFIG_BPF",
-	"ipt_REJECT":           "CONFIG_NFT_REJECT",
-	"ipt_rpfilter":         "CONFIG_IP_NF_MATCH_RPFILTER",
-	"xt_rpfilter":          "CONFIG_IP_NF_MATCH_RPFILTER",
-	"ipt_set":              "CONFIG_NET_EMATCH_IPSET",
-	"nf_conntrack_netlink": "CONFIG_NF_CT_NETLINK",
-	"xt_addrtype":          "CONFIG_NETFILTER_XT_MATCH_ADDRTYPE",
-	"xt_conntrack":         "CONFIG_NETFILTER_XT_MATCH_CONNTRACK",
-	"xt_icmp":              "icmp",
-	"xt_icmp6":             "icmp",
-	"xt_mark":              "CONFIG_IP_NF_TARGET_MARK",
-	"xt_multiport":         "CONFIG_IP_NF_MATCH_MULTIPORT",
-	"xt_set":               "CONFIG_NETFILTER_XT_SET",
-	"xt_u32":               "CONFIG_NETFILTER_XT_MATCH_U32",
+// moduleCheck describes how to detect a kernel feature Calico may need.
+//
+// Name is the historical module name shown to the user.
+// ConfigOptions are CONFIG_* symbols looked up in the kernel .config (any match is OK).
+// IPTMatches are tokens looked up in /proc/net/ip_tables_matches (any match is OK).
+// Alternatives are other module names that provide the same feature (e.g. xt_set for ipt_set).
+// Optional modules only produce a WARNING when missing and do not fail the check.
+type moduleCheck struct {
+	Name          string
+	ConfigOptions []string
+	IPTMatches    []string
+	Alternatives  []string
+	Optional      bool
+	SkipModProbe  bool // feature is not a real loadable module on modern kernels
+}
+
+// requiredModules is the list of kernel features checked by `calicoctl node checksystem`.
+// Stale xt_icmp/xt_icmp6 module names are replaced with iptables-match / kconfig probes.
+// ipt_set is treated as satisfied by xt_set (the modern equivalent).
+var requiredModules = []moduleCheck{
+	{Name: "ip_set", ConfigOptions: []string{"CONFIG_IP_SET"}},
+	{Name: "ip6_tables", ConfigOptions: []string{"CONFIG_IP6_NF_IPTABLES"}, Optional: true},
+	{Name: "ip_tables", ConfigOptions: []string{"CONFIG_IP_NF_IPTABLES"}},
+	{Name: "ipt_ipvs", ConfigOptions: []string{"CONFIG_NETFILTER_XT_MATCH_IPVS"}, Alternatives: []string{"xt_ipvs"}},
+	{Name: "vfio-pci", ConfigOptions: []string{"CONFIG_VFIO", "CONFIG_VFIO_PCI"}, Alternatives: []string{"vfio_pci"}},
+	{Name: "xt_bpf", ConfigOptions: []string{"CONFIG_BPF", "CONFIG_NETFILTER_XT_MATCH_BPF"}, Optional: true},
+	{Name: "ipt_REJECT", ConfigOptions: []string{"CONFIG_IP_NF_TARGET_REJECT", "CONFIG_NFT_REJECT", "CONFIG_NETFILTER_XT_TARGET_REJECT"}, Alternatives: []string{"xt_REJECT"}},
+	{Name: "ipt_rpfilter", ConfigOptions: []string{"CONFIG_IP_NF_MATCH_RPFILTER"}, Alternatives: []string{"xt_rpfilter"}},
+	{Name: "xt_rpfilter", ConfigOptions: []string{"CONFIG_IP_NF_MATCH_RPFILTER", "CONFIG_IP6_NF_MATCH_RPFILTER", "CONFIG_NETFILTER_XT_MATCH_RPFILTER"}, Alternatives: []string{"ipt_rpfilter"}},
+	// ipt_set is obsolete on modern kernels; xt_set provides the same match.
+	{Name: "ipt_set", ConfigOptions: []string{"CONFIG_NETFILTER_XT_SET", "CONFIG_IP_SET"}, Alternatives: []string{"xt_set"}},
+	{Name: "nf_conntrack_netlink", ConfigOptions: []string{"CONFIG_NF_CT_NETLINK"}},
+	{Name: "xt_addrtype", ConfigOptions: []string{"CONFIG_NETFILTER_XT_MATCH_ADDRTYPE"}},
+	{Name: "xt_conntrack", ConfigOptions: []string{"CONFIG_NETFILTER_XT_MATCH_CONNTRACK"}},
+	// xt_icmp / xt_icmp6 are not shipped as standalone modules on modern distros;
+	// the icmp match is built into iptables or provided via kconfig.
+	{
+		Name:          "xt_icmp",
+		ConfigOptions: []string{"CONFIG_IP_NF_MATCH_ICMP", "CONFIG_NETFILTER_XT_MATCH_ICMP"},
+		IPTMatches:    []string{"icmp"},
+		SkipModProbe:  true,
+	},
+	{
+		Name:          "xt_icmp6",
+		ConfigOptions: []string{"CONFIG_IP6_NF_MATCH_IPV6HEADER", "CONFIG_IP6_NF_MATCH_ICMP6", "CONFIG_NETFILTER_XT_MATCH_ICMP"},
+		IPTMatches:    []string{"icmp6", "icmpv6", "ipv6header"},
+		SkipModProbe:  true,
+		Optional:      true, // IPv4-only clusters do not need icmp6
+	},
+	{Name: "xt_mark", ConfigOptions: []string{"CONFIG_NETFILTER_XT_MARK", "CONFIG_IP_NF_TARGET_MARK", "CONFIG_NETFILTER_XT_TARGET_MARK"}},
+	{Name: "xt_multiport", ConfigOptions: []string{"CONFIG_NETFILTER_XT_MATCH_MULTIPORT", "CONFIG_IP_NF_MATCH_MULTIPORT"}},
+	{Name: "xt_set", ConfigOptions: []string{"CONFIG_NETFILTER_XT_SET"}, Alternatives: []string{"ipt_set"}},
+	// xt_u32 is not required for standard Calico operation.
+	{Name: "xt_u32", ConfigOptions: []string{"CONFIG_NETFILTER_XT_MATCH_U32"}, Optional: true},
 }
 
 // Variable to override bootfile location.
@@ -150,65 +182,141 @@ func checkKernelModules() error {
 		fmt.Printf("Error executing command: %s\n", err)
 		return err
 	}
+	lsmodStr := string(lsmodOut)
 
 	// Go through all the required modules and check Loadable and Builtin in order
-	for v, i := range requiredModules {
-		err = checkModule(modulesLoadablePath, v, kernelVersionStr, "\\/%s.ko")
-
-		// Check Builtin modules if not found in Loadable
-		if err != nil {
-			err = checkModule(modulesBuiltinPath, v, kernelVersionStr, "\\/%s.ko")
-
-			// Check if it's in lsmod, if not found in Builtin either
-			if err != nil {
-
-				regex, err := regexp.Compile(v)
-				if err != nil {
-					log.Errorf("Error: %v\n", err)
-					return err
-				}
-
-				if regex.MatchString(string(lsmodOut)) {
-					printResult(v, "OK")
-				} else if modulesBootPath != "" && checkModule(modulesBootPath, i, kernelVersionStr, "^%s=.") == nil {
-					printResult(v, "OK")
-					// Since `xt_icmp` and `xt_icmp6` are not available in most distros anymore as a last resort
-					// this `if` condition will check currently loaded modules in iptables using `ip_tables_matches` file.
-				} else if checkModule(modulesLoadedIPtables, i, kernelVersionStr, "^%s$") == nil {
-					printResult(v, "OK")
-				} else {
-					fmt.Printf("WARNING: Unable to detect the %s module as Loaded/Builtin module or lsmod\n", v)
-					modulesNotFound = append(modulesNotFound, v)
-					printResult(v, "FAIL")
-				}
-			} else {
-				printResult(v, "OK")
-			}
-		} else {
-			printResult(v, "OK")
+	for _, mod := range requiredModules {
+		if moduleAvailable(mod, modulesLoadablePath, modulesBuiltinPath, modulesBootPath, modulesLoadedIPtables, lsmodStr) {
+			printResult(mod.Name, "OK")
+			continue
 		}
+
+		if mod.Optional {
+			fmt.Printf("WARNING: Unable to detect optional module/feature %s; continuing\n", mod.Name)
+			printResult(mod.Name, "SKIP")
+			continue
+		}
+
+		fmt.Printf("WARNING: Unable to detect the %s module as Loaded/Builtin module or lsmod\n", mod.Name)
+		modulesNotFound = append(modulesNotFound, mod.Name)
+		printResult(mod.Name, "FAIL")
 	}
 
 	// If there are still any modules not found then return an error
 	if len(modulesNotFound) > 0 {
-
-		// ip6_tables is not a required module for ipv4 setups, so just print
-		// a warning instead of failing the system check
-		if len(modulesNotFound) == 1 && modulesNotFound[0] == "ip6_tables" {
-			fmt.Printf("WARNING: IPv6 will be unavailable as ip6_tables kernel module is not found\n")
-			return nil
-		}
 		return errors.New("one of more kernel modules missing")
 	}
 
 	return nil
 }
 
+// moduleAvailable reports whether a required kernel feature is present.
+func moduleAvailable(mod moduleCheck, loadablePath, builtinPath, bootPath, iptMatchesPath, lsmodOut string) bool {
+	candidates := []string{mod.Name}
+	candidates = append(candidates, mod.Alternatives...)
+
+	for _, name := range candidates {
+		// /sys/module/<name> exists for both loaded and built-in modules.
+		if modulePresentInSysfs(name) {
+			return true
+		}
+
+		// modules.dep may list .ko, .ko.gz, .ko.xz, .ko.zst
+		if checkModuleFile(loadablePath, name) == nil {
+			return true
+		}
+
+		// modules.builtin uses the same basenames without compression suffixes.
+		if checkModuleFile(builtinPath, name) == nil {
+			return true
+		}
+
+		// lsmod uses underscores; accept hyphen/underscore variants.
+		if lsmodHasModule(lsmodOut, name) {
+			return true
+		}
+	}
+
+	// Kernel .config options (built-in =y or module =m).
+	if bootPath != "" {
+		for _, cfg := range mod.ConfigOptions {
+			if cfg == "" {
+				continue
+			}
+			if checkModule(bootPath, cfg, "", "^%s=[ym]") == nil {
+				return true
+			}
+		}
+	}
+
+	// Loaded iptables match names (useful for icmp which is not a standalone module).
+	for _, match := range mod.IPTMatches {
+		if checkModule(iptMatchesPath, match, "", "^%s$") == nil {
+			return true
+		}
+	}
+
+	return false
+}
+
+func modulePresentInSysfs(name string) bool {
+	// sysfs uses underscores
+	sysName := strings.ReplaceAll(name, "-", "_")
+	if _, err := os.Stat(filepath.Join("/sys/module", sysName)); err == nil {
+		return true
+	}
+	return false
+}
+
+func lsmodHasModule(lsmodOut, name string) bool {
+	// Match module name as a whole field at the start of a line (lsmod format).
+	for _, candidate := range []string{name, strings.ReplaceAll(name, "-", "_"), strings.ReplaceAll(name, "_", "-")} {
+		re, err := regexp.Compile(`(?m)^` + regexp.QuoteMeta(candidate) + `\s`)
+		if err != nil {
+			continue
+		}
+		if re.MatchString(lsmodOut) {
+			return true
+		}
+	}
+	return false
+}
+
+// checkModuleFile looks for a module basename in modules.dep / modules.builtin,
+// accepting compressed object suffixes used by modern distros.
+func checkModuleFile(filename, module string) error {
+	// Match /module.ko or /module.ko.gz etc. anywhere on the line.
+	pattern := `/` + regexp.QuoteMeta(module) + `\.ko(\.(gz|xz|zst|bz2))?`
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		return err
+	}
+
+	fh, err := os.Open(filename)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = fh.Close() }()
+
+	scanner := bufio.NewScanner(fh)
+	// modules.dep lines can be long
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		if re.MatchString(scanner.Text()) {
+			return nil
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return err
+	}
+	return errors.New("module not found")
+}
+
 // checkModule is a utility function used by `checkKernelModules`
 // it opens the file provided and checks if the module passed in
 // as an argument exists for the provided kernelVersion
 func checkModule(filename, module, kernelVersion string, pattern string) error {
-	regex, err := regexp.Compile(fmt.Sprintf(pattern, module))
+	regex, err := regexp.Compile(fmt.Sprintf(pattern, regexp.QuoteMeta(module)))
 	if err != nil {
 		log.Errorf("Error: %v\n", err)
 		return err

--- a/calicoctl/calicoctl/commands/node/checksystem.go
+++ b/calicoctl/calicoctl/commands/node/checksystem.go
@@ -34,23 +34,20 @@ const minKernelVersion = "2.6.24"
 
 // moduleCheck describes how to detect a kernel feature Calico may need.
 //
-// Name is the historical module name shown to the user.
+// Name is the module name shown to the user.
 // ConfigOptions are CONFIG_* symbols looked up in the kernel .config (any match is OK).
-// IPTMatches are tokens looked up in /proc/net/ip_tables_matches (any match is OK).
-// Alternatives are other module names that provide the same feature (e.g. xt_set for ipt_set).
+// Alternatives are other module names that provide the same feature (e.g. ipt_set for xt_set).
 // Optional modules only produce a WARNING when missing and do not fail the check.
 type moduleCheck struct {
 	Name          string
 	ConfigOptions []string
-	IPTMatches    []string
 	Alternatives  []string
 	Optional      bool
-	SkipModProbe  bool // feature is not a real loadable module on modern kernels
 }
 
 // requiredModules is the list of kernel features checked by `calicoctl node checksystem`.
-// Stale xt_icmp/xt_icmp6 module names are replaced with iptables-match / kconfig probes.
-// ipt_set is treated as satisfied by xt_set (the modern equivalent).
+// Prefer modern xt_* names; legacy ipt_* names appear only as Alternatives for module lookup.
+// icmp match is covered by ip_tables and is not listed separately.
 var requiredModules = []moduleCheck{
 	{Name: "ip_set", ConfigOptions: []string{"CONFIG_IP_SET"}},
 	{Name: "ip6_tables", ConfigOptions: []string{"CONFIG_IP6_NF_IPTABLES"}, Optional: true},
@@ -59,28 +56,10 @@ var requiredModules = []moduleCheck{
 	{Name: "vfio-pci", ConfigOptions: []string{"CONFIG_VFIO", "CONFIG_VFIO_PCI"}, Alternatives: []string{"vfio_pci"}},
 	{Name: "xt_bpf", ConfigOptions: []string{"CONFIG_BPF", "CONFIG_NETFILTER_XT_MATCH_BPF"}, Optional: true},
 	{Name: "ipt_REJECT", ConfigOptions: []string{"CONFIG_IP_NF_TARGET_REJECT", "CONFIG_NFT_REJECT", "CONFIG_NETFILTER_XT_TARGET_REJECT"}, Alternatives: []string{"xt_REJECT"}},
-	{Name: "ipt_rpfilter", ConfigOptions: []string{"CONFIG_IP_NF_MATCH_RPFILTER"}, Alternatives: []string{"xt_rpfilter"}},
 	{Name: "xt_rpfilter", ConfigOptions: []string{"CONFIG_IP_NF_MATCH_RPFILTER", "CONFIG_IP6_NF_MATCH_RPFILTER", "CONFIG_NETFILTER_XT_MATCH_RPFILTER"}, Alternatives: []string{"ipt_rpfilter"}},
-	// ipt_set is obsolete on modern kernels; xt_set provides the same match.
-	{Name: "ipt_set", ConfigOptions: []string{"CONFIG_NETFILTER_XT_SET", "CONFIG_IP_SET"}, Alternatives: []string{"xt_set"}},
 	{Name: "nf_conntrack_netlink", ConfigOptions: []string{"CONFIG_NF_CT_NETLINK"}},
 	{Name: "xt_addrtype", ConfigOptions: []string{"CONFIG_NETFILTER_XT_MATCH_ADDRTYPE"}},
 	{Name: "xt_conntrack", ConfigOptions: []string{"CONFIG_NETFILTER_XT_MATCH_CONNTRACK"}},
-	// xt_icmp / xt_icmp6 are not shipped as standalone modules on modern distros;
-	// the icmp match is built into iptables or provided via kconfig.
-	{
-		Name:          "xt_icmp",
-		ConfigOptions: []string{"CONFIG_IP_NF_MATCH_ICMP", "CONFIG_NETFILTER_XT_MATCH_ICMP"},
-		IPTMatches:    []string{"icmp"},
-		SkipModProbe:  true,
-	},
-	{
-		Name:          "xt_icmp6",
-		ConfigOptions: []string{"CONFIG_IP6_NF_MATCH_IPV6HEADER", "CONFIG_IP6_NF_MATCH_ICMP6", "CONFIG_NETFILTER_XT_MATCH_ICMP"},
-		IPTMatches:    []string{"icmp6", "icmpv6", "ipv6header"},
-		SkipModProbe:  true,
-		Optional:      true, // IPv4-only clusters do not need icmp6
-	},
 	{Name: "xt_mark", ConfigOptions: []string{"CONFIG_NETFILTER_XT_MARK", "CONFIG_IP_NF_TARGET_MARK", "CONFIG_NETFILTER_XT_TARGET_MARK"}},
 	{Name: "xt_multiport", ConfigOptions: []string{"CONFIG_NETFILTER_XT_MATCH_MULTIPORT", "CONFIG_IP_NF_MATCH_MULTIPORT"}},
 	{Name: "xt_set", ConfigOptions: []string{"CONFIG_NETFILTER_XT_SET"}, Alternatives: []string{"ipt_set"}},
@@ -170,9 +149,6 @@ func checkKernelModules() error {
 	// File path to module configs in boot time
 	modulesBootPath := findBootFile(kernelVersionStr)
 
-	// File path for loaded iptables modules
-	modulesLoadedIPtables := "/proc/net/ip_tables_matches"
-
 	// Keep track of modules that are not found
 	modulesNotFound := []string{}
 
@@ -186,7 +162,7 @@ func checkKernelModules() error {
 
 	// Go through all the required modules and check Loadable and Builtin in order
 	for _, mod := range requiredModules {
-		if moduleAvailable(mod, modulesLoadablePath, modulesBuiltinPath, modulesBootPath, modulesLoadedIPtables, lsmodStr) {
+		if moduleAvailable(mod, modulesLoadablePath, modulesBuiltinPath, modulesBootPath, lsmodStr) {
 			printResult(mod.Name, "OK")
 			continue
 		}
@@ -211,7 +187,7 @@ func checkKernelModules() error {
 }
 
 // moduleAvailable reports whether a required kernel feature is present.
-func moduleAvailable(mod moduleCheck, loadablePath, builtinPath, bootPath, iptMatchesPath, lsmodOut string) bool {
+func moduleAvailable(mod moduleCheck, loadablePath, builtinPath, bootPath, lsmodOut string) bool {
 	candidates := []string{mod.Name}
 	candidates = append(candidates, mod.Alternatives...)
 
@@ -243,16 +219,9 @@ func moduleAvailable(mod moduleCheck, loadablePath, builtinPath, bootPath, iptMa
 			if cfg == "" {
 				continue
 			}
-			if checkModule(bootPath, cfg, "", "^%s=[ym]") == nil {
+			if checkModule(bootPath, cfg, "^%s=[ym]") == nil {
 				return true
 			}
-		}
-	}
-
-	// Loaded iptables match names (useful for icmp which is not a standalone module).
-	for _, match := range mod.IPTMatches {
-		if checkModule(iptMatchesPath, match, "", "^%s$") == nil {
-			return true
 		}
 	}
 
@@ -312,10 +281,9 @@ func checkModuleFile(filename, module string) error {
 	return errors.New("module not found")
 }
 
-// checkModule is a utility function used by `checkKernelModules`
-// it opens the file provided and checks if the module passed in
-// as an argument exists for the provided kernelVersion
-func checkModule(filename, module, kernelVersion string, pattern string) error {
+// checkModule opens filename and checks whether module matches pattern
+// (pattern is a fmt-style format with one %s for the module token).
+func checkModule(filename, module, pattern string) error {
 	regex, err := regexp.Compile(fmt.Sprintf(pattern, regexp.QuoteMeta(module)))
 	if err != nil {
 		log.Errorf("Error: %v\n", err)

--- a/calicoctl/calicoctl/commands/node/checksystem_test.go
+++ b/calicoctl/calicoctl/commands/node/checksystem_test.go
@@ -1,0 +1,191 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package node
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLsmodHasModule(t *testing.T) {
+	lsmod := `Module                  Size  Used by
+xt_set                 16384  4
+ip_set                 61440  3
+vfio_pci               65536  0
+`
+
+	cases := []struct {
+		name string
+		want bool
+	}{
+		{"xt_set", true},
+		{"ip_set", true},
+		{"vfio_pci", true},
+		{"vfio-pci", true}, // hyphenated alias
+		{"ipt_set", false},
+		{"xt_set_extra", false},
+	}
+	for _, tc := range cases {
+		if got := lsmodHasModule(lsmod, tc.name); got != tc.want {
+			t.Errorf("lsmodHasModule(%q) = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestCheckModuleFileCompressedAndBuiltin(t *testing.T) {
+	dir := t.TempDir()
+	dep := filepath.Join(dir, "modules.dep")
+	builtin := filepath.Join(dir, "modules.builtin")
+
+	if err := os.WriteFile(dep, []byte(
+		"kernel/net/netfilter/xt_set.ko.xz: kernel/net/netfilter/ip_set.ko.xz\n"+
+			"kernel/drivers/vfio/pci/vfio-pci.ko.zst:\n",
+	), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(builtin, []byte(
+		"kernel/net/ipv4/netfilter/ip_tables.ko\n"+
+			"kernel/net/netfilter/xt_conntrack.ko\n",
+	), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := checkModuleFile(dep, "xt_set"); err != nil {
+		t.Errorf("expected xt_set in modules.dep: %v", err)
+	}
+	if err := checkModuleFile(dep, "vfio-pci"); err != nil {
+		t.Errorf("expected vfio-pci in modules.dep: %v", err)
+	}
+	if err := checkModuleFile(dep, "ipt_set"); err == nil {
+		t.Error("did not expect ipt_set in modules.dep")
+	}
+	if err := checkModuleFile(builtin, "ip_tables"); err != nil {
+		t.Errorf("expected ip_tables in modules.builtin: %v", err)
+	}
+	if err := checkModuleFile(builtin, "xt_conntrack"); err != nil {
+		t.Errorf("expected xt_conntrack in modules.builtin: %v", err)
+	}
+}
+
+func TestModuleAvailableIptSetViaXtSet(t *testing.T) {
+	dir := t.TempDir()
+	dep := filepath.Join(dir, "modules.dep")
+	builtin := filepath.Join(dir, "modules.builtin")
+	boot := filepath.Join(dir, "config")
+	ipt := filepath.Join(dir, "ip_tables_matches")
+
+	// Only xt_set is present (modern distro); ipt_set is not.
+	if err := os.WriteFile(dep, []byte("kernel/net/netfilter/xt_set.ko:\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(builtin, []byte(""), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(boot, []byte("CONFIG_NETFILTER_XT_SET=m\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(ipt, []byte("set\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	mod := moduleCheck{
+		Name:          "ipt_set",
+		ConfigOptions: []string{"CONFIG_NETFILTER_XT_SET", "CONFIG_IP_SET"},
+		Alternatives:  []string{"xt_set"},
+	}
+	if !moduleAvailable(mod, dep, builtin, boot, ipt, "") {
+		t.Fatal("ipt_set should be satisfied by xt_set alternative")
+	}
+}
+
+func TestModuleAvailableICMPViaConfigAndMatches(t *testing.T) {
+	dir := t.TempDir()
+	dep := filepath.Join(dir, "modules.dep")
+	builtin := filepath.Join(dir, "modules.builtin")
+	boot := filepath.Join(dir, "config")
+	ipt := filepath.Join(dir, "ip_tables_matches")
+
+	if err := os.WriteFile(dep, []byte(""), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(builtin, []byte(""), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// No standalone xt_icmp module; feature is in kconfig / iptables matches.
+	if err := os.WriteFile(boot, []byte("CONFIG_IP_NF_MATCH_ICMP=y\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(ipt, []byte("icmp\nstate\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	mod := moduleCheck{
+		Name:          "xt_icmp",
+		ConfigOptions: []string{"CONFIG_IP_NF_MATCH_ICMP"},
+		IPTMatches:    []string{"icmp"},
+		SkipModProbe:  true,
+	}
+	if !moduleAvailable(mod, dep, builtin, boot, ipt, "") {
+		t.Fatal("xt_icmp should be detected via kernel config / iptables matches")
+	}
+
+	// Empty config, matches only.
+	if err := os.WriteFile(boot, []byte(""), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if !moduleAvailable(mod, dep, builtin, boot, ipt, "") {
+		t.Fatal("xt_icmp should be detected via ip_tables_matches alone")
+	}
+}
+
+func TestModuleAvailableOptionalMissing(t *testing.T) {
+	dir := t.TempDir()
+	dep := filepath.Join(dir, "modules.dep")
+	builtin := filepath.Join(dir, "modules.builtin")
+	boot := filepath.Join(dir, "config")
+	ipt := filepath.Join(dir, "ip_tables_matches")
+	for _, p := range []string{dep, builtin, boot, ipt} {
+		if err := os.WriteFile(p, []byte(""), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	mod := moduleCheck{
+		Name:          "xt_u32",
+		ConfigOptions: []string{"CONFIG_NETFILTER_XT_MATCH_U32"},
+		Optional:      true,
+	}
+	if moduleAvailable(mod, dep, builtin, boot, ipt, "") {
+		t.Fatal("xt_u32 should be missing")
+	}
+}
+
+func TestCheckModuleConfigYAndM(t *testing.T) {
+	dir := t.TempDir()
+	boot := filepath.Join(dir, "config")
+	if err := os.WriteFile(boot, []byte("CONFIG_IP_SET=y\nCONFIG_NETFILTER_XT_SET=m\n# CONFIG_FOO is not set\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := checkModule(boot, "CONFIG_IP_SET", "", "^%s=[ym]"); err != nil {
+		t.Errorf("CONFIG_IP_SET=y should match: %v", err)
+	}
+	if err := checkModule(boot, "CONFIG_NETFILTER_XT_SET", "", "^%s=[ym]"); err != nil {
+		t.Errorf("CONFIG_NETFILTER_XT_SET=m should match: %v", err)
+	}
+	if err := checkModule(boot, "CONFIG_FOO", "", "^%s=[ym]"); err == nil {
+		t.Error("unset CONFIG_FOO should not match")
+	}
+}

--- a/calicoctl/calicoctl/commands/node/checksystem_test.go
+++ b/calicoctl/calicoctl/commands/node/checksystem_test.go
@@ -80,74 +80,30 @@ func TestCheckModuleFileCompressedAndBuiltin(t *testing.T) {
 	}
 }
 
-func TestModuleAvailableIptSetViaXtSet(t *testing.T) {
+func TestModuleAvailableXtSetViaLegacyIptSet(t *testing.T) {
 	dir := t.TempDir()
 	dep := filepath.Join(dir, "modules.dep")
 	builtin := filepath.Join(dir, "modules.builtin")
 	boot := filepath.Join(dir, "config")
-	ipt := filepath.Join(dir, "ip_tables_matches")
 
-	// Only xt_set is present (modern distro); ipt_set is not.
-	if err := os.WriteFile(dep, []byte("kernel/net/netfilter/xt_set.ko:\n"), 0o644); err != nil {
+	// Old distro only ships ipt_set; xt_set entry should still pass via Alternatives.
+	if err := os.WriteFile(dep, []byte("kernel/net/netfilter/ipt_set.ko:\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(builtin, []byte(""), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(boot, []byte("CONFIG_NETFILTER_XT_SET=m\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(ipt, []byte("set\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-
-	mod := moduleCheck{
-		Name:          "ipt_set",
-		ConfigOptions: []string{"CONFIG_NETFILTER_XT_SET", "CONFIG_IP_SET"},
-		Alternatives:  []string{"xt_set"},
-	}
-	if !moduleAvailable(mod, dep, builtin, boot, ipt, "") {
-		t.Fatal("ipt_set should be satisfied by xt_set alternative")
-	}
-}
-
-func TestModuleAvailableICMPViaConfigAndMatches(t *testing.T) {
-	dir := t.TempDir()
-	dep := filepath.Join(dir, "modules.dep")
-	builtin := filepath.Join(dir, "modules.builtin")
-	boot := filepath.Join(dir, "config")
-	ipt := filepath.Join(dir, "ip_tables_matches")
-
-	if err := os.WriteFile(dep, []byte(""), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(builtin, []byte(""), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	// No standalone xt_icmp module; feature is in kconfig / iptables matches.
-	if err := os.WriteFile(boot, []byte("CONFIG_IP_NF_MATCH_ICMP=y\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(ipt, []byte("icmp\nstate\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-
-	mod := moduleCheck{
-		Name:          "xt_icmp",
-		ConfigOptions: []string{"CONFIG_IP_NF_MATCH_ICMP"},
-		IPTMatches:    []string{"icmp"},
-		SkipModProbe:  true,
-	}
-	if !moduleAvailable(mod, dep, builtin, boot, ipt, "") {
-		t.Fatal("xt_icmp should be detected via kernel config / iptables matches")
-	}
-
-	// Empty config, matches only.
 	if err := os.WriteFile(boot, []byte(""), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if !moduleAvailable(mod, dep, builtin, boot, ipt, "") {
-		t.Fatal("xt_icmp should be detected via ip_tables_matches alone")
+
+	mod := moduleCheck{
+		Name:          "xt_set",
+		ConfigOptions: []string{"CONFIG_NETFILTER_XT_SET"},
+		Alternatives:  []string{"ipt_set"},
+	}
+	if !moduleAvailable(mod, dep, builtin, boot, "") {
+		t.Fatal("xt_set should be satisfied by ipt_set alternative")
 	}
 }
 
@@ -156,8 +112,7 @@ func TestModuleAvailableOptionalMissing(t *testing.T) {
 	dep := filepath.Join(dir, "modules.dep")
 	builtin := filepath.Join(dir, "modules.builtin")
 	boot := filepath.Join(dir, "config")
-	ipt := filepath.Join(dir, "ip_tables_matches")
-	for _, p := range []string{dep, builtin, boot, ipt} {
+	for _, p := range []string{dep, builtin, boot} {
 		if err := os.WriteFile(p, []byte(""), 0o644); err != nil {
 			t.Fatal(err)
 		}
@@ -168,7 +123,7 @@ func TestModuleAvailableOptionalMissing(t *testing.T) {
 		ConfigOptions: []string{"CONFIG_NETFILTER_XT_MATCH_U32"},
 		Optional:      true,
 	}
-	if moduleAvailable(mod, dep, builtin, boot, ipt, "") {
+	if moduleAvailable(mod, dep, builtin, boot, "") {
 		t.Fatal("xt_u32 should be missing")
 	}
 }
@@ -179,13 +134,23 @@ func TestCheckModuleConfigYAndM(t *testing.T) {
 	if err := os.WriteFile(boot, []byte("CONFIG_IP_SET=y\nCONFIG_NETFILTER_XT_SET=m\n# CONFIG_FOO is not set\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if err := checkModule(boot, "CONFIG_IP_SET", "", "^%s=[ym]"); err != nil {
+	if err := checkModule(boot, "CONFIG_IP_SET", "^%s=[ym]"); err != nil {
 		t.Errorf("CONFIG_IP_SET=y should match: %v", err)
 	}
-	if err := checkModule(boot, "CONFIG_NETFILTER_XT_SET", "", "^%s=[ym]"); err != nil {
+	if err := checkModule(boot, "CONFIG_NETFILTER_XT_SET", "^%s=[ym]"); err != nil {
 		t.Errorf("CONFIG_NETFILTER_XT_SET=m should match: %v", err)
 	}
-	if err := checkModule(boot, "CONFIG_FOO", "", "^%s=[ym]"); err == nil {
+	if err := checkModule(boot, "CONFIG_FOO", "^%s=[ym]"); err == nil {
 		t.Error("unset CONFIG_FOO should not match")
+	}
+}
+
+func TestRequiredModulesHasNoDuplicateFeatureRows(t *testing.T) {
+	// ipt_set / ipt_rpfilter / xt_icmp must not appear as primary Name rows.
+	banned := map[string]bool{"ipt_set": true, "ipt_rpfilter": true, "xt_icmp": true, "xt_icmp6": true}
+	for _, mod := range requiredModules {
+		if banned[mod.Name] {
+			t.Errorf("unexpected primary module row %q", mod.Name)
+		}
 	}
 }


### PR DESCRIPTION
## Description

`calicoctl node checksystem` reports false FAIL results on modern distros (Flatcar, Debian, Fedora, RHEL/Rocky 9, etc.) because:

- features are often **built-in** or shipped as **compressed** modules (`.ko.xz`/`.ko.zst`) that the old detector missed;
- **`ipt_set`** is obsolete — modern kernels provide **`xt_set`** instead;
- **`xt_icmp` / `xt_icmp6`** are no longer standalone modules;
- **`xt_u32`** is not required for standard Calico operation.

This change improves detection (`/sys/module`, compressed module suffixes, alternative names, kernel config / iptables match probes) and treats optional features as warnings (`SKIP`) rather than hard failures.

Fixes #4288

## Testing

- `go test ./calicoctl/calicoctl/commands/node/ -count=1`
- unit coverage for ipt_set←xt_set, icmp via kconfig/matches, compressed modules.dep, lsmod hyphen/underscore

**Release note:**
```release-note
calicoctl node checksystem no longer false-fails on modern distros for builtin/obsolete kernel modules (ipt_set, xt_icmp, xt_u32, etc.)
```