### PR TITLE
cni-plugin: CNI spec 1.1.0 support (STATUS verb, GC/CHECK stubs); default config to cniVersion 1.0.0

### DIFF
--- a/charts/calico/templates/calico-config.yaml
+++ b/charts/calico/templates/calico-config.yaml
@@ -69,7 +69,7 @@ data:
   cni_network_config: |-
     {
         "name": "canal",
-        "cniVersion": "0.3.1",
+        "cniVersion": "1.0.0",
         "plugins": [
             {
                 "type": "flannel",
@@ -103,7 +103,7 @@ data:
   cni_network_config: |-
     {
       "name": "k8s-pod-network",
-      "cniVersion": "0.3.1",
+      "cniVersion": "1.0.0",
       "plugins": [
         {
           "type": "calico",

--- a/cni-plugin/internal/pkg/testutils/utils_linux.go
+++ b/cni-plugin/internal/pkg/testutils/utils_linux.go
@@ -141,6 +141,37 @@ func RunIPAMPlugin(netconf, command, args, cid, cniVersion string) (*cniv1.Resul
 	return result, e, exitCode
 }
 
+// RunCNIVerb executes the named plugin binary (from $BIN) with the given
+// CNI_COMMAND and netconf on stdin. For verbs that don't target a specific
+// container (STATUS, GC). Returns the process exit code and stdout.
+func RunCNIVerb(pluginBinary, command, netconf string, extraEnv []string) (int, []byte) {
+	cmd := &exec.Cmd{
+		Env: append([]string{
+			"CNI_NETNS=b",
+			"CNI_IFNAME=c",
+			"CNI_PATH=d",
+			fmt.Sprintf("CNI_COMMAND=%s", command),
+		}, extraEnv...),
+		Path: fmt.Sprintf("%s/%s", os.Getenv("BIN"), pluginBinary),
+	}
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		panic(err)
+	}
+	if _, err := io.WriteString(stdin, netconf+"\n"); err != nil {
+		panic(err)
+	}
+	if err := stdin.Close(); err != nil {
+		panic(err)
+	}
+	session, err := gexec.Start(cmd, ginkgo.GinkgoWriter, ginkgo.GinkgoWriter)
+	if err != nil {
+		panic(err)
+	}
+	session.Wait(10)
+	return session.ExitCode(), session.Out.Contents()
+}
+
 func CreateContainerNamespace() (containerNs ns.NetNS, containerId string, err error) {
 	containerNs, err = testutils.NewNS()
 	if err != nil {

--- a/cni-plugin/internal/pkg/utils/utils.go
+++ b/cni-plugin/internal/pkg/utils/utils.go
@@ -26,6 +26,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/DeRuina/timberjack"
 	"github.com/containernetworking/cni/pkg/skel"
@@ -636,6 +637,28 @@ func GetHandleID(netName, containerID, workload string) string {
 		"ContainerID": containerID,
 	}).Debug("Generated IPAM handle")
 	return handleID
+}
+
+// CheckDatastoreReady verifies that the Calico datastore is reachable and
+// ready to process requests. Used by the CNI STATUS verb and the -t
+// datastore-connection test.
+func CheckDatastoreReady(conf types.NetConf, timeout time.Duration) error {
+	calicoClient, err := CreateClient(conf)
+	if err != nil {
+		return err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	ci, err := calicoClient.ClusterInformation().Get(ctx, "default", options.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("error getting ClusterInformation: %v", err)
+	}
+	if !*ci.Spec.DatastoreReady {
+		logrus.Info("Upgrade may be in progress, ready flag is not set")
+		//nolint:staticcheck // Ignore ST1005: error strings should not be capitalized
+		return errors.New("Calico is currently not ready to process requests")
+	}
+	return nil
 }
 
 func CreateClient(conf types.NetConf) (client.Interface, error) {

--- a/cni-plugin/pkg/install/install_linux.go
+++ b/cni-plugin/pkg/install/install_linux.go
@@ -19,7 +19,7 @@ package install
 func defaultNetConf() string {
 	netconf := `{
   "name": "k8s-pod-network",
-  "cniVersion": "0.3.1",
+  "cniVersion": "1.0.0",
   "plugins": [
     {
       "type": "calico",

--- a/cni-plugin/pkg/install/install_test.go
+++ b/cni-plugin/pkg/install/install_test.go
@@ -24,7 +24,7 @@ import (
 
 var expectedDefaultConfig string = `{
   "name": "k8s-pod-network",
-  "cniVersion": "0.3.1",
+  "cniVersion": "1.0.0",
   "plugins": [
     {
       "type": "calico",

--- a/cni-plugin/pkg/install/install_windows.go
+++ b/cni-plugin/pkg/install/install_windows.go
@@ -31,7 +31,7 @@ import (
 func defaultNetConf() string {
 	netconf := `{
   "name": "Calico",
-  "cniVersion": "0.3.1",
+  "cniVersion": "1.0.0",
   "plugins": [
     {
       "type": "calico",

--- a/cni-plugin/pkg/ipamplugin/ipam_plugin.go
+++ b/cni-plugin/pkg/ipamplugin/ipam_plugin.go
@@ -112,14 +112,38 @@ func Main(version string) {
 	}
 
 	funcs := skel.CNIFuncs{
-		Add:   cmdAdd,
-		Check: nil,
-		Del:   cmdDel,
+		Add:    cmdAdd,
+		Check:  nil,
+		Del:    cmdDel,
+		Status: cmdStatus,
 	}
 
 	skel.PluginMainFuncs(funcs,
-		cniSpecVersion.PluginSupports("0.1.0", "0.2.0", "0.3.0", "0.3.1", "0.4.0", "1.0.0"),
+		cniSpecVersion.PluginSupports("0.1.0", "0.2.0", "0.3.0", "0.3.1", "0.4.0", "1.0.0", "1.1.0"),
 		"Calico CNI IPAM "+version)
+}
+
+// errPluginNotAvailable is the CNI spec 1.1 STATUS error code meaning the
+// plugin cannot service ADD requests right now. libcni defines no constant
+// for it (it only defines ErrTryAgainLater=11).
+const errPluginNotAvailable uint = 50
+
+const statusTimeout = 2 * time.Second
+
+// cmdStatus implements the CNI spec 1.1.0 STATUS verb for the IPAM plugin:
+// succeed (exit 0, no output) if IP allocation could plausibly succeed, i.e.
+// the Calico datastore is reachable and ready.
+func cmdStatus(args *skel.CmdArgs) error {
+	conf := types.NetConf{}
+	if err := json.Unmarshal(args.StdinData, &conf); err != nil {
+		return cnitypes.NewError(cnitypes.ErrDecodingFailure, "failed to load netconf", err.Error())
+	}
+	utils.ConfigureLogging(conf)
+
+	if err := utils.CheckDatastoreReady(conf, statusTimeout); err != nil {
+		return cnitypes.NewError(errPluginNotAvailable, "Calico datastore is not ready", err.Error())
+	}
+	return nil
 }
 
 type ipamArgs struct {

--- a/cni-plugin/pkg/plugin/plugin.go
+++ b/cni-plugin/pkg/plugin/plugin.go
@@ -163,7 +163,7 @@ func cmdAdd(args *skel.CmdArgs) (err error) {
 		conf.CNIVersion = "0.2.0"
 	}
 
-	if version.Compare(conf.CNIVersion, "1.0.0", ">") {
+	if version.Compare(conf.CNIVersion, "1.1.0", ">") {
 		return fmt.Errorf("unsupported CNI version %s", conf.CNIVersion)
 	}
 

--- a/cni-plugin/pkg/plugin/plugin.go
+++ b/cni-plugin/pkg/plugin/plugin.go
@@ -711,8 +711,28 @@ func cmdDel(args *skel.CmdArgs) (err error) {
 	return
 }
 
+// cmdDummyCheck is a stub CHECK (CNI spec >= 0.4.0): it accepts the request
+// without verifying anything, reporting every attachment as healthy. Note
+// that CHECK must produce no stdout on success.
+// TODO(#12965): replace with real verification of the attachment against
+// prevResult (WEP exists, IPAM handle still holds the prevResult IPs).
 func cmdDummyCheck(args *skel.CmdArgs) (err error) {
-	fmt.Println("OK")
+	logrus.Debug("CNI CHECK (stub): reporting attachment as healthy")
+	return nil
+}
+
+// cmdDummyGc is a stub GC (CNI spec 1.1.0): it accepts the request but does
+// not clean anything up. Stale IPAM allocations are still reclaimed by the
+// kube-controllers IPAM GC (see design/ipam/ipam-gc.md).
+// TODO(#12965): implement node-local release of stale IPAM handles based on
+// the runtime's cni.dev/valid-attachments list.
+func cmdDummyGc(args *skel.CmdArgs) (err error) {
+	conf := types.NetConf{}
+	if err := json.Unmarshal(args.StdinData, &conf); err != nil {
+		return cnitypes.NewError(cnitypes.ErrDecodingFailure, "failed to load netconf", err.Error())
+	}
+	utils.ConfigureLogging(conf)
+	logrus.WithField("network", conf.Name).Info("CNI GC (stub): no cleanup performed")
 	return nil
 }
 
@@ -799,6 +819,7 @@ func Main(version string) {
 		Del:    cmdDel,
 		Check:  cmdDummyCheck,
 		Status: cmdStatus,
+		GC:     cmdDummyGc,
 	}
 	skel.PluginMainFuncs(funcs,
 		cniSpecVersion.PluginSupports("0.1.0", "0.2.0", "0.3.0", "0.3.1", "0.4.0", "1.0.0", "1.1.0"),

--- a/cni-plugin/pkg/plugin/plugin.go
+++ b/cni-plugin/pkg/plugin/plugin.go
@@ -74,21 +74,9 @@ func testConnection() error {
 		return fmt.Errorf("failed to load netconf: %v", err)
 	}
 
-	// Create a new client.
-	calicoClient, err := utils.CreateClient(conf)
-	if err != nil {
+	// Create a client and check the datastore is ready.
+	if err := utils.CheckDatastoreReady(conf, testConnectionTimeout); err != nil {
 		return err
-	}
-	ctx, cancel := context.WithTimeout(context.Background(), testConnectionTimeout)
-	defer cancel()
-	ci, err := calicoClient.ClusterInformation().Get(ctx, "default", options.GetOptions{})
-	if err != nil {
-		return fmt.Errorf("error getting ClusterInformation: %v", err)
-	}
-	if !*ci.Spec.DatastoreReady {
-		logrus.Info("Upgrade may be in progress, ready flag is not set")
-		//nolint:staticcheck // Ignore ST1005: error strings should not be capitalized
-		return errors.New("Calico is currently not ready to process requests")
 	}
 
 	// If we have a kubeconfig, test connection to the APIServer
@@ -728,6 +716,27 @@ func cmdDummyCheck(args *skel.CmdArgs) (err error) {
 	return nil
 }
 
+// errPluginNotAvailable is the CNI spec 1.1 STATUS error code meaning the
+// plugin cannot service ADD requests right now. libcni defines no constant
+// for it (it only defines ErrTryAgainLater=11).
+const errPluginNotAvailable uint = 50
+
+// cmdStatus implements the CNI spec 1.1.0 STATUS verb: succeed (exit 0, no
+// output) if the plugin is ready to service ADD requests, i.e. the Calico
+// datastore is reachable and ready.
+func cmdStatus(args *skel.CmdArgs) error {
+	conf := types.NetConf{}
+	if err := json.Unmarshal(args.StdinData, &conf); err != nil {
+		return cnitypes.NewError(cnitypes.ErrDecodingFailure, "failed to load netconf", err.Error())
+	}
+	utils.ConfigureLogging(conf)
+
+	if err := utils.CheckDatastoreReady(conf, testConnectionTimeout); err != nil {
+		return cnitypes.NewError(errPluginNotAvailable, "Calico datastore is not ready", err.Error())
+	}
+	return nil
+}
+
 func Main(version string) {
 	// Set up logging formatting.
 	logutils.ConfigureFormatter("cni-plugin")
@@ -786,11 +795,12 @@ func Main(version string) {
 	}
 
 	funcs := skel.CNIFuncs{
-		Add:   cmdAdd,
-		Del:   cmdDel,
-		Check: cmdDummyCheck,
+		Add:    cmdAdd,
+		Del:    cmdDel,
+		Check:  cmdDummyCheck,
+		Status: cmdStatus,
 	}
 	skel.PluginMainFuncs(funcs,
-		cniSpecVersion.PluginSupports("0.1.0", "0.2.0", "0.3.0", "0.3.1", "0.4.0", "1.0.0"),
+		cniSpecVersion.PluginSupports("0.1.0", "0.2.0", "0.3.0", "0.3.1", "0.4.0", "1.0.0", "1.1.0"),
 		"Calico CNI plugin "+version)
 }

--- a/cni-plugin/tests/calico_cni_v11_test.go
+++ b/cni-plugin/tests/calico_cni_v11_test.go
@@ -30,7 +30,7 @@ import (
 // Tests for the CNI spec v1.1.0 verbs (STATUS, GC). These pin their own
 // "cniVersion": "1.1.0" rather than using the suite-wide CNI_SPEC_VERSION,
 // since the new verbs are only valid at 1.1.0.
-var _ = Describe("CNI spec v1.1 STATUS", func() {
+var _ = Describe("CNI spec v1.1 verbs", func() {
 	BeforeEach(func() {
 		// Wipes the datastore and seeds ClusterInformation with
 		// datastoreReady=true, which STATUS requires.
@@ -57,6 +57,23 @@ var _ = Describe("CNI spec v1.1 STATUS", func() {
 	It("returns success for calico-ipam when the datastore is ready", func() {
 		exitCode, stdout := testutils.RunCNIVerb("calico-ipam", "STATUS", netconf, nil)
 		Expect(exitCode).To(Equal(0), "STATUS failed: %s", string(stdout))
+	})
+
+	It("accepts GC requests (stub: no cleanup performed)", func() {
+		gcConf := strings.Replace(netconf, `"ipam"`,
+			`"cni.dev/valid-attachments": [{"containerID": "gc-test-container", "ifname": "eth0"}], "ipam"`, 1)
+		exitCode, stdout := testutils.RunCNIVerb("calico", "GC", gcConf, nil)
+		Expect(exitCode).To(Equal(0), "GC failed: %s", string(stdout))
+		// GC success must produce no result on stdout.
+		Expect(strings.TrimSpace(string(stdout))).To(BeEmpty())
+	})
+
+	It("accepts CHECK requests (stub: no verification) with empty stdout", func() {
+		exitCode, stdout := testutils.RunCNIVerb("calico", "CHECK", netconf,
+			[]string{"CNI_CONTAINERID=check-test-container"})
+		Expect(exitCode).To(Equal(0), "CHECK failed: %s", string(stdout))
+		// CHECK success must produce no output on stdout.
+		Expect(strings.TrimSpace(string(stdout))).To(BeEmpty())
 	})
 
 	It("returns CNI error code 50 when the datastore is unreachable", func() {

--- a/cni-plugin/tests/calico_cni_v11_test.go
+++ b/cni-plugin/tests/calico_cni_v11_test.go
@@ -15,6 +15,7 @@
 package main_test
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -25,6 +26,10 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/projectcalico/calico/cni-plugin/internal/pkg/testutils"
+	"github.com/projectcalico/calico/libcalico-go/lib/apis/internalapi"
+	client "github.com/projectcalico/calico/libcalico-go/lib/clientv3"
+	"github.com/projectcalico/calico/libcalico-go/lib/names"
+	"github.com/projectcalico/calico/libcalico-go/lib/options"
 )
 
 // Tests for the CNI spec v1.1.0 verbs (STATUS, GC). These pin their own
@@ -57,6 +62,30 @@ var _ = Describe("CNI spec v1.1 verbs", func() {
 	It("returns success for calico-ipam when the datastore is ready", func() {
 		exitCode, stdout := testutils.RunCNIVerb("calico-ipam", "STATUS", netconf, nil)
 		Expect(exitCode).To(Equal(0), "STATUS failed: %s", string(stdout))
+	})
+
+	It("networks and tears down a container with a 1.1.0 config", func() {
+		// Regression test: cmdAdd used to carry its own version gate,
+		// rejecting configs above 1.0.0 even though 1.1.0 is advertised.
+		if os.Getenv("DATASTORE_TYPE") == "kubernetes" {
+			Skip("ADD/DEL exercised in etcd lane; KDD ADD needs pod scaffolding")
+		}
+		calicoClient, err := client.NewFromEnv()
+		Expect(err).NotTo(HaveOccurred())
+		n := internalapi.NewNode()
+		n.Name, err = names.Hostname()
+		Expect(err).NotTo(HaveOccurred())
+		_, err = calicoClient.Nodes().Create(context.Background(), n, options.SetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		testutils.MustCreateNewIPPool(calicoClient, "10.99.0.0/24", false, false, true)
+
+		containerID, result, _, _, _, contNs, err := testutils.CreateContainerWithId(netconf, "", testutils.TEST_DEFAULT_NS, "", "v11-add-test")
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(len(result.IPs)).Should(Equal(1))
+
+		exitCode, err := testutils.DeleteContainerWithId(netconf, contNs.Path(), "", testutils.TEST_DEFAULT_NS, containerID)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(exitCode).To(Equal(0))
 	})
 
 	It("accepts GC requests (stub: no cleanup performed)", func() {

--- a/cni-plugin/tests/calico_cni_v11_test.go
+++ b/cni-plugin/tests/calico_cni_v11_test.go
@@ -1,0 +1,75 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	cnitypes "github.com/containernetworking/cni/pkg/types"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/projectcalico/calico/cni-plugin/internal/pkg/testutils"
+)
+
+// Tests for the CNI spec v1.1.0 verbs (STATUS, GC). These pin their own
+// "cniVersion": "1.1.0" rather than using the suite-wide CNI_SPEC_VERSION,
+// since the new verbs are only valid at 1.1.0.
+var _ = Describe("CNI spec v1.1 STATUS", func() {
+	BeforeEach(func() {
+		// Wipes the datastore and seeds ClusterInformation with
+		// datastoreReady=true, which STATUS requires.
+		testutils.WipeDatastore()
+	})
+
+	netconf := fmt.Sprintf(`{
+	  "cniVersion": "1.1.0",
+	  "name": "net-status",
+	  "type": "calico",
+	  "etcd_endpoints": "http://%s:2379",
+	  "datastore_type": "%s",
+	  "log_level": "info",
+	  "nodename_file_optional": true,
+	  "ipam": {"type": "calico-ipam"},
+	  "kubernetes": {"kubeconfig": "%s"}
+	}`, os.Getenv("ETCD_IP"), os.Getenv("DATASTORE_TYPE"), os.Getenv("KUBECONFIG"))
+
+	It("returns success when the datastore is ready", func() {
+		exitCode, stdout := testutils.RunCNIVerb("calico", "STATUS", netconf, nil)
+		Expect(exitCode).To(Equal(0), "STATUS failed: %s", string(stdout))
+	})
+
+	It("returns success for calico-ipam when the datastore is ready", func() {
+		exitCode, stdout := testutils.RunCNIVerb("calico-ipam", "STATUS", netconf, nil)
+		Expect(exitCode).To(Equal(0), "STATUS failed: %s", string(stdout))
+	})
+
+	It("returns CNI error code 50 when the datastore is unreachable", func() {
+		if os.Getenv("DATASTORE_TYPE") != "etcdv3" {
+			Skip("unreachable-datastore case is simulated via bad etcd endpoints")
+		}
+		badConf := strings.Replace(netconf,
+			fmt.Sprintf("http://%s:2379", os.Getenv("ETCD_IP")),
+			"http://10.255.255.1:5", 1)
+		exitCode, stdout := testutils.RunCNIVerb("calico", "STATUS", badConf, nil)
+		Expect(exitCode).NotTo(Equal(0))
+		var cniErr cnitypes.Error
+		Expect(json.Unmarshal(stdout, &cniErr)).To(Succeed())
+		Expect(cniErr.Code).To(Equal(uint(50)))
+	})
+})

--- a/manifests/calico-bpf.yaml
+++ b/manifests/calico-bpf.yaml
@@ -64,7 +64,7 @@ data:
   cni_network_config: |-
     {
       "name": "k8s-pod-network",
-      "cniVersion": "0.3.1",
+      "cniVersion": "1.0.0",
       "plugins": [
         {
           "type": "calico",

--- a/manifests/calico-etcd.yaml
+++ b/manifests/calico-etcd.yaml
@@ -85,7 +85,7 @@ data:
   cni_network_config: |-
     {
       "name": "k8s-pod-network",
-      "cniVersion": "0.3.1",
+      "cniVersion": "1.0.0",
       "plugins": [
         {
           "type": "calico",

--- a/manifests/calico-policy-only.yaml
+++ b/manifests/calico-policy-only.yaml
@@ -73,7 +73,7 @@ data:
   cni_network_config: |-
     {
       "name": "k8s-pod-network",
-      "cniVersion": "0.3.1",
+      "cniVersion": "1.0.0",
       "plugins": [
         {
           "type": "calico",

--- a/manifests/calico-typha.yaml
+++ b/manifests/calico-typha.yaml
@@ -75,7 +75,7 @@ data:
   cni_network_config: |-
     {
       "name": "k8s-pod-network",
-      "cniVersion": "0.3.1",
+      "cniVersion": "1.0.0",
       "plugins": [
         {
           "type": "calico",

--- a/manifests/calico-v3-crds.yaml
+++ b/manifests/calico-v3-crds.yaml
@@ -66,7 +66,7 @@ data:
   cni_network_config: |-
     {
       "name": "k8s-pod-network",
-      "cniVersion": "0.3.1",
+      "cniVersion": "1.0.0",
       "plugins": [
         {
           "type": "calico",

--- a/manifests/calico-vxlan.yaml
+++ b/manifests/calico-vxlan.yaml
@@ -59,7 +59,7 @@ data:
   cni_network_config: |-
     {
       "name": "k8s-pod-network",
-      "cniVersion": "0.3.1",
+      "cniVersion": "1.0.0",
       "plugins": [
         {
           "type": "calico",

--- a/manifests/calico.yaml
+++ b/manifests/calico.yaml
@@ -59,7 +59,7 @@ data:
   cni_network_config: |-
     {
       "name": "k8s-pod-network",
-      "cniVersion": "0.3.1",
+      "cniVersion": "1.0.0",
       "plugins": [
         {
           "type": "calico",

--- a/manifests/canal-etcd.yaml
+++ b/manifests/canal-etcd.yaml
@@ -92,7 +92,7 @@ data:
   cni_network_config: |-
     {
         "name": "canal",
-        "cniVersion": "0.3.1",
+        "cniVersion": "1.0.0",
         "plugins": [
             {
                 "type": "flannel",

--- a/manifests/canal.yaml
+++ b/manifests/canal.yaml
@@ -66,7 +66,7 @@ data:
   cni_network_config: |-
     {
       "name": "k8s-pod-network",
-      "cniVersion": "0.3.1",
+      "cniVersion": "1.0.0",
       "plugins": [
         {
           "type": "calico",

--- a/manifests/flannel-migration/calico.yaml
+++ b/manifests/flannel-migration/calico.yaml
@@ -59,7 +59,7 @@ data:
   cni_network_config: |-
     {
       "name": "k8s-pod-network",
-      "cniVersion": "0.3.1",
+      "cniVersion": "1.0.0",
       "plugins": [
         {
           "type": "calico",


### PR DESCRIPTION
Part of the fix for #12965 (Calico delegate breaks after multus cniVersion bumped to 1.1.0). Companion operator PR: tigera/operator#5090 (defaults the operator-generated config to 1.0.0 and adds `spec.cni.specVersion`).

## What

Four commits:

1. **STATUS verb (real, CNI spec 1.1.0)** for both `calico` and `calico-ipam`: reports ready (exit 0) when the Calico datastore is reachable and its ready flag is set, else CNI error code 50 ("plugin not available", the same convention Cilium uses). Reuses the ClusterInformation readiness check that has gated CNI config installation via the `-t` flag for years, extracted into `utils.CheckDatastoreReady`. Both binaries now advertise spec 1.1.0.

2. **GC verb (stub) + spec-clean CHECK stub.** GC accepts `cni.dev/valid-attachments` and performs no cleanup — stale IPAM allocations remain the responsibility of the kube-controllers IPAM GC. The CHECK stub no longer prints `OK` to stdout (the spec requires empty stdout on success, and CHECK becomes reachable once configs move past 0.4.0). Real GC (node-local release of stale IPAM handles) and real CHECK (verify the attachment against prevResult) are follow-up work.

   Note: GC and STATUS are only invocable with a config at `cniVersion: 1.1.0`, which no shipped configuration uses (see below) — they are opt-in surface. CHECK's stub behavior is observably identical to today, where CHECK is never invoked.

3. **cmdAdd version-gate fix**: cmdAdd carried its own hardcoded ceiling rejecting configs above 1.0.0 even though VERSION advertised 1.1.0 — found by live validation on OpenShift, now with an ADD/DEL regression test at 1.1.0.

4. **Default config bump 0.3.1 → 1.0.0**: the manifest-install template (`calico-config` ConfigMap) and the install-cni fallback template. Multus requires delegates ≥ 0.4.0; every supported runtime accepts 1.0.0 (containerd ≥ 1.6 / CRI-O ≥ 1.24); existing attachments are unaffected on upgrade (the runtime replays each attachment's original cniVersion at DEL). Deliberately **not** 1.1.0: configs at 1.1.0 require newer runtime libcni (containerd 2.0 / CRI-O ~1.30) and the bundled third-party plugins (portmap et al, built against libcni v1.0.1) top out at 1.0.0.

## Testing

- New UT: STATUS (both binaries, ready + unreachable-datastore→code 50), GC/CHECK dispatch with empty-stdout assertions, ADD/DEL at 1.1.0; full `ut-etcd`/`ut-kdd` and `test-install-cni` green.
- **OpenShift 5.0.0-ec.3** (multus top-level 1.1.0 — the breaking config): reproduced the crash at 0.3.1; config at 1.0.0 heals the cluster; with these binaries and a 1.1.0 config, ADD/DEL work through multus and STATUS/GC respond correctly on-node.
- **GA OpenShift 4.18** (multus 0.4.0): config at 1.0.0 with stock and PR binaries — no regression, hostPort/portmap verified.

## Follow-ups (to be filed)

- Real GC: release stale node-local IPAM handles per `cni.dev/valid-attachments`.
- Real CHECK: verify WEP + IPAM handle against prevResult.
- Rebase the `projectcalico/containernetworking-plugins` fork (currently libcni v1.0.1) and bump `CNI_VERSION` in metadata.mk so the bundled chain supports 1.1.0.
- install-cni writes the conflist non-atomically; multus's fsnotify watcher can transiently read partial JSON during a config rewrite.

**Release note:**
```release-note
The Calico CNI plugin now supports CNI spec v1.1.0 (STATUS verb; GC and CHECK accepted) and the default CNI configuration uses cniVersion 1.0.0, enabling Calico as a multus delegate on OpenShift 4.23+.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)