### PR TITLE
Clarify calicoctl datastore migrate-policy-names help text (release-v3.32)

### DIFF
--- a/calicoctl/calicoctl/commands/datastore.go
+++ b/calicoctl/calicoctl/commands/datastore.go
@@ -33,7 +33,7 @@ func Datastore(args []string) error {
   <BINARY_NAME> datastore <command> [<args>...]
 
     migrate               Migrate the contents of an etcdv3 datastore to a Kubernetes datastore.
-    migrate-policy-names  Rewrite pre-v3.32 policy names in an etcdv3 datastore to drop the tier prefix.
+    migrate-policy-names  Rewrite pre-v3.32 policy names in an etcdv3 datastore to drop the legacy "default." tier prefix.
 
 Options:
   -h --help      Show this screen.


### PR DESCRIPTION
release-v3.32 equivalent of #13302.

The `migrate-policy-names` one-line help said it drops "the tier prefix", but the command only rewrites default-tier policy names. Updated the summary to name the legacy "default." prefix specifically, matching the fuller description the subcommand already prints.

This is a separate change from #13302 rather than an auto-pick, because calicoctl still uses docopt on this branch (docopt was removed on master in #12624), so the wording lives in a different place here.

Companion docs update: tigera/docs#2877.

```release-note
None
```
