### PR TITLE
Add descriptions and examples to calicoctl command help

### DIFF
--- a/calicoctl/calicoctl/commands/cluster_command.go
+++ b/calicoctl/calicoctl/commands/cluster_command.go
@@ -24,6 +24,7 @@ func newClusterCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "cluster",
 		Short: "Access cluster information",
+		Long:  `Access cluster-wide Calico information.`,
 	}
 	cmd.AddCommand(newClusterDiagsCommand())
 	return cmd
@@ -33,6 +34,10 @@ func newClusterDiagsCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "diags",
 		Short: "Collect snapshot of diagnostic info and logs related to Calico at the cluster-level",
+		Long: `Collect a snapshot of cluster-wide Calico diagnostics and logs. Unlike node
+diags, which runs on a single host, this gathers information across the
+cluster.`,
+		Example: `  calicoctl cluster diags`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			config, _ := cmd.Flags().GetString("config")
 			since, _ := cmd.Flags().GetString("since")

--- a/calicoctl/calicoctl/commands/command.go
+++ b/calicoctl/calicoctl/commands/command.go
@@ -115,6 +115,12 @@ node instance.`,
 	versionCmd := &cobra.Command{
 		Use:   "version",
 		Short: "Display the version of this binary",
+		Long:  `Display version information for calicoctl, and for the cluster when it can be reached.`,
+		Example: `  # Show client and cluster versions.
+  calicoctl version
+
+  # Show only the client version.
+  calicoctl version --client`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			config, _ := cmd.Flags().GetString("config")
 			poll, _ := cmd.Flags().GetString("poll")

--- a/calicoctl/calicoctl/commands/crud_commands.go
+++ b/calicoctl/calicoctl/commands/crud_commands.go
@@ -39,6 +39,14 @@ func newCreateCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "Create a resource by file, directory or stdin",
+		Long: `Create one or more Calico resources from a file, directory, or stdin, in YAML
+or JSON format. Use create when you want the command to fail if a resource
+already exists; use apply if you'd rather create-or-update.`,
+		Example: `  # Create resources from a file.
+  calicoctl create -f ./policy.yaml
+
+  # Create resources from stdin.
+  cat policy.json | calicoctl create -f -`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			parsedArgs := argsFromCRUDFlags(cmd, args)
 			parsedArgs["--skip-exists"], _ = cmd.Flags().GetBool("skip-exists")
@@ -54,6 +62,15 @@ func newApplyCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "apply",
 		Short: "Apply a resource by file, directory or stdin",
+		Long: `Create or update one or more Calico resources from a file, directory, or stdin,
+in YAML or JSON format. Apply adds resources that don't exist yet and updates
+those that do, so it's the right choice when you don't care whether the resource
+is already present.`,
+		Example: `  # Apply resources from a file.
+  calicoctl apply -f ./policy.yaml
+
+  # Apply resources from stdin.
+  cat policy.json | calicoctl apply -f -`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			parsedArgs := argsFromCRUDFlags(cmd, args)
 			return createOrApplyOrValidate(parsedArgs, "apply")
@@ -67,6 +84,11 @@ func newReplaceCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "replace",
 		Short: "Replace a resource by file, directory or stdin",
+		Long: `Replace one or more existing Calico resources from a file, directory, or stdin,
+in YAML or JSON format. Replace fails if a resource doesn't already exist; use
+apply if you want it created in that case.`,
+		Example: `  # Replace resources from a file.
+  calicoctl replace -f ./policy.yaml`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			parsedArgs := argsFromCRUDFlags(cmd, args)
 			results := common.ExecuteConfigCommand(parsedArgs, common.ActionUpdate)
@@ -81,6 +103,12 @@ func newValidateCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "validate",
 		Short: "Validate a resource by file, directory or stdin without applying it",
+		Long: `Validate one or more Calico resources from a file, directory, or stdin without
+applying them. Validation runs entirely offline - checking syntax, structure,
+and schema without touching the datastore - so it's useful for catching errors
+before you apply resources to a cluster.`,
+		Example: `  # Validate resources in a file.
+  calicoctl validate -f ./policy.yaml`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			parsedArgs := argsFromCRUDFlags(cmd, args)
 			return createOrApplyOrValidate(parsedArgs, "validate")
@@ -192,6 +220,14 @@ func newDeleteCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "delete [KIND [NAME...]]",
 		Short: "Delete a resource by file, directory, stdin, or type and name",
+		Long: `Delete one or more Calico resources, either by type and name or from a file,
+directory, or stdin. Deleting a resource that doesn't exist is treated as an
+error unless --skip-not-exists is set.`,
+		Example: `  # Delete specific policies by name.
+  calicoctl delete networkpolicy foo bar
+
+  # Delete the resources described in a file.
+  calicoctl delete -f ./policy.yaml`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			parsedArgs := argsFromCRUDFlags(cmd, args)
 			parsedArgs["--skip-not-exists"], _ = cmd.Flags().GetBool("skip-not-exists")
@@ -240,7 +276,11 @@ func newPatchCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "patch KIND NAME",
 		Short: "Patch a pre-existing resource in place",
-		Args:  cobra.ExactArgs(2),
+		Long: `Patch a single existing Calico resource in place. Use patch to change specific
+fields without supplying the whole resource, as you'd have to with replace.`,
+		Example: `  # Set a route reflector cluster ID on a node.
+  calicoctl patch node node-0 --patch '{"spec":{"bgp":{"routeReflectorClusterID":"224.0.0.1"}}}'`,
+		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			parsedArgs := argsFromCRUDFlags(cmd, args)
 			parsedArgs["--patch"], _ = cmd.Flags().GetString("patch")

--- a/calicoctl/calicoctl/commands/datastore_command.go
+++ b/calicoctl/calicoctl/commands/datastore_command.go
@@ -24,6 +24,8 @@ func newDatastoreCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "datastore",
 		Short: "Calico datastore management",
+		Long: `Manage the Calico datastore, including migrating data between datastore types
+and rewriting legacy policy names.`,
 	}
 	cmd.AddCommand(newMigrateCommand())
 	cmd.AddCommand(newMigratePolicyNamesCommand())
@@ -34,6 +36,10 @@ func newMigratePolicyNamesCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "migrate-policy-names",
 		Short: "Rewrite pre-v3.32 policy names in an etcdv3 datastore to drop the legacy \"default.\" tier prefix",
+		Long: `Rewrite pre-v3.32 policy names in an etcdv3 datastore to drop the legacy
+"default." tier prefix. Run this once when upgrading an etcdv3-backed cluster
+past v3.32 so existing policy names match the current naming scheme.`,
+		Example: `  calicoctl datastore migrate-policy-names`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			config, _ := cmd.Flags().GetString("config")
 			allowMismatch, _ := cmd.Flags().GetBool("allow-version-mismatch")
@@ -48,6 +54,9 @@ func newMigrateCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "migrate",
 		Short: "Migrate the contents of an etcdv3 datastore to a Kubernetes datastore",
+		Long: `Migrate the contents of an etcdv3 datastore to a Kubernetes datastore. The
+subcommands lock the datastore, export its contents to YAML, import them into
+Kubernetes, and unlock when done.`,
 	}
 	cmd.AddCommand(
 		newMigrateExportCommand(),
@@ -62,6 +71,10 @@ func newMigrateExportCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "export",
 		Short: "Export the contents of the etcdv3 datastore to yaml",
+		Long: `Export the contents of an etcdv3 datastore to YAML. This is the first step in
+migrating to a Kubernetes datastore; feed the output into datastore migrate
+import.`,
+		Example: `  calicoctl datastore migrate export > datastore.yaml`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			config, _ := cmd.Flags().GetString("config")
 			allowMismatch, _ := cmd.Flags().GetBool("allow-version-mismatch")
@@ -76,6 +89,10 @@ func newMigrateImportCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "import",
 		Short: "Store and convert yaml of resources into the Kubernetes datastore",
+		Long: `Import resources from a YAML export into a Kubernetes datastore. Takes the
+output of datastore migrate export and loads it into the Kubernetes-backed
+datastore.`,
+		Example: `  calicoctl datastore migrate import -f datastore.yaml`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			config, _ := cmd.Flags().GetString("config")
 			filename, _ := cmd.Flags().GetString("filename")
@@ -91,6 +108,9 @@ func newMigrateLockCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "lock",
 		Short: "Lock the datastore to prevent changes during migration",
+		Long: `Lock the datastore to prevent changes during a migration. Run this before
+exporting so nothing changes while the migration is in progress.`,
+		Example: `  calicoctl datastore migrate lock`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			config, _ := cmd.Flags().GetString("config")
 			allowMismatch, _ := cmd.Flags().GetBool("allow-version-mismatch")
@@ -103,8 +123,10 @@ func newMigrateLockCommand() *cobra.Command {
 
 func newMigrateUnlockCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "unlock",
-		Short: "Unlock the datastore to allow changes after migration",
+		Use:     "unlock",
+		Short:   "Unlock the datastore to allow changes after migration",
+		Long:    `Unlock the datastore to allow changes again once a migration is complete.`,
+		Example: `  calicoctl datastore migrate unlock`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			config, _ := cmd.Flags().GetString("config")
 			allowMismatch, _ := cmd.Flags().GetBool("allow-version-mismatch")

--- a/calicoctl/calicoctl/commands/datastore_command.go
+++ b/calicoctl/calicoctl/commands/datastore_command.go
@@ -33,7 +33,7 @@ func newDatastoreCommand() *cobra.Command {
 func newMigratePolicyNamesCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "migrate-policy-names",
-		Short: "Rewrite pre-v3.32 policy names in an etcdv3 datastore to drop the tier prefix",
+		Short: "Rewrite pre-v3.32 policy names in an etcdv3 datastore to drop the legacy \"default.\" tier prefix",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			config, _ := cmd.Flags().GetString("config")
 			allowMismatch, _ := cmd.Flags().GetBool("allow-version-mismatch")

--- a/calicoctl/calicoctl/commands/get_command.go
+++ b/calicoctl/calicoctl/commands/get_command.go
@@ -30,6 +30,15 @@ func newGetCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "get [KIND [NAME...]]",
 		Short: "Get a resource by file, directory, stdin, or type and name",
+		Long: `Get one or more Calico resources - all resources of a type, specific ones by
+name, or those described in a file. Output can be a table (the default), YAML,
+JSON, or a custom template; the YAML and JSON output can be fed back into apply
+or replace.`,
+		Example: `  # List all network policies.
+  calicoctl get networkpolicy
+
+  # Get specific policies as YAML.
+  calicoctl get networkpolicy my-policy-1 my-policy-2 -o yaml`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			parsedArgs := argsFromCRUDFlags(cmd, args)
 

--- a/calicoctl/calicoctl/commands/ipam_command.go
+++ b/calicoctl/calicoctl/commands/ipam_command.go
@@ -38,6 +38,9 @@ func newIPAMCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "ipam",
 		Short: "IP address management",
+		Long: `Inspect and manage how Calico allocates IP addresses. These commands check
+datastore integrity, release addresses, show usage, and tune IPAM
+configuration.`,
 	}
 	cmd.AddCommand(
 		newIPAMCheckCommand(),
@@ -53,6 +56,11 @@ func newIPAMCheckCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "check",
 		Short: "Check the integrity of the IPAM datastructures",
+		Long: `Check the integrity of Calico's IPAM data structures and report leaked or
+improperly allocated IP addresses. The report it produces can later be passed
+to ipam release.`,
+		Example: `  # Check IPAM and write a report of problem IPs.
+  calicoctl ipam check --show-problem-ips -o report.json`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			config, _ := cmd.Flags().GetString("config")
 			showAllIPs, _ := cmd.Flags().GetBool("show-all-ips")
@@ -112,6 +120,14 @@ func newIPAMReleaseCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "release",
 		Short: "Release a Calico assigned IP address",
+		Long: `Release one or more Calico-assigned IP addresses. Release a single address
+with --ip, or release the leaked addresses identified in a report from ipam
+check.`,
+		Example: `  # Release a single IP.
+  calicoctl ipam release --ip 10.0.0.1
+
+  # Release leaked IPs from a check report.
+  calicoctl ipam release --from-report report.json`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			config, _ := cmd.Flags().GetString("config")
 			ip, _ := cmd.Flags().GetString("ip")
@@ -174,6 +190,14 @@ func newIPAMShowCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "show",
 		Short: "Show details of a Calico assigned IP address or overall IP usage",
+		Long: `Show details of Calico IP address usage. With no flags it summarizes pool
+usage; the flags drill into a specific address, individual blocks, borrowed
+addresses, or the current IPAM configuration.`,
+		Example: `  # Summarize IP pool usage.
+  calicoctl ipam show
+
+  # Check whether a specific IP is in use.
+  calicoctl ipam show --ip 10.0.0.1`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			config, _ := cmd.Flags().GetString("config")
 			ip, _ := cmd.Flags().GetString("ip")
@@ -222,7 +246,11 @@ func newIPAMSplitCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "split NUMBER",
 		Short: "Split an IP pool into the specified number of smaller IP pools",
-		Args:  cobra.ExactArgs(1),
+		Long: `Split an IP pool into the given number of smaller pools of equal size. Useful
+for carving a large pool into per-zone or per-node pools.`,
+		Example: `  # Split a pool into 4 smaller pools.
+  calicoctl ipam split 4 --name my-pool`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			config, _ := cmd.Flags().GetString("config")
 			cidr, _ := cmd.Flags().GetString("cidr")
@@ -251,6 +279,10 @@ func newIPAMConfigureCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "configure",
 		Short: "Configure IPAM",
+		Long: `Configure cluster-wide Calico IPAM settings, such as strict affinity and the
+maximum number of blocks per host.`,
+		Example: `  # Require strict affinity (disable IP borrowing).
+  calicoctl ipam configure --strictaffinity=true`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			config, _ := cmd.Flags().GetString("config")
 			strictAffinity, _ := cmd.Flags().GetString("strictaffinity")

--- a/calicoctl/calicoctl/commands/label_command.go
+++ b/calicoctl/calicoctl/commands/label_command.go
@@ -30,7 +30,18 @@ func newLabelCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "label KIND NAME [key=value | key]",
 		Short: "Add or update labels of resources",
-		Args:  cobra.MinimumNArgs(3),
+		Long: `Add, update, or remove labels on an existing Calico resource. Set a label with
+key=value (add --overwrite to replace an existing value), or remove one by
+passing the key with --remove.`,
+		Example: `  # Add a label to a node.
+  calicoctl label nodes node1 cluster=frontend
+
+  # Overwrite an existing label value.
+  calicoctl label nodes node1 cluster=backend --overwrite
+
+  # Remove a label.
+  calicoctl label nodes node1 cluster --remove`,
+		Args: cobra.MinimumNArgs(3),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			overwrite, _ := cmd.Flags().GetBool("overwrite")
 			remove, _ := cmd.Flags().GetBool("remove")

--- a/calicoctl/calicoctl/commands/node_command_darwin.go
+++ b/calicoctl/calicoctl/commands/node_command_darwin.go
@@ -24,6 +24,9 @@ func newNodeCommand() *cobra.Command {
 	return &cobra.Command{
 		Use:   "node",
 		Short: "Calico node management",
+		Long: `Manage a Calico node instance. These commands run directly on the compute host
+where the node is running, and cover starting the node, checking its status,
+and gathering diagnostics.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("'calicoctl node' commands are not available on this OS")
 		},

--- a/calicoctl/calicoctl/commands/node_command_linux.go
+++ b/calicoctl/calicoctl/commands/node_command_linux.go
@@ -24,6 +24,9 @@ func newNodeCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "node",
 		Short: "Calico node management",
+		Long: `Manage a Calico node instance. These commands run directly on the compute host
+where the node is running, and cover starting the node, checking its status,
+and gathering diagnostics.`,
 	}
 	cmd.AddCommand(
 		newNodeStatusCommand(),
@@ -38,6 +41,9 @@ func newNodeStatusCommand() *cobra.Command {
 	return &cobra.Command{
 		Use:   "status",
 		Short: "View the current status of a Calico node",
+		Long: `Show the current status of the Calico node on this host, including uptime and
+BGP peering states. Must be run on the node whose status you want.`,
+		Example: `  calicoctl node status`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return node.Status()
 		},
@@ -48,6 +54,10 @@ func newNodeDiagsCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "diags",
 		Short: "Gather a diagnostics bundle for a Calico node",
+		Long: `Gather a diagnostics bundle from the Calico node on this host. Run it on the
+affected node when troubleshooting a networking problem; it collects logs and
+system information useful for diagnosis.`,
+		Example: `  calicoctl node diags`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			logDir, _ := cmd.Flags().GetString("log-dir")
 			return node.Diags(logDir)
@@ -59,8 +69,10 @@ func newNodeDiagsCommand() *cobra.Command {
 
 func newNodeChecksystemCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "checksystem",
-		Short: "Verify the compute host is able to run a Calico node instance",
+		Use:     "checksystem",
+		Short:   "Verify the compute host is able to run a Calico node instance",
+		Long:    `Verify that this host meets the system requirements to run a Calico node instance.`,
+		Example: `  calicoctl node checksystem`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			kernelConfig, _ := cmd.Flags().GetString("kernel-config")
 			return node.Checksystem(kernelConfig)
@@ -74,6 +86,11 @@ func newNodeRunCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "run",
 		Short: "Run the Calico node container image",
+		Long: `Start the Calico node container on this host. Runs the calico/node image with
+the supplied networking options; most options mirror fields on the node
+resource and are autodetected when omitted.`,
+		Example: `  # Start calico/node, autodetecting the IPv4 address.
+  calicoctl node run --ip autodetect --ip-autodetection-method can-reach=8.8.8.8`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c := node.RunConfig{}
 			c.IP, _ = cmd.Flags().GetString("ip")

--- a/calicoctl/calicoctl/commands/node_command_windows.go
+++ b/calicoctl/calicoctl/commands/node_command_windows.go
@@ -24,6 +24,9 @@ func newNodeCommand() *cobra.Command {
 	return &cobra.Command{
 		Use:   "node",
 		Short: "Calico node management",
+		Long: `Manage a Calico node instance. These commands run directly on the compute host
+where the node is running, and cover starting the node, checking its status,
+and gathering diagnostics.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("'calicoctl node' commands are not available on this OS")
 		},


### PR DESCRIPTION
The docopt to cobra migration (#12624) dropped the descriptions calicoctl used to print for each command. This adds them back for cobra: every command's `--help` now shows a short description of what it does and when you'd use it, and the leaf commands include usage examples. The descriptions are deliberately shorter than the old docopt text - purpose first, not a wall of prose.

This is cobra-only, so it doesn't apply to release-v3.32 where calicoctl still uses docopt.

It also clarifies the `migrate-policy-names` one-line summary, which said it drops "the tier prefix" but only rewrites default-tier policy names. It now names the legacy "default." prefix specifically. That wording fix goes to release-v3.32 separately (#13303).

Companion docs update: tigera/docs#2878.

```release-note
None
```
