### PR TITLE
networking-calico: regression test for resync mid-live-migration

### DIFF
--- a/networking-calico/networking_calico/plugins/ml2/drivers/calico/test/test_plugin_etcd.py
+++ b/networking-calico/networking_calico/plugins/ml2/drivers/calico/test/test_plugin_etcd.py
@@ -2581,6 +2581,32 @@ class TestLiveMigration(TestPluginEtcdBase):
         # The new LM is NOT in the deletes set.
         self.assertNotIn(self._lm_key(self.DEST_HOST), self.recent_deletes)
 
+    def test_resync_does_not_delete_dest_wep_mid_migration(self):
+        """Resync must not delete the dest WEP of an in-flight migration.
+
+        Regression test for a v3.32 bug (CI-2021): the pre-v3.33 resync's
+        deletion sweep only expected WEP names derived from each port's
+        binding:host_id - still the source host while a migration is in flight
+        - so it reaped the destination WEP and recreated it moments later,
+        making Felix on the destination host tear the endpoint down
+        mid-migration.  The reworked resync computes desired (port, host)
+        slots from binding:profile.migrating_to as well, so it should not
+        delete anything here; this test pins that down, asserting no
+        deletions at all (which also covers the source WEP and LM).
+        """
+        self._do_initial_resync()
+
+        # Start a live migration; this creates the destination WEP and
+        # LiveMigration resource in etcd.
+        self._pre_migrate()
+        self.recent_writes = {}
+        self.recent_deletes = set()
+
+        self._trigger_resync()
+
+        # Nothing should be deleted, even transiently.
+        self.assertEtcdDeletes(set())
+
     def test_resync_no_op_when_lm_already_correct(self):
         """Full resync no-ops when LM and dest WEP already match Neutron."""
         self._do_initial_resync()


### PR DESCRIPTION
Test-only change (Jira CI-2021).

In v3.32, the networking-calico resync deletion sweep only expected WEP names derived from each port's `binding:host_id` — still the source host while a live migration is in flight — so it transiently deleted the destination WEP, and Felix on the destination host tore the endpoint down mid-migration.  That bug is fixed on the v3.32 branch by #13285.

The reworked resync on master computes desired (port, host) slots from `binding:profile.migrating_to` as well, so it is not affected.  This PR adds a regression test pinning that down: a resync during an in-flight migration must delete nothing at all.  It complements the existing `test_resync_no_op_when_lm_already_correct`, which asserts that the destination WEP and LiveMigration are untouched but does not assert the absence of other deletions (e.g. of the source WEP).

Testing done: full `TestLiveMigration` suite (18 tests) via `make -C networking-calico tox-caracal`, black and flake8 all pass.

**Release note:**
```release-note
None
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)