### PR TITLE
Enforce IP pool AllowedUses in AssignIP

### DIFF
--- a/cni-plugin/internal/pkg/testutils/utils.go
+++ b/cni-plugin/internal/pkg/testutils/utils.go
@@ -100,6 +100,26 @@ func MustCreateNewIPPoolBlockSize(c client.Interface, cidr string, ipip, natOutg
 	return pool.Name
 }
 
+// MustCreateNewIPPoolAllowedUses creates an enabled Calico IP pool with the given
+// AllowedUses, so tests can exercise IPAM's use-based pool filtering.
+func MustCreateNewIPPoolAllowedUses(c client.Interface, cidr string, allowedUses []api.IPPoolAllowedUse) string {
+	name := strings.ReplaceAll(cidr, ".", "-")
+	name = strings.ReplaceAll(name, ":", "-")
+	name = strings.ReplaceAll(name, "/", "-")
+
+	pool := api.NewIPPool()
+	pool.Name = name
+	pool.Spec.CIDR = cidr
+	pool.Spec.IPIPMode = api.IPIPModeNever
+	pool.Spec.AllowedUses = allowedUses
+
+	_, err := c.IPPools().Create(context.Background(), pool, options.SetOptions{})
+	if err != nil {
+		panic(err)
+	}
+	return pool.Name
+}
+
 func MustDeleteIPPool(c client.Interface, cidr string) {
 	name := strings.ReplaceAll(cidr, ".", "-")
 	name = strings.ReplaceAll(name, ":", "-")

--- a/cni-plugin/pkg/ipamplugin/ipam_plugin.go
+++ b/cni-plugin/pkg/ipamplugin/ipam_plugin.go
@@ -244,6 +244,10 @@ func cmdAdd(args *skel.CmdArgs) error {
 			HandleID: &handleID,
 			Hostname: nodename,
 			Attrs:    attrs,
+			// A specific-IP request (the ipAddrs annotation) is a workload
+			// allocation, same as the auto-assign path below; declare it so
+			// IPAM enforces the pool's AllowedUses.
+			IntendedUse: v3.IPPoolAllowedUseWorkload,
 		}
 
 		// For VMI pods with persistence enabled, limit the IPs per handle so that parallel calls for the same VM don't over-allocate (instead one will fail and then the retry will go through the IP persistence path).

--- a/cni-plugin/tests/calico_cni_ipam_test.go
+++ b/cni-plugin/tests/calico_cni_ipam_test.go
@@ -455,6 +455,17 @@ var _ = Describe("Calico IPAM Tests", func() {
 				Expect(exitCode).Should(BeNumerically(">", 0))
 			})
 		})
+		Context("Pass an IP from a pool that disallows the workload use", func() {
+			It("should reject the assignment", func() {
+				// The ipAddrs path requests IntendedUse: Workload, so an IP that
+				// falls in a pool not marked for workloads must be rejected rather
+				// than silently assigned.
+				testutils.MustCreateNewIPPoolAllowedUses(calicoClient, "10.123.0.0/16",
+					[]apiv3.IPPoolAllowedUse{apiv3.IPPoolAllowedUseTunnel})
+				_, _, exitCode := testutils.RunIPAMPlugin(netconf, "ADD", "IP=10.123.0.5", cid, cniVersion)
+				Expect(exitCode).Should(BeNumerically(">", 0))
+			})
+		})
 	})
 
 	Describe("Run IPAM DEL", func() {

--- a/design/ipam/ipam-cni.md
+++ b/design/ipam/ipam-cni.md
@@ -78,7 +78,7 @@ annotations are read as defaults; per-pod annotations override.
 
 | Annotation | What it does |
 |---|---|
-| `cni.projectcalico.org/ipAddrs` | JSON array of IPs. Each IP allocated via `AssignIP` - goes through IPAM, tracked normally. |
+| `cni.projectcalico.org/ipAddrs` | JSON array of IPs. Each IP allocated via `AssignIP` with `IntendedUse: Workload` - goes through IPAM, tracked normally, and the containing pool's `allowedUses` is enforced (an IP from a non-workload pool is rejected). |
 | `cni.projectcalico.org/ipAddrsNoIpam` | JSON array of IPs. **Bypasses IPAM entirely**, no allocation record. Requires `feature_control.ip_addrs_no_ipam=true`. |
 | `cni.projectcalico.org/ipv4pools`, `ipv6pools` | Pool names or CIDRs scoping the allocation. Feeds `utils.ResolvePools` ahead of the conf default. |
 | `cni.projectcalico.org/ipFamilies` | `["IPv4","IPv6"]` - controls which families to assign. |

--- a/design/ipam/ipam-core-library.md
+++ b/design/ipam/ipam-core-library.md
@@ -19,6 +19,7 @@ The library's contract is `Interface` in [`interface.go`](../../libcalico-go/lib
 here. A few methods carry design-relevant constraints worth calling out:
 
 - **`AutoAssign`** returns block-masked CIDRs, not `/32` (or `/128`). Callers narrow at the boundary. This is load-bearing for the CNI plugin's per-block route programming.
+- **`AssignIP`** enforces the target pool's `allowedUses` when `AssignIPArgs.IntendedUse` is non-empty: it fails if the pool containing the requested IP does not permit that use, mirroring the `filterPoolsByUse` filter `AutoAssign` applies. Callers that leave `IntendedUse` empty are exempt (back-compat). This closes a gap where a specific-IP request (e.g. the CNI `ipAddrs` annotation) could draw from a pool not sanctioned for its use.
 - **`ReleaseIPs`** takes `ReleaseOptions` with a sequence number; every release path must plumb it through (see [CAS retry and sequence numbers](#cas-retry-and-sequence-numbers)).
 - **`SetOwnerAttributes`** is KubeVirt-only and swaps owner attributes under preconditions, without releasing and re-allocating. Felix's live-migration monitor is the only non-CNI
   caller.

--- a/libcalico-go/lib/ipam/ipam.go
+++ b/libcalico-go/lib/ipam/ipam.go
@@ -982,6 +982,17 @@ func (c ipamClient) AssignIP(ctx context.Context, args AssignIPArgs) error {
 		return errors.New("The provided IP address is not in a configured pool\n")
 	}
 
+	// Enforce the pool's AllowedUses against the caller's intended use, mirroring
+	// what the auto-assign path already does via filterPoolsByUse.  AutoAssign
+	// filters candidate pools by use, but AssignIP historically skipped the check,
+	// so a specific-IP request (e.g. the CNI ipAddrs annotation) could draw from a
+	// pool not sanctioned for that use.  Only enforce when the caller declares a
+	// use; callers that leave IntendedUse empty are unaffected.
+	if args.IntendedUse != "" && !slices.Contains(pool.Spec.AllowedUses, args.IntendedUse) {
+		return fmt.Errorf("IP address %s is in IP pool %q, which is not allowed for use %q (allowedUses: %v)",
+			args.IP, pool.Name, args.IntendedUse, pool.Spec.AllowedUses)
+	}
+
 	cfg, err := c.GetIPAMConfig(ctx)
 	if err != nil {
 		log.Errorf("Error getting IPAM Config: %v", err)

--- a/libcalico-go/lib/ipam/ipam_test.go
+++ b/libcalico-go/lib/ipam/ipam_test.go
@@ -718,6 +718,59 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 		})
 	})
 
+	Describe("AssignIP AllowedUses enforcement", func() {
+		var hostname string
+
+		BeforeEach(func() {
+			Expect(bc.Clean()).To(Succeed())
+			ipPools.Pools = map[string]ipamtestutils.Pool{
+				// Workload-only pool: does not permit Tunnel.
+				"10.0.0.0/24": {Enabled: true, AllowedUses: []v3.IPPoolAllowedUse{v3.IPPoolAllowedUseWorkload}},
+				// Default pool: empty AllowedUses defaults to [Workload, Tunnel].
+				"20.0.0.0/24": {Enabled: true},
+			}
+			hostname = "assignip-alloweduses"
+			applyNode(bc, kc, hostname, nil)
+		})
+
+		AfterEach(func() {
+			deleteNode(bc, kc, hostname)
+			ipPools.Pools = map[string]ipamtestutils.Pool{}
+			Expect(bc.Clean()).To(Succeed())
+		})
+
+		assign := func(ip string, use v3.IPPoolAllowedUse) error {
+			return ic.AssignIP(context.Background(), AssignIPArgs{
+				IP:          cnet.IP{IP: net.ParseIP(ip)},
+				Hostname:    hostname,
+				IntendedUse: use,
+			})
+		}
+
+		It("should reject an IP whose pool does not allow the intended use", func() {
+			// Pool permits only Workload, so a Tunnel request must fail rather than
+			// silently drawing from a pool not sanctioned for that use.
+			err := assign("10.0.0.1", v3.IPPoolAllowedUseTunnel)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("not allowed for use"))
+		})
+
+		It("should allow an IP whose pool permits the intended use", func() {
+			Expect(assign("10.0.0.2", v3.IPPoolAllowedUseWorkload)).To(Succeed())
+		})
+
+		It("should allow any use when IntendedUse is unset (back-compat)", func() {
+			// Historical callers leave IntendedUse empty; they must be unaffected.
+			Expect(assign("10.0.0.3", "")).To(Succeed())
+		})
+
+		It("should allow Tunnel from a default pool (empty AllowedUses defaults to Workload+Tunnel)", func() {
+			// Guards node tunnel-IP assignment, which draws from the default pool
+			// with IntendedUse: Tunnel, against regression.
+			Expect(assign("20.0.0.1", v3.IPPoolAllowedUseTunnel)).To(Succeed())
+		})
+	})
+
 	Describe("Reservation tests", func() {
 		var hostname string
 		BeforeEach(func() {

--- a/libcalico-go/lib/ipam/ipam_types.go
+++ b/libcalico-go/lib/ipam/ipam_types.go
@@ -55,7 +55,9 @@ type AssignIPArgs struct {
 	// If specified, the attributes of reserved IPv4 addresses in the block.
 	HostReservedAttr *HostReservedAttr
 
-	// The intended use for the IP address.  Used to determine the affinityType of the host.
+	// The intended use for the IP address.  Determines the affinityType of the
+	// host and, when non-empty, is enforced against the containing pool's
+	// AllowedUses (the assignment fails if the pool does not allow this use).
 	IntendedUse v3.IPPoolAllowedUse
 
 	// MaxAllocToHandlePerIPVersion specifies the maximum number of IPs per IP version (IPv4/IPv6)


### PR DESCRIPTION
`AutoAssign` filters candidate pools by their `AllowedUses`, but `AssignIP` skipped the check. A specific-IP request — e.g. the CNI `cni.projectcalico.org/ipAddrs` annotation — went through `AssignIP` and could draw from a pool not sanctioned for that use.

This enforces the containing pool's `AllowedUses` in `AssignIP` when the caller sets a non-empty `IntendedUse`, reusing the same predicate as the auto-assign path (`filterPoolsByUse`). Callers that leave `IntendedUse` empty are unaffected. The CNI `ipAddrs` path now declares `IntendedUse: Workload`, matching the auto-assign path, so a specific-IP request is held to the same rule as an auto-assigned one.

Behaviour change: an `ipAddrs` request that points at a pool whose `allowedUses` excludes `Workload` (e.g. a `Tunnel`- or `LoadBalancer`-only pool) now fails with a clear error instead of silently allocating from it. The `Tunnel` (node tunnel IP) and `LoadBalancer` callers are unaffected in practice — their pools already permit those uses, and the check only makes `AssignIP` as strict as `AutoAssign` already is.

Tests: unit tests in `libcalico-go` cover `AssignIP` rejecting a mismatched use, allowing a permitted use, ignoring an empty use, and still allowing `Tunnel` from a default pool; a CNI IPAM test covers an `ipAddrs` IP from a non-workload pool being rejected.

**Release note:**
```release-note
The `cni.projectcalico.org/ipAddrs` annotation (and any AssignIP caller that sets an intended use) now honours the target IP pool's `allowedUses`: requesting an IP from a pool that does not permit workload use fails instead of allocating from it.
```