### PR TITLE
BPF: use the kernel-selected underlay source for overlay encap

### DIFF
--- a/felix/bpf-gpl/fib_co_re.h
+++ b/felix/bpf-gpl/fib_co_re.h
@@ -253,20 +253,21 @@ skip_redir_ifindex:
 			};
 			__u64 flags = 0;
 			__u32 size = 0;
+			/* Leave the tunnel key's local (outer/underlay source) address unset by
+			 * truncating the key before the local address.  bpf_skb_set_tunnel_key then
+			 * omits it and the kernel selects the source by routing to the remote VTEP,
+			 * i.e. the node's real underlay IP.  The overlay tunnel-device IP is not
+			 * underlay-routable and must never be the outer source: some fabrics (e.g.
+			 * GCP anti-spoof) drop packets sourced from it. */
 #ifdef IPVER6
-			ipv6_addr_t local_ip_copy = CALI_CONFIGURABLE(host_tunnel_ip);
-			if (ip_void(local_ip_copy)) {
-				local_ip_copy = CALI_CONFIGURABLE(host_ip);
-			}
 			ipv6_addr_t_to_be32_4_ip(key.remote_ipv6, &dest_rt->next_hop);
-			ipv6_addr_t_to_be32_4_ip(key.local_ipv6, &local_ip_copy);
 			flags |= BPF_F_TUNINFO_IPV6;
+			size = offsetof(struct bpf_tunnel_key, local_ipv6);
 #else
 			key.remote_ipv4 = bpf_htonl(dest_rt->next_hop);
-			key.local_ipv4 = ip_void(HOST_TUNNEL_IP) ? bpf_htonl(HOST_IP) : bpf_htonl(HOST_TUNNEL_IP);
 			flags |= BPF_F_ZERO_CSUM_TX;
+			size = offsetof(struct bpf_tunnel_key, local_ipv4);
 #endif
-			size = sizeof(struct bpf_tunnel_key);
 
 			int err = bpf_skb_set_tunnel_key(ctx->skb, &key, size, flags);
 			CALI_DEBUG("bpf_skb_set_tunnel_key %d nh " IP_FMT, err, &dest_rt->next_hop);
@@ -305,20 +306,21 @@ skip_redir_ifindex:
 
 			__u64 flags = 0;
 			__u32 size = 0;
+			/* Leave the tunnel key's local (outer/underlay source) address unset by
+			 * truncating the key before the local address.  bpf_skb_set_tunnel_key then
+			 * omits it and the kernel selects the source by routing to the remote VTEP,
+			 * i.e. the node's real underlay IP.  The overlay tunnel-device IP is not
+			 * underlay-routable and must never be the outer source: some fabrics (e.g.
+			 * GCP anti-spoof) drop packets sourced from it. */
 #ifdef IPVER6
-			ipv6_addr_t local_ip_copy = CALI_CONFIGURABLE(host_tunnel_ip);
-			if (ip_void(local_ip_copy)) {
-				local_ip_copy = CALI_CONFIGURABLE(host_ip);
-			}
 			ipv6_addr_t_to_be32_4_ip(key.remote_ipv6, &dest_rt->next_hop);
-			ipv6_addr_t_to_be32_4_ip(key.local_ipv6, &local_ip_copy);
 			flags |= BPF_F_TUNINFO_IPV6;
+			size = offsetof(struct bpf_tunnel_key, local_ipv6);
 #else
 			key.remote_ipv4 = bpf_htonl(dest_rt->next_hop);
-			key.local_ipv4 = ip_void(HOST_TUNNEL_IP) ? bpf_htonl(HOST_IP) : bpf_htonl(HOST_TUNNEL_IP);
 			flags |= BPF_F_ZERO_CSUM_TX;
+			size = offsetof(struct bpf_tunnel_key, local_ipv4);
 #endif
-			size = sizeof(struct bpf_tunnel_key);
 
 			int err = bpf_skb_set_tunnel_key(ctx->skb, &key, size, flags);
 			CALI_DEBUG("bpf_skb_set_tunnel_key %d nh " IP_FMT, err, &dest_rt->next_hop);

--- a/felix/fv/bpf_overlay_ip_test.go
+++ b/felix/fv/bpf_overlay_ip_test.go
@@ -16,6 +16,7 @@ package fv_test
 
 import (
 	"fmt"
+	"regexp"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -153,6 +154,51 @@ func describeBPFOverlayTunnelAddrTests(tunnel string) bool {
 			cc.ExpectSome(w[1], w[0])
 
 			cc.CheckConnectivity(conntrackChecks(tc.Felixes)...)
+		})
+
+		It("should use the host IP, not the tunnel IP, as the overlay underlay source", func() {
+			// The outer (underlay) source of encapsulated host-networked traffic must be
+			// the node's own IP.  The overlay tunnel-device IP is not underlay-routable; a
+			// fabric that checks source addresses (e.g. GCP) drops packets carrying it.
+			// Connectivity alone does not catch this on a permissive underlay, so capture
+			// the encapsulated traffic and check its outer source.  Selection is done with
+			// tcpdump's own filter (by outer source host), not by parsing its text, whose
+			// format varies by tcpdump version.
+			var encap []string
+			var tunnelAddr string
+			switch tunnel {
+			case "vxlan":
+				tunnelAddr = tc.Felixes[0].ExpectedVXLANTunnelAddr
+				encap = []string{"udp", "and", "port", "4789"}
+			case "ipip":
+				tunnelAddr = tc.Felixes[0].ExpectedIPIPTunnelAddr
+				encap = []string{"ip", "proto", "4"}
+			}
+			Expect(tunnelAddr).NotTo(BeEmpty(), "tunnel address should be assigned in TunnelAddress mode")
+
+			// Any captured packet line contains " > "; the tcpdump banner does not.
+			pkt := regexp.MustCompile(" > ")
+
+			// Encapsulated packets whose outer source is the node IP (correct).
+			fromNode := tc.Felixes[0].AttachTCPDump("eth0")
+			fromNode.SetLogEnabled(true)
+			fromNode.AddMatcher("pkt", pkt)
+			fromNode.Start(infra, append(append([]string{"-n"}, encap...), "and", "src", "host", tc.Felixes[0].IP)...)
+
+			// Encapsulated packets whose outer source is the tunnel IP (the bug).
+			fromTunnel := tc.Felixes[0].AttachTCPDump("eth0")
+			fromTunnel.SetLogEnabled(true)
+			fromTunnel.AddMatcher("pkt", pkt)
+			fromTunnel.Start(infra, append(append([]string{"-n"}, encap...), "and", "src", "host", tunnelAddr)...)
+
+			// Host-networked -> remote workload drives the encapsulated host-origin flow.
+			cc.ExpectSome(hostW[0], w[1])
+			cc.CheckConnectivity(conntrackChecks(tc.Felixes)...)
+
+			Eventually(fromNode.MatchCountFn("pkt"), "5s", "100ms").Should(BeNumerically(">", 0),
+				fmt.Sprintf("overlay outer source should be the node IP %s", tc.Felixes[0].IP))
+			Consistently(fromTunnel.MatchCountFn("pkt"), "2s", "100ms").Should(BeZero(),
+				fmt.Sprintf("overlay outer source must never be the tunnel IP %s", tunnelAddr))
 		})
 	})
 }


### PR DESCRIPTION
Fixes a regression introduced by #11919 (not yet in a release).

**Problem**

In BPF mode, host-originated traffic to a remote workload over a VXLAN/IPIP overlay is encapsulated via `bpf_skb_set_tunnel_key`. Since the `BPFOverlayHostSourceIP=TunnelAddress` path landed, the tunnel key's local (outer/underlay) source was set to the overlay tunnel-device IP (`HOST_TUNNEL_IP`). That address is not routable on the underlay, so fabrics that check the packet source (e.g. GCP anti-spoof) silently drop the encapsulated packets. Effect: host-networked → remote pod/service across nodes fails, including aggregated API servers reached by the host-networked kube-apiserver.

**Fix**

Leave the tunnel key's local address unset (truncate the key before `local_ipv4`/`local_ipv6`) so the kernel selects the outer source by routing to the remote VTEP — the node's real underlay IP. This restores the pre-#11919 behavior, is correct for both `TunnelAddress` and `HostAddress`, and does not depend on `HOST_IP` being configured. The tunnel device IP keeps its inner (overlay) source role via the existing SNAT in `tc.c`.

**Test**

FV assertion (`TunnelAddress`, VXLAN and IPIP) captures the encapsulated host→remote-workload traffic on the underlay interface and asserts the outer source is the node IP, never the tunnel IP. The prior test only checked connectivity, which passes on the permissive FV underlay regardless of the outer source.

**Release note:**
```release-note
NONE
```
