### PR TITLE
calicoctl: show NAME in default `get wep` output

### DIFF
--- a/calicoctl/calicoctl/resourcemgr/workloadendpoint.go
+++ b/calicoctl/calicoctl/resourcemgr/workloadendpoint.go
@@ -28,7 +28,7 @@ func init() {
 		internalapi.NewWorkloadEndpointList(),
 		true,
 		[]string{"workloadendpoint", "workloadendpoints", "wep", "weps"},
-		[]string{"WORKLOAD", "NODE", "NETWORKS", "INTERFACE"},
+		[]string{"NAME", "WORKLOAD", "NODE", "NETWORKS", "INTERFACE"},
 		[]string{"NAME", "WORKLOAD", "NODE", "NETWORKS", "INTERFACE", "PROFILES", "NATS"},
 		// NAMESPACE may be prepended in GrabTableTemplate so needs to remain in the map below
 		map[string]string{


### PR DESCRIPTION
`calicoctl get wep` omitted the resource NAME from its default (non-wide) table, so getting the name needed for a follow-on `calicoctl get wep <name> -o yaml` required `-o wide` or `-o yaml` first. NAME is now included by default, matching the wide output which already had it.

**Release note:**
```release-note
`calicoctl get wep` now includes the NAME column in its default output.
```