### PR TITLE
Add weekly Calico/OpenStack e2e runs on ArgoCI (CORE-13115)

### DIFF
--- a/.argoci/README.md
+++ b/.argoci/README.md
@@ -14,7 +14,10 @@ migrated off Semaphore's scheduled e2e builds.
   corresponding `.semaphore/end-to-end/pipelines/*.yml` (same jobs, same
   schedule). `cc-argoci-handler` expands each into a full CronWorkflow (checkout,
   secret loading, node placement, dind, exit handler, notifications, labels,
-  metrics), picked up automatically on merge to the default branch.
+  metrics), picked up automatically on merge to the default branch. The one
+  exception to the mirroring is `cron/e2e-openstack.yaml` (the weekly
+  Calico-for-OpenStack e2e tests), which is new here rather than migrated
+  from one of this repo's Semaphore pipelines.
 
 These crons and scripts are maintained **by hand** going forward: edit the
 YAML (or the scripts) directly to change a suite's jobs, env, or schedule.

--- a/.argoci/cron/e2e-openstack.yaml
+++ b/.argoci/cron/e2e-openstack.yaml
@@ -29,12 +29,10 @@ globalPrologue: |
   export INSTALLER="${INSTALLER:-packaged}"
   export PROVISIONER="${PROVISIONER:-gcp-openstack}"
 
-  # TEMPORARY (pre-merge cron-ci testing): run only the smoke subset while
-  # shaking out the ArgoCI wiring.  Revert to full-fv — the whole pytest
-  # suite, within which the multi-region tests self-activate on the jobs
-  # whose cluster has a second region (see MULTI_REGION below) — before
-  # merging.
-  export OPENSTACK_TEST_SPEC="${OPENSTACK_TEST_SPEC:-smoke}"
+  # Run the whole pytest suite (banzai's default selects only the smoke
+  # subset).  The multi-region tests within it self-activate on the jobs
+  # whose cluster has a second region — see MULTI_REGION below.
+  export OPENSTACK_TEST_SPEC="${OPENSTACK_TEST_SPEC:-full-fv}"
   source .argoci/scripts/global_prologue.sh
 globalEpilogue: |
   source "${CI_HOME}/${CI_GIT_DIR}/.argoci/scripts/global_epilogue.sh"

--- a/.argoci/cron/e2e-openstack.yaml
+++ b/.argoci/cron/e2e-openstack.yaml
@@ -29,10 +29,12 @@ globalPrologue: |
   export INSTALLER="${INSTALLER:-packaged}"
   export PROVISIONER="${PROVISIONER:-gcp-openstack}"
 
-  # Run the whole pytest suite (banzai's default selects only the smoke
-  # subset).  The multi-region tests within it self-activate on the jobs
-  # whose cluster has a second region — see MULTI_REGION below.
-  export OPENSTACK_TEST_SPEC="${OPENSTACK_TEST_SPEC:-full-fv}"
+  # TEMPORARY (pre-merge cron-ci testing): run only the smoke subset while
+  # shaking out the ArgoCI wiring.  Revert to full-fv — the whole pytest
+  # suite, within which the multi-region tests self-activate on the jobs
+  # whose cluster has a second region (see MULTI_REGION below) — before
+  # merging.
+  export OPENSTACK_TEST_SPEC="${OPENSTACK_TEST_SPEC:-smoke}"
   source .argoci/scripts/global_prologue.sh
 globalEpilogue: |
   source "${CI_HOME}/${CI_GIT_DIR}/.argoci/scripts/global_epilogue.sh"

--- a/.argoci/cron/e2e-openstack.yaml
+++ b/.argoci/cron/e2e-openstack.yaml
@@ -1,0 +1,83 @@
+# Condensed ArgoCI e2e workflow; cc-argoci-handler expands it into a CronWorkflow at runtime.
+# Weekly Calico-for-OpenStack e2e tests (CORE-13115), maintained here by hand.
+#
+# Deployment is pure Banzai: the gcp-openstack provisioner stands up an
+# OpenStack (Caracal) cluster on GCE VMs and the packaged installer layers
+# Calico onto it.  banzai-core's defaults for this provisioner/installer pair
+# cover everything OpenStack-specific: GCP placement (europe-west3-c in the
+# openstack-calico-test VPC), Calico packages from ppa:project-calico/master,
+# calico/{ctl,node}:master images, and the test image
+# (gcr.io/unique-caldron-775/openstack-e2e:stable, built from
+# tigera/calico-test — the only remaining use of that repo's coding).
+# Release branches will need INSTALL_SOURCE / CALICOCTL_IMAGE /
+# CALICO_NODE_IMAGE overrides here once we publish packages and images from
+# release branches.
+#
+# Four jobs: {full-fv, multi-region} x {Ubuntu 24.04 Noble, 22.04 Jammy}.
+# There is no separate smoke job: smoke (a single mainline connectivity test)
+# is a strict subset of full-fv, so adds nothing on a weekly cadence.
+version: condensed
+generateName: e2e-openstack-
+# Sundays 17:00 UTC (the handler emits no CronWorkflow timezone, so cron
+# fields are UTC).
+schedule: 0 17 * * 0
+globalPrologue: |
+  cd "${CI_HOME}/${CI_GIT_DIR}"
+  export ARGO_WORKFLOW_NAME="{{workflow.name}}"
+  export ARGO_WORKFLOW_UID="{{workflow.uid}}"
+  export FUNCTIONAL_AREA="${FUNCTIONAL_AREA:-openstack}"
+  export INSTALLER="${INSTALLER:-packaged}"
+  export PROVISIONER="${PROVISIONER:-gcp-openstack}"
+
+  # Run the whole pytest suite (banzai's default selects only the smoke
+  # subset).  The multi-region tests within it self-activate on the jobs
+  # whose cluster has a second region — see MULTI_REGION below.
+  export OPENSTACK_TEST_SPEC="${OPENSTACK_TEST_SPEC:-full-fv}"
+  source .argoci/scripts/global_prologue.sh
+globalEpilogue: |
+  source "${CI_HOME}/${CI_GIT_DIR}/.argoci/scripts/global_epilogue.sh"
+defaults:
+  secretBundles:
+    - banzai-secrets
+steps:
+  # CLUSTER_IMAGE: empty selects the provisioner's default Ubuntu 24.04 Noble
+  # image (see banzai-core provisioners/gcp-openstack/terraform/variables.tf);
+  # the family reference below tracks the latest 22.04 Jammy image.  Both
+  # series run OpenStack Caracal — natively on Noble, via the Ubuntu Cloud
+  # Archive on Jammy (the install scripts pick this up from the OS codename
+  # automatically).
+  - name: full-fv
+    services:
+      - docker
+    matrix:
+      - name: caranoble
+        env:
+          - name: CLUSTER_IMAGE
+            value: ""
+      - name: carajammy
+        env:
+          - name: CLUSTER_IMAGE
+            value: projects/ubuntu-os-cloud/global/images/family/ubuntu-2204-lts
+    commands: |
+      .argoci/scripts/body_standard.sh
+
+  # As above, plus a second OpenStack region (one more controller + compute);
+  # the full-fv suite's multi-region tests activate when the rendered test
+  # config shows two regions.
+  - name: multi-region
+    services:
+      - docker
+    env:
+      - name: MULTI_REGION
+        value: "true"
+    matrix:
+      - name: caranoble
+        env:
+          - name: CLUSTER_IMAGE
+            value: ""
+      - name: carajammy
+        env:
+          - name: CLUSTER_IMAGE
+            value: projects/ubuntu-os-cloud/global/images/family/ubuntu-2204-lts
+    commands: |
+      .argoci/scripts/body_standard.sh

--- a/.argoci/scripts/global_epilogue.sh
+++ b/.argoci/scripts/global_epilogue.sh
@@ -25,6 +25,20 @@ if [[ "${CI_EXIT_CODE}" != "0" || "${TEST_TYPE}" == "ocp-cert" ]]; then
   echo "[INFO] capturing diags"
   bz diags |& tee "${BZ_LOGS_DIR}/diagnostic.log" || true
   gsutil cp "${BZ_LOCAL_DIR}/${DIAGS_ARCHIVE_FILENAME}" "${ARTIFACT_DEST}/diags.tgz" || true
+
+  # Per-test diags, where the suite collects them (openstack-e2e does, into
+  # ${REPORT_DIR}/diags/) — distinct from the bz cluster diags above.
+  if [[ -d "${REPORT_DIR}/diags" ]]; then
+    gsutil -m cp -r "${REPORT_DIR}/diags" "${ARTIFACT_DEST}/" || true
+  fi
+fi
+
+# Suites that emit a tree of JUnit files rather than a single junit.xml (e.g.
+# openstack-e2e writes one xmlrunner file per test class under results/) get
+# them merged into ${REPORT_DIR}/junit.xml, so the publish below uploads one
+# test report that the ArgoCI viewer renders with collapsible suites.
+if [[ ! -f "${REPORT_DIR}/junit.xml" && -d "${REPORT_DIR}" ]]; then
+  python3 "$(dirname "${BASH_SOURCE[0]}")/merge_junit.py" "${REPORT_DIR}" "${REPORT_DIR}/junit.xml" || true
 fi
 
 # Publish JUnit + logs.

--- a/.argoci/scripts/global_prologue.sh
+++ b/.argoci/scripts/global_prologue.sh
@@ -91,15 +91,31 @@ export USER="${USER:-argoci}"
 export PROVISIONER=${PROVISIONER:-gcp-kubeadm}
 export INSTALLER=${INSTALLER:-"manual"}
 export DATAPLANE=${DATAPLANE:-CalicoIptables}
-export TEST_TYPE=${TEST_TYPE:-k8s-e2e}
+
+# Mirror banzai-core's TEST_TYPE defaulting: gcp-openstack profiles run the
+# OpenStack e2e tests via `bz tests`; everything else runs k8s-e2e.
+# run_tests.sh and REPORT_DIR below both key off this.
+if [[ "${PROVISIONER}" == "gcp-openstack" ]]; then
+  export TEST_TYPE=${TEST_TYPE:-openstack-e2e}
+else
+  export TEST_TYPE=${TEST_TYPE:-k8s-e2e}
+fi
 export GOOGLE_PROJECT=${GOOGLE_PROJECT:-unique-caldron-775}
-export GOOGLE_REGIONS=("us-central1" "us-west1")
-export GOOGLE_REGION=${GOOGLE_REGION:-${GOOGLE_REGIONS[RANDOM%${#GOOGLE_REGIONS[@]}]}}
-# --project is required: without it gcloud uses the runner's default project
-# (tigera-cc-dev on ArgoCI, where the SA can't list zones) instead of the e2e
-# project, and GOOGLE_ZONE fails to resolve for every unpinned gcp job.
-export GOOGLE_ZONE=${GOOGLE_ZONE:-$(gcloud compute zones list --project "${GOOGLE_PROJECT}" --filter="region~'$GOOGLE_REGION'" --format="value(name)" | awk 'BEGIN {srand()} {a[NR]=$0} rand() * NR < 1 {zone=$0} END {print zone}')}
-export GOOGLE_NETWORK=${GOOGLE_NETWORK:-semaphore-autotest}
+
+# GCP placement: gcp-openstack has its own defaults in banzai-core
+# (europe-west3-c in the openstack-calico-test VPC, which carries the
+# firewall rules the OpenStack nodes need), so leave the variables unset
+# there and let those defaults apply.  Everything else spreads across the
+# US regions on the semaphore-autotest network, as on Semaphore.
+if [[ "${PROVISIONER}" != "gcp-openstack" ]]; then
+  export GOOGLE_REGIONS=("us-central1" "us-west1")
+  export GOOGLE_REGION=${GOOGLE_REGION:-${GOOGLE_REGIONS[RANDOM%${#GOOGLE_REGIONS[@]}]}}
+  # --project is required: without it gcloud uses the runner's default project
+  # (tigera-cc-dev on ArgoCI, where the SA can't list zones) instead of the e2e
+  # project, and GOOGLE_ZONE fails to resolve for every unpinned gcp job.
+  export GOOGLE_ZONE=${GOOGLE_ZONE:-$(gcloud compute zones list --project "${GOOGLE_PROJECT}" --filter="region~'$GOOGLE_REGION'" --format="value(name)" | awk 'BEGIN {srand()} {a[NR]=$0} rand() * NR < 1 {zone=$0} END {print zone}')}
+  export GOOGLE_NETWORK=${GOOGLE_NETWORK:-semaphore-autotest}
+fi
 export AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION:-us-west-2}
 
 # RELEASE_STREAM: release-vX.Y -> vX.Y, else master. BRANCH is passed by the

--- a/.argoci/scripts/merge_junit.py
+++ b/.argoci/scripts/merge_junit.py
@@ -50,8 +50,11 @@ def main():
     src_dir, out_path = sys.argv[1], sys.argv[2]
     out_abs = os.path.abspath(out_path)
 
+    # Sort both walk axes so the merged suite order is deterministic (and
+    # alphabetical) — the ArgoCI viewer renders suites in file order.
     suites = []
-    for dirpath, _, filenames in os.walk(src_dir):
+    for dirpath, dirnames, filenames in os.walk(src_dir):
+        dirnames.sort()
         for fn in sorted(filenames):
             path = os.path.join(dirpath, fn)
             if not fn.lower().endswith(".xml") or os.path.abspath(path) == out_abs:

--- a/.argoci/scripts/merge_junit.py
+++ b/.argoci/scripts/merge_junit.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Merge JUnit/xUnit XML files into a single <testsuites> report.
+
+Usage: merge_junit.py <dir> <output>
+
+Scans <dir> recursively for *.xml files whose root element is <testsuite> or
+<testsuites>, and writes all of the contained <testsuite> elements under a single
+<testsuites> root at <output>.  This turns a report tree of many per-class files (e.g.
+the openstack-e2e runner's xmlrunner output, one TEST-*.xml per test class) into the
+single-file form that the ArgoCI viewer renders as one test report with collapsible
+suites.
+
+Best-effort by design, since it runs from the CI epilogue: files that fail to parse
+(or whose root is some other XML) are skipped with a warning, and if no suites are
+found at all, no output is written and the exit code is still 0.
+"""
+
+import os
+import sys
+import xml.etree.ElementTree as ET
+
+# Parse with defusedxml when available (XXE / entity-expansion hardening).  The
+# inputs are our own test runner's output, but they do transit a test container, so
+# prefer the hardened parser; fall back to stdlib (whose expat has built-in
+# billion-laughs limits on modern images) rather than fail the epilogue.
+try:
+    from defusedxml.ElementTree import parse as xml_parse
+except ImportError:
+    xml_parse = ET.parse
+
+
+def collect_suites(path):
+    # Catch broadly, not just ParseError: defusedxml signals rejected content with
+    # its own exception types, and a bad input file must never fail the epilogue.
+    try:
+        root = xml_parse(path).getroot()
+    except Exception as e:
+        print(f"[WARN] merge_junit: skipping {path}: {e}", file=sys.stderr)
+        return []
+    if root.tag == "testsuite":
+        return [root]
+    if root.tag == "testsuites":
+        return root.findall("testsuite")
+    return []
+
+
+def main():
+    if len(sys.argv) != 3:
+        sys.exit(f"usage: {sys.argv[0]} <dir> <output>")
+    src_dir, out_path = sys.argv[1], sys.argv[2]
+    out_abs = os.path.abspath(out_path)
+
+    suites = []
+    for dirpath, _, filenames in os.walk(src_dir):
+        for fn in sorted(filenames):
+            path = os.path.join(dirpath, fn)
+            if not fn.lower().endswith(".xml") or os.path.abspath(path) == out_abs:
+                continue
+            suites.extend(collect_suites(path))
+
+    if not suites:
+        print(
+            f"[INFO] merge_junit: no JUnit XML found under {src_dir}; nothing to merge"
+        )
+        return
+
+    merged = ET.Element("testsuites")
+    merged.extend(suites)
+    ET.ElementTree(merged).write(out_path, encoding="utf-8", xml_declaration=True)
+    print(f"[INFO] merge_junit: wrote {len(suites)} suite(s) to {out_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds a weekly ArgoCI cron (`.argoci/cron/e2e-openstack.yaml`) running the Calico-for-OpenStack e2e tests: four jobs — {full-fv, multi-region} × {Ubuntu Noble, Ubuntu Jammy}, all on OpenStack Caracal — every Sunday 17:00 UTC.

Deployment is pure Banzai (gcp-openstack provisioner + packaged installer); only the test code still comes from tigera/calico-test, via the `gcr.io/unique-caldron-775/openstack-e2e:stable` image.  `global_prologue.sh` becomes provisioner-aware so the cron needs no OpenStack-specific pins: for gcp-openstack it defaults `TEST_TYPE=openstack-e2e` (mirroring banzai-core) and leaves `GOOGLE_REGION/ZONE/NETWORK` unset so banzai-core's defaults for that provisioner (europe-west3-c, openstack-calico-test VPC) apply.

Also included: test results render in the ArgoCI viewer.  The epilogue merges the runner's per-class xmlrunner XML into a single `junit.xml` (new `.argoci/scripts/merge_junit.py`) and publishes it to the step's artifact prefix, where the viewer auto-renders it as a test report; per-test diags upload on failure.  (Companion fix in tigera/calico-test — `e2e-entrypoint.sh` collecting the XML from the container CWD — validated via the rebuilt `openstack-e2e:stable` image.)

**Testing** (via the `cron-ci` label, which submits the changed cron as a one-off ArgoCI run from this branch):
- Smoke runs: all four matrix jobs provisioned, installed, and passed; `junit.xml` renders as a test report in the viewer.
- Full-fv run: all four matrix jobs passed.

Note: the one-off runs' GitHub statuses (`cronci/e2e-openstack`) don't appear on this PR due to a token-scoping issue, tracked in tigera/cc-utils#173.  Scheduled runs are unaffected.

**Release note:**
```release-note
None
```
