### PR TITLE
calicoctl cluster diags: collect --previous logs for all containers in a pod

### DIFF
--- a/calicoctl/calicoctl/commands/cluster/diags.go
+++ b/calicoctl/calicoctl/commands/cluster/diags.go
@@ -718,30 +718,38 @@ func diagsCmdsForPod(dir, linkDir string, opts *diagOpts, nodeName, namespace st
 			SymLink:  fmt.Sprintf("%s/%s/%s.txt", linkDir, namespace, pod.Name),
 		},
 	}
-	// If any container has restarted, also grab the previous incarnation's
-	// logs — those are usually the ones that explain the restart.
-	if hasPreviousLogs(pod) {
+	// For each container that has restarted, also grab the previous
+	// incarnation's logs — those are usually the ones that explain the
+	// restart. We collect them per-container rather than with a single
+	// --all-containers invocation: `kubectl logs --previous --all-containers`
+	// fails outright if any one container in the pod has no previous
+	// incarnation, which would lose the crashed container's logs — exactly
+	// the ones we came for. Requesting only the containers that actually have
+	// a prior incarnation, one command each, sidesteps that.
+	for _, container := range containersWithPreviousLogs(pod) {
 		cmds = append(cmds, common.Cmd{
-			Info:     fmt.Sprintf("Collect previous logs for pod %s", pod.Name),
-			CmdStr:   fmt.Sprintf("kubectl logs --previous --since=%s -n %s %s --all-containers", opts.Since, namespace, pod.Name),
-			FilePath: fmt.Sprintf("%s/%s.previous.log", namespaceDir, pod.Name),
-			SymLink:  fmt.Sprintf("%s/%s/%s.previous.log", linkDir, namespace, pod.Name),
+			Info:     fmt.Sprintf("Collect previous logs for container %s in pod %s", container, pod.Name),
+			CmdStr:   fmt.Sprintf("kubectl logs --previous --since=%s -n %s %s -c %s", opts.Since, namespace, pod.Name, container),
+			FilePath: fmt.Sprintf("%s/%s.%s.previous.log", namespaceDir, pod.Name, container),
+			SymLink:  fmt.Sprintf("%s/%s/%s.%s.previous.log", linkDir, namespace, pod.Name, container),
 		})
 	}
 	return cmds
 }
 
-// hasPreviousLogs reports whether any container in the pod has a prior
-// incarnation worth fetching logs from.
-func hasPreviousLogs(pod *apiv1.Pod) bool {
+// containersWithPreviousLogs returns the names of the pod's containers (both
+// regular and init) that have a prior incarnation worth fetching logs from,
+// i.e. the container has restarted or has a previously terminated state.
+func containersWithPreviousLogs(pod *apiv1.Pod) []string {
 	statuses := append([]apiv1.ContainerStatus{}, pod.Status.ContainerStatuses...)
 	statuses = append(statuses, pod.Status.InitContainerStatuses...)
+	var names []string
 	for _, cs := range statuses {
 		if cs.RestartCount > 0 || cs.LastTerminationState.Terminated != nil {
-			return true
+			names = append(names, cs.Name)
 		}
 	}
-	return false
+	return names
 }
 
 // bpfJSONCmd builds a diagnostic command that dumps calico-bpf state as JSON,

--- a/calicoctl/calicoctl/commands/cluster/diags.go
+++ b/calicoctl/calicoctl/commands/cluster/diags.go
@@ -718,36 +718,54 @@ func diagsCmdsForPod(dir, linkDir string, opts *diagOpts, nodeName, namespace st
 			SymLink:  fmt.Sprintf("%s/%s/%s.txt", linkDir, namespace, pod.Name),
 		},
 	}
-	// For each container that has restarted, also grab the previous
-	// incarnation's logs — those are usually the ones that explain the
-	// restart. We collect them per-container rather than with a single
-	// --all-containers invocation: `kubectl logs --previous --all-containers`
-	// fails outright if any one container in the pod has no previous
-	// incarnation, which would lose the crashed container's logs — exactly
-	// the ones we came for. Requesting only the containers that actually have
-	// a prior incarnation, one command each, sidesteps that.
-	for _, container := range containersWithPreviousLogs(pod) {
-		cmds = append(cmds, common.Cmd{
-			Info:     fmt.Sprintf("Collect previous logs for container %s in pod %s", container, pod.Name),
-			CmdStr:   fmt.Sprintf("kubectl logs --previous --since=%s -n %s %s -c %s", opts.Since, namespace, pod.Name, container),
-			FilePath: fmt.Sprintf("%s/%s.%s.previous.log", namespaceDir, pod.Name, container),
-			SymLink:  fmt.Sprintf("%s/%s/%s.%s.previous.log", linkDir, namespace, pod.Name, container),
-		})
+	// If any container in the pod has a prior incarnation (it restarted or has
+	// a previously terminated state), grab the previous-incarnation logs for
+	// *every* container in the pod — those are usually the ones that explain
+	// the restart, and a crashed container's siblings are often the fastest way
+	// to understand what tipped it over.
+	//
+	// We emit one command per container rather than a single --all-containers
+	// invocation: `kubectl logs --previous --all-containers` fails outright if
+	// any one container in the pod has no previous incarnation, which would
+	// lose the crashed container's logs — exactly the ones we came for.
+	// Per-container commands are independent, so a container that happens to
+	// have no previous incarnation fails harmlessly on its own without
+	// discarding any sibling's previous logs.
+	if podHasPreviousLogs(pod) {
+		for _, container := range allContainerNames(pod) {
+			cmds = append(cmds, common.Cmd{
+				Info:     fmt.Sprintf("Collect previous logs for container %s in pod %s", container, pod.Name),
+				CmdStr:   fmt.Sprintf("kubectl logs --previous --since=%s -n %s %s -c %s", opts.Since, namespace, pod.Name, container),
+				FilePath: fmt.Sprintf("%s/%s.%s.previous.log", namespaceDir, pod.Name, container),
+				SymLink:  fmt.Sprintf("%s/%s/%s.%s.previous.log", linkDir, namespace, pod.Name, container),
+			})
+		}
 	}
 	return cmds
 }
 
-// containersWithPreviousLogs returns the names of the pod's containers (both
-// regular and init) that have a prior incarnation worth fetching logs from,
-// i.e. the container has restarted or has a previously terminated state.
-func containersWithPreviousLogs(pod *apiv1.Pod) []string {
+// podHasPreviousLogs reports whether any container in the pod (regular or init)
+// has a prior incarnation worth fetching logs from, i.e. the container has
+// restarted or has a previously terminated state.
+func podHasPreviousLogs(pod *apiv1.Pod) bool {
+	statuses := append([]apiv1.ContainerStatus{}, pod.Status.ContainerStatuses...)
+	statuses = append(statuses, pod.Status.InitContainerStatuses...)
+	for _, cs := range statuses {
+		if cs.RestartCount > 0 || cs.LastTerminationState.Terminated != nil {
+			return true
+		}
+	}
+	return false
+}
+
+// allContainerNames returns the names of every container in the pod, both
+// regular and init.
+func allContainerNames(pod *apiv1.Pod) []string {
 	statuses := append([]apiv1.ContainerStatus{}, pod.Status.ContainerStatuses...)
 	statuses = append(statuses, pod.Status.InitContainerStatuses...)
 	var names []string
 	for _, cs := range statuses {
-		if cs.RestartCount > 0 || cs.LastTerminationState.Terminated != nil {
-			names = append(names, cs.Name)
-		}
+		names = append(names, cs.Name)
 	}
 	return names
 }

--- a/calicoctl/calicoctl/commands/cluster/diags.go
+++ b/calicoctl/calicoctl/commands/cluster/diags.go
@@ -729,15 +729,23 @@ func diagsCmdsForPod(dir, linkDir string, opts *diagOpts, nodeName, namespace st
 	// any one container in the pod has no previous incarnation, which would
 	// lose the crashed container's logs — exactly the ones we came for.
 	// Per-container commands are independent, so a container that happens to
-	// have no previous incarnation fails harmlessly on its own without
-	// discarding any sibling's previous logs.
+	// have no previous incarnation fails harmlessly on its own.
+	//
+	// OmitIfEmpty drops the output for those never-restarted siblings: their
+	// `kubectl logs --previous` fails with a "not found" message, and we don't
+	// want that cluttering the bundle as an empty .previous.log. Attempting
+	// every container and keeping only the non-empty results means the bundle
+	// ends up with a .previous.log for exactly the containers that genuinely
+	// have previous logs, without relying on the restart-count heuristic to
+	// pick them ahead of time.
 	if podHasPreviousLogs(pod) {
 		for _, container := range allContainerNames(pod) {
 			cmds = append(cmds, common.Cmd{
-				Info:     fmt.Sprintf("Collect previous logs for container %s in pod %s", container, pod.Name),
-				CmdStr:   fmt.Sprintf("kubectl logs --previous --since=%s -n %s %s -c %s", opts.Since, namespace, pod.Name, container),
-				FilePath: fmt.Sprintf("%s/%s.%s.previous.log", namespaceDir, pod.Name, container),
-				SymLink:  fmt.Sprintf("%s/%s/%s.%s.previous.log", linkDir, namespace, pod.Name, container),
+				Info:        fmt.Sprintf("Collect previous logs for container %s in pod %s", container, pod.Name),
+				CmdStr:      fmt.Sprintf("kubectl logs --previous --since=%s -n %s %s -c %s", opts.Since, namespace, pod.Name, container),
+				FilePath:    fmt.Sprintf("%s/%s.%s.previous.log", namespaceDir, pod.Name, container),
+				SymLink:     fmt.Sprintf("%s/%s/%s.%s.previous.log", linkDir, namespace, pod.Name, container),
+				OmitIfEmpty: true,
 			})
 		}
 	}

--- a/calicoctl/calicoctl/commands/cluster/diags_test.go
+++ b/calicoctl/calicoctl/commands/cluster/diags_test.go
@@ -185,26 +185,50 @@ func TestDiagsCmdsForPod_Previous(t *testing.T) {
 	// A pod with no restarts gets only the current-log and describe commands.
 	steady := &apiv1.Pod{}
 	steady.Name = "calico-typha-0"
-	steady.Status.ContainerStatuses = []apiv1.ContainerStatus{{RestartCount: 0}}
+	steady.Status.ContainerStatuses = []apiv1.ContainerStatus{{Name: "calico-typha", RestartCount: 0}}
 	cmds := diagsCmdsForPod("/dir", "/links", opts, "nodeA", "calico-system", steady)
 	Expect(cmdStrs(cmds)).NotTo(ContainElement(ContainSubstring("--previous")))
 
 	// A pod whose container has restarted picks up an extra previous-log
-	// command alongside the usual current-log + describe.
+	// command, scoped to that specific container (not --all-containers), so a
+	// crashed container's logs survive even when sibling containers have no
+	// previous incarnation.
 	restarted := &apiv1.Pod{}
 	restarted.Name = "calico-apiserver-0"
-	restarted.Status.ContainerStatuses = []apiv1.ContainerStatus{{RestartCount: 2}}
+	restarted.Status.ContainerStatuses = []apiv1.ContainerStatus{
+		{Name: "calico-apiserver", RestartCount: 2},
+		{Name: "calico-apiserver-sidecar", RestartCount: 0},
+	}
 	cmds = diagsCmdsForPod("/dir", "/links", opts, "nodeA", "calico-apiserver", restarted)
-	Expect(cmdStrs(cmds)).To(ContainElement(ContainSubstring("kubectl logs --previous")))
+	prev := filterStrs(cmdStrs(cmds), "--previous")
+	// Only the restarted container is fetched, and it is scoped with -c.
+	Expect(prev).To(HaveLen(1))
+	Expect(prev[0]).To(ContainSubstring("kubectl logs --previous"))
+	Expect(prev[0]).To(ContainSubstring("-c calico-apiserver"))
+	Expect(prev[0]).NotTo(ContainSubstring("--all-containers"))
 
-	// An init container that previously terminated also flips the flag.
+	// An init container that previously terminated also gets its previous logs.
 	initTerminated := &apiv1.Pod{}
 	initTerminated.Name = "calico-node-xyz"
 	initTerminated.Status.InitContainerStatuses = []apiv1.ContainerStatus{{
+		Name:                 "install-cni",
 		LastTerminationState: apiv1.ContainerState{Terminated: &apiv1.ContainerStateTerminated{ExitCode: 1}},
 	}}
 	cmds = diagsCmdsForPod("/dir", "/links", opts, "nodeA", "calico-system", initTerminated)
-	Expect(cmdStrs(cmds)).To(ContainElement(ContainSubstring("kubectl logs --previous")))
+	Expect(cmdStrs(cmds)).To(ContainElement(And(
+		ContainSubstring("kubectl logs --previous"),
+		ContainSubstring("-c install-cni"),
+	)))
+}
+
+func filterStrs(strs []string, substr string) []string {
+	var out []string
+	for _, s := range strs {
+		if strings.Contains(s, substr) {
+			out = append(out, s)
+		}
+	}
+	return out
 }
 
 func cmdStrs(cmds []common.Cmd) []string {

--- a/calicoctl/calicoctl/commands/cluster/diags_test.go
+++ b/calicoctl/calicoctl/commands/cluster/diags_test.go
@@ -191,10 +191,10 @@ func TestDiagsCmdsForPod_Previous(t *testing.T) {
 
 	// A pod where even one container has restarted picks up previous-log
 	// commands for *every* container in the pod, each scoped with -c (not
-	// --all-containers). Per-container commands are independent, so a healthy
-	// sibling that has no previous incarnation fails harmlessly on its own
-	// without discarding the crashed container's logs — exactly the ones the
-	// bundle needs to explain the restart.
+	// --all-containers). The commands are marked OmitIfEmpty so a never-restarted
+	// sibling — whose `kubectl logs --previous` fails with "not found" — is
+	// dropped from the bundle rather than written as an empty .previous.log,
+	// while the crashed container's logs (the ones the bundle needs) survive.
 	restarted := &apiv1.Pod{}
 	restarted.Name = "calico-apiserver-0"
 	restarted.Status.ContainerStatuses = []apiv1.ContainerStatus{
@@ -202,14 +202,16 @@ func TestDiagsCmdsForPod_Previous(t *testing.T) {
 		{Name: "calico-apiserver-sidecar", RestartCount: 0},
 	}
 	cmds = diagsCmdsForPod("/dir", "/links", opts, "nodeA", "calico-apiserver", restarted)
-	prev := filterStrs(cmdStrs(cmds), "--previous")
+	prevCmds := previousCmds(cmds)
 	// Both the restarted container and its never-restarted sibling are fetched,
-	// each scoped with -c, and none use --all-containers.
-	Expect(prev).To(HaveLen(2))
-	for _, p := range prev {
-		Expect(p).To(ContainSubstring("kubectl logs --previous"))
-		Expect(p).NotTo(ContainSubstring("--all-containers"))
+	// each scoped with -c, none use --all-containers, and all are OmitIfEmpty.
+	Expect(prevCmds).To(HaveLen(2))
+	for _, c := range prevCmds {
+		Expect(c.CmdStr).To(ContainSubstring("kubectl logs --previous"))
+		Expect(c.CmdStr).NotTo(ContainSubstring("--all-containers"))
+		Expect(c.OmitIfEmpty).To(BeTrue())
 	}
+	prev := cmdStrs(prevCmds)
 	Expect(prev).To(ContainElement(ContainSubstring("-c calico-apiserver")))
 	Expect(prev).To(ContainElement(ContainSubstring("-c calico-apiserver-sidecar")))
 
@@ -231,6 +233,16 @@ func TestDiagsCmdsForPod_Previous(t *testing.T) {
 		ContainSubstring("-c install-cni"),
 	)))
 	Expect(prev).To(ContainElement(ContainSubstring("-c calico-node")))
+}
+
+func previousCmds(cmds []common.Cmd) []common.Cmd {
+	var out []common.Cmd
+	for _, c := range cmds {
+		if strings.Contains(c.CmdStr, "--previous") {
+			out = append(out, c)
+		}
+	}
+	return out
 }
 
 func filterStrs(strs []string, substr string) []string {

--- a/calicoctl/calicoctl/commands/cluster/diags_test.go
+++ b/calicoctl/calicoctl/commands/cluster/diags_test.go
@@ -189,10 +189,12 @@ func TestDiagsCmdsForPod_Previous(t *testing.T) {
 	cmds := diagsCmdsForPod("/dir", "/links", opts, "nodeA", "calico-system", steady)
 	Expect(cmdStrs(cmds)).NotTo(ContainElement(ContainSubstring("--previous")))
 
-	// A pod whose container has restarted picks up an extra previous-log
-	// command, scoped to that specific container (not --all-containers), so a
-	// crashed container's logs survive even when sibling containers have no
-	// previous incarnation.
+	// A pod where even one container has restarted picks up previous-log
+	// commands for *every* container in the pod, each scoped with -c (not
+	// --all-containers). Per-container commands are independent, so a healthy
+	// sibling that has no previous incarnation fails harmlessly on its own
+	// without discarding the crashed container's logs — exactly the ones the
+	// bundle needs to explain the restart.
 	restarted := &apiv1.Pod{}
 	restarted.Name = "calico-apiserver-0"
 	restarted.Status.ContainerStatuses = []apiv1.ContainerStatus{
@@ -201,24 +203,34 @@ func TestDiagsCmdsForPod_Previous(t *testing.T) {
 	}
 	cmds = diagsCmdsForPod("/dir", "/links", opts, "nodeA", "calico-apiserver", restarted)
 	prev := filterStrs(cmdStrs(cmds), "--previous")
-	// Only the restarted container is fetched, and it is scoped with -c.
-	Expect(prev).To(HaveLen(1))
-	Expect(prev[0]).To(ContainSubstring("kubectl logs --previous"))
-	Expect(prev[0]).To(ContainSubstring("-c calico-apiserver"))
-	Expect(prev[0]).NotTo(ContainSubstring("--all-containers"))
+	// Both the restarted container and its never-restarted sibling are fetched,
+	// each scoped with -c, and none use --all-containers.
+	Expect(prev).To(HaveLen(2))
+	for _, p := range prev {
+		Expect(p).To(ContainSubstring("kubectl logs --previous"))
+		Expect(p).NotTo(ContainSubstring("--all-containers"))
+	}
+	Expect(prev).To(ContainElement(ContainSubstring("-c calico-apiserver")))
+	Expect(prev).To(ContainElement(ContainSubstring("-c calico-apiserver-sidecar")))
 
-	// An init container that previously terminated also gets its previous logs.
+	// An init container that previously terminated also triggers collection,
+	// and its previous logs are fetched by name.
 	initTerminated := &apiv1.Pod{}
 	initTerminated.Name = "calico-node-xyz"
+	initTerminated.Status.ContainerStatuses = []apiv1.ContainerStatus{{Name: "calico-node", RestartCount: 0}}
 	initTerminated.Status.InitContainerStatuses = []apiv1.ContainerStatus{{
 		Name:                 "install-cni",
 		LastTerminationState: apiv1.ContainerState{Terminated: &apiv1.ContainerStateTerminated{ExitCode: 1}},
 	}}
 	cmds = diagsCmdsForPod("/dir", "/links", opts, "nodeA", "calico-system", initTerminated)
-	Expect(cmdStrs(cmds)).To(ContainElement(And(
+	prev = filterStrs(cmdStrs(cmds), "--previous")
+	// The terminated init container triggers collection for the whole pod, so
+	// the never-restarted main container is fetched too.
+	Expect(prev).To(ContainElement(And(
 		ContainSubstring("kubectl logs --previous"),
 		ContainSubstring("-c install-cni"),
 	)))
+	Expect(prev).To(ContainElement(ContainSubstring("-c calico-node")))
 }
 
 func filterStrs(strs []string, substr string) []string {

--- a/calicoctl/calicoctl/commands/common/cmd.go
+++ b/calicoctl/calicoctl/commands/common/cmd.go
@@ -108,6 +108,14 @@ type Cmd struct {
 	// version skew: e.g. try a JSON dump, fall back to the plain-text dump.
 	FallbackCmdStr   string
 	FallbackFilePath string
+
+	// OmitIfEmpty, when set, suppresses the output file (and its symlink) when
+	// the command fails or produces no output. This is for commands collected
+	// opportunistically across a set — e.g. previous-incarnation logs attempted
+	// for every container in a pod, including containers that never restarted.
+	// Those make kubectl fail with a short "not found" message; writing that as
+	// a .previous.log just clutters the bundle, so we drop it instead.
+	OmitIfEmpty bool
 }
 
 // ExecCmdWriteToFile executes the provided command c and outputs the result to a
@@ -156,6 +164,17 @@ func ExecCmdWriteToFile(logPrefix string, c Cmd) {
 				}
 			}
 		}
+	}
+
+	// Opportunistically-collected commands (OmitIfEmpty) — e.g. previous-log
+	// collection attempted for every container in a pod, including ones that
+	// never restarted — routinely "fail" for containers with no previous
+	// incarnation. Treat an error or empty output as "nothing to collect": skip
+	// the file, the symlink, and the noisy failure log rather than cluttering
+	// the bundle with kubectl's "not found" message.
+	if c.OmitIfEmpty && (err != nil || len(bytes.TrimSpace(content)) == 0) {
+		logCtx.Debugf("Nothing to collect for command %q; omitting file", c.CmdStr)
+		return
 	}
 
 	if err != nil {

--- a/calicoctl/calicoctl/commands/common/cmd_test.go
+++ b/calicoctl/calicoctl/commands/common/cmd_test.go
@@ -112,3 +112,65 @@ func TestExecCmdWriteToFile_PrimarySucceeds(t *testing.T) {
 		t.Fatalf("fallback file should not exist when primary succeeds")
 	}
 }
+
+// TestExecCmdWriteToFile_OmitIfEmpty_Failed verifies that when OmitIfEmpty is
+// set and the command fails, no output file (and no symlink) is written. This
+// is the never-restarted-sibling case: `kubectl logs --previous` fails with a
+// "not found" message, which we don't want cluttering the bundle.
+func TestExecCmdWriteToFile_OmitIfEmpty_Failed(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "pod.sidecar.previous.log")
+	linkPath := filepath.Join(dir, "links", "pod.sidecar.previous.log")
+
+	common.ExecCmdWriteToFile("[test]", common.Cmd{
+		CmdStr:      "false", // exits non-zero, as `kubectl logs --previous` does for a container with no previous incarnation
+		FilePath:    logPath,
+		SymLink:     linkPath,
+		OmitIfEmpty: true,
+	})
+
+	if _, err := os.Stat(logPath); !os.IsNotExist(err) {
+		t.Fatalf("expected no output file for a failed OmitIfEmpty command, stat err=%v", err)
+	}
+	if _, err := os.Lstat(linkPath); !os.IsNotExist(err) {
+		t.Fatalf("expected no symlink for a failed OmitIfEmpty command, stat err=%v", err)
+	}
+}
+
+// TestExecCmdWriteToFile_OmitIfEmpty_EmptyOutput verifies that a command that
+// succeeds but produces only whitespace is also omitted when OmitIfEmpty is set.
+func TestExecCmdWriteToFile_OmitIfEmpty_EmptyOutput(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "pod.container.previous.log")
+
+	common.ExecCmdWriteToFile("[test]", common.Cmd{
+		CmdStr:      "echo   ", // succeeds, output is whitespace only
+		FilePath:    logPath,
+		OmitIfEmpty: true,
+	})
+
+	if _, err := os.Stat(logPath); !os.IsNotExist(err) {
+		t.Fatalf("expected no output file for empty OmitIfEmpty output, stat err=%v", err)
+	}
+}
+
+// TestExecCmdWriteToFile_OmitIfEmpty_NonEmpty verifies that OmitIfEmpty does not
+// suppress real output: a crashed container with previous logs is still written.
+func TestExecCmdWriteToFile_OmitIfEmpty_NonEmpty(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "pod.crasher.previous.log")
+
+	common.ExecCmdWriteToFile("[test]", common.Cmd{
+		CmdStr:      "echo panic: goodbye",
+		FilePath:    logPath,
+		OmitIfEmpty: true,
+	})
+
+	got, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("reading output file: %v", err)
+	}
+	if strings.TrimSpace(string(got)) != "panic: goodbye" {
+		t.Fatalf("unexpected content: %q", got)
+	}
+}


### PR DESCRIPTION
### Description

Follow-up to #13233. That PR moved previous-incarnation log collection to a per-container model, but it only emitted a `kubectl logs --previous -c <container>` command for the containers that *themselves* restarted. In a multi-container pod where one container crashed and its siblings stayed healthy, the healthy siblings' previous logs were never collected.

This change makes `calicoctl cluster diags`:

1. **Attempt previous logs for every container in a pod whenever any one container (regular or init) has a prior incarnation** — rather than pre-selecting only the containers whose restart count is non-zero. This no longer relies on the restart-count heuristic to pick the right containers ahead of time, so nothing is missed if a container has a prior incarnation the status fields don't cleanly advertise.
2. **Omit empty/failed results from the bundle.** A never-restarted sibling's `kubectl logs --previous` fails with a short "not found" message. Rather than write that as a cluttered (and misleading) `.previous.log`, a new `OmitIfEmpty` flag on `common.Cmd` suppresses the output file *and* its symlink when the command fails or produces no output. Also suppresses the noisy "Failed to run command" log line for those expected failures.

Net result: the bundle ends up with a `<pod>.<container>.previous.log` for **exactly** the containers that genuinely have previous logs — the crashed container plus any sibling that also has a prior incarnation — with no empty files.

### Changes

- `common.Cmd` gains an `OmitIfEmpty` field; `ExecCmdWriteToFile` skips the file + symlink (and the failure log) when set and the command fails or yields empty output.
- `diagsCmdsForPod` collects previous logs for `allContainerNames(pod)` (regular + init) whenever `podHasPreviousLogs(pod)` is true, with `OmitIfEmpty: true`. `containersWithPreviousLogs` is replaced by `podHasPreviousLogs` + `allContainerNames`.

### Type of change

Enhancement to existing diagnostics behavior.

### Testing

- `go test ./calicoctl/calicoctl/commands/common/... ./calicoctl/calicoctl/commands/cluster/...` passes.
- `common`: new `TestExecCmdWriteToFile_OmitIfEmpty_{Failed,EmptyOutput,NonEmpty}` assert that a failed or empty command writes no file (and no symlink) under `OmitIfEmpty`, while real output is still written.
- `cluster`: `TestDiagsCmdsForPod_Previous` asserts that a one-container-restarted pod emits previous-log commands for **both** the restarted container and its sibling, each `-c`-scoped, none `--all-containers`, and all `OmitIfEmpty`.
- `go vet`, `go build`, and `gofmt` clean.

**Release note:**
```release-note
calicoctl cluster diags now attempts previous-container logs for every container in a pod whenever any container in that pod has restarted, and omits the empty result for containers that have no previous incarnation, so a crashed container's siblings are captured when they have previous logs without cluttering the bundle.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
