### PR TITLE
Route e2e GitHub traffic through the in-cluster caching proxy

### DIFF
--- a/.argoci/cron/e2e-benchmarking.yaml
+++ b/.argoci/cron/e2e-benchmarking.yaml
@@ -30,6 +30,7 @@ steps:
   - name: benchmarks
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: AWS_NODE_INSTANCE_TYPE
         value: m5.large
@@ -66,6 +67,7 @@ steps:
   - name: tiger-bench
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: INSTALLER
         value: operator

--- a/.argoci/cron/e2e-bpf.yaml
+++ b/.argoci/cron/e2e-bpf.yaml
@@ -23,6 +23,7 @@ steps:
   - name: arm64-smoke-tests-kubeadm-arm64
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: ENABLE_WIREGUARD
         value: "true"
@@ -50,6 +51,7 @@ steps:
   - name: arm64-smoke-tests-aks-arm64
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: AZ_VM_SIZE
         value: Standard_D4plds_v5
@@ -81,6 +83,7 @@ steps:
   - name: bpf-run-matrix-aws-encap
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: CLUSTER_NODES
         value: "3"
@@ -112,6 +115,7 @@ steps:
   - name: bpf-run-matrix-aws-single-subnet-dual-ip-family
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: BGP_STATUS
         value: Enabled
@@ -153,6 +157,7 @@ steps:
   - name: bpf-run-matrix-aws-talos-no-encap-dsr
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: BGP_STATUS
         value: Enabled
@@ -179,6 +184,7 @@ steps:
   - name: bpf-run-matrix-gcp-bpf-dp-dsr
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: BPF_NETWORK_BOOTSTRAP
         value: Enabled
@@ -205,6 +211,7 @@ steps:
   - name: bpf-run-matrix-gcp-bpf-dp-encap-w-nodelocal-dnscache
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: CLUSTER_IMAGE
         value: ubuntu-2204-lts
@@ -234,6 +241,7 @@ steps:
   - name: bpf-run-matrix-aks-w-aks-cni
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: CLUSTER_NODES
         value: "3"
@@ -255,6 +263,7 @@ steps:
   - name: bpf-run-matrix-aks-w-calico-cni
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: AZ_CREATE_MODE
         value: AKS
@@ -279,6 +288,7 @@ steps:
   - name: bpf-run-matrix-bpf-aks-w-aks-cni-overlay
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: AZ_CREATE_MODE
         value: AKS
@@ -305,6 +315,7 @@ steps:
   - name: bpf-run-matrix-aws-kops-rhel8-2
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: CLUSTER_IMAGE
         value: ami-02f147dfb8be58a10
@@ -327,6 +338,7 @@ steps:
   - name: bpf-run-matrix-aws-lb-bpf
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: BGP_STATUS
         value: Enabled
@@ -360,6 +372,7 @@ steps:
   - name: bpf-run-matrix-aws-lb-iptables
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: BGP_STATUS
         value: Enabled
@@ -395,6 +408,7 @@ steps:
   - name: bpf-run-matrix-eks-w-aws-cni
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: AWS_K8S_CNI_VERSION
         value: NA
@@ -422,6 +436,7 @@ steps:
   - name: bpf-run-matrix-eks-w-calico-cni
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: CLUSTER_NODES
         value: "3"
@@ -451,6 +466,7 @@ steps:
   - name: bpf-run-matrix-bpf-eks-aws-cni-lb
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: CLUSTER_NODES
         value: "3"
@@ -476,6 +492,7 @@ steps:
   - name: bpf-run-matrix-aws-kubeadm-dual-stack
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: CLUSTER_NODES
         value: "3"
@@ -519,6 +536,7 @@ steps:
   - name: bpf-run-matrix-kops-w-calico-cni-ipv6
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: BGP_STATUS
         value: Disabled
@@ -566,6 +584,7 @@ steps:
   - name: bpf-run-matrix-kops-w-calico-cni-ipv4
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: BGP_STATUS
         value: Disabled
@@ -607,6 +626,7 @@ steps:
   - name: bpf-mini-scale-runs
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: NUM_INFRA_NODES
         value: "3"
@@ -623,6 +643,7 @@ steps:
   - name: 9k-mtu-runs-aws-bpf-9k-mtu
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: CLUSTER_NODES
         value: "3"
@@ -650,6 +671,7 @@ steps:
   - name: 9k-mtu-runs-aws-iptables-9k-mtu
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: CLUSTER_NODES
         value: "3"
@@ -679,6 +701,7 @@ steps:
   - name: bpf-mode-switch
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: DATAPLANE
         value: CalicoIptables
@@ -695,6 +718,7 @@ steps:
   - name: wireguard
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: AZ_CREATE_MODE
         value: AKS
@@ -717,6 +741,7 @@ steps:
   - name: usage-reporting-with-bpf
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: CLUSTER_NODES
         value: "1"
@@ -742,6 +767,7 @@ steps:
   - name: kubevirt-e2e-tests
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: E2E_TEST_CONFIG
         value: e2e/config/gcp-kubevirt.yaml

--- a/.argoci/cron/e2e-certification.yaml
+++ b/.argoci/cron/e2e-certification.yaml
@@ -23,6 +23,7 @@ steps:
   - name: standalone-cluster-tests
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: ENABLE_OCP_VIRT
         value: "true"
@@ -48,6 +49,7 @@ steps:
   - name: hcp-setup-hosting
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: HCP_STAGE
         value: setup-hosting
@@ -62,6 +64,7 @@ steps:
   - name: hcp-hosted-setup-and-tests
     services:
       - docker
+      - http-cache-proxy
     depends:
       - hcp-setup-hosting
     env:
@@ -97,6 +100,7 @@ onExit:
   - name: hcp-destroy-hosting
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: HCP_STAGE
         value: destroy-hosting

--- a/.argoci/cron/e2e-iptables.yaml
+++ b/.argoci/cron/e2e-iptables.yaml
@@ -23,6 +23,7 @@ steps:
   - name: openshift-ocp
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: INSTALLER
         value: operator
@@ -46,6 +47,7 @@ steps:
   - name: arm64-smoke-tests-aks-arm64
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: AZ_VM_SIZE
         value: Standard_D4plds_v5
@@ -77,6 +79,7 @@ steps:
   - name: arm64-smoke-tests-eks-arm64-calico-cni
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: AWS_NODE_INSTANCE_TYPE
         value: t4g.large
@@ -102,6 +105,7 @@ steps:
   - name: aks-aks-w-calico-cni
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: AZ_CREATE_MODE
         value: AKS
@@ -127,6 +131,7 @@ steps:
   - name: aks-aks-w-aks-cni
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: AZ_CREATE_MODE
         value: AKS
@@ -149,6 +154,7 @@ steps:
   - name: aks-aks-private-w-aks-cni-overlay
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: AZ_CREATE_MODE
         value: AKS
@@ -173,6 +179,7 @@ steps:
   - name: aks-aks-migrate-from-vendored-calico-cni-to-calico-cni
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: AZ_CREATE_MODE
         value: AKS
@@ -196,6 +203,7 @@ steps:
     jobSize: large
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: ENABLE_CALICOCTL_APISERVER
         value: "true"
@@ -238,6 +246,7 @@ steps:
     jobSize: large
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: ENABLE_DUAL_STACK
         value: "true"
@@ -273,6 +282,7 @@ steps:
     jobSize: large
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: ENABLE_AUTOHEP
         value: "true"
@@ -283,6 +293,7 @@ steps:
   - name: ipvs
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: KUBE_PROXY_MODE
         value: ipvs
@@ -301,6 +312,7 @@ steps:
     jobSize: large
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: ENABLE_USAGE
         value: "true"
@@ -320,6 +332,7 @@ steps:
   - name: k8s-beta-runs
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: ENABLE_CALICOCTL_APISERVER
         value: "true"
@@ -341,6 +354,7 @@ steps:
   - name: k8s-distros
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: K8S_VERSION
         value: v1.31.3
@@ -356,6 +370,7 @@ steps:
   - name: wireguard-vxlan-k8s-e2e
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: ENABLE_EXTERNAL_NODE
         value: "true"
@@ -383,6 +398,7 @@ steps:
   - name: wireguard-k8s-e2e
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: ENABLE_EXTERNAL_NODE
         value: "true"
@@ -417,6 +433,7 @@ steps:
     jobSize: large
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: INSTALLER
         value: manual
@@ -443,6 +460,7 @@ steps:
     jobSize: large
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: INSTALLER
         value: manual
@@ -470,6 +488,7 @@ steps:
   - name: wireguard-regression-k8s-e2e-kdd-new
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: DISABLE_IPIP
         value: "true"
@@ -495,6 +514,7 @@ steps:
   - name: wireguard-regression-k8s-e2e-kdd-old
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: DISABLE_IPIP
         value: "true"
@@ -522,6 +542,7 @@ steps:
   - name: wireguard-regression-k8s-e2e-aks-w-aks-cni-overlay
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: AZ_CREATE_MODE
         value: AKS
@@ -548,6 +569,7 @@ steps:
   - name: focused-wireguard-e2e-aks-w-azure-cni
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: ENABLE_WIREGUARD
         value: "true"
@@ -581,6 +603,7 @@ steps:
   - name: focused-wireguard-e2e-aks-with-calico-cni
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: AKS_CNI
         value: calico
@@ -616,6 +639,7 @@ steps:
   - name: focused-wireguard-e2e-eks-kdd-aws-cni
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: AWS_K8S_CNI_VERSION
         value: NA
@@ -638,6 +662,7 @@ steps:
   - name: focused-wireguard-e2e-eks-kdd-calico-cni
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: AWS_K8S_CNI_VERSION
         value: NA
@@ -660,6 +685,7 @@ steps:
   - name: distro-support
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: CLUSTER_ROUTING_MODE
         value: Felix
@@ -705,6 +731,7 @@ steps:
   - name: datastore-k8s-e2e-kdd-old
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: ENABLE_CALICOCTL_APISERVER
         value: "true"
@@ -734,6 +761,7 @@ steps:
   - name: datastore-k8s-e2e-kdd-new
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: ENABLE_CALICOCTL_APISERVER
         value: "true"
@@ -765,6 +793,7 @@ steps:
   - name: datastore-k8s-e2e-etcd
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: INSTALL_ETCD_POD
         value: "true"
@@ -785,6 +814,7 @@ steps:
     jobSize: large
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: CALICO_MANIFEST
         value: manifests/flannel-migration/calico.yaml
@@ -814,6 +844,7 @@ steps:
   - name: kubevirt-e2e-tests
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: E2E_TEST_CONFIG
         value: e2e/config/gcp-kubevirt.yaml

--- a/.argoci/cron/e2e-nftables.yaml
+++ b/.argoci/cron/e2e-nftables.yaml
@@ -26,6 +26,7 @@ steps:
   - name: nftables-mode-arm64-wg
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: ENABLE_WIREGUARD
         value: "true"
@@ -57,6 +58,7 @@ steps:
   - name: nftables-talos-nftables-talos
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: ENCAPSULATION_TYPE
         value: VXLAN
@@ -72,6 +74,7 @@ steps:
   - name: nftables-talos-native-v3-crds-gcp
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: CLUSTER_ROUTING_MODE
         value: Felix
@@ -93,6 +96,7 @@ steps:
   - name: nftables-talos-native-v3-crds-aws
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: K8S_VERSION
         value: stable-3
@@ -105,6 +109,7 @@ steps:
   - name: nftables-mode-eks-eks-w-aws-cni
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: K8S_VERSION
         value: stable-1
@@ -120,6 +125,7 @@ steps:
   - name: nftables-mode-eks-eks-w-calico-cni
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: INSTALLER
         value: helmerator
@@ -144,6 +150,7 @@ steps:
     jobSize: large
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: ENABLE_DUAL_STACK
         value: "true"
@@ -167,6 +174,7 @@ steps:
     jobSize: large
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: ENABLE_DUAL_STACK
         value: "true"
@@ -185,6 +193,7 @@ steps:
   - name: kubevirt-e2e-tests
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: E2E_TEST_CONFIG
         value: e2e/config/gcp-kubevirt.yaml

--- a/.argoci/cron/e2e-patch-verification.yaml
+++ b/.argoci/cron/e2e-patch-verification.yaml
@@ -24,6 +24,7 @@ steps:
     jobSize: large
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: CNI_PLUGIN
         value: Calico
@@ -50,6 +51,7 @@ steps:
   - name: manifests-flannel-migration
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: AWS_NODE_INSTANCE_TYPE
         value: t3.large
@@ -84,6 +86,7 @@ steps:
   - name: manifests-canal
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: CLUSTER_IMAGE
         value: ubuntu-2204-lts
@@ -110,6 +113,7 @@ steps:
   - name: manifests-canal-migration
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: CALICO_MANIFEST
         value: manifests/flannel-migration/calico.yaml
@@ -138,6 +142,7 @@ steps:
   - name: manifests-calico-etcd
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: CLUSTER_IMAGE
         value: ubuntu-2404-lts-amd64
@@ -170,6 +175,7 @@ steps:
   - name: manifests-operator-migration
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: CLUSTER_IMAGE
         value: ubuntu-2404-lts-amd64
@@ -202,6 +208,7 @@ steps:
   - name: operator-helmerator-aks-w-aks-cni-overlay
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: AZ_CREATE_MODE
         value: AKS
@@ -224,6 +231,7 @@ steps:
   - name: operator-helmerator-eks-w-calico-cni
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: AWS_NODE_INSTANCE_TYPE
         value: t3.large
@@ -258,6 +266,7 @@ steps:
   - name: operator-helmerator-eks-w-aws-cni
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: AWS_K8S_CNI_VERSION
         value: NA
@@ -284,6 +293,7 @@ steps:
   - name: operator-helmerator-windows-aws-kubeadm-containerd
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: CNI_PLUGIN
         value: Calico
@@ -310,6 +320,7 @@ steps:
   - name: operator-helmerator-windows-aws-kubeadm-docker
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: CLUSTER_IMAGE
         value: jammy-22.04
@@ -340,6 +351,7 @@ steps:
   - name: operator-helmerator-rke2
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: CLUSTER_IMAGE
         value: ubuntu-2204-lts
@@ -364,6 +376,7 @@ steps:
   - name: kubevirt-e2e-tests
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: E2E_TEST_CONFIG
         value: e2e/config/gcp-kubevirt.yaml
@@ -380,6 +393,7 @@ steps:
   - name: openshift
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: DATAPLANE
         value: CalicoBPF

--- a/.argoci/cron/e2e-test.yaml
+++ b/.argoci/cron/e2e-test.yaml
@@ -23,6 +23,7 @@ steps:
   - name: calico-tests
     services:
       - docker
+      - http-cache-proxy
     matrix:
       - name: gcp-kubeadm-stable-operator-calicobpf
         env:

--- a/.argoci/cron/e2e-upgrade.yaml
+++ b/.argoci/cron/e2e-upgrade.yaml
@@ -28,6 +28,7 @@ steps:
   - name: calico-tests-aks-byo-cni-w-azurelinux
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: AZ_NETWORK_PLUGIN
         value: none
@@ -49,6 +50,7 @@ steps:
   - name: calico-tests-eks
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: K8S_E2E_FLAGS
         value: --ginkgo.focus=(\[Conformance\]|Observe|RBAC) --ginkgo.skip=(\[Slow\]|\[Disruptive\]|\[DataPath\]|sig-node|sig-apps|sig-storage|sig-scheduling|sig-calico-enterprise|DNS.should.provide.DNS|DNS.should.resolve.DNS|DNS.should.provide./etc|IP.address.is.not.reallocated|Proxy.version.v1)
@@ -70,6 +72,7 @@ steps:
   - name: calico-tests-kubeadm-iptables
     services:
       - docker
+      - http-cache-proxy
     matrix:
       - name: aws-kubeadm-stable-3-operator-calicoiptables
         env:
@@ -86,6 +89,7 @@ steps:
   - name: calico-tests-kubeadm-bpf
     services:
       - docker
+      - http-cache-proxy
     matrix:
       - name: gcp-kubeadm-stable-operator-calicobpf
         env:
@@ -102,6 +106,7 @@ steps:
   - name: calico-tests-rke2
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: PROVISIONER
         value: gcp-rke2
@@ -121,6 +126,7 @@ steps:
   - name: calico-tests-openshift
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: PROVISIONER
         value: aws-openshift

--- a/.argoci/cron/e2e-vpp.yaml
+++ b/.argoci/cron/e2e-vpp.yaml
@@ -35,6 +35,7 @@ steps:
   - name: k8s-e2e-st-v3-28-regression-test
     services:
       - docker
+      - http-cache-proxy
     matrix:
       - name: gcp-kubeadm-calico-vpp-nohuge-yaml-v3-28-v3-28-0
         env:
@@ -51,6 +52,7 @@ steps:
   - name: k8s-e2e-st-vpp-kadm
     services:
       - docker
+      - http-cache-proxy
     matrix:
       - name: gcp-kubeadm-calico-vpp-nohuge-yaml
         env:
@@ -69,6 +71,7 @@ steps:
   - name: k8s-e2e-st-vpp-kadm-huge
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: ENABLE_HUGEPAGES
         value: "true"
@@ -90,6 +93,7 @@ steps:
   - name: k8s-e2e-st-vpp-kadm-vx-huge
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: BGP_STATUS
         value: Enabled
@@ -109,6 +113,7 @@ steps:
   - name: k8s-e2e-st-vpp-kadm-wg-huge
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: ENABLE_HUGEPAGES
         value: "true"
@@ -126,6 +131,7 @@ steps:
   - name: k8s-e2e-st-vpp-eks
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: FAILSAFE_443
         value: "true"
@@ -147,6 +153,7 @@ steps:
   - name: k8s-e2e-st-vpp-eks-dpdk
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: ENABLE_HUGEPAGES
         value: "true"
@@ -170,6 +177,7 @@ steps:
   - name: k8s-e2e-st-vpp-kadm-ipsec-huge
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: ENABLE_HUGEPAGES
         value: "true"
@@ -187,6 +195,7 @@ steps:
   - name: vpp-openshift
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: AWS_INSTANCE_TYPE
         value: m5.xlarge
@@ -200,6 +209,7 @@ steps:
   - name: iptables-openshift
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: AWS_INSTANCE_TYPE
         value: m5.xlarge

--- a/.argoci/cron/e2e-windows.yaml
+++ b/.argoci/cron/e2e-windows.yaml
@@ -25,6 +25,7 @@ steps:
   - name: calico-windows-azr-aso-2022-stable-nftables-vxlan
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: DATAPLANE
         value: CalicoNftables
@@ -41,6 +42,7 @@ steps:
   - name: calico-windows-azr-aks-2022-stable-1-iptables-no-encap-azure-cni
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: DATAPLANE
         value: CalicoIptables


### PR DESCRIPTION
### Description

Adds the `http-cache-proxy` service to **every step of all 10 scheduled e2e suites** in `.argoci/cron/*.yaml` (105 steps total). This routes each step's GitHub API and clone traffic through the in-cluster GitHub caching proxy (`github-cache-proxy.argoci.svc:3128`), collapsing duplicate calls and cutting the rate-limit throttling that argoci e2e hits.

The `http-cache-proxy` preset (cc-argoci-handler ≥ v0.19) is **env-only** — it sets `HTTPS_PROXY`/`HTTP_PROXY`/`NO_PROXY` on the step; `NO_PROXY` keeps GCS, the metadata server and in-cluster endpoints direct. No sidecar, no resource cost.

Change per step is a single additive line:
```yaml
    services:
      - docker
      - http-cache-proxy   # <-- added
```

### ✅ CA gate cleared — safe to merge

The proxy MITMs GitHub TLS, so the step image must trust the proxy's interception CA (ships in `ubuntu-cloud-providers:v0.106`). The handler's `DefaultStepImage` was bumped v0.104 → v0.106 (tigera/cc-utils#171) and is **deployed to argoci** (handler v0.21, deployed by @rory). On merge the pre-processor re-expands these crons, so each step gets the CA-bearing image and the proxy in the same shot — no window where the proxy runs without the CA.

### Backports (release branches)

- release-v3.32 → #13297
- release-v3.31 → #13298
- release-v3.30 → #13299

### Release Note

```release-note
None
```
