### PR TITLE
[v3.30] fix(whisker): pull nginx from mainline repo (CVE-2026-42055)

### DIFF
--- a/whisker/docker-image/Dockerfile
+++ b/whisker/docker-image/Dockerfile
@@ -20,7 +20,7 @@ RUN dnf upgrade -y
 
 COPY docker-image/nginx.repo /etc/yum.repos.d/nginx.repo
 
-RUN dnf --enablerepo=nginx-stable install -y \
+RUN dnf --enablerepo=nginx-mainline install -y \
   nginx
 
 FROM scratch AS source

--- a/whisker/docker-image/nginx.repo
+++ b/whisker/docker-image/nginx.repo
@@ -1,6 +1,6 @@
-[nginx-stable]
-name=nginx stable repo
-baseurl=http://nginx.org/packages/rhel/$releasever/$basearch/
+[nginx-mainline]
+name=nginx mainline repo
+baseurl=http://nginx.org/packages/mainline/rhel/$releasever/$basearch/
 gpgcheck=1
 enabled=0
 gpgkey=https://nginx.org/keys/nginx_signing.key


### PR DESCRIPTION
Cherry-pick of #13283.

fix(whisker): pull nginx from mainline repo (CVE-2026-42055)

Stable nginx (1.30.x) carries the backported fix at 1.30.3, but image scanners match NVD's mainline affected range (< 1.31.2) across the whole 1.30.x stable line, so patched stable builds still flag. Mainline 1.31.2+ (repo serves 1.31.3) clears both the CVE and the scan. Whisker's nginx is a static SPA server with no HTTP/2 upstream and no grpc_pass, so moving to mainline is a safe, backward-compatible change.