### PR TITLE
[release-v3.32] Allow calico-typha to write ClusterInformation

### DIFF
--- a/webhooks/pkg/clusterinfo/clusterinfo.go
+++ b/webhooks/pkg/clusterinfo/clusterinfo.go
@@ -35,6 +35,7 @@ const saNamespaceFile = "/var/run/secrets/kubernetes.io/serviceaccount/namespace
 var allowedServiceAccounts = map[string]struct{}{
 	"calico-node":             {},
 	"calico-kube-controllers": {},
+	"calico-typha":            {},
 }
 
 type webhook struct {

--- a/webhooks/pkg/clusterinfo/clusterinfo_test.go
+++ b/webhooks/pkg/clusterinfo/clusterinfo_test.go
@@ -45,6 +45,12 @@ func TestAdmit(t *testing.T) {
 			expectAllow: true,
 		},
 		{
+			name:        "calico-typha can update",
+			username:    "system:serviceaccount:calico-system:calico-typha",
+			operation:   v1.Update,
+			expectAllow: true,
+		},
+		{
 			name:        "calico-node in wrong namespace cannot create",
 			username:    "system:serviceaccount:default:calico-node",
 			operation:   v1.Create,
@@ -117,6 +123,7 @@ func TestIsAllowedUser(t *testing.T) {
 	}{
 		{"system:serviceaccount:calico-system:calico-node", true},
 		{"system:serviceaccount:calico-system:calico-kube-controllers", true},
+		{"system:serviceaccount:calico-system:calico-typha", true},
 		{"system:serviceaccount:kube-system:calico-node", false},
 		{"system:serviceaccount:default:calico-node", false},
 		{"system:serviceaccount:calico-system:my-app", false},


### PR DESCRIPTION
Backport of #13313 to release-v3.32.

calico-typha writes the DatastoreReady field on ClusterInformation during startup, but it wasn't on the write allowlist, so the cluster-info webhook denied it. In v3 CRD mode (no aggregated apiserver) that blocks typha from initializing the datastore, which keeps calico-node from becoming ready.

Related: #12010

```release-note
None
```