### PR TITLE
Route e2e GitHub traffic through the in-cluster caching proxy (release-v3.30)

### DIFF
--- a/.argoci/cron/e2e-benchmarking.yaml
+++ b/.argoci/cron/e2e-benchmarking.yaml
@@ -30,6 +30,7 @@ steps:
   - name: benchmarks
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: AWS_NODE_INSTANCE_TYPE
         value: m5.large

--- a/.argoci/cron/e2e-bpf.yaml
+++ b/.argoci/cron/e2e-bpf.yaml
@@ -23,6 +23,7 @@ steps:
   - name: arm64-smoke-tests-kubeadm-arm64
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: ENABLE_WIREGUARD
         value: "true"
@@ -50,6 +51,7 @@ steps:
   - name: arm64-smoke-tests-aks-arm64
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: AZ_VM_SIZE
         value: Standard_D4plds_v5
@@ -81,6 +83,7 @@ steps:
   - name: bpf-run-matrix-aws-encap
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: CLUSTER_NODES
         value: "3"
@@ -108,6 +111,7 @@ steps:
   - name: bpf-run-matrix-aws-single-subnet
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: BGP_STATUS
         value: Enabled
@@ -145,6 +149,7 @@ steps:
   - name: bpf-run-matrix-aws-talos-no-encap-dsr
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: BGP_STATUS
         value: Enabled
@@ -171,6 +176,7 @@ steps:
   - name: bpf-run-matrix-gcp-bpf-dp-dsr
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: BPF_NETWORK_BOOTSTRAP
         value: Enabled
@@ -195,6 +201,7 @@ steps:
   - name: bpf-run-matrix-gcp-bpf-dp-encap-w-nodelocal-dnscache
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: CLUSTER_IMAGE
         value: ubuntu-2204-lts
@@ -224,6 +231,7 @@ steps:
   - name: bpf-run-matrix-aks-w-aks-cni
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: CLUSTER_NODES
         value: "3"
@@ -245,6 +253,7 @@ steps:
   - name: bpf-run-matrix-aks-w-calico-cni
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: AZ_CREATE_MODE
         value: AKS
@@ -269,6 +278,7 @@ steps:
   - name: bpf-run-matrix-bpf-aks-w-aks-cni-overlay
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: AZ_CREATE_MODE
         value: AKS
@@ -295,6 +305,7 @@ steps:
   - name: bpf-run-matrix-aws-kops-rhel8-2
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: CLUSTER_IMAGE
         value: ami-02f147dfb8be58a10
@@ -317,6 +328,7 @@ steps:
   - name: bpf-run-matrix-aws-lb-bpf
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: BGP_STATUS
         value: Enabled
@@ -350,6 +362,7 @@ steps:
   - name: bpf-run-matrix-aws-lb-iptables
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: BGP_STATUS
         value: Enabled
@@ -385,6 +398,7 @@ steps:
   - name: bpf-run-matrix-eks-w-aws-cni
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: AWS_K8S_CNI_VERSION
         value: NA
@@ -412,6 +426,7 @@ steps:
   - name: bpf-run-matrix-eks-w-calico-cni
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: CLUSTER_NODES
         value: "3"
@@ -441,6 +456,7 @@ steps:
   - name: bpf-run-matrix-bpf-eks-aws-cni-lb
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: CLUSTER_NODES
         value: "3"
@@ -466,6 +482,7 @@ steps:
   - name: bpf-run-matrix-aws-kubeadm-dual-stack
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: CLUSTER_NODES
         value: "3"
@@ -509,6 +526,7 @@ steps:
   - name: bpf-run-matrix-kops-w-calico-cni-ipv6
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: BGP_STATUS
         value: Disabled
@@ -556,6 +574,7 @@ steps:
   - name: bpf-run-matrix-kops-w-calico-cni-ipv4
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: BGP_STATUS
         value: Disabled
@@ -597,6 +616,7 @@ steps:
   - name: bpf-mini-scale-runs
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: NUM_INFRA_NODES
         value: "3"
@@ -613,6 +633,7 @@ steps:
   - name: 9k-mtu-runs-aws-bpf-9k-mtu
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: CLUSTER_NODES
         value: "3"
@@ -640,6 +661,7 @@ steps:
   - name: 9k-mtu-runs-aws-iptables-9k-mtu
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: CLUSTER_NODES
         value: "3"
@@ -669,6 +691,7 @@ steps:
   - name: bpf-mode-switch
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: DATAPLANE
         value: CalicoIptables
@@ -685,6 +708,7 @@ steps:
   - name: wireguard
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: AZ_CREATE_MODE
         value: AKS
@@ -707,6 +731,7 @@ steps:
   - name: usage-reporting-with-bpf
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: CLUSTER_NODES
         value: "1"

--- a/.argoci/cron/e2e-certification.yaml
+++ b/.argoci/cron/e2e-certification.yaml
@@ -23,6 +23,7 @@ steps:
   - name: standalone-cluster-tests
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: ENABLE_OCP_VIRT
         value: "true"
@@ -48,6 +49,7 @@ steps:
   - name: hcp-setup-hosting
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: HCP_STAGE
         value: setup-hosting
@@ -62,6 +64,7 @@ steps:
   - name: hcp-hosted-setup-and-tests
     services:
       - docker
+      - http-cache-proxy
     depends:
       - hcp-setup-hosting
     env:
@@ -97,6 +100,7 @@ onExit:
   - name: hcp-destroy-hosting
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: HCP_STAGE
         value: destroy-hosting

--- a/.argoci/cron/e2e-iptables.yaml
+++ b/.argoci/cron/e2e-iptables.yaml
@@ -23,6 +23,7 @@ steps:
   - name: openshift-ocp
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: INSTALLER
         value: operator
@@ -46,6 +47,7 @@ steps:
   - name: arm64-smoke-tests-aks-arm64
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: AZ_VM_SIZE
         value: Standard_D4plds_v5
@@ -77,6 +79,7 @@ steps:
   - name: arm64-smoke-tests-eks-arm64-calico-cni
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: AWS_NODE_INSTANCE_TYPE
         value: t4g.large
@@ -102,6 +105,7 @@ steps:
   - name: aks-aks-w-calico-cni
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: AZ_CREATE_MODE
         value: AKS
@@ -127,6 +131,7 @@ steps:
   - name: aks-aks-w-aks-cni
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: AZ_CREATE_MODE
         value: AKS
@@ -149,6 +154,7 @@ steps:
   - name: aks-aks-private-w-aks-cni-overlay
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: AZ_CREATE_MODE
         value: AKS
@@ -173,6 +179,7 @@ steps:
   - name: aks-aks-migrate-from-vendored-calico-cni-to-calico-cni
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: AZ_CREATE_MODE
         value: AKS
@@ -196,6 +203,7 @@ steps:
     jobSize: large
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: ENABLE_DUAL_STACK
         value: "true"
@@ -236,6 +244,7 @@ steps:
     jobSize: large
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: ENABLE_DUAL_STACK
         value: "true"
@@ -271,6 +280,7 @@ steps:
     jobSize: large
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: ENABLE_AUTOHEP
         value: "true"
@@ -281,6 +291,7 @@ steps:
   - name: ipvs
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: KUBE_PROXY_MODE
         value: ipvs
@@ -297,6 +308,7 @@ steps:
     jobSize: large
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: ENABLE_USAGE
         value: "true"
@@ -316,6 +328,7 @@ steps:
   - name: k8s-beta-runs
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: PROVISIONER
         value: gcp-kubeadm
@@ -335,6 +348,7 @@ steps:
   - name: k8s-distros
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: K8S_VERSION
         value: v1.31.3
@@ -350,6 +364,7 @@ steps:
   - name: wireguard-vxlan-k8s-e2e
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: ENABLE_EXTERNAL_NODE
         value: "true"
@@ -377,6 +392,7 @@ steps:
   - name: wireguard-k8s-e2e
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: ENABLE_EXTERNAL_NODE
         value: "true"
@@ -411,6 +427,7 @@ steps:
     jobSize: large
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: INSTALLER
         value: manual
@@ -437,6 +454,7 @@ steps:
     jobSize: large
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: INSTALLER
         value: manual
@@ -464,6 +482,7 @@ steps:
   - name: wireguard-regression-k8s-e2e-kdd-new
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: DISABLE_IPIP
         value: "true"
@@ -489,6 +508,7 @@ steps:
   - name: wireguard-regression-k8s-e2e-kdd-old
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: DISABLE_IPIP
         value: "true"
@@ -514,6 +534,7 @@ steps:
   - name: wireguard-regression-k8s-e2e-aks-w-aks-cni-overlay
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: AZ_CREATE_MODE
         value: AKS
@@ -540,6 +561,7 @@ steps:
   - name: focused-wireguard-e2e-aks-w-azure-cni
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: ENABLE_WIREGUARD
         value: "true"
@@ -573,6 +595,7 @@ steps:
   - name: focused-wireguard-e2e-aks-with-calico-cni
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: AKS_CNI
         value: calico
@@ -608,6 +631,7 @@ steps:
   - name: focused-wireguard-e2e-eks-kdd-aws-cni
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: AWS_K8S_CNI_VERSION
         value: NA
@@ -630,6 +654,7 @@ steps:
   - name: focused-wireguard-e2e-eks-kdd-calico-cni
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: AWS_K8S_CNI_VERSION
         value: NA
@@ -652,6 +677,7 @@ steps:
   - name: distro-support
     services:
       - docker
+      - http-cache-proxy
     matrix:
       - name: ubuntu-2404-lts-gcp-kubeadm
         env:
@@ -694,6 +720,7 @@ steps:
   - name: datastore-k8s-e2e-kdd-old
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: PROVISIONER
         value: gcp-kubeadm
@@ -721,6 +748,7 @@ steps:
   - name: datastore-k8s-e2e-kdd-new
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: K8S_E2E_FLAGS
         value: --ginkgo.focus=(\[sig-calico\]|\[Conformance\]) --ginkgo.skip=(\[Slow\]|\[Disruptive\]|\[DataPath\]|WireGuard|NoTierPrefix)
@@ -750,6 +778,7 @@ steps:
   - name: datastore-k8s-e2e-etcd
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: INSTALL_ETCD_POD
         value: "true"
@@ -768,6 +797,7 @@ steps:
     jobSize: large
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: CALICO_MANIFEST
         value: manifests/flannel-migration/calico.yaml

--- a/.argoci/cron/e2e-nftables.yaml
+++ b/.argoci/cron/e2e-nftables.yaml
@@ -26,6 +26,7 @@ steps:
   - name: nftables-mode-arm64-wg
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: ENABLE_WIREGUARD
         value: "true"
@@ -57,6 +58,7 @@ steps:
   - name: nftables-talos
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: ENCAPSULATION_TYPE
         value: VXLAN
@@ -72,6 +74,7 @@ steps:
   - name: nftables-mode-eks-eks-w-aws-cni
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: K8S_VERSION
         value: stable-1
@@ -87,6 +90,7 @@ steps:
   - name: nftables-mode-eks-eks-w-calico-cni
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: INSTALLER
         value: helmerator
@@ -111,6 +115,7 @@ steps:
     jobSize: large
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: ENABLE_DUAL_STACK
         value: "true"
@@ -134,6 +139,7 @@ steps:
     jobSize: large
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: ENABLE_DUAL_STACK
         value: "true"

--- a/.argoci/cron/e2e-patch-verification.yaml
+++ b/.argoci/cron/e2e-patch-verification.yaml
@@ -24,6 +24,7 @@ steps:
     jobSize: large
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: CNI_PLUGIN
         value: Calico
@@ -50,6 +51,7 @@ steps:
   - name: manifests-flannel-migration
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: AWS_NODE_INSTANCE_TYPE
         value: t3.large
@@ -84,6 +86,7 @@ steps:
   - name: manifests-canal
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: CLUSTER_IMAGE
         value: ubuntu-2204-lts
@@ -110,6 +113,7 @@ steps:
   - name: manifests-canal-migration
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: CALICO_MANIFEST
         value: manifests/flannel-migration/calico.yaml
@@ -138,6 +142,7 @@ steps:
   - name: manifests-calico-etcd
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: CLUSTER_IMAGE
         value: ubuntu-2404-lts-amd64
@@ -170,6 +175,7 @@ steps:
   - name: manifests-operator-migration
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: CLUSTER_IMAGE
         value: ubuntu-2404-lts-amd64
@@ -202,6 +208,7 @@ steps:
   - name: operator-helmerator-aks-w-aks-cni-overlay
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: AZ_CREATE_MODE
         value: AKS
@@ -224,6 +231,7 @@ steps:
   - name: operator-helmerator-eks-w-calico-cni
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: AWS_NODE_INSTANCE_TYPE
         value: t3.large
@@ -258,6 +266,7 @@ steps:
   - name: operator-helmerator-eks-w-aws-cni
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: AWS_K8S_CNI_VERSION
         value: NA
@@ -284,6 +293,7 @@ steps:
   - name: operator-helmerator-windows-aws-kubeadm-containerd
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: CNI_PLUGIN
         value: Calico
@@ -310,6 +320,7 @@ steps:
   - name: operator-helmerator-windows-aws-kubeadm-docker
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: CLUSTER_IMAGE
         value: jammy-22.04
@@ -340,6 +351,7 @@ steps:
   - name: operator-helmerator-rke2
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: CLUSTER_IMAGE
         value: ubuntu-2204-lts
@@ -364,6 +376,7 @@ steps:
   - name: openshift
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: DATAPLANE
         value: CalicoBPF

--- a/.argoci/cron/e2e-test.yaml
+++ b/.argoci/cron/e2e-test.yaml
@@ -23,6 +23,7 @@ steps:
   - name: calico-tests
     services:
       - docker
+      - http-cache-proxy
     matrix:
       - name: gcp-kubeadm-stable-operator-calicobpf
         env:

--- a/.argoci/cron/e2e-upgrade.yaml
+++ b/.argoci/cron/e2e-upgrade.yaml
@@ -29,6 +29,7 @@ steps:
   - name: calico-tests-aks-byo-cni-w-azurelinux
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: AZ_NETWORK_PLUGIN
         value: none
@@ -50,6 +51,7 @@ steps:
   - name: calico-tests-eks
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: K8S_E2E_FLAGS
         value: --ginkgo.focus=(\[Conformance\]|Observe|RBAC) --ginkgo.skip=(\[Slow\]|\[Disruptive\]|\[DataPath\]|sig-node|sig-apps|sig-storage|sig-scheduling|sig-calico-enterprise|DNS.should.provide.DNS|DNS.should.resolve.DNS|DNS.should.provide./etc|IP.address.is.not.reallocated|Proxy.version.v1|Feature:AutoHEPs|staged.network.policy|NoTierPrefix)
@@ -71,6 +73,7 @@ steps:
   - name: calico-tests-kubeadm-iptables
     services:
       - docker
+      - http-cache-proxy
     matrix:
       - name: aws-kubeadm-stable-3-operator-calicoiptables
         env:
@@ -87,6 +90,7 @@ steps:
   - name: calico-tests-kubeadm-bpf
     services:
       - docker
+      - http-cache-proxy
     matrix:
       - name: gcp-kubeadm-stable-operator-calicobpf
         env:
@@ -103,6 +107,7 @@ steps:
   - name: calico-tests-rke2
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: PROVISIONER
         value: gcp-rke2
@@ -122,6 +127,7 @@ steps:
   - name: calico-tests-openshift
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: PROVISIONER
         value: aws-openshift

--- a/.argoci/cron/e2e-windows.yaml
+++ b/.argoci/cron/e2e-windows.yaml
@@ -22,6 +22,7 @@ steps:
   - name: calico-windows-aws-kubeadm-1809-stable-3-iptables-none
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: DATAPLANE
         value: CalicoIptables
@@ -40,6 +41,7 @@ steps:
   - name: calico-windows-gcp-kubeadm-2022-stable-bpf-vxlan
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: DATAPLANE
         value: CalicoBPF
@@ -56,6 +58,7 @@ steps:
   - name: calico-windows-gcp-rancher-2022-stable-1-nftables-vxlan
     services:
       - docker
+      - http-cache-proxy
     env:
       - name: DATAPLANE
         value: CalicoNftables


### PR DESCRIPTION
### Description

Backport of **#13296** to `release-v3.30`. Adds the `http-cache-proxy` service to every step of all scheduled e2e suites in `.argoci/cron/*.yaml`, routing GitHub API + clone traffic through the in-cluster caching proxy to cut argoci rate-limit throttling.

Re-applied as the same deterministic transform (insert `- http-cache-proxy` after each `- docker`) rather than a git cherry-pick — the release-branch cron files differ from master (no `e2e-vpp.yaml`, different matrices), so a literal cherry-pick would conflict. Every step's `services:` list gets the proxy; YAML validated.

### ✅ CA gate cleared — safe to merge

Requires the step image to trust the proxy's interception CA (in `ubuntu-cloud-providers:v0.106`). The handler's `DefaultStepImage` is global across branches and was bumped v0.104 → v0.106 (tigera/cc-utils#171), deployed to argoci (handler v0.21, deployed by @rory) — so it covers this branch too. On merge the pre-processor re-expands with the CA-bearing image + proxy together.

### Release Note

```release-note
None
```
