### PR TITLE
felix/collector: fix collector UT data races; enable -race for felix UTs

### DIFF
--- a/felix/Makefile
+++ b/felix/Makefile
@@ -291,7 +291,9 @@ UT_PACKAGES_TO_SKIP?=fv,k8sfv,bpf/ut
 .PHONY: ut
 ut combined.coverprofile: $(SRC_FILES) $(LIBBPF_A) $(BPF_APACHE_O_FILES)
 	@echo Running Go UTs.
-	$(DOCKER_RUN) $(CALICO_BUILD) ./utils/run-coverage -skip-package $(UT_PACKAGES_TO_SKIP) $(GINKGO_ARGS)
+	# run-coverage runs ginkgo with the race detector enabled, which requires
+	# CGO, so use the CGO build container.
+	$(DOCKER_GO_BUILD_CGO) ./utils/run-coverage -skip-package $(UT_PACKAGES_TO_SKIP) $(GINKGO_ARGS)
 
 ###############################################################################
 # FV Tests

--- a/felix/collector/collector.go
+++ b/felix/collector/collector.go
@@ -202,7 +202,6 @@ func newCollector(lc *calc.LookupsCache, cfg *Config) Collector {
 	c := &collector{
 		luc:                   lc,
 		epStats:               make(map[tuple.Tuple]*Data),
-		ticker:                jitter.NewTicker(cfg.ExportingInterval, cfg.ExportingInterval/10),
 		config:                cfg,
 		dumpLog:               log.New(),
 		ds:                    make(chan *proto.DataplaneStats, 1000),
@@ -217,11 +216,8 @@ func newCollector(lc *calc.LookupsCache, cfg *Config) Collector {
 		c.policyStoreManager = policystore.NewPolicyStoreManager()
 	}
 
-	// Only run the re-evaluation sweep when pending policies are enabled; leaving the ticker nil
-	// masks the sweep out of the main loop entirely.
 	if apiv3.FlowLogsPolicyEvaluationModeType(cfg.PolicyEvaluationMode) == apiv3.FlowLogsPolicyEvaluationModeContinuous {
-		log.Infof("Pending policies enabled, initiating pending policy evaluation ticker")
-		c.tickerPolicyEval = jitter.NewTicker(recalcInterval, cfg.FlowLogsFlushInterval/10)
+		log.Infof("Pending policies enabled")
 	} else {
 		log.Infof("Pending policies disabled")
 	}
@@ -248,6 +244,15 @@ func (c *collector) Start() error {
 		return fmt.Errorf("ConntrackInfoReader failed to start: %w", err)
 	}
 
+	// Create the tickers here rather than in newCollector so their goroutines
+	// share the stats-collection loop's lifecycle: a collector that is never
+	// Started spawns no ticker goroutines, and the loop stops them on exit.
+	c.ticker = jitter.NewTicker(c.config.ExportingInterval, c.config.ExportingInterval/10)
+	// Only run the re-evaluation sweep when pending policies are enabled; leaving the ticker nil
+	// masks the sweep out of the main loop entirely.
+	if apiv3.FlowLogsPolicyEvaluationModeType(c.config.PolicyEvaluationMode) == apiv3.FlowLogsPolicyEvaluationModeContinuous {
+		c.tickerPolicyEval = jitter.NewTicker(c.config.FlowLogsFlushInterval*8/10, c.config.FlowLogsFlushInterval/10)
+	}
 	go c.startStatsCollectionAndReporting()
 
 	if apiv3.FlowLogsPolicyEvaluationModeType(c.config.PolicyEvaluationMode) == apiv3.FlowLogsPolicyEvaluationModeContinuous {
@@ -302,6 +307,16 @@ func (c *collector) SetConntrackInfoReader(cir types.ConntrackInfoReader) {
 }
 
 func (c *collector) startStatsCollectionAndReporting() {
+	// The tickers are created in Start just before this goroutine is launched.
+	// Stop them on any loop exit so their goroutines don't outlive us. Doing it
+	// here (as the loop returns) rather than in Stop() means we never close a
+	// ticker channel while still selecting on it, which would busy-spin.
+	defer c.ticker.Stop()
+	if c.tickerPolicyEval != nil {
+		// Nil unless pending policies are enabled; see Start.
+		defer c.tickerPolicyEval.Stop()
+	}
+
 	var (
 		pktInfoC <-chan types.PacketInfo
 		ctInfoC  <-chan []types.ConntrackInfo

--- a/felix/collector/collector.go
+++ b/felix/collector/collector.go
@@ -183,6 +183,16 @@ type collector struct {
 	// policyEvalMinInterval is the minimum time between re-evaluations of one flow. Half the
 	// ticker interval.
 	policyEvalMinInterval time.Duration
+
+	// stopC signals the stats collection goroutine to return; closed by Stop().
+	stopC chan struct{}
+
+	// thunkC lets a caller run a closure on the collector's own goroutine. The
+	// collector goroutine owns epStats (and the Data values within it) with no
+	// locking, so this is the only race-free way to read or mutate that state
+	// from another goroutine. Only tests currently use it, via the runOnLoop
+	// helper; in production nothing sends to it and the select case is dormant.
+	thunkC chan func()
 }
 
 // newCollector instantiates a new collector. The StartDataplaneStatsCollector function is the only public
@@ -199,6 +209,8 @@ func newCollector(lc *calc.LookupsCache, cfg *Config) Collector {
 		displayDebugTraceLogs: cfg.DisplayDebugTraceLogs,
 		policyStoreManager:    cfg.PolicyStoreManager,
 		policyEvalMinInterval: recalcInterval / 2,
+		stopC:                 make(chan struct{}),
+		thunkC:                make(chan func()),
 	}
 
 	if c.policyStoreManager == nil {
@@ -343,6 +355,12 @@ func (c *collector) startStatsCollectionAndReporting() {
 				batchTriggerC = nil
 				policyEvalTickC = c.policyEvalTickChan()
 			}
+		case fn := <-c.thunkC:
+			// Run a caller-supplied closure on this goroutine, giving it
+			// race-free access to collector-owned state. See thunkC.
+			fn()
+		case <-c.stopC:
+			return
 		}
 	}
 }
@@ -354,6 +372,13 @@ func (c *collector) policyEvalTickChan() <-chan time.Time {
 		return nil
 	}
 	return c.tickerPolicyEval.Channel()
+}
+
+// Stop signals the stats collection goroutine started by Start to return. It
+// must be called at most once. It does not stop the info readers or metric
+// reporters; those have their own lifecycles.
+func (c *collector) Stop() {
+	close(c.stopC)
 }
 
 // loopProcessingDataplaneInfoUpdates processes the dataplane info updates. The dataplaneInfoReader

--- a/felix/collector/collector.go
+++ b/felix/collector/collector.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/gavv/monotime"
@@ -180,12 +181,15 @@ type collector struct {
 	recalcSnapshot []*Data
 	// recalcSweepStart is when the current snapshot was taken, for the sweep-duration histogram.
 	recalcSweepStart time.Time
+	// recalcInterval is the period of the policy re-evaluation sweep ticker.
+	recalcInterval time.Duration
 	// policyEvalMinInterval is the minimum time between re-evaluations of one flow. Half the
 	// ticker interval.
 	policyEvalMinInterval time.Duration
 
 	// stopC signals the stats collection goroutine to return; closed by Stop().
-	stopC chan struct{}
+	stopC    chan struct{}
+	stopOnce sync.Once
 
 	// thunkC lets a caller run a closure on the collector's own goroutine. The
 	// collector goroutine owns epStats (and the Data values within it) with no
@@ -207,6 +211,7 @@ func newCollector(lc *calc.LookupsCache, cfg *Config) Collector {
 		ds:                    make(chan *proto.DataplaneStats, 1000),
 		displayDebugTraceLogs: cfg.DisplayDebugTraceLogs,
 		policyStoreManager:    cfg.PolicyStoreManager,
+		recalcInterval:        recalcInterval,
 		policyEvalMinInterval: recalcInterval / 2,
 		stopC:                 make(chan struct{}),
 		thunkC:                make(chan func()),
@@ -251,7 +256,7 @@ func (c *collector) Start() error {
 	// Only run the re-evaluation sweep when pending policies are enabled; leaving the ticker nil
 	// masks the sweep out of the main loop entirely.
 	if apiv3.FlowLogsPolicyEvaluationModeType(c.config.PolicyEvaluationMode) == apiv3.FlowLogsPolicyEvaluationModeContinuous {
-		c.tickerPolicyEval = jitter.NewTicker(c.config.FlowLogsFlushInterval*8/10, c.config.FlowLogsFlushInterval/10)
+		c.tickerPolicyEval = jitter.NewTicker(c.recalcInterval, c.config.FlowLogsFlushInterval/10)
 	}
 	go c.startStatsCollectionAndReporting()
 
@@ -389,11 +394,11 @@ func (c *collector) policyEvalTickChan() <-chan time.Time {
 	return c.tickerPolicyEval.Channel()
 }
 
-// Stop signals the stats collection goroutine started by Start to return. It
-// must be called at most once. It does not stop the info readers or metric
-// reporters; those have their own lifecycles.
+// Stop signals the stats collection goroutine started by Start to return. It is
+// idempotent. It does not stop the info readers or metric reporters; those have
+// their own lifecycles.
 func (c *collector) Stop() {
-	close(c.stopC)
+	c.stopOnce.Do(func() { close(c.stopC) })
 }
 
 // loopProcessingDataplaneInfoUpdates processes the dataplane info updates. The dataplaneInfoReader

--- a/felix/collector/collector_test.go
+++ b/felix/collector/collector_test.go
@@ -18,7 +18,6 @@ package collector
 
 import (
 	"fmt"
-	"maps"
 	net2 "net"
 	"slices"
 	"testing"
@@ -688,14 +687,9 @@ var _ = Describe("NFLOG Datasource", func() {
 
 				// Verify that RuleHits are not processed.  The RuleHits are applied after the
 				// epStats entry is inserted, so keep checking rather than sampling immediately.
-				// epStats and its Data are owned by the collector goroutine, so read on-loop.
 				Consistently(func() [2]int {
-					var lens [2]int
-					c.runOnLoop(func() {
-						data := c.epStats[*t]
-						lens = [2]int{len(data.IngressRuleTrace.Path()), len(data.EgressRuleTrace.Path())}
-					})
-					return lens
+					data := c.epStatsSnapshot()[*t]
+					return [2]int{len(data.IngressRuleTrace.Path()), len(data.EgressRuleTrace.Path())}
 				}, "500ms", "100ms").Should(Equal([2]int{0, 0}),
 					"Ingress/EgressRuleTrace Paths should stay empty when source endpoint is marked for deletion")
 			})
@@ -729,14 +723,9 @@ var _ = Describe("NFLOG Datasource", func() {
 
 				// Verify that RuleHits are not processed.  The RuleHits are applied after the
 				// epStats entry is inserted, so keep checking rather than sampling immediately.
-				// epStats and its Data are owned by the collector goroutine, so read on-loop.
 				Consistently(func() [2]int {
-					var lens [2]int
-					c.runOnLoop(func() {
-						data := c.epStats[*t]
-						lens = [2]int{len(data.IngressRuleTrace.Path()), len(data.EgressRuleTrace.Path())}
-					})
-					return lens
+					data := c.epStatsSnapshot()[*t]
+					return [2]int{len(data.IngressRuleTrace.Path()), len(data.EgressRuleTrace.Path())}
 				}, "500ms", "100ms").Should(Equal([2]int{0, 0}),
 					"Ingress/EgressRuleTrace Paths should stay empty when destination endpoint is marked for deletion")
 			})
@@ -770,14 +759,9 @@ var _ = Describe("NFLOG Datasource", func() {
 
 				// Verify that RuleHits are not processed.  The RuleHits are applied after the
 				// epStats entry is inserted, so keep checking rather than sampling immediately.
-				// epStats and its Data are owned by the collector goroutine, so read on-loop.
 				Consistently(func() [2]int {
-					var lens [2]int
-					c.runOnLoop(func() {
-						data := c.epStats[*t]
-						lens = [2]int{len(data.IngressRuleTrace.Path()), len(data.EgressRuleTrace.Path())}
-					})
-					return lens
+					data := c.epStatsSnapshot()[*t]
+					return [2]int{len(data.IngressRuleTrace.Path()), len(data.EgressRuleTrace.Path())}
 				}, "500ms", "100ms").Should(Equal([2]int{0, 0}),
 					"Ingress/EgressRuleTrace Paths should stay empty when remote source endpoint is marked for deletion")
 			})
@@ -809,11 +793,7 @@ var _ = Describe("NFLOG Datasource", func() {
 
 				// Verify that RuleHits were processed (Path should NOT be empty)
 				Eventually(func() int {
-					var pathLen int
-					c.runOnLoop(func() {
-						pathLen = len(c.epStats[*t].IngressRuleTrace.Path())
-					})
-					return pathLen
+					return len(c.epStatsSnapshot()[*t].IngressRuleTrace.Path())
 				}, "500ms", "50ms").Should(BeNumerically(">", 0), "IngressRuleTrace Path should NOT be empty when endpoints are active")
 			})
 		})
@@ -1121,28 +1101,16 @@ func countersOfCtEntry(e nfnetlink.CtEntry) ctCounters {
 
 func countersOfData(c *collector, t tuple.Tuple) func() (ctCounters, error) {
 	return func() (ctCounters, error) {
-		// epStats and the Data within it are owned by the collector goroutine,
-		// so read the counters on that goroutine.
-		var (
-			cs ctCounters
-			ok bool
-		)
-		c.runOnLoop(func() {
-			var data *Data
-			if data, ok = c.epStats[t]; !ok {
-				return
-			}
-			cs = ctCounters{
-				Packets:        data.ConntrackPacketsCounter(),
-				Bytes:          data.ConntrackBytesCounter(),
-				PacketsReverse: data.ConntrackPacketsCounterReverse(),
-				BytesReverse:   data.ConntrackBytesCounterReverse(),
-			}
-		})
+		data, ok := c.epStatsSnapshot()[t]
 		if !ok {
 			return ctCounters{}, fmt.Errorf("no epStats entry for tuple %v", &t)
 		}
-		return cs, nil
+		return ctCounters{
+			Packets:        data.ConntrackPacketsCounter(),
+			Bytes:          data.ConntrackBytesCounter(),
+			PacketsReverse: data.ConntrackPacketsCounterReverse(),
+			BytesReverse:   data.ConntrackBytesCounterReverse(),
+		}, nil
 	}
 }
 
@@ -1154,15 +1122,14 @@ func countersOfData(c *collector, t tuple.Tuple) func() (ctCounters, error) {
 // afterwards.  Asserting on those fields immediately after the entry appears
 // is therefore racy; the counters are written last, so once they match, the
 // whole update has been applied.
+// The returned Data is a clone, so its fields can be read directly.
 func eventuallyExpectCtStats(c *collector, t tuple.Tuple, e nfnetlink.CtEntry) *Data {
 	GinkgoHelper()
 	Eventually(countersOfData(c, t), "2s", "100ms").Should(Equal(countersOfCtEntry(e)))
 	var data *Data
 	c.runOnLoop(func() {
-		data = c.epStats[t]
+		data = c.epStats[t].clone()
 	})
-	// NOTE: the returned *Data is owned by the collector goroutine; callers must
-	// read its fields via c.runOnLoop, not directly.
 	return data
 }
 
@@ -1272,13 +1239,9 @@ var _ = Describe("Conntrack Datasource", func() {
 			Eventually(c.epStatsSnapshot, "500ms", "100ms").Should(HaveKey(*t))
 
 			// Flag the data as reported, swap local endpoints from mock data and send in CT entry again.
-			var oldSrc, oldDest calc.EndpointData
-			c.runOnLoop(func() {
-				data := c.epStats[*t]
-				data.Reported = true
-				oldSrc = data.SrcEp
-				oldDest = data.DstEp
-			})
+			before := c.epStatsSnapshot()[*t]
+			oldSrc, oldDest := before.SrcEp, before.DstEp
+			c.runOnLoop(func() { c.epStats[*t].Reported = true })
 
 			lm.SetMockData(epMapSwapLocal, nil, nil, nil)
 			ciReaderSenderChan <- []clttypes.ConntrackInfo{convertCtEntry(inCtEntry, 0)}
@@ -1286,14 +1249,9 @@ var _ = Describe("Conntrack Datasource", func() {
 			// This is a reported flow, and is a conntrack update - this should not impact the stored data at all since
 			// the endpoint should not be changing for a constant connection.
 			Consistently(c.epStatsSnapshot, "500ms", "100ms").Should(HaveKey(*t))
-			var newSrc, newDest calc.EndpointData
-			c.runOnLoop(func() {
-				data := c.epStats[*t]
-				newSrc = data.SrcEp
-				newDest = data.DstEp
-			})
-			Expect(newSrc).To(Equal(oldSrc))
-			Expect(newDest).To(Equal(oldDest))
+			data := c.epStatsSnapshot()[*t]
+			Expect(data.SrcEp).To(Equal(oldSrc))
+			Expect(data.DstEp).To(Equal(oldDest))
 		})
 		It("should handle destination changing on next conntrack update for unreported flow", func() {
 			t := tuple.New(remoteIp1, localIp1, proto_tcp, srcPort, dstPort)
@@ -1303,27 +1261,19 @@ var _ = Describe("Conntrack Datasource", func() {
 			Eventually(c.epStatsSnapshot, "500ms", "100ms").Should(HaveKey(*t))
 
 			// Data is not reported. swap local endpoints from mock data and send in packetinfo entry again.
-			var oldSrc, oldDest calc.EndpointData
-			c.runOnLoop(func() {
-				data := c.epStats[*t]
-				oldSrc = data.SrcEp
-				oldDest = data.DstEp
-			})
+			before := c.epStatsSnapshot()[*t]
+			oldSrc, oldDest := before.SrcEp, before.DstEp
 
 			lm.SetMockData(epMapSwapLocal, nil, nil, nil)
 			ciReaderSenderChan <- []clttypes.ConntrackInfo{convertCtEntry(inCtEntry, 0)}
 
 			// This is an unreported flow, and is a conntrack update. We can update the endpoint.
 			Consistently(c.epStatsSnapshot, "500ms", "100ms").Should(HaveKey(*t))
-			// The endpoint swap is applied on the collector goroutine, so poll DstEp on-loop.
+			// The endpoint swap is applied on the collector goroutine, so keep polling for it.
 			Eventually(func() calc.EndpointData {
-				var dstEp calc.EndpointData
-				c.runOnLoop(func() { dstEp = c.epStats[*t].DstEp })
-				return dstEp
+				return c.epStatsSnapshot()[*t].DstEp
 			}, "2s", "100ms").ShouldNot(Equal(oldDest))
-			var srcEp calc.EndpointData
-			c.runOnLoop(func() { srcEp = c.epStats[*t].SrcEp })
-			Expect(srcEp).To(Equal(oldSrc))
+			Expect(c.epStatsSnapshot()[*t].SrcEp).To(Equal(oldSrc))
 		})
 		It("should handle destination becoming non-local by removing entry on next packetinfo update for reported flow", func() {
 			pktinfo := nflogReader.ConvertNflogPkt(rules.RuleDirIngress, ingressPktAllow[ingressPktAllowNflogTuple])
@@ -1344,6 +1294,8 @@ var _ = Describe("Conntrack Datasource", func() {
 			// This is a reported flow but we are going through packet processing still. It should be expired and
 			// removed.
 			Eventually(c.epStatsSnapshot, "500ms", "100ms").ShouldNot(HaveKey(*t))
+			// The entry has been removed from epStats, so a snapshot cannot reach it; read the
+			// Data the collector goroutine still owns on-loop.
 			var reported bool
 			c.runOnLoop(func() { reported = data.Reported })
 			Expect(reported).To(BeFalse())
@@ -1356,29 +1308,18 @@ var _ = Describe("Conntrack Datasource", func() {
 			Eventually(c.epStatsSnapshot, "500ms", "100ms").Should(HaveKey(*t))
 
 			// Data is not reported. Remove endpoints from mock data and send in packetinfo entry again.
-			var data *Data
-			var oldSrc, oldDest calc.EndpointData
-			c.runOnLoop(func() {
-				data = c.epStats[*t]
-				oldSrc = data.SrcEp
-				oldDest = data.DstEp
-			})
+			before := c.epStatsSnapshot()[*t]
+			oldSrc, oldDest := before.SrcEp, before.DstEp
 			lm.SetMockData(epMapDelete, nil, nil, nil)
 			c.runOnLoop(func() { c.applyPacketInfo(pktinfo) })
 
 			// This is an unreported flow but we are going through packet processing still. However, since the endpoint
 			// data has been removed assume it has just been deleted and don't downgrade our endpoint data.
 			Consistently(c.epStatsSnapshot, "500ms", "100ms").Should(HaveKey(*t))
-			var reported bool
-			var newSrc, newDest calc.EndpointData
-			c.runOnLoop(func() {
-				reported = data.Reported
-				newSrc = data.SrcEp
-				newDest = data.DstEp
-			})
-			Expect(reported).To(BeFalse())
-			Expect(newSrc).To(Equal(oldSrc))
-			Expect(newDest).To(Equal(oldDest))
+			after := c.epStatsSnapshot()[*t]
+			Expect(after.Reported).To(BeFalse())
+			Expect(after.SrcEp).To(Equal(oldSrc))
+			Expect(after.DstEp).To(Equal(oldDest))
 		})
 		It("should handle destination changing on next packetinfo update for reported flow", func() {
 			pktinfo := nflogReader.ConvertNflogPkt(rules.RuleDirIngress, ingressPktAllow[ingressPktAllowNflogTuple])
@@ -1388,14 +1329,9 @@ var _ = Describe("Conntrack Datasource", func() {
 			Eventually(c.epStatsSnapshot, "500ms", "100ms").Should(HaveKey(*t))
 
 			// Flag the data as reported, swap local endpoints from mock data and send in packetinfo entry again.
-			var data *Data
-			var oldSrc, oldDest calc.EndpointData
-			c.runOnLoop(func() {
-				data = c.epStats[*t]
-				data.Reported = true
-				oldSrc = data.SrcEp
-				oldDest = data.DstEp
-			})
+			before := c.epStatsSnapshot()[*t]
+			oldSrc, oldDest := before.SrcEp, before.DstEp
+			c.runOnLoop(func() { c.epStats[*t].Reported = true })
 
 			lm.SetMockData(epMapSwapLocal, nil, nil, nil)
 			c.runOnLoop(func() { c.applyPacketInfo(pktinfo) })
@@ -1403,14 +1339,9 @@ var _ = Describe("Conntrack Datasource", func() {
 			// This is a reported flow but we are going through packet processing still. It should be expired and
 			// the endpoints updated.
 			Consistently(c.epStatsSnapshot, "500ms", "100ms").Should(HaveKey(*t))
-			var reported bool
-			var newSrc, newDest calc.EndpointData
-			c.runOnLoop(func() {
-				reported = data.Reported
-				newSrc = data.SrcEp
-				newDest = data.DstEp
-			})
-			Expect(reported).To(BeFalse())
+			after := c.epStatsSnapshot()[*t]
+			newSrc, newDest := after.SrcEp, after.DstEp
+			Expect(after.Reported).To(BeFalse())
 			Expect(newSrc).To(Equal(oldSrc))
 			Expect(newDest).NotTo(Equal(oldDest))
 		})
@@ -1422,27 +1353,17 @@ var _ = Describe("Conntrack Datasource", func() {
 			Eventually(c.epStatsSnapshot, "500ms", "100ms").Should(HaveKey(*t))
 
 			// Data is not reported, swap local endpoints from mock data and send in CT entry again.
-			var data *Data
-			var oldSrc, oldDest calc.EndpointData
-			c.runOnLoop(func() {
-				data = c.epStats[*t]
-				oldSrc = data.SrcEp
-				oldDest = data.DstEp
-			})
+			before := c.epStatsSnapshot()[*t]
+			oldSrc, oldDest := before.SrcEp, before.DstEp
 
 			lm.SetMockData(epMapSwapLocal, nil, nil, nil)
 			c.runOnLoop(func() { c.applyPacketInfo(pktinfo) })
 
 			// This is an unreported flow, and is a conntrack update. We can update the endpoint.
 			Consistently(c.epStatsSnapshot, "500ms", "100ms").Should(HaveKey(*t))
-			var reported bool
-			var newSrc, newDest calc.EndpointData
-			c.runOnLoop(func() {
-				reported = data.Reported
-				newSrc = data.SrcEp
-				newDest = data.DstEp
-			})
-			Expect(reported).To(BeFalse())
+			after := c.epStatsSnapshot()[*t]
+			newSrc, newDest := after.SrcEp, after.DstEp
+			Expect(after.Reported).To(BeFalse())
 			Expect(newSrc).To(Equal(oldSrc))
 			Expect(newDest).NotTo(Equal(oldDest))
 		})
@@ -1454,12 +1375,10 @@ var _ = Describe("Conntrack Datasource", func() {
 			// will call handlerInfo from c.Start() in BeforeEach
 			ciReaderSenderChan <- []clttypes.ConntrackInfo{convertCtEntry(outCtEntry, 0)}
 
-			eventuallyExpectCtStats(c, *t, outCtEntry)
+			data := eventuallyExpectCtStats(c, *t, outCtEntry)
 
-			var natOutgoingPort int
-			c.runOnLoop(func() { natOutgoingPort = c.epStats[*t].NatOutgoingPort })
 			// Not SNAT'd so natOutgoingPort should not be set.
-			Expect(natOutgoingPort).Should(Equal(0))
+			Expect(data.NatOutgoingPort).Should(Equal(0))
 		})
 		It("should create a single entry with outbound direction for SNAT'd packet with nat outgoing port set", func() {
 			t := tuple.New(localIp1, remoteIp1, proto_tcp, srcPort, dstPort)
@@ -1467,11 +1386,9 @@ var _ = Describe("Conntrack Datasource", func() {
 			// will call handlerInfo from c.Start() in BeforeEach
 			ciReaderSenderChan <- []clttypes.ConntrackInfo{convertCtEntry(outCtEntryWithSNAT, 0)}
 
-			eventuallyExpectCtStats(c, *t, outCtEntryWithSNAT)
+			data := eventuallyExpectCtStats(c, *t, outCtEntryWithSNAT)
 
-			var natOutgoingPort int
-			c.runOnLoop(func() { natOutgoingPort = c.epStats[*t].NatOutgoingPort })
-			Expect(natOutgoingPort).Should(Equal(nodeSrcPort))
+			Expect(data.NatOutgoingPort).Should(Equal(nodeSrcPort))
 		})
 		It("should create a single entry with outbound direction for SNAT'd packet sent to self without nat outgoing port set", func() {
 			t := tuple.New(localIp1, localIp1, proto_tcp, srcPort, srcPort2)
@@ -1479,11 +1396,9 @@ var _ = Describe("Conntrack Datasource", func() {
 			// will call handlerInfo from c.Start() in BeforeEach
 			ciReaderSenderChan <- []clttypes.ConntrackInfo{convertCtEntry(outCtEntrySNATToServiceToSelf, 0)}
 
-			eventuallyExpectCtStats(c, *t, outCtEntrySNATToServiceToSelf)
+			data := eventuallyExpectCtStats(c, *t, outCtEntrySNATToServiceToSelf)
 
-			var natOutgoingPort int
-			c.runOnLoop(func() { natOutgoingPort = c.epStats[*t].NatOutgoingPort })
-			Expect(natOutgoingPort).Should(Equal(0))
+			Expect(data.NatOutgoingPort).Should(Equal(0))
 		})
 		It("should handle source becoming non-local by removing entry on next conntrack update for reported flow", func() {
 			t := tuple.New(localIp1, remoteIp1, proto_tcp, srcPort, dstPort)
@@ -1526,13 +1441,9 @@ var _ = Describe("Conntrack Datasource", func() {
 			Eventually(c.epStatsSnapshot, "500ms", "100ms").Should(HaveKey(*t))
 
 			// Flag the data as reported, swap local endpoints from mock data and send in CT entry again.
-			var oldSrc, oldDest calc.EndpointData
-			c.runOnLoop(func() {
-				data := c.epStats[*t]
-				data.Reported = true
-				oldSrc = data.SrcEp
-				oldDest = data.DstEp
-			})
+			before := c.epStatsSnapshot()[*t]
+			oldSrc, oldDest := before.SrcEp, before.DstEp
+			c.runOnLoop(func() { c.epStats[*t].Reported = true })
 
 			lm.SetMockData(epMapSwapLocal, nil, nil, nil)
 			ciReaderSenderChan <- []clttypes.ConntrackInfo{convertCtEntry(outCtEntry, 0)}
@@ -1540,14 +1451,9 @@ var _ = Describe("Conntrack Datasource", func() {
 			// This is a reported flow, and is a conntrack update - this should not impact the stored data at all since
 			// the endpoint should not be changing for a constant connection.
 			Consistently(c.epStatsSnapshot, "500ms", "100ms").Should(HaveKey(*t))
-			var newSrc, newDest calc.EndpointData
-			c.runOnLoop(func() {
-				data := c.epStats[*t]
-				newSrc = data.SrcEp
-				newDest = data.DstEp
-			})
-			Expect(newSrc).To(Equal(oldSrc))
-			Expect(newDest).To(Equal(oldDest))
+			after := c.epStatsSnapshot()[*t]
+			Expect(after.SrcEp).To(Equal(oldSrc))
+			Expect(after.DstEp).To(Equal(oldDest))
 		})
 		It("should handle source changing on next conntrack update for unreported flow", func() {
 			t := tuple.New(localIp1, remoteIp1, proto_tcp, srcPort, dstPort)
@@ -1557,27 +1463,19 @@ var _ = Describe("Conntrack Datasource", func() {
 			Eventually(c.epStatsSnapshot, "500ms", "100ms").Should(HaveKey(*t))
 
 			// Data is not reported. swap local endpoints from mock data and send in packetinfo entry again.
-			var oldSrc, oldDest calc.EndpointData
-			c.runOnLoop(func() {
-				data := c.epStats[*t]
-				oldSrc = data.SrcEp
-				oldDest = data.DstEp
-			})
+			before := c.epStatsSnapshot()[*t]
+			oldSrc, oldDest := before.SrcEp, before.DstEp
 
 			lm.SetMockData(epMapSwapLocal, nil, nil, nil)
 			ciReaderSenderChan <- []clttypes.ConntrackInfo{convertCtEntry(outCtEntry, 0)}
 
 			// This is an unreported flow, and is a conntrack update. We can update the endpoint.
 			Consistently(c.epStatsSnapshot, "500ms", "100ms").Should(HaveKey(*t))
-			// The endpoint swap is applied on the collector goroutine, so poll SrcEp on-loop.
+			// The endpoint swap is applied on the collector goroutine, so keep polling for it.
 			Eventually(func() calc.EndpointData {
-				var srcEp calc.EndpointData
-				c.runOnLoop(func() { srcEp = c.epStats[*t].SrcEp })
-				return srcEp
+				return c.epStatsSnapshot()[*t].SrcEp
 			}, "2s", "100ms").ShouldNot(Equal(oldSrc))
-			var dstEp calc.EndpointData
-			c.runOnLoop(func() { dstEp = c.epStats[*t].DstEp })
-			Expect(dstEp).To(Equal(oldDest))
+			Expect(c.epStatsSnapshot()[*t].DstEp).To(Equal(oldDest))
 		})
 		It("should handle source becoming non-local by removing entry on next packetinfo update for reported flow", func() {
 			pktinfo := nflogReader.ConvertNflogPkt(rules.RuleDirEgress, egressPktAllow[egressPktAllowNflogTuple])
@@ -1610,29 +1508,18 @@ var _ = Describe("Conntrack Datasource", func() {
 			Eventually(c.epStatsSnapshot, "500ms", "100ms").Should(HaveKey(*t))
 
 			// Data is not reported. Remove endpoints from mock data and send in packetinfo entry again.
-			var data *Data
-			var oldSrc, oldDest calc.EndpointData
-			c.runOnLoop(func() {
-				data = c.epStats[*t]
-				oldSrc = data.SrcEp
-				oldDest = data.DstEp
-			})
+			before := c.epStatsSnapshot()[*t]
+			oldSrc, oldDest := before.SrcEp, before.DstEp
 			lm.SetMockData(epMapDelete, nil, nil, nil)
 			c.runOnLoop(func() { c.applyPacketInfo(pktinfo) })
 
 			// This is an unreported flow but we are going through packet processing still. However, since the endpoint
 			// data has been removed assume it has just been deleted and don't downgrade our endpoint data.
 			Consistently(c.epStatsSnapshot, "500ms", "100ms").Should(HaveKey(*t))
-			var reported bool
-			var newSrc, newDest calc.EndpointData
-			c.runOnLoop(func() {
-				reported = data.Reported
-				newSrc = data.SrcEp
-				newDest = data.DstEp
-			})
-			Expect(reported).To(BeFalse())
-			Expect(newSrc).To(Equal(oldSrc))
-			Expect(newDest).To(Equal(oldDest))
+			after := c.epStatsSnapshot()[*t]
+			Expect(after.Reported).To(BeFalse())
+			Expect(after.SrcEp).To(Equal(oldSrc))
+			Expect(after.DstEp).To(Equal(oldDest))
 		})
 		It("should handle source changing on next packetinfo update for reported flow", func() {
 			pktinfo := nflogReader.ConvertNflogPkt(rules.RuleDirEgress, egressPktAllow[egressPktAllowNflogTuple])
@@ -1642,14 +1529,9 @@ var _ = Describe("Conntrack Datasource", func() {
 			Eventually(c.epStatsSnapshot, "500ms", "100ms").Should(HaveKey(*t))
 
 			// Flag the data as reported, swap local endpoints from mock data and send in packetinfo entry again.
-			var data *Data
-			var oldSrc, oldDest calc.EndpointData
-			c.runOnLoop(func() {
-				data = c.epStats[*t]
-				data.Reported = true
-				oldSrc = data.SrcEp
-				oldDest = data.DstEp
-			})
+			before := c.epStatsSnapshot()[*t]
+			oldSrc, oldDest := before.SrcEp, before.DstEp
+			c.runOnLoop(func() { c.epStats[*t].Reported = true })
 
 			lm.SetMockData(epMapSwapLocal, nil, nil, nil)
 			c.runOnLoop(func() { c.applyPacketInfo(pktinfo) })
@@ -1657,14 +1539,9 @@ var _ = Describe("Conntrack Datasource", func() {
 			// This is a reported flow but we are going through packet processing still. It should be expired and
 			// the endpoints updated.
 			Consistently(c.epStatsSnapshot, "500ms", "100ms").Should(HaveKey(*t))
-			var reported bool
-			var newSrc, newDest calc.EndpointData
-			c.runOnLoop(func() {
-				reported = data.Reported
-				newSrc = data.SrcEp
-				newDest = data.DstEp
-			})
-			Expect(reported).To(BeFalse())
+			after := c.epStatsSnapshot()[*t]
+			newSrc, newDest := after.SrcEp, after.DstEp
+			Expect(after.Reported).To(BeFalse())
 			Expect(newSrc).NotTo(Equal(oldSrc))
 			Expect(newDest).To(Equal(oldDest))
 		})
@@ -1676,27 +1553,17 @@ var _ = Describe("Conntrack Datasource", func() {
 			Eventually(c.epStatsSnapshot, "500ms", "100ms").Should(HaveKey(*t))
 
 			// Data is not reported, swap local endpoints from mock data and send in CT entry again.
-			var data *Data
-			var oldSrc, oldDest calc.EndpointData
-			c.runOnLoop(func() {
-				data = c.epStats[*t]
-				oldSrc = data.SrcEp
-				oldDest = data.DstEp
-			})
+			before := c.epStatsSnapshot()[*t]
+			oldSrc, oldDest := before.SrcEp, before.DstEp
 
 			lm.SetMockData(epMapSwapLocal, nil, nil, nil)
 			c.runOnLoop(func() { c.applyPacketInfo(pktinfo) })
 
 			// This is an unreported flow, and is a conntrack update. We can update the endpoint.
 			Consistently(c.epStatsSnapshot, "500ms", "100ms").Should(HaveKey(*t))
-			var reported bool
-			var newSrc, newDest calc.EndpointData
-			c.runOnLoop(func() {
-				reported = data.Reported
-				newSrc = data.SrcEp
-				newDest = data.DstEp
-			})
-			Expect(reported).To(BeFalse())
+			after := c.epStatsSnapshot()[*t]
+			newSrc, newDest := after.SrcEp, after.DstEp
+			Expect(after.Reported).To(BeFalse())
 			Expect(newSrc).NotTo(Equal(oldSrc))
 			Expect(newDest).To(Equal(oldDest))
 		})
@@ -1836,13 +1703,8 @@ var _ = Describe("Conntrack Datasource", func() {
 
 			// Flagging as expired will attempt to expire the data when NFLOGs and service info are gathered.
 			By("flagging the data as expired")
-			var isDNAT bool
-			c.runOnLoop(func() {
-				data := c.epStats[*t]
-				data.Expired = true
-				isDNAT = data.IsDNAT
-			})
-			Expect(isDNAT).Should(BeTrue())
+			c.runOnLoop(func() { c.epStats[*t].Expired = true })
+			Expect(c.epStatsSnapshot()[*t].IsDNAT).Should(BeTrue())
 
 			By("handling nflog updates for destination matching on policy - all policy info is now gathered, but no service")
 			c.runOnLoop(func() {
@@ -1883,13 +1745,8 @@ var _ = Describe("Conntrack Datasource", func() {
 
 			// Flagging as expired will attempt to expire the data when NFLOGs and service info are gathered.
 			By("flagging the data as expired")
-			var isDNAT bool
-			c.runOnLoop(func() {
-				data := c.epStats[*t]
-				data.Expired = true
-				isDNAT = data.IsDNAT
-			})
-			Expect(isDNAT).Should(BeTrue())
+			c.runOnLoop(func() { c.epStats[*t].Expired = true })
+			Expect(c.epStatsSnapshot()[*t].IsDNAT).Should(BeTrue())
 
 			By("handling ingree nflog updates for destination matching on policy - all policy info is now gathered, but no service")
 			c.runOnLoop(func() {
@@ -2111,9 +1968,12 @@ func (mr *mockReporter) Start() error {
 
 // runOnLoop runs fn on the collector's own goroutine and blocks until it
 // returns. The collector goroutine owns epStats and the Data values it holds
-// with no locking, so this is the only race-free way for a test to read or
-// mutate that state. The collector must have been Start()ed and not yet
-// Stop()ped.
+// with no locking, so anything that mutates that state, or that calls a
+// collector method which touches it, has to run here. The collector must have
+// been Start()ed and not yet Stop()ped.
+//
+// To *read* that state, prefer epStatsSnapshot: it hands back clones, which a
+// test can then read directly.
 //
 // Do not run Gomega assertions inside fn: a failed assertion panics, and on the
 // collector goroutine Ginkgo cannot attribute the panic to the running spec.
@@ -2127,16 +1987,43 @@ func (c *collector) runOnLoop(fn func()) {
 	<-done
 }
 
-// epStatsSnapshot returns a shallow clone of epStats, taken on the collector's
-// goroutine, so it is safe to poll with Eventually/Consistently and the HaveKey
-// matcher. The *Data values are still owned by the collector goroutine; read
-// their fields via runOnLoop, not through the returned map.
+// epStatsSnapshot returns a clone of epStats, taken on the collector's goroutine,
+// so it is safe both to poll with Eventually/Consistently and to read the Data
+// fields of directly. The Data values are cloned too, so nothing in the returned
+// map is shared with the collector.
+//
+// Writes still have to go through runOnLoop: mutating a clone changes nothing.
 func (c *collector) epStatsSnapshot() map[tuple.Tuple]*Data {
-	var snapshot map[tuple.Tuple]*Data
+	snapshot := map[tuple.Tuple]*Data{}
 	c.runOnLoop(func() {
-		snapshot = maps.Clone(c.epStats)
+		for t, data := range c.epStats {
+			snapshot[t] = data.clone()
+		}
 	})
 	return snapshot
+}
+
+// clone returns a copy of d that shares no mutable state with the original, so a
+// test can read it while the collector goroutine keeps running. The *calc.RuleID
+// and EndpointData values it points to are treated as immutable once published,
+// so they are shared rather than copied.
+func (d *Data) clone() *Data {
+	clone := *d
+	clone.IngressRuleTrace = d.IngressRuleTrace.clone()
+	clone.EgressRuleTrace = d.EgressRuleTrace.clone()
+	clone.IngressPendingRuleIDs = slices.Clone(d.IngressPendingRuleIDs)
+	clone.EgressPendingRuleIDs = slices.Clone(d.EgressPendingRuleIDs)
+	return &clone
+}
+
+// clone returns a copy of t that shares no backing array with the original. Note
+// that t.path usually aliases t.pathArray, so copying the struct alone would
+// leave the copy's path pointing back into the original's array.
+func (t *RuleTrace) clone() RuleTrace {
+	clone := *t
+	clone.path = slices.Clone(t.path)
+	clone.rulesToReport = slices.Clone(t.rulesToReport)
+	return clone
 }
 
 func (mr *mockReporter) Report(u any) error {

--- a/felix/collector/collector_test.go
+++ b/felix/collector/collector_test.go
@@ -18,6 +18,7 @@ package collector
 
 import (
 	"fmt"
+	"maps"
 	net2 "net"
 	"slices"
 	"testing"
@@ -596,25 +597,24 @@ var _ = Describe("NFLOG Datasource", func() {
 			c = newCollector(lm, conf).(*collector)
 			c.SetPacketInfoReader(nflogReader)
 			c.SetConntrackInfoReader(dummyConntrackInfoReader{})
-			go func() {
-				Expect(c.Start()).NotTo(HaveOccurred())
-			}()
+			Expect(c.Start()).NotTo(HaveOccurred())
 		})
 		AfterEach(func() {
 			nflogReader.Stop()
+			c.Stop()
 		})
 		Describe("Test local destination", func() {
 			It("should receive a single stat update with allow ruleid trace", func() {
 				t := tuple.New(remoteIp1, localIp1, proto_tcp, srcPort, dstPort)
 				nflogReader.IngressC <- ingressPktAllow
-				Eventually(c.epStats).Should(HaveKey(*t))
+				Eventually(c.epStatsSnapshot).Should(HaveKey(*t))
 			})
 		})
 		Describe("Test local to local", func() {
 			It("should receive a single stat update with deny ruleid trace", func() {
 				t := tuple.New(localIp1, localIp2, proto_tcp, srcPort, dstPort)
 				nflogReader.IngressC <- localPktIngress
-				Eventually(c.epStats).Should(HaveKey(*t))
+				Eventually(c.epStatsSnapshot).Should(HaveKey(*t))
 			})
 		})
 	})
@@ -652,13 +652,12 @@ var _ = Describe("NFLOG Datasource", func() {
 			c = newCollector(lm, conf).(*collector)
 			c.SetPacketInfoReader(nflogReader)
 			c.SetConntrackInfoReader(dummyConntrackInfoReader{})
-			go func() {
-				Expect(c.Start()).NotTo(HaveOccurred())
-			}()
+			Expect(c.Start()).NotTo(HaveOccurred())
 		})
 
 		AfterEach(func() {
 			nflogReader.Stop()
+			c.Stop()
 		})
 
 		Describe("Test source endpoint marked for deletion", func() {
@@ -685,13 +684,18 @@ var _ = Describe("NFLOG Datasource", func() {
 
 				// Send NFLOG packet - this should create the tuple but skip RuleHits processing
 				nflogReader.IngressC <- localPktIngress
-				Eventually(c.epStats).Should(HaveKey(*t))
+				Eventually(c.epStatsSnapshot).Should(HaveKey(*t))
 
-				data := c.epStats[*t]
 				// Verify that RuleHits are not processed.  The RuleHits are applied after the
 				// epStats entry is inserted, so keep checking rather than sampling immediately.
+				// epStats and its Data are owned by the collector goroutine, so read on-loop.
 				Consistently(func() [2]int {
-					return [2]int{len(data.IngressRuleTrace.Path()), len(data.EgressRuleTrace.Path())}
+					var lens [2]int
+					c.runOnLoop(func() {
+						data := c.epStats[*t]
+						lens = [2]int{len(data.IngressRuleTrace.Path()), len(data.EgressRuleTrace.Path())}
+					})
+					return lens
 				}, "500ms", "100ms").Should(Equal([2]int{0, 0}),
 					"Ingress/EgressRuleTrace Paths should stay empty when source endpoint is marked for deletion")
 			})
@@ -721,13 +725,18 @@ var _ = Describe("NFLOG Datasource", func() {
 
 				// Send NFLOG packet - this should create the tuple but skip RuleHits processing
 				nflogReader.IngressC <- localPktIngress
-				Eventually(c.epStats).Should(HaveKey(*t))
+				Eventually(c.epStatsSnapshot).Should(HaveKey(*t))
 
-				data := c.epStats[*t]
 				// Verify that RuleHits are not processed.  The RuleHits are applied after the
 				// epStats entry is inserted, so keep checking rather than sampling immediately.
+				// epStats and its Data are owned by the collector goroutine, so read on-loop.
 				Consistently(func() [2]int {
-					return [2]int{len(data.IngressRuleTrace.Path()), len(data.EgressRuleTrace.Path())}
+					var lens [2]int
+					c.runOnLoop(func() {
+						data := c.epStats[*t]
+						lens = [2]int{len(data.IngressRuleTrace.Path()), len(data.EgressRuleTrace.Path())}
+					})
+					return lens
 				}, "500ms", "100ms").Should(Equal([2]int{0, 0}),
 					"Ingress/EgressRuleTrace Paths should stay empty when destination endpoint is marked for deletion")
 			})
@@ -757,13 +766,18 @@ var _ = Describe("NFLOG Datasource", func() {
 
 				// Send NFLOG packet - this should create the tuple but skip RuleHits processing
 				nflogReader.IngressC <- ingressPktAllow
-				Eventually(c.epStats).Should(HaveKey(*t))
+				Eventually(c.epStatsSnapshot).Should(HaveKey(*t))
 
-				data := c.epStats[*t]
 				// Verify that RuleHits are not processed.  The RuleHits are applied after the
 				// epStats entry is inserted, so keep checking rather than sampling immediately.
+				// epStats and its Data are owned by the collector goroutine, so read on-loop.
 				Consistently(func() [2]int {
-					return [2]int{len(data.IngressRuleTrace.Path()), len(data.EgressRuleTrace.Path())}
+					var lens [2]int
+					c.runOnLoop(func() {
+						data := c.epStats[*t]
+						lens = [2]int{len(data.IngressRuleTrace.Path()), len(data.EgressRuleTrace.Path())}
+					})
+					return lens
 				}, "500ms", "100ms").Should(Equal([2]int{0, 0}),
 					"Ingress/EgressRuleTrace Paths should stay empty when remote source endpoint is marked for deletion")
 			})
@@ -791,12 +805,15 @@ var _ = Describe("NFLOG Datasource", func() {
 
 				// Send NFLOG packet - this should create the tuple AND process RuleHits
 				nflogReader.IngressC <- localPktIngress
-				Eventually(c.epStats).Should(HaveKey(*t))
+				Eventually(c.epStatsSnapshot).Should(HaveKey(*t))
 
-				data := c.epStats[*t]
 				// Verify that RuleHits were processed (Path should NOT be empty)
 				Eventually(func() int {
-					return len(data.IngressRuleTrace.Path())
+					var pathLen int
+					c.runOnLoop(func() {
+						pathLen = len(c.epStats[*t].IngressRuleTrace.Path())
+					})
+					return pathLen
 				}, "500ms", "50ms").Should(BeNumerically(">", 0), "IngressRuleTrace Path should NOT be empty when endpoints are active")
 			})
 		})
@@ -1104,16 +1121,28 @@ func countersOfCtEntry(e nfnetlink.CtEntry) ctCounters {
 
 func countersOfData(c *collector, t tuple.Tuple) func() (ctCounters, error) {
 	return func() (ctCounters, error) {
-		data, ok := c.epStats[t]
+		// epStats and the Data within it are owned by the collector goroutine,
+		// so read the counters on that goroutine.
+		var (
+			cs ctCounters
+			ok bool
+		)
+		c.runOnLoop(func() {
+			var data *Data
+			if data, ok = c.epStats[t]; !ok {
+				return
+			}
+			cs = ctCounters{
+				Packets:        data.ConntrackPacketsCounter(),
+				Bytes:          data.ConntrackBytesCounter(),
+				PacketsReverse: data.ConntrackPacketsCounterReverse(),
+				BytesReverse:   data.ConntrackBytesCounterReverse(),
+			}
+		})
 		if !ok {
 			return ctCounters{}, fmt.Errorf("no epStats entry for tuple %v", &t)
 		}
-		return ctCounters{
-			Packets:        data.ConntrackPacketsCounter(),
-			Bytes:          data.ConntrackBytesCounter(),
-			PacketsReverse: data.ConntrackPacketsCounterReverse(),
-			BytesReverse:   data.ConntrackBytesCounterReverse(),
-		}, nil
+		return cs, nil
 	}
 }
 
@@ -1128,7 +1157,13 @@ func countersOfData(c *collector, t tuple.Tuple) func() (ctCounters, error) {
 func eventuallyExpectCtStats(c *collector, t tuple.Tuple, e nfnetlink.CtEntry) *Data {
 	GinkgoHelper()
 	Eventually(countersOfData(c, t), "2s", "100ms").Should(Equal(countersOfCtEntry(e)))
-	return c.epStats[t]
+	var data *Data
+	c.runOnLoop(func() {
+		data = c.epStats[t]
+	})
+	// NOTE: the returned *Data is owned by the collector goroutine; callers must
+	// read its fields via c.runOnLoop, not directly.
+	return data
 }
 
 var _ = Describe("Conntrack Datasource", func() {
@@ -1183,6 +1218,10 @@ var _ = Describe("Conntrack Datasource", func() {
 		Expect(c.Start()).NotTo(HaveOccurred())
 	})
 
+	AfterEach(func() {
+		c.Stop()
+	})
+
 	Describe("Test local destination", func() {
 		It("should create a single entry in inbound direction", func() {
 			t := tuple.New(remoteIp1, localIp1, proto_tcp, srcPort, dstPort)
@@ -1197,23 +1236,24 @@ var _ = Describe("Conntrack Datasource", func() {
 			// will call handlerInfo from c.Start() in BeforeEach
 			ciReaderSenderChan <- []clttypes.ConntrackInfo{convertCtEntry(inCtEntry, 0)}
 
-			Eventually(c.epStats, "500ms", "100ms").Should(HaveKey(*t))
+			Eventually(c.epStatsSnapshot, "500ms", "100ms").Should(HaveKey(*t))
 
 			// Flag the data as reported, remove endpoints from mock data and send in CT entry again.
-			data := c.epStats[*t]
-			data.Reported = true
+			c.runOnLoop(func() {
+				c.epStats[*t].Reported = true
+			})
 			lm.SetMockData(epMapDelete, nil, nil, nil)
 			ciReaderSenderChan <- []clttypes.ConntrackInfo{convertCtEntry(inCtEntry, 0)}
 
 			// This is a reported flow, and is a conntrack update - this should not impact the stored data at all.
-			Consistently(c.epStats, "500ms", "100ms").Should(HaveKey(*t))
+			Consistently(c.epStatsSnapshot, "500ms", "100ms").Should(HaveKey(*t))
 		})
 		It("should handle destination becoming non-local by removing entry on next conntrack update for unreported flow", func() {
 			t := tuple.New(remoteIp1, localIp1, proto_tcp, srcPort, dstPort)
 			// will call handlerInfo from c.Start() in BeforeEach
 			ciReaderSenderChan <- []clttypes.ConntrackInfo{convertCtEntry(inCtEntry, 0)}
 
-			Eventually(c.epStats, "500ms", "100ms").Should(HaveKey(*t))
+			Eventually(c.epStatsSnapshot, "500ms", "100ms").Should(HaveKey(*t))
 
 			// Data is not reported. Remove endpoints from mock data and send in CT entry again.
 			lm.SetMockData(epMapDelete, nil, nil, nil)
@@ -1222,132 +1262,189 @@ var _ = Describe("Conntrack Datasource", func() {
 			// This is an unreported flow, and is a conntrack update. We can update the endpoint, but we never downgrade
 			// to having no endpoint (since we handle the situation where endpoint is deleted before we gather all
 			// logs).
-			Consistently(c.epStats, "500ms", "100ms").Should(HaveKey(*t))
+			Consistently(c.epStatsSnapshot, "500ms", "100ms").Should(HaveKey(*t))
 		})
 		It("should handle destination changing on next conntrack update for reported flow", func() {
 			t := tuple.New(remoteIp1, localIp1, proto_tcp, srcPort, dstPort)
 			// will call handlerInfo from c.Start() in BeforeEach
 			ciReaderSenderChan <- []clttypes.ConntrackInfo{convertCtEntry(inCtEntry, 0)}
 
-			Eventually(c.epStats, "500ms", "100ms").Should(HaveKey(*t))
+			Eventually(c.epStatsSnapshot, "500ms", "100ms").Should(HaveKey(*t))
 
 			// Flag the data as reported, swap local endpoints from mock data and send in CT entry again.
-			data := c.epStats[*t]
-			data.Reported = true
-			oldSrc := data.SrcEp
-			oldDest := data.DstEp
+			var oldSrc, oldDest calc.EndpointData
+			c.runOnLoop(func() {
+				data := c.epStats[*t]
+				data.Reported = true
+				oldSrc = data.SrcEp
+				oldDest = data.DstEp
+			})
 
 			lm.SetMockData(epMapSwapLocal, nil, nil, nil)
 			ciReaderSenderChan <- []clttypes.ConntrackInfo{convertCtEntry(inCtEntry, 0)}
 
 			// This is a reported flow, and is a conntrack update - this should not impact the stored data at all since
 			// the endpoint should not be changing for a constant connection.
-			Consistently(c.epStats, "500ms", "100ms").Should(HaveKey(*t))
-			Expect(data.SrcEp).To(Equal(oldSrc))
-			Expect(data.DstEp).To(Equal(oldDest))
+			Consistently(c.epStatsSnapshot, "500ms", "100ms").Should(HaveKey(*t))
+			var newSrc, newDest calc.EndpointData
+			c.runOnLoop(func() {
+				data := c.epStats[*t]
+				newSrc = data.SrcEp
+				newDest = data.DstEp
+			})
+			Expect(newSrc).To(Equal(oldSrc))
+			Expect(newDest).To(Equal(oldDest))
 		})
 		It("should handle destination changing on next conntrack update for unreported flow", func() {
 			t := tuple.New(remoteIp1, localIp1, proto_tcp, srcPort, dstPort)
 			// will call handlerInfo from c.Start() in BeforeEach
 			ciReaderSenderChan <- []clttypes.ConntrackInfo{convertCtEntry(inCtEntry, 0)}
 
-			Eventually(c.epStats, "500ms", "100ms").Should(HaveKey(*t))
+			Eventually(c.epStatsSnapshot, "500ms", "100ms").Should(HaveKey(*t))
 
 			// Data is not reported. swap local endpoints from mock data and send in packetinfo entry again.
-			data := c.epStats[*t]
-			oldSrc := data.SrcEp
-			oldDest := data.DstEp
+			var oldSrc, oldDest calc.EndpointData
+			c.runOnLoop(func() {
+				data := c.epStats[*t]
+				oldSrc = data.SrcEp
+				oldDest = data.DstEp
+			})
 
 			lm.SetMockData(epMapSwapLocal, nil, nil, nil)
 			ciReaderSenderChan <- []clttypes.ConntrackInfo{convertCtEntry(inCtEntry, 0)}
 
 			// This is an unreported flow, and is a conntrack update. We can update the endpoint.
-			Consistently(c.epStats, "500ms", "100ms").Should(HaveKey(*t))
-			Eventually(func() calc.EndpointData { return data.DstEp }, "2s", "100ms").ShouldNot(Equal(oldDest))
-			Expect(data.SrcEp).To(Equal(oldSrc))
+			Consistently(c.epStatsSnapshot, "500ms", "100ms").Should(HaveKey(*t))
+			// The endpoint swap is applied on the collector goroutine, so poll DstEp on-loop.
+			Eventually(func() calc.EndpointData {
+				var dstEp calc.EndpointData
+				c.runOnLoop(func() { dstEp = c.epStats[*t].DstEp })
+				return dstEp
+			}, "2s", "100ms").ShouldNot(Equal(oldDest))
+			var srcEp calc.EndpointData
+			c.runOnLoop(func() { srcEp = c.epStats[*t].SrcEp })
+			Expect(srcEp).To(Equal(oldSrc))
 		})
 		It("should handle destination becoming non-local by removing entry on next packetinfo update for reported flow", func() {
 			pktinfo := nflogReader.ConvertNflogPkt(rules.RuleDirIngress, ingressPktAllow[ingressPktAllowNflogTuple])
-			c.applyPacketInfo(pktinfo)
+			c.runOnLoop(func() { c.applyPacketInfo(pktinfo) })
 			t := tuple.New(remoteIp1, localIp1, proto_tcp, srcPort, dstPort)
 
-			Eventually(c.epStats, "500ms", "100ms").Should(HaveKey(*t))
+			Eventually(c.epStatsSnapshot, "500ms", "100ms").Should(HaveKey(*t))
 
 			// Flag the data as reported, remove endpoints from mock data and send in packetinfo entry again.
-			data := c.epStats[*t]
-			data.Reported = true
+			var data *Data
+			c.runOnLoop(func() {
+				data = c.epStats[*t]
+				data.Reported = true
+			})
 			lm.SetMockData(epMapDelete, nil, nil, nil)
-			c.applyPacketInfo(pktinfo)
+			c.runOnLoop(func() { c.applyPacketInfo(pktinfo) })
 
 			// This is a reported flow but we are going through packet processing still. It should be expired and
 			// removed.
-			Eventually(c.epStats, "500ms", "100ms").ShouldNot(HaveKey(*t))
-			Expect(data.Reported).To(BeFalse())
+			Eventually(c.epStatsSnapshot, "500ms", "100ms").ShouldNot(HaveKey(*t))
+			var reported bool
+			c.runOnLoop(func() { reported = data.Reported })
+			Expect(reported).To(BeFalse())
 		})
 		It("should handle destination becoming non-local by removing entry on next packetinfo update for unreported flow", func() {
 			pktinfo := nflogReader.ConvertNflogPkt(rules.RuleDirIngress, ingressPktAllow[ingressPktAllowNflogTuple])
-			c.applyPacketInfo(pktinfo)
+			c.runOnLoop(func() { c.applyPacketInfo(pktinfo) })
 			t := tuple.New(remoteIp1, localIp1, proto_tcp, srcPort, dstPort)
 
-			Eventually(c.epStats, "500ms", "100ms").Should(HaveKey(*t))
+			Eventually(c.epStatsSnapshot, "500ms", "100ms").Should(HaveKey(*t))
 
 			// Data is not reported. Remove endpoints from mock data and send in packetinfo entry again.
-			data := c.epStats[*t]
-			oldSrc := data.SrcEp
-			oldDest := data.DstEp
+			var data *Data
+			var oldSrc, oldDest calc.EndpointData
+			c.runOnLoop(func() {
+				data = c.epStats[*t]
+				oldSrc = data.SrcEp
+				oldDest = data.DstEp
+			})
 			lm.SetMockData(epMapDelete, nil, nil, nil)
-			c.applyPacketInfo(pktinfo)
+			c.runOnLoop(func() { c.applyPacketInfo(pktinfo) })
 
 			// This is an unreported flow but we are going through packet processing still. However, since the endpoint
 			// data has been removed assume it has just been deleted and don't downgrade our endpoint data.
-			Consistently(c.epStats, "500ms", "100ms").Should(HaveKey(*t))
-			Expect(data.Reported).To(BeFalse())
-			Expect(data.SrcEp).To(Equal(oldSrc))
-			Expect(data.DstEp).To(Equal(oldDest))
+			Consistently(c.epStatsSnapshot, "500ms", "100ms").Should(HaveKey(*t))
+			var reported bool
+			var newSrc, newDest calc.EndpointData
+			c.runOnLoop(func() {
+				reported = data.Reported
+				newSrc = data.SrcEp
+				newDest = data.DstEp
+			})
+			Expect(reported).To(BeFalse())
+			Expect(newSrc).To(Equal(oldSrc))
+			Expect(newDest).To(Equal(oldDest))
 		})
 		It("should handle destination changing on next packetinfo update for reported flow", func() {
 			pktinfo := nflogReader.ConvertNflogPkt(rules.RuleDirIngress, ingressPktAllow[ingressPktAllowNflogTuple])
-			c.applyPacketInfo(pktinfo)
+			c.runOnLoop(func() { c.applyPacketInfo(pktinfo) })
 			t := tuple.New(remoteIp1, localIp1, proto_tcp, srcPort, dstPort)
 
-			Eventually(c.epStats, "500ms", "100ms").Should(HaveKey(*t))
+			Eventually(c.epStatsSnapshot, "500ms", "100ms").Should(HaveKey(*t))
 
 			// Flag the data as reported, swap local endpoints from mock data and send in packetinfo entry again.
-			data := c.epStats[*t]
-			data.Reported = true
-			oldSrc := data.SrcEp
-			oldDest := data.DstEp
+			var data *Data
+			var oldSrc, oldDest calc.EndpointData
+			c.runOnLoop(func() {
+				data = c.epStats[*t]
+				data.Reported = true
+				oldSrc = data.SrcEp
+				oldDest = data.DstEp
+			})
 
 			lm.SetMockData(epMapSwapLocal, nil, nil, nil)
-			c.applyPacketInfo(pktinfo)
+			c.runOnLoop(func() { c.applyPacketInfo(pktinfo) })
 
 			// This is a reported flow but we are going through packet processing still. It should be expired and
 			// the endpoints updated.
-			Consistently(c.epStats, "500ms", "100ms").Should(HaveKey(*t))
-			Expect(data.Reported).To(BeFalse())
-			Expect(data.SrcEp).To(Equal(oldSrc))
-			Expect(data.DstEp).NotTo(Equal(oldDest))
+			Consistently(c.epStatsSnapshot, "500ms", "100ms").Should(HaveKey(*t))
+			var reported bool
+			var newSrc, newDest calc.EndpointData
+			c.runOnLoop(func() {
+				reported = data.Reported
+				newSrc = data.SrcEp
+				newDest = data.DstEp
+			})
+			Expect(reported).To(BeFalse())
+			Expect(newSrc).To(Equal(oldSrc))
+			Expect(newDest).NotTo(Equal(oldDest))
 		})
 		It("should handle destination changing on next packetinfo update for unreported flow", func() {
 			pktinfo := nflogReader.ConvertNflogPkt(rules.RuleDirIngress, ingressPktAllow[ingressPktAllowNflogTuple])
-			c.applyPacketInfo(pktinfo)
+			c.runOnLoop(func() { c.applyPacketInfo(pktinfo) })
 			t := tuple.New(remoteIp1, localIp1, proto_tcp, srcPort, dstPort)
 
-			Eventually(c.epStats, "500ms", "100ms").Should(HaveKey(*t))
+			Eventually(c.epStatsSnapshot, "500ms", "100ms").Should(HaveKey(*t))
 
 			// Data is not reported, swap local endpoints from mock data and send in CT entry again.
-			data := c.epStats[*t]
-			oldSrc := data.SrcEp
-			oldDest := data.DstEp
+			var data *Data
+			var oldSrc, oldDest calc.EndpointData
+			c.runOnLoop(func() {
+				data = c.epStats[*t]
+				oldSrc = data.SrcEp
+				oldDest = data.DstEp
+			})
 
 			lm.SetMockData(epMapSwapLocal, nil, nil, nil)
-			c.applyPacketInfo(pktinfo)
+			c.runOnLoop(func() { c.applyPacketInfo(pktinfo) })
 
 			// This is an unreported flow, and is a conntrack update. We can update the endpoint.
-			Consistently(c.epStats, "500ms", "100ms").Should(HaveKey(*t))
-			Expect(data.Reported).To(BeFalse())
-			Expect(data.SrcEp).To(Equal(oldSrc))
-			Expect(data.DstEp).NotTo(Equal(oldDest))
+			Consistently(c.epStatsSnapshot, "500ms", "100ms").Should(HaveKey(*t))
+			var reported bool
+			var newSrc, newDest calc.EndpointData
+			c.runOnLoop(func() {
+				reported = data.Reported
+				newSrc = data.SrcEp
+				newDest = data.DstEp
+			})
+			Expect(reported).To(BeFalse())
+			Expect(newSrc).To(Equal(oldSrc))
+			Expect(newDest).NotTo(Equal(oldDest))
 		})
 	})
 	Describe("Test local source", func() {
@@ -1357,10 +1454,12 @@ var _ = Describe("Conntrack Datasource", func() {
 			// will call handlerInfo from c.Start() in BeforeEach
 			ciReaderSenderChan <- []clttypes.ConntrackInfo{convertCtEntry(outCtEntry, 0)}
 
-			data := eventuallyExpectCtStats(c, *t, outCtEntry)
+			eventuallyExpectCtStats(c, *t, outCtEntry)
 
+			var natOutgoingPort int
+			c.runOnLoop(func() { natOutgoingPort = c.epStats[*t].NatOutgoingPort })
 			// Not SNAT'd so natOutgoingPort should not be set.
-			Expect(data.NatOutgoingPort).Should(Equal(0))
+			Expect(natOutgoingPort).Should(Equal(0))
 		})
 		It("should create a single entry with outbound direction for SNAT'd packet with nat outgoing port set", func() {
 			t := tuple.New(localIp1, remoteIp1, proto_tcp, srcPort, dstPort)
@@ -1368,9 +1467,11 @@ var _ = Describe("Conntrack Datasource", func() {
 			// will call handlerInfo from c.Start() in BeforeEach
 			ciReaderSenderChan <- []clttypes.ConntrackInfo{convertCtEntry(outCtEntryWithSNAT, 0)}
 
-			data := eventuallyExpectCtStats(c, *t, outCtEntryWithSNAT)
+			eventuallyExpectCtStats(c, *t, outCtEntryWithSNAT)
 
-			Expect(data.NatOutgoingPort).Should(Equal(nodeSrcPort))
+			var natOutgoingPort int
+			c.runOnLoop(func() { natOutgoingPort = c.epStats[*t].NatOutgoingPort })
+			Expect(natOutgoingPort).Should(Equal(nodeSrcPort))
 		})
 		It("should create a single entry with outbound direction for SNAT'd packet sent to self without nat outgoing port set", func() {
 			t := tuple.New(localIp1, localIp1, proto_tcp, srcPort, srcPort2)
@@ -1378,32 +1479,35 @@ var _ = Describe("Conntrack Datasource", func() {
 			// will call handlerInfo from c.Start() in BeforeEach
 			ciReaderSenderChan <- []clttypes.ConntrackInfo{convertCtEntry(outCtEntrySNATToServiceToSelf, 0)}
 
-			data := eventuallyExpectCtStats(c, *t, outCtEntrySNATToServiceToSelf)
+			eventuallyExpectCtStats(c, *t, outCtEntrySNATToServiceToSelf)
 
-			Expect(data.NatOutgoingPort).Should(Equal(0))
+			var natOutgoingPort int
+			c.runOnLoop(func() { natOutgoingPort = c.epStats[*t].NatOutgoingPort })
+			Expect(natOutgoingPort).Should(Equal(0))
 		})
 		It("should handle source becoming non-local by removing entry on next conntrack update for reported flow", func() {
 			t := tuple.New(localIp1, remoteIp1, proto_tcp, srcPort, dstPort)
 			// will call handlerInfo from c.Start() in BeforeEach
 			ciReaderSenderChan <- []clttypes.ConntrackInfo{convertCtEntry(outCtEntry, 0)}
 
-			Eventually(c.epStats, "500ms", "100ms").Should(HaveKey(*t))
+			Eventually(c.epStatsSnapshot, "500ms", "100ms").Should(HaveKey(*t))
 
 			// Flag the data as reported, remove endpoints from mock data and send in CT entry again.
-			data := c.epStats[*t]
-			data.Reported = true
+			c.runOnLoop(func() {
+				c.epStats[*t].Reported = true
+			})
 			lm.SetMockData(epMapDelete, nil, nil, nil)
 			ciReaderSenderChan <- []clttypes.ConntrackInfo{convertCtEntry(outCtEntry, 0)}
 
 			// This is a reported flow, and is a conntrack update - this should not impact the stored data at all.
-			Consistently(c.epStats, "500ms", "100ms").Should(HaveKey(*t))
+			Consistently(c.epStatsSnapshot, "500ms", "100ms").Should(HaveKey(*t))
 		})
 		It("should handle source becoming non-local by removing entry on next conntrack update for unreported flow", func() {
 			t := tuple.New(localIp1, remoteIp1, proto_tcp, srcPort, dstPort)
 			// will call handlerInfo from c.Start() in BeforeEach
 			ciReaderSenderChan <- []clttypes.ConntrackInfo{convertCtEntry(outCtEntry, 0)}
 
-			Eventually(c.epStats, "500ms", "100ms").Should(HaveKey(*t))
+			Eventually(c.epStatsSnapshot, "500ms", "100ms").Should(HaveKey(*t))
 
 			// Data is not reported. Remove endpoints from mock data and send in CT entry again.
 			lm.SetMockData(epMapDelete, nil, nil, nil)
@@ -1412,132 +1516,189 @@ var _ = Describe("Conntrack Datasource", func() {
 			// This is an unreported flow, and is a conntrack update. We can update the endpoint, but we never downgrade
 			// to having no endpoint (since we handle the situation where endpoint is deleted before we gather all
 			// logs).
-			Consistently(c.epStats, "500ms", "100ms").Should(HaveKey(*t))
+			Consistently(c.epStatsSnapshot, "500ms", "100ms").Should(HaveKey(*t))
 		})
 		It("should handle source changing on next conntrack update for reported flow", func() {
 			t := tuple.New(localIp1, remoteIp1, proto_tcp, srcPort, dstPort)
 			// will call handlerInfo from c.Start() in BeforeEach
 			ciReaderSenderChan <- []clttypes.ConntrackInfo{convertCtEntry(outCtEntry, 0)}
 
-			Eventually(c.epStats, "500ms", "100ms").Should(HaveKey(*t))
+			Eventually(c.epStatsSnapshot, "500ms", "100ms").Should(HaveKey(*t))
 
 			// Flag the data as reported, swap local endpoints from mock data and send in CT entry again.
-			data := c.epStats[*t]
-			data.Reported = true
-			oldSrc := data.SrcEp
-			oldDest := data.DstEp
+			var oldSrc, oldDest calc.EndpointData
+			c.runOnLoop(func() {
+				data := c.epStats[*t]
+				data.Reported = true
+				oldSrc = data.SrcEp
+				oldDest = data.DstEp
+			})
 
 			lm.SetMockData(epMapSwapLocal, nil, nil, nil)
 			ciReaderSenderChan <- []clttypes.ConntrackInfo{convertCtEntry(outCtEntry, 0)}
 
 			// This is a reported flow, and is a conntrack update - this should not impact the stored data at all since
 			// the endpoint should not be changing for a constant connection.
-			Consistently(c.epStats, "500ms", "100ms").Should(HaveKey(*t))
-			Expect(data.SrcEp).To(Equal(oldSrc))
-			Expect(data.DstEp).To(Equal(oldDest))
+			Consistently(c.epStatsSnapshot, "500ms", "100ms").Should(HaveKey(*t))
+			var newSrc, newDest calc.EndpointData
+			c.runOnLoop(func() {
+				data := c.epStats[*t]
+				newSrc = data.SrcEp
+				newDest = data.DstEp
+			})
+			Expect(newSrc).To(Equal(oldSrc))
+			Expect(newDest).To(Equal(oldDest))
 		})
 		It("should handle source changing on next conntrack update for unreported flow", func() {
 			t := tuple.New(localIp1, remoteIp1, proto_tcp, srcPort, dstPort)
 			// will call handlerInfo from c.Start() in BeforeEach
 			ciReaderSenderChan <- []clttypes.ConntrackInfo{convertCtEntry(outCtEntry, 0)}
 
-			Eventually(c.epStats, "500ms", "100ms").Should(HaveKey(*t))
+			Eventually(c.epStatsSnapshot, "500ms", "100ms").Should(HaveKey(*t))
 
 			// Data is not reported. swap local endpoints from mock data and send in packetinfo entry again.
-			data := c.epStats[*t]
-			oldSrc := data.SrcEp
-			oldDest := data.DstEp
+			var oldSrc, oldDest calc.EndpointData
+			c.runOnLoop(func() {
+				data := c.epStats[*t]
+				oldSrc = data.SrcEp
+				oldDest = data.DstEp
+			})
 
 			lm.SetMockData(epMapSwapLocal, nil, nil, nil)
 			ciReaderSenderChan <- []clttypes.ConntrackInfo{convertCtEntry(outCtEntry, 0)}
 
 			// This is an unreported flow, and is a conntrack update. We can update the endpoint.
-			Consistently(c.epStats, "500ms", "100ms").Should(HaveKey(*t))
-			Eventually(func() calc.EndpointData { return data.SrcEp }, "2s", "100ms").ShouldNot(Equal(oldSrc))
-			Expect(data.DstEp).To(Equal(oldDest))
+			Consistently(c.epStatsSnapshot, "500ms", "100ms").Should(HaveKey(*t))
+			// The endpoint swap is applied on the collector goroutine, so poll SrcEp on-loop.
+			Eventually(func() calc.EndpointData {
+				var srcEp calc.EndpointData
+				c.runOnLoop(func() { srcEp = c.epStats[*t].SrcEp })
+				return srcEp
+			}, "2s", "100ms").ShouldNot(Equal(oldSrc))
+			var dstEp calc.EndpointData
+			c.runOnLoop(func() { dstEp = c.epStats[*t].DstEp })
+			Expect(dstEp).To(Equal(oldDest))
 		})
 		It("should handle source becoming non-local by removing entry on next packetinfo update for reported flow", func() {
 			pktinfo := nflogReader.ConvertNflogPkt(rules.RuleDirEgress, egressPktAllow[egressPktAllowNflogTuple])
-			c.applyPacketInfo(pktinfo)
+			c.runOnLoop(func() { c.applyPacketInfo(pktinfo) })
 			t := tuple.New(localIp1, remoteIp1, proto_udp, srcPort, dstPort)
 
-			Eventually(c.epStats, "500ms", "100ms").Should(HaveKey(*t))
+			Eventually(c.epStatsSnapshot, "500ms", "100ms").Should(HaveKey(*t))
 
 			// Flag the data as reported, remove endpoints from mock data and send in packetinfo entry again.
-			data := c.epStats[*t]
-			data.Reported = true
+			var data *Data
+			c.runOnLoop(func() {
+				data = c.epStats[*t]
+				data.Reported = true
+			})
 			lm.SetMockData(epMapDelete, nil, nil, nil)
-			c.applyPacketInfo(pktinfo)
+			c.runOnLoop(func() { c.applyPacketInfo(pktinfo) })
 
 			// This is a reported flow but we are going through packet processing still. It should be expired and
 			// removed.
-			Eventually(c.epStats, "500ms", "100ms").ShouldNot(HaveKey(*t))
-			Expect(data.Reported).To(BeFalse())
+			Eventually(c.epStatsSnapshot, "500ms", "100ms").ShouldNot(HaveKey(*t))
+			var reported bool
+			c.runOnLoop(func() { reported = data.Reported })
+			Expect(reported).To(BeFalse())
 		})
 		It("should handle source becoming non-local by removing entry on next packetinfo update for unreported flow", func() {
 			pktinfo := nflogReader.ConvertNflogPkt(rules.RuleDirEgress, egressPktAllow[egressPktAllowNflogTuple])
-			c.applyPacketInfo(pktinfo)
+			c.runOnLoop(func() { c.applyPacketInfo(pktinfo) })
 			t := tuple.New(localIp1, remoteIp1, proto_udp, srcPort, dstPort)
 
-			Eventually(c.epStats, "500ms", "100ms").Should(HaveKey(*t))
+			Eventually(c.epStatsSnapshot, "500ms", "100ms").Should(HaveKey(*t))
 
 			// Data is not reported. Remove endpoints from mock data and send in packetinfo entry again.
-			data := c.epStats[*t]
-			oldSrc := data.SrcEp
-			oldDest := data.DstEp
+			var data *Data
+			var oldSrc, oldDest calc.EndpointData
+			c.runOnLoop(func() {
+				data = c.epStats[*t]
+				oldSrc = data.SrcEp
+				oldDest = data.DstEp
+			})
 			lm.SetMockData(epMapDelete, nil, nil, nil)
-			c.applyPacketInfo(pktinfo)
+			c.runOnLoop(func() { c.applyPacketInfo(pktinfo) })
 
 			// This is an unreported flow but we are going through packet processing still. However, since the endpoint
 			// data has been removed assume it has just been deleted and don't downgrade our endpoint data.
-			Consistently(c.epStats, "500ms", "100ms").Should(HaveKey(*t))
-			Expect(data.Reported).To(BeFalse())
-			Expect(data.SrcEp).To(Equal(oldSrc))
-			Expect(data.DstEp).To(Equal(oldDest))
+			Consistently(c.epStatsSnapshot, "500ms", "100ms").Should(HaveKey(*t))
+			var reported bool
+			var newSrc, newDest calc.EndpointData
+			c.runOnLoop(func() {
+				reported = data.Reported
+				newSrc = data.SrcEp
+				newDest = data.DstEp
+			})
+			Expect(reported).To(BeFalse())
+			Expect(newSrc).To(Equal(oldSrc))
+			Expect(newDest).To(Equal(oldDest))
 		})
 		It("should handle source changing on next packetinfo update for reported flow", func() {
 			pktinfo := nflogReader.ConvertNflogPkt(rules.RuleDirEgress, egressPktAllow[egressPktAllowNflogTuple])
-			c.applyPacketInfo(pktinfo)
+			c.runOnLoop(func() { c.applyPacketInfo(pktinfo) })
 			t := tuple.New(localIp1, remoteIp1, proto_udp, srcPort, dstPort)
 
-			Eventually(c.epStats, "500ms", "100ms").Should(HaveKey(*t))
+			Eventually(c.epStatsSnapshot, "500ms", "100ms").Should(HaveKey(*t))
 
 			// Flag the data as reported, swap local endpoints from mock data and send in packetinfo entry again.
-			data := c.epStats[*t]
-			data.Reported = true
-			oldSrc := data.SrcEp
-			oldDest := data.DstEp
+			var data *Data
+			var oldSrc, oldDest calc.EndpointData
+			c.runOnLoop(func() {
+				data = c.epStats[*t]
+				data.Reported = true
+				oldSrc = data.SrcEp
+				oldDest = data.DstEp
+			})
 
 			lm.SetMockData(epMapSwapLocal, nil, nil, nil)
-			c.applyPacketInfo(pktinfo)
+			c.runOnLoop(func() { c.applyPacketInfo(pktinfo) })
 
 			// This is a reported flow but we are going through packet processing still. It should be expired and
 			// the endpoints updated.
-			Consistently(c.epStats, "500ms", "100ms").Should(HaveKey(*t))
-			Expect(data.Reported).To(BeFalse())
-			Expect(data.SrcEp).NotTo(Equal(oldSrc))
-			Expect(data.DstEp).To(Equal(oldDest))
+			Consistently(c.epStatsSnapshot, "500ms", "100ms").Should(HaveKey(*t))
+			var reported bool
+			var newSrc, newDest calc.EndpointData
+			c.runOnLoop(func() {
+				reported = data.Reported
+				newSrc = data.SrcEp
+				newDest = data.DstEp
+			})
+			Expect(reported).To(BeFalse())
+			Expect(newSrc).NotTo(Equal(oldSrc))
+			Expect(newDest).To(Equal(oldDest))
 		})
 		It("should handle source changing on next packetinfo update for unreported flow", func() {
 			pktinfo := nflogReader.ConvertNflogPkt(rules.RuleDirEgress, egressPktAllow[egressPktAllowNflogTuple])
-			c.applyPacketInfo(pktinfo)
+			c.runOnLoop(func() { c.applyPacketInfo(pktinfo) })
 			t := tuple.New(localIp1, remoteIp1, proto_udp, srcPort, dstPort)
 
-			Eventually(c.epStats, "500ms", "100ms").Should(HaveKey(*t))
+			Eventually(c.epStatsSnapshot, "500ms", "100ms").Should(HaveKey(*t))
 
 			// Data is not reported, swap local endpoints from mock data and send in CT entry again.
-			data := c.epStats[*t]
-			oldSrc := data.SrcEp
-			oldDest := data.DstEp
+			var data *Data
+			var oldSrc, oldDest calc.EndpointData
+			c.runOnLoop(func() {
+				data = c.epStats[*t]
+				oldSrc = data.SrcEp
+				oldDest = data.DstEp
+			})
 
 			lm.SetMockData(epMapSwapLocal, nil, nil, nil)
-			c.applyPacketInfo(pktinfo)
+			c.runOnLoop(func() { c.applyPacketInfo(pktinfo) })
 
 			// This is an unreported flow, and is a conntrack update. We can update the endpoint.
-			Consistently(c.epStats, "500ms", "100ms").Should(HaveKey(*t))
-			Expect(data.Reported).To(BeFalse())
-			Expect(data.SrcEp).NotTo(Equal(oldSrc))
-			Expect(data.DstEp).To(Equal(oldDest))
+			Consistently(c.epStatsSnapshot, "500ms", "100ms").Should(HaveKey(*t))
+			var reported bool
+			var newSrc, newDest calc.EndpointData
+			c.runOnLoop(func() {
+				reported = data.Reported
+				newSrc = data.SrcEp
+				newDest = data.DstEp
+			})
+			Expect(reported).To(BeFalse())
+			Expect(newSrc).NotTo(Equal(oldSrc))
+			Expect(newDest).To(Equal(oldDest))
 		})
 	})
 	Describe("Test local source to local destination", func() {
@@ -1595,7 +1756,7 @@ var _ = Describe("Conntrack Datasource", func() {
 			By("handling an nflog update for destination matching on policy - all policy info is now gathered",
 				func() {
 					pktinfo := nflogReader.ConvertNflogPkt(rules.RuleDirIngress, ingressPktAllow[ingressPktAllowNflogTuple])
-					c.applyPacketInfo(pktinfo)
+					c.runOnLoop(func() { c.applyPacketInfo(pktinfo) })
 				},
 			)
 
@@ -1603,7 +1764,7 @@ var _ = Describe("Conntrack Datasource", func() {
 			inCtEntryStateTimeWait := inCtEntry
 			inCtEntryStateTimeWait.ProtoInfo.State = nfnl.TCP_CONNTRACK_TIME_WAIT
 			ciReaderSenderChan <- []clttypes.ConntrackInfo{convertCtEntry(inCtEntryStateTimeWait, 0)}
-			Eventually(c.epStats, "500ms", "100ms").ShouldNot(HaveKey(*t))
+			Eventually(c.epStatsSnapshot, "500ms", "100ms").ShouldNot(HaveKey(*t))
 		})
 
 		It("Handle TCP conntrack entries with TCP state TIME_WAIT before NFLOGs gathered", func() {
@@ -1633,42 +1794,36 @@ var _ = Describe("Conntrack Datasource", func() {
 			inCtEntryStateTimeWait := inCtEntry
 			inCtEntryStateTimeWait.ProtoInfo.State = nfnl.TCP_CONNTRACK_TIME_WAIT
 			ciReaderSenderChan <- []clttypes.ConntrackInfo{convertCtEntry(inCtEntryStateTimeWait, 0)}
-			Eventually(c.epStats, "500ms", "100ms").Should(HaveKey(*t))
+			Eventually(c.epStatsSnapshot, "500ms", "100ms").Should(HaveKey(*t))
 
 			By("handling an nflog update for destination matching on policy - all policy info is now gathered",
 				func() {
 					pktinfo := nflogReader.ConvertNflogPkt(rules.RuleDirIngress, ingressPktAllow[ingressPktAllowNflogTuple])
-					c.applyPacketInfo(pktinfo)
+					c.runOnLoop(func() { c.applyPacketInfo(pktinfo) })
 				},
 			)
-			Eventually(c.epStats, "500ms", "100ms").ShouldNot(HaveKey(*t))
+			Eventually(c.epStatsSnapshot, "500ms", "100ms").ShouldNot(HaveKey(*t))
 		})
 	})
 
 	Describe("Test data race", func() {
 		It("getDataAndUpdateEndpoints does not cause a data race contention with deleteDataFromEpStats after deleteDataFromEpStats removes it from epstats", func() {
 			existingTuple := tuple.New(remoteIp1, localIp1, proto_tcp, srcPort, dstPort)
-			testData := c.getDataAndUpdateEndpoints(*existingTuple, false, true)
-
 			newTuple := tuple.New(localIp1, localIp2, proto_tcp, srcPort, dstPort)
 
+			// The collector owns epStats on its own goroutine, so run the get/delete/get
+			// sequence there. This exercises that a get for a fresh tuple succeeds right
+			// after a different tuple's entry is deleted.
 			var resultantNewTupleData *Data
-
-			time.AfterFunc(2*time.Second, func() {
+			c.runOnLoop(func() {
+				testData := c.getDataAndUpdateEndpoints(*existingTuple, false, true)
 				c.deleteDataFromEpStats(testData)
-			})
-
-			// ok Get is a little after feedupdate because feedupdate has some preprocesssing
-			// before it accesses flowstore
-			time.AfterFunc(2*time.Second+10*time.Millisecond, func() {
 				resultantNewTupleData = c.getDataAndUpdateEndpoints(*newTuple, false, true)
 			})
 
-			time.Sleep(3 * time.Second)
-
-			Expect(c.epStats).ShouldNot(HaveKey(*existingTuple))
-			Expect(c.epStats).Should(HaveKey(*newTuple))
-			Expect(resultantNewTupleData).ToNot(Equal(nil))
+			Expect(c.epStatsSnapshot()).ShouldNot(HaveKey(*existingTuple))
+			Expect(c.epStatsSnapshot()).Should(HaveKey(*newTuple))
+			Expect(resultantNewTupleData).ToNot(BeNil())
 		})
 	})
 
@@ -1677,17 +1832,24 @@ var _ = Describe("Conntrack Datasource", func() {
 			By("handling a conntrack update to start tracking stats for tuple (w/ DNAT)")
 			t := tuple.New(localIp1, localIp2, proto_tcp, srcPort, dstPort)
 			ciReaderSenderChan <- []clttypes.ConntrackInfo{convertCtEntry(localCtEntryWithDNAT, 0)}
-			data := eventuallyExpectCtStats(c, *t, localCtEntryWithDNAT)
+			eventuallyExpectCtStats(c, *t, localCtEntryWithDNAT)
 
 			// Flagging as expired will attempt to expire the data when NFLOGs and service info are gathered.
 			By("flagging the data as expired")
-			data.Expired = true
-			Expect(data.IsDNAT).Should(BeTrue())
+			var isDNAT bool
+			c.runOnLoop(func() {
+				data := c.epStats[*t]
+				data.Expired = true
+				isDNAT = data.IsDNAT
+			})
+			Expect(isDNAT).Should(BeTrue())
 
 			By("handling nflog updates for destination matching on policy - all policy info is now gathered, but no service")
-			c.applyPacketInfo(nflogReader.ConvertNflogPkt(rules.RuleDirIngress, localPktIngress[localPktIngressNflogTuple]))
-			c.applyPacketInfo(nflogReader.ConvertNflogPkt(rules.RuleDirEgress, localPktEgress[localPktEgressNflogTuple]))
-			Eventually(c.epStats, "500ms", "100ms").Should(HaveKey(*t))
+			c.runOnLoop(func() {
+				c.applyPacketInfo(nflogReader.ConvertNflogPkt(rules.RuleDirIngress, localPktIngress[localPktIngressNflogTuple]))
+				c.applyPacketInfo(nflogReader.ConvertNflogPkt(rules.RuleDirEgress, localPktEgress[localPktEgressNflogTuple]))
+			})
+			Eventually(c.epStatsSnapshot, "500ms", "100ms").Should(HaveKey(*t))
 
 			By("creating a matching service for the pre-DNAT cluster IP and port")
 			lm.SetMockData(nil, nil, nil, map[model.ResourceKey]*kapiv1.Service{
@@ -1707,23 +1869,33 @@ var _ = Describe("Conntrack Datasource", func() {
 			})
 
 			By("handling another nflog update for destination matching on policy - should rematch and expire the entry")
-			c.applyPacketInfo(nflogReader.ConvertNflogPkt(rules.RuleDirIngress, localPktIngress[localPktIngressNflogTuple]))
-			Expect(c.epStats).ShouldNot(HaveKey(*t))
+			c.runOnLoop(func() {
+				c.applyPacketInfo(nflogReader.ConvertNflogPkt(rules.RuleDirIngress, localPktIngress[localPktIngressNflogTuple]))
+			})
+			Expect(c.epStatsSnapshot()).ShouldNot(HaveKey(*t))
 		})
 		It("handle pre-DNAT info on nflog update", func() {
 			By("handling egress nflog updates for destination matching on policy - this contains pre-DNAT info")
 			t := tuple.New(localIp1, localIp2, proto_tcp, srcPort, dstPort)
-			c.applyPacketInfo(nflogReader.ConvertNflogPkt(rules.RuleDirIngress, localPktIngressWithDNAT[localPktIngressWithDNATNflogTuple]))
+			c.runOnLoop(func() {
+				c.applyPacketInfo(nflogReader.ConvertNflogPkt(rules.RuleDirIngress, localPktIngressWithDNAT[localPktIngressWithDNATNflogTuple]))
+			})
 
 			// Flagging as expired will attempt to expire the data when NFLOGs and service info are gathered.
 			By("flagging the data as expired")
-			data := c.epStats[*t]
-			data.Expired = true
-			Expect(data.IsDNAT).Should(BeTrue())
+			var isDNAT bool
+			c.runOnLoop(func() {
+				data := c.epStats[*t]
+				data.Expired = true
+				isDNAT = data.IsDNAT
+			})
+			Expect(isDNAT).Should(BeTrue())
 
 			By("handling ingree nflog updates for destination matching on policy - all policy info is now gathered, but no service")
-			c.applyPacketInfo(nflogReader.ConvertNflogPkt(rules.RuleDirEgress, localPktEgress[localPktEgressNflogTuple]))
-			Expect(c.epStats).Should(HaveKey(*t))
+			c.runOnLoop(func() {
+				c.applyPacketInfo(nflogReader.ConvertNflogPkt(rules.RuleDirEgress, localPktEgress[localPktEgressNflogTuple]))
+			})
+			Expect(c.epStatsSnapshot()).Should(HaveKey(*t))
 
 			By("creating a matching service for the pre-DNAT cluster IP and port")
 			lm.SetMockData(nil, nil, nil, map[model.ResourceKey]*kapiv1.Service{
@@ -1743,8 +1915,10 @@ var _ = Describe("Conntrack Datasource", func() {
 			})
 
 			By("handling another nflog update for destination matching on policy - should rematch and expire the entry")
-			c.applyPacketInfo(nflogReader.ConvertNflogPkt(rules.RuleDirIngress, localPktIngress[localPktIngressNflogTuple]))
-			Expect(c.epStats).ShouldNot(HaveKey(*t))
+			c.runOnLoop(func() {
+				c.applyPacketInfo(nflogReader.ConvertNflogPkt(rules.RuleDirIngress, localPktIngress[localPktIngressNflogTuple]))
+			})
+			Expect(c.epStatsSnapshot()).ShouldNot(HaveKey(*t))
 		})
 	})
 })
@@ -1800,12 +1974,11 @@ var _ = Describe("Reporting Metrics", func() {
 	})
 	AfterEach(func() {
 		nflogReader.Stop()
+		c.Stop()
 	})
 	Context("Without process info enabled", func() {
 		BeforeEach(func() {
-			go func() {
-				Expect(c.Start()).NotTo(HaveOccurred())
-			}()
+			Expect(c.Start()).NotTo(HaveOccurred())
 		})
 		Describe("Report Denied Packets", func() {
 			BeforeEach(func() {
@@ -1934,6 +2107,36 @@ func newMockReporter() *mockReporter {
 
 func (mr *mockReporter) Start() error {
 	return nil
+}
+
+// runOnLoop runs fn on the collector's own goroutine and blocks until it
+// returns. The collector goroutine owns epStats and the Data values it holds
+// with no locking, so this is the only race-free way for a test to read or
+// mutate that state. The collector must have been Start()ed and not yet
+// Stop()ped.
+//
+// Do not run Gomega assertions inside fn: a failed assertion panics, and on the
+// collector goroutine Ginkgo cannot attribute the panic to the running spec.
+// Capture the values fn observes and assert on them after runOnLoop returns.
+func (c *collector) runOnLoop(fn func()) {
+	done := make(chan struct{})
+	c.thunkC <- func() {
+		defer close(done)
+		fn()
+	}
+	<-done
+}
+
+// epStatsSnapshot returns a shallow clone of epStats, taken on the collector's
+// goroutine, so it is safe to poll with Eventually/Consistently and the HaveKey
+// matcher. The *Data values are still owned by the collector goroutine; read
+// their fields via runOnLoop, not through the returned map.
+func (c *collector) epStatsSnapshot() map[tuple.Tuple]*Data {
+	var snapshot map[tuple.Tuple]*Data
+	c.runOnLoop(func() {
+		snapshot = maps.Clone(c.epStats)
+	})
+	return snapshot
 }
 
 func (mr *mockReporter) Report(u any) error {

--- a/felix/collector/collector_test.go
+++ b/felix/collector/collector_test.go
@@ -4037,10 +4037,11 @@ func TestContinuousModeRunsSweepFromMainLoop(t *testing.T) {
 		PolicyEvaluationMode:  string(v3.FlowLogsPolicyEvaluationModeContinuous),
 	}).(*collector)
 
-	Expect(c.tickerPolicyEval).ToNot(BeNil(), "continuous mode should arm the policy-eval ticker")
-
 	before := testutil.ToFloat64(counterPolicyEvalFlows.WithLabelValues(string(policyEvalRecalc)))
 	Expect(c.Start()).To(Succeed())
+	t.Cleanup(c.Stop)
+
+	Expect(c.tickerPolicyEval).ToNot(BeNil(), "continuous mode should arm the policy-eval ticker")
 
 	// Hand the flow to the collector over its reporting channel so that it is created on the
 	// collector's own goroutine.
@@ -4063,6 +4064,11 @@ func TestContinuousModeRunsSweepFromMainLoop(t *testing.T) {
 func TestNonContinuousModeLeavesSweepIdle(t *testing.T) {
 	RegisterTestingT(t)
 	c, _, _ := setupPolicyEvalCollector(t) // no PolicyEvaluationMode set
+
+	// The ticker is armed by Start (so its goroutine shares the stats loop's lifecycle), so
+	// start the collector before checking that this mode leaves it unarmed.
+	Expect(c.Start()).To(Succeed())
+	t.Cleanup(c.Stop)
 
 	Expect(c.tickerPolicyEval).To(BeNil())
 	Expect(c.policyEvalTickChan()).To(BeNil(), "a nil channel masks the sweep out of the select")

--- a/felix/collector/collector_test.go
+++ b/felix/collector/collector_test.go
@@ -19,6 +19,7 @@ package collector
 import (
 	"fmt"
 	net2 "net"
+	"reflect"
 	"slices"
 	"testing"
 	"time"
@@ -687,10 +688,7 @@ var _ = Describe("NFLOG Datasource", func() {
 
 				// Verify that RuleHits are not processed.  The RuleHits are applied after the
 				// epStats entry is inserted, so keep checking rather than sampling immediately.
-				Consistently(func() [2]int {
-					data := c.epStatsSnapshot()[*t]
-					return [2]int{len(data.IngressRuleTrace.Path()), len(data.EgressRuleTrace.Path())}
-				}, "500ms", "100ms").Should(Equal([2]int{0, 0}),
+				Consistently(pathLengthsOfData(c, *t), "500ms", "100ms").Should(Equal(pathLengths{0, 0}),
 					"Ingress/EgressRuleTrace Paths should stay empty when source endpoint is marked for deletion")
 			})
 		})
@@ -723,10 +721,7 @@ var _ = Describe("NFLOG Datasource", func() {
 
 				// Verify that RuleHits are not processed.  The RuleHits are applied after the
 				// epStats entry is inserted, so keep checking rather than sampling immediately.
-				Consistently(func() [2]int {
-					data := c.epStatsSnapshot()[*t]
-					return [2]int{len(data.IngressRuleTrace.Path()), len(data.EgressRuleTrace.Path())}
-				}, "500ms", "100ms").Should(Equal([2]int{0, 0}),
+				Consistently(pathLengthsOfData(c, *t), "500ms", "100ms").Should(Equal(pathLengths{0, 0}),
 					"Ingress/EgressRuleTrace Paths should stay empty when destination endpoint is marked for deletion")
 			})
 		})
@@ -759,10 +754,7 @@ var _ = Describe("NFLOG Datasource", func() {
 
 				// Verify that RuleHits are not processed.  The RuleHits are applied after the
 				// epStats entry is inserted, so keep checking rather than sampling immediately.
-				Consistently(func() [2]int {
-					data := c.epStatsSnapshot()[*t]
-					return [2]int{len(data.IngressRuleTrace.Path()), len(data.EgressRuleTrace.Path())}
-				}, "500ms", "100ms").Should(Equal([2]int{0, 0}),
+				Consistently(pathLengthsOfData(c, *t), "500ms", "100ms").Should(Equal(pathLengths{0, 0}),
 					"Ingress/EgressRuleTrace Paths should stay empty when remote source endpoint is marked for deletion")
 			})
 		})
@@ -792,9 +784,9 @@ var _ = Describe("NFLOG Datasource", func() {
 				Eventually(c.epStatsSnapshot).Should(HaveKey(*t))
 
 				// Verify that RuleHits were processed (Path should NOT be empty)
-				Eventually(func() int {
-					return len(c.epStatsSnapshot()[*t].IngressRuleTrace.Path())
-				}, "500ms", "50ms").Should(BeNumerically(">", 0), "IngressRuleTrace Path should NOT be empty when endpoints are active")
+				Eventually(pathLengthsOfData(c, *t), "500ms", "50ms").Should(
+					HaveField("Ingress", BeNumerically(">", 0)),
+					"IngressRuleTrace Path should NOT be empty when endpoints are active")
 			})
 		})
 	})
@@ -1096,6 +1088,24 @@ func countersOfCtEntry(e nfnetlink.CtEntry) ctCounters {
 		Bytes:          *counter.New(e.OriginalCounters.Bytes),
 		PacketsReverse: *counter.New(e.ReplyCounters.Packets),
 		BytesReverse:   *counter.New(e.ReplyCounters.Bytes),
+	}
+}
+
+// pathLengths is the ingress/egress rule-trace path lengths of one epStats entry.
+type pathLengths struct {
+	Ingress, Egress int
+}
+
+// pathLengthsOfData returns an Eventually/Consistently poll function for the
+// rule-trace path lengths of tuple t, or {-1, -1} if the entry is missing from
+// epStats (rather than nil-panicking mid-poll).
+func pathLengthsOfData(c *collector, t tuple.Tuple) func() pathLengths {
+	return func() pathLengths {
+		data := c.epStatsSnapshot()[t]
+		if data == nil {
+			return pathLengths{-1, -1}
+		}
+		return pathLengths{len(data.IngressRuleTrace.Path()), len(data.EgressRuleTrace.Path())}
 	}
 }
 
@@ -1674,7 +1684,7 @@ var _ = Describe("Conntrack Datasource", func() {
 	})
 
 	Describe("Test data race", func() {
-		It("getDataAndUpdateEndpoints does not cause a data race contention with deleteDataFromEpStats after deleteDataFromEpStats removes it from epstats", func() {
+		It("getDataAndUpdateEndpoints succeeds for a fresh tuple immediately after another entry is deleted from epStats", func() {
 			existingTuple := tuple.New(remoteIp1, localIp1, proto_tcp, srcPort, dstPort)
 			newTuple := tuple.New(localIp1, localIp2, proto_tcp, srcPort, dstPort)
 
@@ -1979,12 +1989,20 @@ func (mr *mockReporter) Start() error {
 // collector goroutine Ginkgo cannot attribute the panic to the running spec.
 // Capture the values fn observes and assert on them after runOnLoop returns.
 func (c *collector) runOnLoop(fn func()) {
+	GinkgoHelper()
 	done := make(chan struct{})
-	c.thunkC <- func() {
+	thunk := func() {
 		defer close(done)
 		fn()
 	}
-	<-done
+	select {
+	case c.thunkC <- thunk:
+		<-done
+	case <-c.stopC:
+		// Without this case a send to a stopped (or never started) collector
+		// would block forever and the suite would hang with no clue why.
+		Fail("runOnLoop called on a collector that is not running")
+	}
 }
 
 // epStatsSnapshot returns a clone of epStats, taken on the collector's goroutine,
@@ -2024,6 +2042,52 @@ func (t *RuleTrace) clone() RuleTrace {
 	clone.path = slices.Clone(t.path)
 	clone.rulesToReport = slices.Clone(t.rulesToReport)
 	return clone
+}
+
+// TestCloneCoversAllFields fails when a field holding a reference is added to
+// Data, or to a struct nested in it, without teaching the clone helpers above
+// about it. On failure: deep-copy the field in clone(), or list it in handled
+// with a note saying why sharing it with the collector goroutine is safe.
+func TestCloneCoversAllFields(t *testing.T) {
+	// Field name -> why the clone helpers are already correct for it.
+	handled := map[string]string{
+		"Data.SrcEp":                 "shared: EndpointData is immutable once published",
+		"Data.DstEp":                 "shared: EndpointData is immutable once published",
+		"Data.IngressPendingRuleIDs": "deep-copied by (*Data).clone",
+		"Data.EgressPendingRuleIDs":  "deep-copied by (*Data).clone",
+		"RuleTrace.path":             "deep-copied by (*RuleTrace).clone",
+		"RuleTrace.rulesToReport":    "deep-copied by (*RuleTrace).clone",
+		"RuleTrace.pathArray":        "shared: elements are RuleIDs, immutable once published",
+	}
+
+	var holdsRef func(ty reflect.Type) bool
+	holdsRef = func(ty reflect.Type) bool {
+		switch ty.Kind() {
+		case reflect.Slice, reflect.Map, reflect.Pointer, reflect.Interface,
+			reflect.Chan, reflect.Func, reflect.UnsafePointer:
+			return true
+		case reflect.Array:
+			return holdsRef(ty.Elem())
+		default:
+			return false
+		}
+	}
+
+	var check func(ty reflect.Type)
+	check = func(ty reflect.Type) {
+		for i := 0; i < ty.NumField(); i++ {
+			f := ty.Field(i)
+			name := ty.Name() + "." + f.Name
+			switch {
+			case handled[name] != "":
+			case holdsRef(f.Type):
+				t.Errorf("%s holds a reference (%s) that clone() does not know about", name, f.Type)
+			case f.Type.Kind() == reflect.Struct:
+				check(f.Type)
+			}
+		}
+	}
+	check(reflect.TypeOf(Data{}))
 }
 
 func (mr *mockReporter) Report(u any) error {

--- a/felix/netlinkshim/mocknetlink/netlink.go
+++ b/felix/netlinkshim/mocknetlink/netlink.go
@@ -350,6 +350,12 @@ func (d *MockNetlinkDataplane) GetFeatures() *environment.Features {
 }
 
 func (d *MockNetlinkDataplane) ResetDeltas() {
+	// The route table's conntrack cleanup runs on a background goroutine that
+	// touches deletedConntrackEntries under the mutex (see RemoveConntrackFlows),
+	// so take the lock here too rather than racing the reset against it.
+	d.mutex.Lock()
+	defer d.mutex.Unlock()
+
 	d.AddedLinks = set.New[string]()
 	d.DeletedLinks = set.New[string]()
 	d.AddedAddrs = set.New[string]()

--- a/felix/utils/run-coverage
+++ b/felix/utils/run-coverage
@@ -38,8 +38,10 @@ if [ "$#" -eq 0 ]; then
   echo "Packages with tests: $test_pkgs"
 fi
 
+# Run with the race detector enabled to catch data races in the UTs. The race
+# detector requires atomic coverage mode (it rejects -covermode=count).
 set -x
-ginkgo -cover -covermode=count -coverpkg=${go_dirs} -keep-going -r "$@"
+ginkgo --race -cover -covermode=atomic -coverpkg=${go_dirs} -keep-going -r "$@"
 set +x
 
 gocovmerge $(find . -name 'coverprofile.out') > combined.coverprofile


### PR DESCRIPTION
## What / why

The `collector` runs a single goroutine (`startStatsCollectionAndReporting`) that owns `epStats` and the `Data` values within it, with no locking. The unit tests reached into that state directly from the test goroutine — `Eventually(c.epStats)`, `data.Reported = true`, direct `applyPacketInfo(...)` calls — racing with the collector goroutine's ticker-driven processing. This was tolerated only because the felix UTs did not run under `-race`.

This PR makes the `felix/collector` UTs race-free and enables `-race` for the felix UTs so further races get caught.

## How

- **Thunk channel + `Stop()`** on the collector. A new `case fn := <-c.thunkC: fn()` in the select loop lets a caller run a closure on the collector's own goroutine — the only race-free way to touch collector-owned state. `Stop()` shuts the goroutine down (addressing the long-standing "done channel" `TODO`). Both are dormant in production (nothing sends to `thunkC`; nothing calls `Stop()` yet).
- **Two test helpers** built on that: `runOnLoop(fn)` for race-free reads/mutations, and `epStatsSnapshot()` (an on-loop map clone) for `Eventually`/`Consistently` key checks. All direct `epStats`/`Data` access in the NFLOG and Conntrack blocks routes through these. Master's existing flakiness helpers `eventuallyExpectCtStats` / `countersOfData` were made race-free the same way (they now read on the collector goroutine), which keeps their poll-based semantics while removing the races. The "Test data race" spec, which used `time.AfterFunc` goroutines to force an interleaving, now runs its get/delete/get sequence on the loop, matching production.
- **Fixed a pre-existing race** in the NFLOG / Reporting-Metrics setup: `Start()` does not block, so wrapping it in `go func(){ ... }()` let two specs' `Start()` calls overlap and race on a package-global timestamp. `Start()` is now synchronous, and every block that starts the collector `Stop()`s it.
- **Enabled `-race`** for the felix UTs: `run-coverage` now runs `ginkgo --race -covermode=atomic` (the race detector requires atomic coverage mode), and the `ut` target uses the CGO build container.
- **`felix/netlinkshim/mocknetlink`: locked `ResetDeltas`.** Enabling `-race` surfaced a pre-existing race in the routetable UT (`TestRules`): the route table removes conntrack flows on a background goroutine (`MockNetlinkDataplane.RemoveConntrackFlows`, which touches `deletedConntrackEntries` under the mutex), while `ResetDeltas` reassigned that field without the mutex. `ResetDeltas` now takes the mutex, like the other accessors of that state.

## Testing

The whole felix UT suite (the `make -C felix ut` scope — excludes `fv`, `k8sfv`, `bpf/ut`) passes under `-race` with zero data races: 37 packages, `ginkgo --race`, Test Suite Passed — confirmed both locally and on CI (the "Felix: UT" job is green under `-race`). Concurrency-heavy packages were also stress-run repeatedly standalone under `-race` to shore up the nondeterministic detector (collector, routetable, wireguard, ifacemonitor, routerule).

The felix UT packages that actually raced were `collector`, `collector/flowlog` (fixed independently on master, see below), and `routetable` (via the `mocknetlink` mock above) — all now resolved.

## Notes

- Rebased onto current `master`; integrated with the collector-test flakiness fixes that landed in the meantime (kept their `Eventually`/`Consistently` semantics, made the state access race-free).
- `felix/collector/flowlog` was fixed independently on `master` while this was in review, so the flowlog commit that was originally here has been dropped; master's `flowlog` is `-race` clean.

**Release note:**
```release-note
NONE
```
