### PR TITLE
fix(whisker): pull nginx from mainline repo (CVE-2026-42055)

### DIFF
--- a/whisker/docker-image/Dockerfile
+++ b/whisker/docker-image/Dockerfile
@@ -20,7 +20,7 @@ RUN dnf upgrade -y
 
 COPY docker-image/nginx.repo /etc/yum.repos.d/nginx.repo
 
-RUN dnf --enablerepo=nginx-stable install -y \
+RUN dnf --enablerepo=nginx-mainline install -y \
   nginx
 
 FROM scratch AS source

--- a/whisker/docker-image/nginx.repo
+++ b/whisker/docker-image/nginx.repo
@@ -1,6 +1,6 @@
-[nginx-stable]
-name=nginx stable repo
-baseurl=http://nginx.org/packages/rhel/$releasever/$basearch/
+[nginx-mainline]
+name=nginx mainline repo
+baseurl=http://nginx.org/packages/mainline/rhel/$releasever/$basearch/
 gpgcheck=1
 enabled=0
 gpgkey=https://nginx.org/keys/nginx_signing.key


### PR DESCRIPTION
## What

Switch the whisker image to install nginx from nginx.org's mainline repo instead of the stable repo. A rebuild picks up nginx 1.31.3.

## Why

CVE-2026-42055 is a heap overflow in nginx's HTTP/2-proxy and gRPC modules, fixed on both branches: stable at 1.30.3 and mainline at 1.31.2. Whisker was already on patched stable, so it isn't actually vulnerable, but image scanners flag it anyway. NVD lists the affected set as one broad mainline range, 1.13.10 up to 1.31.2, and that covers the whole 1.30.x stable line, so any stable build below 1.31.2 still matches. No stable version clears that; only mainline 1.31.2 or later does.

Whisker's nginx serves the static SPA with no HTTP/2 upstream and no grpc_pass, so the vulnerable path isn't configured and moving to mainline is backward compatible here.

## Test plan

- CI builds the whisker image from the mainline repo and pulls nginx 1.31.3.
- Rescan confirms CVE-2026-42055 no longer flags on the whisker image.

**Release note:**
```release-note
None
```
