### PR TITLE
Route e2e GitHub traffic through the in-cluster caching proxy (release-v3.31)

### DIFF
--- a/.argoci/cron/e2e-benchmarking.yaml
+++ b/.argoci/cron/e2e-benchmarking.yaml
@@ -30,6 +30,7 @@ steps:
   - name: benchmarks
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: AWS_NODE_INSTANCE_TYPE
         value: m5.large

--- a/.argoci/cron/e2e-bpf.yaml
+++ b/.argoci/cron/e2e-bpf.yaml
@@ -23,6 +23,7 @@ steps:
   - name: arm64-smoke-tests-kubeadm-arm64
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: ENABLE_WIREGUARD
         value: "true"
@@ -54,6 +55,7 @@ steps:
   - name: arm64-smoke-tests-aks-arm64
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: AZ_VM_SIZE
         value: Standard_D4plds_v5
@@ -85,6 +87,7 @@ steps:
   - name: bpf-run-matrix-aws-encap
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: CLUSTER_NODES
         value: "3"
@@ -112,6 +115,7 @@ steps:
   - name: bpf-run-matrix-aws-single-subnet
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: BGP_STATUS
         value: Enabled
@@ -149,6 +153,7 @@ steps:
   - name: bpf-run-matrix-aws-no-encap-dsr
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: BGP_STATUS
         value: Enabled
@@ -175,6 +180,7 @@ steps:
   - name: bpf-run-matrix-gcp-bpf-dp-dsr
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: BPF_NETWORK_BOOTSTRAP
         value: Enabled
@@ -199,6 +205,7 @@ steps:
   - name: bpf-run-matrix-gcp-bpf-dp-encap-w-nodelocal-dnscache
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: CLUSTER_IMAGE
         value: ubuntu-2204-lts
@@ -228,6 +235,7 @@ steps:
   - name: bpf-run-matrix-aks-w-aks-cni
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: CLUSTER_NODES
         value: "3"
@@ -249,6 +257,7 @@ steps:
   - name: bpf-run-matrix-aks-w-calico-cni
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: AZ_CREATE_MODE
         value: AKS
@@ -273,6 +282,7 @@ steps:
   - name: bpf-run-matrix-bpf-aks-w-aks-cni-overlay
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: AZ_CREATE_MODE
         value: AKS
@@ -299,6 +309,7 @@ steps:
   - name: bpf-run-matrix-aws-kops-rhel8-2
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: CLUSTER_IMAGE
         value: ami-02f147dfb8be58a10
@@ -321,6 +332,7 @@ steps:
   - name: bpf-run-matrix-aws-lb-bpf
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: BGP_STATUS
         value: Enabled
@@ -354,6 +366,7 @@ steps:
   - name: bpf-run-matrix-aws-lb-iptables
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: BGP_STATUS
         value: Enabled
@@ -389,6 +402,7 @@ steps:
   - name: bpf-run-matrix-eks-w-aws-cni
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: AWS_K8S_CNI_VERSION
         value: NA
@@ -416,6 +430,7 @@ steps:
   - name: bpf-run-matrix-eks-w-calico-cni
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: CLUSTER_NODES
         value: "3"
@@ -445,6 +460,7 @@ steps:
   - name: bpf-run-matrix-bpf-eks-aws-cni-lb
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: CLUSTER_NODES
         value: "3"
@@ -470,6 +486,7 @@ steps:
   - name: bpf-run-matrix-aws-kubeadm-dual-stack
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: CLUSTER_NODES
         value: "3"
@@ -513,6 +530,7 @@ steps:
   - name: bpf-run-matrix-kops-w-calico-cni-ipv6
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: BGP_STATUS
         value: Disabled
@@ -560,6 +578,7 @@ steps:
   - name: bpf-run-matrix-kops-w-calico-cni-ipv4
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: BGP_STATUS
         value: Disabled
@@ -601,6 +620,7 @@ steps:
   - name: bpf-mini-scale-runs
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: NUM_INFRA_NODES
         value: "3"
@@ -617,6 +637,7 @@ steps:
   - name: 9k-mtu-runs-aws-bpf-9k-mtu
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: CLUSTER_NODES
         value: "3"
@@ -644,6 +665,7 @@ steps:
   - name: 9k-mtu-runs-aws-iptables-9k-mtu
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: CLUSTER_NODES
         value: "3"
@@ -673,6 +695,7 @@ steps:
   - name: bpf-mode-switch
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: DATAPLANE
         value: CalicoIptables
@@ -689,6 +712,7 @@ steps:
   - name: wireguard
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: AZ_CREATE_MODE
         value: AKS
@@ -711,6 +735,7 @@ steps:
   - name: usage-reporting-with-bpf
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: CLUSTER_NODES
         value: "1"

--- a/.argoci/cron/e2e-certification.yaml
+++ b/.argoci/cron/e2e-certification.yaml
@@ -23,6 +23,7 @@ steps:
   - name: standalone-cluster-tests
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: ENABLE_OCP_VIRT
         value: "true"
@@ -48,6 +49,7 @@ steps:
   - name: hcp-setup-hosting
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: HCP_STAGE
         value: setup-hosting
@@ -62,6 +64,7 @@ steps:
   - name: hcp-hosted-setup-and-tests
     services:
       - docker
+      - http-cache-proxy
     depends:
       - hcp-setup-hosting
     env:
@@ -97,6 +100,7 @@ onExit:
   - name: hcp-destroy-hosting
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: HCP_STAGE
         value: destroy-hosting

--- a/.argoci/cron/e2e-iptables.yaml
+++ b/.argoci/cron/e2e-iptables.yaml
@@ -23,6 +23,7 @@ steps:
   - name: openshift-ocp
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: INSTALLER
         value: operator
@@ -46,6 +47,7 @@ steps:
   - name: arm64-smoke-tests-aks-arm64
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: AZ_VM_SIZE
         value: Standard_D4plds_v5
@@ -77,6 +79,7 @@ steps:
   - name: arm64-smoke-tests-eks-arm64-calico-cni
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: AWS_NODE_INSTANCE_TYPE
         value: t4g.large
@@ -102,6 +105,7 @@ steps:
   - name: aks-aks-w-calico-cni
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: AZ_CREATE_MODE
         value: AKS
@@ -127,6 +131,7 @@ steps:
   - name: aks-aks-w-aks-cni
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: AZ_CREATE_MODE
         value: AKS
@@ -149,6 +154,7 @@ steps:
   - name: aks-aks-private-w-aks-cni-overlay
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: AZ_CREATE_MODE
         value: AKS
@@ -173,6 +179,7 @@ steps:
   - name: aks-aks-migrate-from-vendored-calico-cni-to-calico-cni
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: AZ_CREATE_MODE
         value: AKS
@@ -196,6 +203,7 @@ steps:
     jobSize: large
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: ENABLE_DUAL_STACK
         value: "true"
@@ -236,6 +244,7 @@ steps:
     jobSize: large
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: ENABLE_DUAL_STACK
         value: "true"
@@ -271,6 +280,7 @@ steps:
     jobSize: large
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: ENABLE_AUTOHEP
         value: "true"
@@ -281,6 +291,7 @@ steps:
   - name: ipvs
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: KUBE_PROXY_MODE
         value: ipvs
@@ -297,6 +308,7 @@ steps:
     jobSize: large
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: ENABLE_USAGE
         value: "true"
@@ -316,6 +328,7 @@ steps:
   - name: k8s-beta-runs
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: PROVISIONER
         value: gcp-kubeadm
@@ -335,6 +348,7 @@ steps:
   - name: k8s-distros
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: K8S_VERSION
         value: v1.31.3
@@ -350,6 +364,7 @@ steps:
   - name: wireguard-vxlan-k8s-e2e
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: ENABLE_EXTERNAL_NODE
         value: "true"
@@ -377,6 +392,7 @@ steps:
   - name: wireguard-k8s-e2e
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: ENABLE_EXTERNAL_NODE
         value: "true"
@@ -411,6 +427,7 @@ steps:
     jobSize: large
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: INSTALLER
         value: manual
@@ -437,6 +454,7 @@ steps:
     jobSize: large
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: INSTALLER
         value: manual
@@ -464,6 +482,7 @@ steps:
   - name: wireguard-regression-k8s-e2e-kdd-new
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: DISABLE_IPIP
         value: "true"
@@ -489,6 +508,7 @@ steps:
   - name: wireguard-regression-k8s-e2e-kdd-old
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: DISABLE_IPIP
         value: "true"
@@ -514,6 +534,7 @@ steps:
   - name: wireguard-regression-k8s-e2e-aks-w-aks-cni-overlay
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: AZ_CREATE_MODE
         value: AKS
@@ -540,6 +561,7 @@ steps:
   - name: focused-wireguard-e2e-aks-w-azure-cni
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: ENABLE_WIREGUARD
         value: "true"
@@ -573,6 +595,7 @@ steps:
   - name: focused-wireguard-e2e-aks-with-calico-cni
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: AKS_CNI
         value: calico
@@ -608,6 +631,7 @@ steps:
   - name: focused-wireguard-e2e-eks-kdd-aws-cni
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: AWS_K8S_CNI_VERSION
         value: NA
@@ -630,6 +654,7 @@ steps:
   - name: focused-wireguard-e2e-eks-kdd-calico-cni
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: AWS_K8S_CNI_VERSION
         value: NA
@@ -652,6 +677,7 @@ steps:
   - name: distro-support
     services:
       - docker
+      - http-cache-proxy
     matrix:
       - name: ubuntu-2404-lts-amd64-gcp-kubeadm
         env:
@@ -694,6 +720,7 @@ steps:
   - name: datastore-k8s-e2e-kdd-old
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: PROVISIONER
         value: gcp-kubeadm
@@ -721,6 +748,7 @@ steps:
   - name: datastore-k8s-e2e-kdd-new
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: K8S_E2E_FLAGS
         value: --ginkgo.focus=(\[sig-calico\]|\[Conformance\]) --ginkgo.skip=(\[Slow\]|\[Disruptive\]|\[DataPath\]|WireGuard|NoTierPrefix)
@@ -750,6 +778,7 @@ steps:
   - name: datastore-k8s-e2e-etcd
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: INSTALL_ETCD_POD
         value: "true"
@@ -768,6 +797,7 @@ steps:
     jobSize: large
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: CALICO_MANIFEST
         value: manifests/flannel-migration/calico.yaml

--- a/.argoci/cron/e2e-nftables.yaml
+++ b/.argoci/cron/e2e-nftables.yaml
@@ -26,6 +26,7 @@ steps:
   - name: nftables-mode-arm64-wg
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: ENABLE_WIREGUARD
         value: "true"
@@ -57,6 +58,7 @@ steps:
   - name: nftables-mode-eks-eks-w-aws-cni
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: K8S_VERSION
         value: stable-1
@@ -72,6 +74,7 @@ steps:
   - name: nftables-mode-eks-eks-w-calico-cni
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: INSTALLER
         value: helmerator
@@ -96,6 +99,7 @@ steps:
     jobSize: large
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: ENABLE_DUAL_STACK
         value: "true"
@@ -119,6 +123,7 @@ steps:
     jobSize: large
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: ENABLE_DUAL_STACK
         value: "true"

--- a/.argoci/cron/e2e-patch-verification.yaml
+++ b/.argoci/cron/e2e-patch-verification.yaml
@@ -24,6 +24,7 @@ steps:
     jobSize: large
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: CNI_PLUGIN
         value: Calico
@@ -50,6 +51,7 @@ steps:
   - name: manifests-flannel-migration
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: AWS_NODE_INSTANCE_TYPE
         value: t3.large
@@ -84,6 +86,7 @@ steps:
   - name: manifests-canal
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: CLUSTER_IMAGE
         value: ubuntu-2204-lts
@@ -110,6 +113,7 @@ steps:
   - name: manifests-canal-migration
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: CALICO_MANIFEST
         value: manifests/flannel-migration/calico.yaml
@@ -138,6 +142,7 @@ steps:
   - name: manifests-calico-etcd
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: CLUSTER_IMAGE
         value: ubuntu-2404-lts-amd64
@@ -170,6 +175,7 @@ steps:
   - name: manifests-operator-migration
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: CLUSTER_IMAGE
         value: ubuntu-2404-lts-amd64
@@ -202,6 +208,7 @@ steps:
   - name: operator-helmerator-aks-w-aks-cni-overlay
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: AZ_CREATE_MODE
         value: AKS
@@ -224,6 +231,7 @@ steps:
   - name: operator-helmerator-openshift-ocp
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: DATAPLANE
         value: CalicoBPF
@@ -240,6 +248,7 @@ steps:
   - name: operator-helmerator-eks-w-calico-cni
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: AWS_NODE_INSTANCE_TYPE
         value: t3.large
@@ -274,6 +283,7 @@ steps:
   - name: operator-helmerator-eks-w-aws-cni
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: AWS_K8S_CNI_VERSION
         value: NA
@@ -300,6 +310,7 @@ steps:
   - name: operator-helmerator-windows-aws-kubeadm-containerd
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: CNI_PLUGIN
         value: Calico
@@ -326,6 +337,7 @@ steps:
   - name: operator-helmerator-windows-aws-kubeadm-docker
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: CLUSTER_IMAGE
         value: jammy-22.04
@@ -356,6 +368,7 @@ steps:
   - name: operator-helmerator-rke2
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: CLUSTER_IMAGE
         value: ubuntu-2204-lts

--- a/.argoci/cron/e2e-test.yaml
+++ b/.argoci/cron/e2e-test.yaml
@@ -23,6 +23,7 @@ steps:
   - name: calico-tests
     services:
       - docker
+      - http-cache-proxy
     matrix:
       - name: gcp-kubeadm-stable-operator-calicobpf
         env:

--- a/.argoci/cron/e2e-upgrade.yaml
+++ b/.argoci/cron/e2e-upgrade.yaml
@@ -29,6 +29,7 @@ steps:
   - name: calico-tests-aks-byo-cni-w-azurelinux
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: AZ_NETWORK_PLUGIN
         value: none
@@ -50,6 +51,7 @@ steps:
   - name: calico-tests-eks
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: K8S_E2E_FLAGS
         value: --ginkgo.focus=(\[Conformance\]|Observe|RBAC) --ginkgo.skip=(\[Slow\]|\[Disruptive\]|\[DataPath\]|sig-node|sig-apps|sig-storage|sig-scheduling|sig-calico-enterprise|DNS.should.provide.DNS|DNS.should.resolve.DNS|DNS.should.provide./etc|IP.address.is.not.reallocated|Proxy.version.v1|NoTierPrefix)
@@ -71,6 +73,7 @@ steps:
   - name: calico-tests-kubeadm-iptables
     services:
       - docker
+      - http-cache-proxy
     matrix:
       - name: aws-kubeadm-stable-3-operator-calicoiptables
         env:
@@ -87,6 +90,7 @@ steps:
   - name: calico-tests-kubeadm-bpf
     services:
       - docker
+      - http-cache-proxy
     matrix:
       - name: gcp-kubeadm-stable-operator-calicobpf
         env:
@@ -103,6 +107,7 @@ steps:
   - name: calico-tests-openshift-4-16
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: PROVISIONER
         value: aws-openshift
@@ -120,6 +125,7 @@ steps:
   - name: calico-tests-rke2
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: PROVISIONER
         value: gcp-rke2

--- a/.argoci/cron/e2e-windows.yaml
+++ b/.argoci/cron/e2e-windows.yaml
@@ -22,6 +22,7 @@ steps:
   - name: calico-windows-aws-kubeadm-1809-stable-3-iptables-none
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: DATAPLANE
         value: CalicoIptables
@@ -40,6 +41,7 @@ steps:
   - name: calico-windows-gcp-kubeadm-2022-stable-bpf-vxlan
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: DATAPLANE
         value: CalicoBPF
@@ -56,6 +58,7 @@ steps:
   - name: calico-windows-gcp-rancher-2022-stable-1-nftables-vxlan
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: DATAPLANE
         value: CalicoNftables


### PR DESCRIPTION
### Description

Backport of **#13296** to `release-v3.31`. Adds the `http-cache-proxy` service to every step of all scheduled e2e suites in `.argoci/cron/*.yaml`, routing GitHub API + clone traffic through the in-cluster caching proxy to cut argoci rate-limit throttling.

Re-applied as the same deterministic transform (insert `- http-cache-proxy` after each `- docker`) rather than a git cherry-pick — the release-branch cron files differ from master (no `e2e-vpp.yaml`, different matrices), so a literal cherry-pick would conflict. Every step's `services:` list gets the proxy; YAML validated.

### ✅ CA gate cleared — safe to merge

Requires the step image to trust the proxy's interception CA (in `ubuntu-cloud-providers:v0.106`). The handler's `DefaultStepImage` is global across branches and was bumped v0.104 → v0.106 (tigera/cc-utils#171), deployed to argoci (handler v0.21, deployed by @rory) — so it covers this branch too. On merge the pre-processor re-expands with the CA-bearing image + proxy together.

### Release Note

```release-note
None
```
