### PR TITLE
[v3.32] networking-calico: don't delete dest WEP of in-flight live migration on resync

### DIFF
--- a/networking-calico/networking_calico/plugins/ml2/drivers/calico/endpoints.py
+++ b/networking-calico/networking_calico/plugins/ml2/drivers/calico/endpoints.py
@@ -136,6 +136,31 @@ class WorkloadEndpointSyncer(ResourceSyncer):
 
         LOG.info("LiveMigration resync done")
 
+    def get_protected_names(self, neutron_map):
+        """Return the destination WEP names for in-flight live migrations.
+
+        While a live migration is in flight, the Neutron port still has
+        binding:host_id set to the source host, so the Neutron map only
+        contains the source WEP name.  The destination WEP - created by the
+        pre-migration update and needed until the migration completes - would
+        therefore look orphaned to the generic deletion sweep, and deleting it
+        would cause Felix on the destination host to tear the endpoint down
+        mid-migration.  Protect those names from deletion;
+        _resync_live_migrations keeps the corresponding data in the correct
+        state.
+        """
+        protected = set()
+        for port in neutron_map.values():
+
+            # Note: binding:profile may carry migrating_to=None, so require a
+            # truthy value here.
+            dest_host = port.get("binding:profile", {}).get("migrating_to")
+            if dest_host:
+                dest_port = port.copy()
+                dest_port["binding:host_id"] = dest_host
+                protected.add(endpoint_name(dest_port))
+        return protected
+
     def delete_legacy_etcd_data(self):
         if self.namespace != datamodel_v3.NO_REGION_NAMESPACE:
             datamodel_v3.delete_legacy(self.resource_kind, "")

--- a/networking-calico/networking_calico/plugins/ml2/drivers/calico/syncer.py
+++ b/networking-calico/networking_calico/plugins/ml2/drivers/calico/syncer.py
@@ -113,6 +113,11 @@ class ResourceSyncer(object):
         # already compared the existing etcd data against Neutron.
         names_compared = set()
 
+        # Names that exist in etcd without a direct counterpart in the Neutron
+        # map, but that must not be deleted; e.g. the destination
+        # WorkloadEndpoint of an in-flight live migration.
+        protected_names = self.get_protected_names(neutron_map)
+
         LOG.info(
             "Resync for %s; got neutron data (%s items), look for incorrect data...",
             self.resource_kind,
@@ -148,6 +153,11 @@ class ResourceSyncer(object):
                             self.resource_kind,
                             name,
                         )
+            elif name in protected_names:
+                # This name has nothing directly corresponding in the Neutron
+                # map, but the subclass has told us that it is still expected,
+                # so it must not be deleted.
+                LOG.info("etcd data protected for %s %s", self.resource_kind, name)
             else:
                 # This name is in etcd but now has nothing corresponding in
                 # Neutron, so remember it for deletion from etcd.
@@ -197,6 +207,18 @@ class ResourceSyncer(object):
         self.delete_legacy_etcd_data()
 
         LOG.info("Resync for %s; done.", self.resource_kind)
+
+    def get_protected_names(self, neutron_map):
+        """Return names that must not be deleted from etcd during this resync.
+
+        These are names that do not appear in the Neutron map - which is keyed
+        by the names that the generic resync computation expects - but that are
+        nevertheless still wanted.  By default there are none, but subclasses
+        may override; see WorkloadEndpointSyncer, which uses this to stop the
+        deletion sweep from reaping the destination WEP of an in-flight live
+        migration.
+        """
+        return set()
 
     def delete_legacy_etcd_data(self):
         # By default this is a no-op, but subclasses may override.

--- a/networking-calico/networking_calico/plugins/ml2/drivers/calico/test/test_plugin_etcd.py
+++ b/networking-calico/networking_calico/plugins/ml2/drivers/calico/test/test_plugin_etcd.py
@@ -2136,6 +2136,29 @@ class TestLiveMigration(TestPluginEtcdBase):
         self.assertIn(self._lm_key(self.DEST_HOST), self.recent_writes)
         self.assertIn(self._ep_key(self.DEST_HOST), self.recent_writes)
 
+    def test_resync_does_not_delete_dest_wep_mid_migration(self):
+        """Resync must not delete the dest WEP of an in-flight migration.
+
+        While a migration is in flight the Neutron port is still bound to the
+        source host, so the destination WEP has no direct counterpart in the
+        Neutron port map and used to be reaped - then recreated - by the
+        periodic resync.  That transient deletion made Felix on the
+        destination host tear down the endpoint mid-migration.
+        """
+        self._do_initial_resync()
+
+        # Start a live migration; this creates the destination WEP and
+        # LiveMigration resource in etcd.
+        self._pre_migrate()
+
+        self._trigger_resync()
+
+        # The destination WEP must not have been deleted, even transiently.
+        self.assertNotIn(self._ep_key(self.DEST_HOST), self.recent_deletes)
+
+        # Neither should anything else have been deleted.
+        self.assertEtcdDeletes(set())
+
     def test_resync_deletes_stale_live_migration(self):
         """Resync deletes orphaned LiveMigration with no migrating port."""
         self._do_initial_resync()


### PR DESCRIPTION
Bug fix for the v3.32 networking-calico periodic resync (Jira CI-2021).

While a live migration is in flight, the Neutron port still has `binding:host_id` set to the source host, with the destination host only in `binding:profile.migrating_to`.  The generic resync deletion sweep therefore saw the destination WEP — created by the pre-migration update — as orphaned and deleted it; `_resync_live_migrations` then recreated it moments later, but Felix on the destination host had already consumed the deletion as a `Deleted` input to its live-migration state machine (`Live → Base`) and torn the endpoint down mid-migration.

This change adds a `get_protected_names` hook to `ResourceSyncer`, overridden by `WorkloadEndpointSyncer` to protect the destination WEP names of in-flight live migrations from the deletion sweep.  The protected set is computed from the same Neutron snapshot as the sweep itself, so no extra DB read is needed and no new race window is introduced.  Creation/ensure of destination WEPs and orphan LiveMigration cleanup remain the job of `_resync_live_migrations`, unchanged.

Testing done: new regression test `test_resync_does_not_delete_dest_wep_mid_migration`, verified to fail without the fix (the resync's deletes contain the destination WEP key, matching the customer-observed behaviour) and pass with it; full `make -C networking-calico tox-caracal`, black and flake8 all pass.

Master (v3.33) is not affected: the reworked resync there already includes destination WEPs, with `migrating_to` validation, in its desired state computation.

**Release note:**
```release-note
Fix that the networking-calico periodic resync could transiently delete the destination WorkloadEndpoint of an in-flight live migration, disrupting the migrated VM's connectivity.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)