### PR TITLE
felix/collector: time-box policy re-evaluation sweep

### DIFF
--- a/felix/collector/collector.go
+++ b/felix/collector/collector.go
@@ -43,6 +43,12 @@ import (
 const (
 	// perHostPolicySubscription is the subscription type for per-host-policy.
 	perHostPolicySubscription = "per-host-policies"
+
+	// policyEvalBatchDuration bounds how long a single policy re-evaluation batch
+	// runs before yielding back to the collector's main select loop, so the other
+	// work sources (conntrack, NFLOG, export ticker, dataplane stats) are not
+	// starved by a large sweep.
+	policyEvalBatchDuration = 100 * time.Millisecond
 )
 
 var (
@@ -83,6 +89,22 @@ var (
 		Name: "felix_collector_epstats",
 		Help: "Total number of entries currently residing in the epStats cache.",
 	})
+
+	// policy re-evaluation (pending rule trace) prometheus metrics
+	counterPolicyEvalBatches = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "felix_collector_policy_eval_batches_total",
+		Help: "Number of time-boxed policy re-evaluation batches processed.",
+	})
+
+	counterPolicyEvalFlows = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "felix_collector_policy_eval_flows_total",
+		Help: "Number of flows evaluated during policy re-evaluation.",
+	})
+
+	histogramPolicyEvalSweepDuration = prometheus.NewHistogram(prometheus.HistogramOpts{
+		Name: "felix_collector_policy_eval_sweep_duration_seconds",
+		Help: "Wall-clock time to drain one policy re-evaluation snapshot across all its batches.",
+	})
 )
 
 func init() {
@@ -91,6 +113,9 @@ func init() {
 	prometheus.MustRegister(gaugeEpStatsCacheSizeLength)
 	prometheus.MustRegister(histogramDataplaneStatsUpdate)
 	prometheus.MustRegister(gaugeDataplaneStatsUpdateErrorsPerMinute)
+	prometheus.MustRegister(counterPolicyEvalBatches)
+	prometheus.MustRegister(counterPolicyEvalFlows)
+	prometheus.MustRegister(histogramPolicyEvalSweepDuration)
 }
 
 type Config struct {
@@ -135,6 +160,14 @@ type collector struct {
 	metricReporters       []types.Reporter
 	policyStoreManager    policystore.PolicyStoreManager
 	displayDebugTraceLogs bool
+
+	// recalcSnapshot holds pointers to the flows still awaiting policy re-evaluation
+	// in the current sweep. It is taken from epStats when the policy-eval ticker fires
+	// and drained in time-boxed batches. The backing array is reused across sweeps.
+	recalcSnapshot []*Data
+	// recalcSweepStart marks when the current snapshot was taken, for the sweep-duration
+	// histogram.
+	recalcSweepStart time.Time
 }
 
 // newCollector instantiates a new collector. The StartDataplaneStatsCollector function is the only public
@@ -251,6 +284,19 @@ func (c *collector) startStatsCollectionAndReporting() {
 		ctInfoC = c.conntrackInfoReader.ConntrackInfoChan()
 	}
 
+	// batchReady is a pre-closed channel: a receive on it is always ready. We use it
+	// as the batch trigger so that, while a policy re-evaluation sweep is in flight, the
+	// select keeps firing batches — but each batch competes fairly with the other cases,
+	// so conntrack, NFLOG, export, and dataplane-stats work is still serviced promptly.
+	batchReady := make(chan struct{})
+	close(batchReady)
+
+	// policyEvalTickC is masked (set to nil, which blocks forever) while a sweep is in
+	// flight, so no new snapshot is taken until the current one drains. batchTriggerC is
+	// the mirror image: nil until a snapshot is pending, then batchReady while draining.
+	policyEvalTickC := c.tickerPolicyEval.Channel()
+	var batchTriggerC <-chan struct{}
+
 	// When a collector is started, we respond to the following events:
 	// 1. StatUpdates for incoming datasources (chan c.mux).
 	// 2. A signal handler that will dump logs on receiving SIGUSR2.
@@ -273,8 +319,18 @@ func (c *collector) startStatsCollectionAndReporting() {
 			dataplaneStatsUpdateStart := time.Now()
 			c.convertDataplaneStatsAndApplyUpdate(ds)
 			histogramDataplaneStatsUpdate.Observe(float64(time.Since(dataplaneStatsUpdateStart).Seconds()))
-		case <-c.tickerPolicyEval.Channel():
-			c.updatePendingRuleTraces()
+		case <-policyEvalTickC:
+			// Take a snapshot of the flows to re-evaluate, then hand off to the batch
+			// path: mask the ticker so no new snapshot starts until this one drains.
+			c.snapshotFlowsForRecalc()
+			policyEvalTickC = nil
+			batchTriggerC = batchReady
+		case <-batchTriggerC:
+			if c.processRecalcBatch(policyEvalBatchDuration) {
+				// Snapshot drained: stop batching and re-arm the ticker.
+				batchTriggerC = nil
+				policyEvalTickC = c.tickerPolicyEval.Channel()
+			}
 		}
 	}
 }
@@ -867,15 +923,68 @@ func (c *collector) convertDataplaneStatsAndApplyUpdate(d *proto.DataplaneStats)
 
 // updatePendingRuleTraces evaluates each flow of epStats against the policies in the PolicyStore
 // to get the latest pending rule trace. It replaces the Data's copy if they are different.
+//
+// This is the eager, single-shot sweep. The main select loop instead drives the sweep in
+// time-boxed batches via snapshotFlowsForRecalc and processRecalcBatch; this method is retained
+// for tests that need the whole sweep to complete synchronously.
 func (c *collector) updatePendingRuleTraces() {
-	// The epStats map may be quite large, so we chose to lock each entry individually to avoid
-	// locking the entire map.
 	for _, data := range c.epStats {
 		if data == nil {
 			continue
 		}
 		c.evaluatePendingRuleTraceForLocalEp(data)
 	}
+}
+
+// snapshotFlowsForRecalc takes a snapshot of the flows to re-evaluate at the start of a policy
+// re-evaluation sweep. It runs on the select goroutine that owns epStats, so the snapshot is a
+// cheap pointer copy; the expensive per-flow evaluation is then spread across time-boxed batches
+// in processRecalcBatch. The backing array is reused across sweeps to avoid re-allocating.
+func (c *collector) snapshotFlowsForRecalc() {
+	c.recalcSnapshot = c.recalcSnapshot[:0]
+	for _, data := range c.epStats {
+		if data == nil {
+			continue
+		}
+		c.recalcSnapshot = append(c.recalcSnapshot, data)
+	}
+	c.recalcSweepStart = time.Now()
+}
+
+// processRecalcBatch evaluates flows from the current snapshot until either the snapshot is empty
+// or the time budget is spent, then returns control to the caller. It returns true when the
+// snapshot has been fully drained.
+func (c *collector) processRecalcBatch(budget time.Duration) bool {
+	counterPolicyEvalBatches.Inc()
+
+	// Check the deadline after each flow rather than before, so we always make forward
+	// progress (at least one flow per batch) even with a very small budget.
+	deadline := time.Now().Add(budget)
+	for len(c.recalcSnapshot) > 0 {
+		// Pop from the tail, niling the slot first so the reused backing array does not
+		// pin an already-processed (and possibly map-deleted) Data until the next sweep.
+		i := len(c.recalcSnapshot) - 1
+		data := c.recalcSnapshot[i]
+		c.recalcSnapshot[i] = nil
+		c.recalcSnapshot = c.recalcSnapshot[:i]
+
+		// Skip flows that other work sources have expired/deleted (or whose tuple has been
+		// reused) since the snapshot was taken.
+		if cur, ok := c.epStats[data.Tuple]; ok && cur == data {
+			c.evaluatePendingRuleTraceForLocalEp(data)
+			counterPolicyEvalFlows.Inc()
+		}
+
+		if !time.Now().Before(deadline) {
+			break
+		}
+	}
+
+	if len(c.recalcSnapshot) == 0 {
+		histogramPolicyEvalSweepDuration.Observe(time.Since(c.recalcSweepStart).Seconds())
+		return true
+	}
+	return false
 }
 
 func (c *collector) evaluatePendingRuleTraceForLocalEp(data *Data) {

--- a/felix/collector/collector.go
+++ b/felix/collector/collector.go
@@ -44,10 +44,8 @@ const (
 	// perHostPolicySubscription is the subscription type for per-host-policy.
 	perHostPolicySubscription = "per-host-policies"
 
-	// policyEvalBatchDuration bounds how long a single policy re-evaluation batch
-	// runs before yielding back to the collector's main select loop, so the other
-	// work sources (conntrack, NFLOG, export ticker, dataplane stats) are not
-	// starved by a large sweep.
+	// policyEvalBatchDuration caps the wall-clock time spent re-evaluating policy in a single
+	// batch, so a large sweep does not starve the collector's other work sources.
 	policyEvalBatchDuration = 100 * time.Millisecond
 )
 
@@ -161,17 +159,13 @@ type collector struct {
 	policyStoreManager    policystore.PolicyStoreManager
 	displayDebugTraceLogs bool
 
-	// recalcSnapshot holds pointers to the flows still awaiting policy re-evaluation
-	// in the current sweep. It is taken from epStats when the policy-eval ticker fires
-	// and drained in time-boxed batches. The backing array is reused across sweeps.
+	// recalcSnapshot holds the flows still awaiting policy re-evaluation in the current sweep.
+	// The backing array is reused across sweeps.
 	recalcSnapshot []*Data
-	// recalcSweepStart marks when the current snapshot was taken, for the sweep-duration
-	// histogram.
+	// recalcSweepStart is when the current snapshot was taken, for the sweep-duration histogram.
 	recalcSweepStart time.Time
-	// policyEvalMinInterval is the minimum time between re-evaluations of a single flow. A flow
-	// evaluated more recently than this is skipped when the sweep reaches it, so that
-	// back-to-back sweeps (when a sweep takes ~a full ticker interval) do not reprocess the
-	// same flow repeatedly. Set to half the ticker interval.
+	// policyEvalMinInterval is the minimum time between re-evaluations of one flow. Half the
+	// ticker interval.
 	policyEvalMinInterval time.Duration
 }
 
@@ -183,7 +177,7 @@ func newCollector(lc *calc.LookupsCache, cfg *Config) Collector {
 		luc:                   lc,
 		epStats:               make(map[tuple.Tuple]*Data),
 		ticker:                jitter.NewTicker(cfg.ExportingInterval, cfg.ExportingInterval/10),
-		tickerPolicyEval:      jitter.NewTicker(recalcInterval, cfg.FlowLogsFlushInterval*1/10),
+		tickerPolicyEval:      jitter.NewTicker(recalcInterval, cfg.FlowLogsFlushInterval/10),
 		config:                cfg,
 		dumpLog:               log.New(),
 		ds:                    make(chan *proto.DataplaneStats, 1000),
@@ -198,7 +192,6 @@ func newCollector(lc *calc.LookupsCache, cfg *Config) Collector {
 
 	if apiv3.FlowLogsPolicyEvaluationModeType(cfg.PolicyEvaluationMode) == apiv3.FlowLogsPolicyEvaluationModeContinuous {
 		log.Infof("Pending policies enabled, initiating pending policy evaluation ticker")
-		c.tickerPolicyEval = jitter.NewTicker(recalcInterval, cfg.FlowLogsFlushInterval*1/10)
 	} else {
 		log.Infof("Pending policies disabled")
 	}
@@ -291,16 +284,13 @@ func (c *collector) startStatsCollectionAndReporting() {
 		ctInfoC = c.conntrackInfoReader.ConntrackInfoChan()
 	}
 
-	// batchReady is a pre-closed channel: a receive on it is always ready. We use it
-	// as the batch trigger so that, while a policy re-evaluation sweep is in flight, the
-	// select keeps firing batches — but each batch competes fairly with the other cases,
-	// so conntrack, NFLOG, export, and dataplane-stats work is still serviced promptly.
+	// batchReady is closed, so a receive on it is always ready: while a sweep is in flight the
+	// select keeps firing batches, each competing with the other cases for the loop. The tick
+	// and batch channels are mutually masked (nil blocks forever) so only one sweep runs at a
+	// time.
 	batchReady := make(chan struct{})
 	close(batchReady)
 
-	// policyEvalTickC is masked (set to nil, which blocks forever) while a sweep is in
-	// flight, so no new snapshot is taken until the current one drains. batchTriggerC is
-	// the mirror image: nil until a snapshot is pending, then batchReady while draining.
 	policyEvalTickC := c.tickerPolicyEval.Channel()
 	var batchTriggerC <-chan struct{}
 
@@ -327,14 +317,11 @@ func (c *collector) startStatsCollectionAndReporting() {
 			c.convertDataplaneStatsAndApplyUpdate(ds)
 			histogramDataplaneStatsUpdate.Observe(float64(time.Since(dataplaneStatsUpdateStart).Seconds()))
 		case <-policyEvalTickC:
-			// Take a snapshot of the flows to re-evaluate, then hand off to the batch
-			// path: mask the ticker so no new snapshot starts until this one drains.
 			c.snapshotFlowsForRecalc()
 			policyEvalTickC = nil
 			batchTriggerC = batchReady
 		case <-batchTriggerC:
 			if c.processRecalcBatch(policyEvalBatchDuration) {
-				// Snapshot drained: stop batching and re-arm the ticker.
 				batchTriggerC = nil
 				policyEvalTickC = c.tickerPolicyEval.Channel()
 			}
@@ -928,86 +915,58 @@ func (c *collector) convertDataplaneStatsAndApplyUpdate(d *proto.DataplaneStats)
 	_ = c.getDataAndUpdateEndpoints(t, false, false)
 }
 
-// updatePendingRuleTraces evaluates each flow of epStats against the policies in the PolicyStore
-// to get the latest pending rule trace. It replaces the Data's copy if they are different.
-//
-// This is the eager, single-shot sweep. The main select loop instead drives the sweep in
-// time-boxed batches via snapshotFlowsForRecalc and processRecalcBatch; this method is retained
-// for tests that need the whole sweep to complete synchronously.
-func (c *collector) updatePendingRuleTraces() {
-	for _, data := range c.epStats {
-		if data == nil {
-			continue
-		}
-		c.evaluatePendingRuleTraceForLocalEp(data)
-	}
-}
-
-// snapshotFlowsForRecalc takes a snapshot of every flow at the start of a policy re-evaluation
-// sweep. It runs on the select goroutine that owns epStats, so the snapshot is a cheap pointer
-// copy; the expensive per-flow evaluation is then spread across time-boxed batches in
-// processRecalcBatch, which decides per flow (at re-evaluation time) whether it is due. The backing
-// array is reused across sweeps to avoid re-allocating.
+// snapshotFlowsForRecalc starts a policy re-evaluation sweep. It runs on the goroutine that owns
+// epStats, so it only copies pointers; processRecalcBatch does the expensive per-flow work.
 func (c *collector) snapshotFlowsForRecalc() {
 	c.recalcSnapshot = c.recalcSnapshot[:0]
 	for _, data := range c.epStats {
-		if data == nil {
-			continue
-		}
 		c.recalcSnapshot = append(c.recalcSnapshot, data)
 	}
 	c.recalcSweepStart = time.Now()
 }
 
-// processRecalcBatch evaluates flows from the current snapshot until either the snapshot is empty
-// or the time budget is spent, then returns control to the caller. It returns true when the
-// snapshot has been fully drained.
+// processRecalcBatch evaluates flows from the current snapshot until the snapshot is empty or the
+// time budget is spent. It returns true once the snapshot has been fully drained.
 //
-// The due/not-due decision is made here, at re-evaluation time, rather than when the snapshot is
-// taken: a sweep can take a while to drain, and a flow that was too recently evaluated to re-do at
-// snapshot time may well be due by the time we reach it. The check is a timestamp comparison, cheap
-// next to the few milliseconds a real evaluation can take.
+// Each flow's due/not-due check happens as the sweep reaches it, so a flow that becomes due while
+// the sweep is draining is still picked up by this sweep.
 func (c *collector) processRecalcBatch(budget time.Duration) bool {
 	counterPolicyEvalBatches.Inc()
 
 	now := monotime.Now()
+	deadline := now + budget
+	minLastEvalAt := now - c.policyEvalMinInterval
 
-	// Check the deadline after each flow rather than before, so we always make forward
-	// progress (at least one flow per batch) even with a very small budget.
-	deadline := time.Now().Add(budget)
 	for len(c.recalcSnapshot) > 0 {
-		// Pop from the tail, niling the slot first so the reused backing array does not
-		// pin an already-processed (and possibly map-deleted) Data until the next sweep.
+		// Pop from the tail; nil the slot so the reused array doesn't pin processed Data.
 		i := len(c.recalcSnapshot) - 1
 		data := c.recalcSnapshot[i]
 		c.recalcSnapshot[i] = nil
 		c.recalcSnapshot = c.recalcSnapshot[:i]
 
-		// Skip flows that other work sources have expired/deleted (or whose tuple has been
-		// reused) since the snapshot was taken.
-		cur, ok := c.epStats[data.Tuple]
-		if !ok || cur != data {
+		// Not due yet.
+		if data.lastPolicyEvalAt != 0 && data.lastPolicyEvalAt > minLastEvalAt {
 			continue
 		}
-		// Skip flows re-evaluated within the last policyEvalMinInterval, so that back-to-back
-		// sweeps (when a sweep takes ~a full ticker interval) do not reprocess the same flow.
-		if data.lastPolicyEvalAt != 0 && now-data.lastPolicyEvalAt < c.policyEvalMinInterval {
+		// Expired, deleted, or the tuple was reused since the snapshot.
+		if cur, ok := c.epStats[data.Tuple]; !ok || cur != data {
 			continue
 		}
 
 		c.evaluatePendingRuleTraceForLocalEp(data)
 		counterPolicyEvalFlows.Inc()
 
-		if !time.Now().Before(deadline) {
+		// Checked last, so every batch evaluates at least one flow.
+		if monotime.Now() >= deadline {
 			break
 		}
 	}
 
-	if len(c.recalcSnapshot) == 0 {
+	drained := len(c.recalcSnapshot) == 0
+	if drained {
 		histogramPolicyEvalSweepDuration.Observe(time.Since(c.recalcSweepStart).Seconds())
-		return true
 	}
-	return false
+	return drained
 }
 
 func (c *collector) evaluatePendingRuleTraceForLocalEp(data *Data) {
@@ -1015,8 +974,7 @@ func (c *collector) evaluatePendingRuleTraceForLocalEp(data *Data) {
 
 	srcEp, dstEp := c.findEndpointBestMatch(data.Tuple)
 
-	// If endpoints have changed compared to what Data currently holds, skip evaluation. Leave
-	// lastPolicyEvalAt unchanged so the flow is retried on the next sweep once endpoints settle.
+	// Endpoints changed mid-flight; leave lastPolicyEvalAt unset so the next sweep retries.
 	if endpointChanged(data.SrcEp, srcEp) || endpointChanged(data.DstEp, dstEp) {
 		return
 	}

--- a/felix/collector/collector.go
+++ b/felix/collector/collector.go
@@ -168,21 +168,28 @@ type collector struct {
 	// recalcSweepStart marks when the current snapshot was taken, for the sweep-duration
 	// histogram.
 	recalcSweepStart time.Time
+	// policyEvalMinInterval is the minimum time between re-evaluations of a single flow. A flow
+	// evaluated more recently than this is skipped when the sweep reaches it, so that
+	// back-to-back sweeps (when a sweep takes ~a full ticker interval) do not reprocess the
+	// same flow repeatedly. Set to half the ticker interval.
+	policyEvalMinInterval time.Duration
 }
 
 // newCollector instantiates a new collector. The StartDataplaneStatsCollector function is the only public
 // function for collector instantiation.
 func newCollector(lc *calc.LookupsCache, cfg *Config) Collector {
+	recalcInterval := cfg.FlowLogsFlushInterval * 8 / 10
 	c := &collector{
 		luc:                   lc,
 		epStats:               make(map[tuple.Tuple]*Data),
 		ticker:                jitter.NewTicker(cfg.ExportingInterval, cfg.ExportingInterval/10),
-		tickerPolicyEval:      jitter.NewTicker(cfg.FlowLogsFlushInterval*8/10, cfg.FlowLogsFlushInterval*1/10),
+		tickerPolicyEval:      jitter.NewTicker(recalcInterval, cfg.FlowLogsFlushInterval*1/10),
 		config:                cfg,
 		dumpLog:               log.New(),
 		ds:                    make(chan *proto.DataplaneStats, 1000),
 		displayDebugTraceLogs: cfg.DisplayDebugTraceLogs,
 		policyStoreManager:    cfg.PolicyStoreManager,
+		policyEvalMinInterval: recalcInterval / 2,
 	}
 
 	if c.policyStoreManager == nil {
@@ -191,7 +198,7 @@ func newCollector(lc *calc.LookupsCache, cfg *Config) Collector {
 
 	if apiv3.FlowLogsPolicyEvaluationModeType(cfg.PolicyEvaluationMode) == apiv3.FlowLogsPolicyEvaluationModeContinuous {
 		log.Infof("Pending policies enabled, initiating pending policy evaluation ticker")
-		c.tickerPolicyEval = jitter.NewTicker(cfg.FlowLogsFlushInterval*8/10, cfg.FlowLogsFlushInterval*1/10)
+		c.tickerPolicyEval = jitter.NewTicker(recalcInterval, cfg.FlowLogsFlushInterval*1/10)
 	} else {
 		log.Infof("Pending policies disabled")
 	}
@@ -936,10 +943,11 @@ func (c *collector) updatePendingRuleTraces() {
 	}
 }
 
-// snapshotFlowsForRecalc takes a snapshot of the flows to re-evaluate at the start of a policy
-// re-evaluation sweep. It runs on the select goroutine that owns epStats, so the snapshot is a
-// cheap pointer copy; the expensive per-flow evaluation is then spread across time-boxed batches
-// in processRecalcBatch. The backing array is reused across sweeps to avoid re-allocating.
+// snapshotFlowsForRecalc takes a snapshot of every flow at the start of a policy re-evaluation
+// sweep. It runs on the select goroutine that owns epStats, so the snapshot is a cheap pointer
+// copy; the expensive per-flow evaluation is then spread across time-boxed batches in
+// processRecalcBatch, which decides per flow (at re-evaluation time) whether it is due. The backing
+// array is reused across sweeps to avoid re-allocating.
 func (c *collector) snapshotFlowsForRecalc() {
 	c.recalcSnapshot = c.recalcSnapshot[:0]
 	for _, data := range c.epStats {
@@ -954,8 +962,15 @@ func (c *collector) snapshotFlowsForRecalc() {
 // processRecalcBatch evaluates flows from the current snapshot until either the snapshot is empty
 // or the time budget is spent, then returns control to the caller. It returns true when the
 // snapshot has been fully drained.
+//
+// The due/not-due decision is made here, at re-evaluation time, rather than when the snapshot is
+// taken: a sweep can take a while to drain, and a flow that was too recently evaluated to re-do at
+// snapshot time may well be due by the time we reach it. The check is a timestamp comparison, cheap
+// next to the few milliseconds a real evaluation can take.
 func (c *collector) processRecalcBatch(budget time.Duration) bool {
 	counterPolicyEvalBatches.Inc()
+
+	now := monotime.Now()
 
 	// Check the deadline after each flow rather than before, so we always make forward
 	// progress (at least one flow per batch) even with a very small budget.
@@ -970,10 +985,18 @@ func (c *collector) processRecalcBatch(budget time.Duration) bool {
 
 		// Skip flows that other work sources have expired/deleted (or whose tuple has been
 		// reused) since the snapshot was taken.
-		if cur, ok := c.epStats[data.Tuple]; ok && cur == data {
-			c.evaluatePendingRuleTraceForLocalEp(data)
-			counterPolicyEvalFlows.Inc()
+		cur, ok := c.epStats[data.Tuple]
+		if !ok || cur != data {
+			continue
 		}
+		// Skip flows re-evaluated within the last policyEvalMinInterval, so that back-to-back
+		// sweeps (when a sweep takes ~a full ticker interval) do not reprocess the same flow.
+		if data.lastPolicyEvalAt != 0 && now-data.lastPolicyEvalAt < c.policyEvalMinInterval {
+			continue
+		}
+
+		c.evaluatePendingRuleTraceForLocalEp(data)
+		counterPolicyEvalFlows.Inc()
 
 		if !time.Now().Before(deadline) {
 			break
@@ -992,11 +1015,13 @@ func (c *collector) evaluatePendingRuleTraceForLocalEp(data *Data) {
 
 	srcEp, dstEp := c.findEndpointBestMatch(data.Tuple)
 
-	// If endpoints have changed compared to what Data currently holds, skip evaluation.
+	// If endpoints have changed compared to what Data currently holds, skip evaluation. Leave
+	// lastPolicyEvalAt unchanged so the flow is retried on the next sweep once endpoints settle.
 	if endpointChanged(data.SrcEp, srcEp) || endpointChanged(data.DstEp, dstEp) {
 		return
 	}
 
+	data.lastPolicyEvalAt = monotime.Now()
 	c.policyStoreManager.DoWithReadLock(func(ps *policystore.PolicyStore) {
 		// Evaluate ingress if destination is local workload endpoint
 		if data.DstEp != nil && !data.DstEp.IsHostEndpoint() && data.DstEp.IsLocal() {

--- a/felix/collector/collector.go
+++ b/felix/collector/collector.go
@@ -918,11 +918,18 @@ func (c *collector) convertDataplaneStatsAndApplyUpdate(d *proto.DataplaneStats)
 // snapshotFlowsForRecalc starts a policy re-evaluation sweep. It runs on the goroutine that owns
 // epStats, so it only copies pointers; processRecalcBatch does the expensive per-flow work.
 func (c *collector) snapshotFlowsForRecalc() {
+	c.recalcSweepStart = time.Now()
+
+	// Right-size the buffer: too small and the sweep re-allocates as it fills it, too large and
+	// we hold onto a big array long after the flow count drops.
+	if cap(c.recalcSnapshot) < len(c.epStats) || cap(c.recalcSnapshot) > 2*len(c.epStats) {
+		c.recalcSnapshot = make([]*Data, 0, len(c.epStats)*3/2)
+	}
+
 	c.recalcSnapshot = c.recalcSnapshot[:0]
 	for _, data := range c.epStats {
 		c.recalcSnapshot = append(c.recalcSnapshot, data)
 	}
-	c.recalcSweepStart = time.Now()
 }
 
 // processRecalcBatch evaluates flows from the current snapshot until the snapshot is empty or the
@@ -938,11 +945,7 @@ func (c *collector) processRecalcBatch(budget time.Duration) bool {
 	minLastEvalAt := now - c.policyEvalMinInterval
 
 	for len(c.recalcSnapshot) > 0 {
-		// Pop from the tail; nil the slot so the reused array doesn't pin processed Data.
-		i := len(c.recalcSnapshot) - 1
-		data := c.recalcSnapshot[i]
-		c.recalcSnapshot[i] = nil
-		c.recalcSnapshot = c.recalcSnapshot[:i]
+		data := c.popFlowForRecalc()
 
 		// Not due yet.
 		if data.lastPolicyEvalAt != 0 && data.lastPolicyEvalAt > minLastEvalAt {
@@ -967,6 +970,16 @@ func (c *collector) processRecalcBatch(budget time.Duration) bool {
 		histogramPolicyEvalSweepDuration.Observe(time.Since(c.recalcSweepStart).Seconds())
 	}
 	return drained
+}
+
+// popFlowForRecalc takes the next flow off the sweep snapshot.
+func (c *collector) popFlowForRecalc() *Data {
+	i := len(c.recalcSnapshot) - 1
+	data := c.recalcSnapshot[i]
+	// Nil the slot so the reused array doesn't pin the Data once it has been processed.
+	c.recalcSnapshot[i] = nil
+	c.recalcSnapshot = c.recalcSnapshot[:i]
+	return data
 }
 
 func (c *collector) evaluatePendingRuleTraceForLocalEp(data *Data) {

--- a/felix/collector/collector.go
+++ b/felix/collector/collector.go
@@ -49,6 +49,15 @@ const (
 	policyEvalBatchDuration = 100 * time.Millisecond
 )
 
+// policyEvalReason is what prompted a pending-policy evaluation. It labels the evaluation counter,
+// so the periodic sweep can be told apart from the one-off evaluation done when a flow appears.
+type policyEvalReason string
+
+const (
+	policyEvalInitial policyEvalReason = "initial"
+	policyEvalRecalc  policyEvalReason = "recalc"
+)
+
 var (
 	// conntrack processing prometheus metrics
 	histogramConntrackLatency = prometheus.NewHistogram(prometheus.HistogramOpts{
@@ -94,10 +103,11 @@ var (
 		Help: "Number of time-boxed policy re-evaluation batches processed.",
 	})
 
-	counterPolicyEvalFlows = prometheus.NewCounter(prometheus.CounterOpts{
+	counterPolicyEvalFlows = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: "felix_collector_policy_eval_flows_total",
-		Help: "Number of flows evaluated during policy re-evaluation.",
-	})
+		Help: "Number of flows whose pending policy was evaluated, by what triggered the evaluation.",
+	},
+		[]string{"reason"})
 
 	histogramPolicyEvalSweepDuration = prometheus.NewHistogram(prometheus.HistogramOpts{
 		Name: "felix_collector_policy_eval_sweep_duration_seconds",
@@ -177,7 +187,6 @@ func newCollector(lc *calc.LookupsCache, cfg *Config) Collector {
 		luc:                   lc,
 		epStats:               make(map[tuple.Tuple]*Data),
 		ticker:                jitter.NewTicker(cfg.ExportingInterval, cfg.ExportingInterval/10),
-		tickerPolicyEval:      jitter.NewTicker(recalcInterval, cfg.FlowLogsFlushInterval/10),
 		config:                cfg,
 		dumpLog:               log.New(),
 		ds:                    make(chan *proto.DataplaneStats, 1000),
@@ -190,8 +199,11 @@ func newCollector(lc *calc.LookupsCache, cfg *Config) Collector {
 		c.policyStoreManager = policystore.NewPolicyStoreManager()
 	}
 
+	// Only run the re-evaluation sweep when pending policies are enabled; leaving the ticker nil
+	// masks the sweep out of the main loop entirely.
 	if apiv3.FlowLogsPolicyEvaluationModeType(cfg.PolicyEvaluationMode) == apiv3.FlowLogsPolicyEvaluationModeContinuous {
 		log.Infof("Pending policies enabled, initiating pending policy evaluation ticker")
+		c.tickerPolicyEval = jitter.NewTicker(recalcInterval, cfg.FlowLogsFlushInterval/10)
 	} else {
 		log.Infof("Pending policies disabled")
 	}
@@ -291,7 +303,7 @@ func (c *collector) startStatsCollectionAndReporting() {
 	batchReady := make(chan struct{})
 	close(batchReady)
 
-	policyEvalTickC := c.tickerPolicyEval.Channel()
+	policyEvalTickC := c.policyEvalTickChan()
 	var batchTriggerC <-chan struct{}
 
 	// When a collector is started, we respond to the following events:
@@ -323,10 +335,19 @@ func (c *collector) startStatsCollectionAndReporting() {
 		case <-batchTriggerC:
 			if c.processRecalcBatch(policyEvalBatchDuration) {
 				batchTriggerC = nil
-				policyEvalTickC = c.tickerPolicyEval.Channel()
+				policyEvalTickC = c.policyEvalTickChan()
 			}
 		}
 	}
+}
+
+// policyEvalTickChan returns the policy re-evaluation tick channel, or nil when pending policies
+// are disabled. A nil channel blocks forever, masking the sweep out of the main loop.
+func (c *collector) policyEvalTickChan() <-chan time.Time {
+	if c.tickerPolicyEval == nil {
+		return nil
+	}
+	return c.tickerPolicyEval.Channel()
 }
 
 // loopProcessingDataplaneInfoUpdates processes the dataplane info updates. The dataplaneInfoReader
@@ -382,7 +403,7 @@ func (c *collector) getDataAndUpdateEndpoints(t tuple.Tuple, expired bool, packe
 		c.updateEpStatsCache(t, data)
 
 		// Perform an initial evaluation of pending rule traces.
-		c.evaluatePendingRuleTraceForLocalEp(data)
+		c.evaluatePendingRuleTraceForLocalEp(data, policyEvalInitial)
 	} else if data.Reported {
 		if !data.UnreportedPacketInfo && !packetinfo {
 			// Data has been reported.  If the request has not come from a packet info update (e.g. nflog) and we do not
@@ -958,8 +979,7 @@ func (c *collector) processRecalcBatch(budget time.Duration) bool {
 			continue
 		}
 
-		c.evaluatePendingRuleTraceForLocalEp(data)
-		counterPolicyEvalFlows.Inc()
+		c.evaluatePendingRuleTraceForLocalEp(data, policyEvalRecalc)
 
 		// Checked last, so every batch evaluates at least one flow.
 		if monotime.Now() >= deadline {
@@ -984,7 +1004,7 @@ func (c *collector) popFlowForRecalc() *Data {
 	return data
 }
 
-func (c *collector) evaluatePendingRuleTraceForLocalEp(data *Data) {
+func (c *collector) evaluatePendingRuleTraceForLocalEp(data *Data, reason policyEvalReason) {
 	flow := TupleAsFlow(data.Tuple)
 
 	srcEp, dstEp := c.findEndpointBestMatch(data.Tuple)
@@ -995,6 +1015,7 @@ func (c *collector) evaluatePendingRuleTraceForLocalEp(data *Data) {
 	}
 
 	data.lastPolicyEvalAt = monotime.Now()
+	counterPolicyEvalFlows.WithLabelValues(string(reason)).Inc()
 	c.policyStoreManager.DoWithReadLock(func(ps *policystore.PolicyStore) {
 		// Evaluate ingress if destination is local workload endpoint
 		if data.DstEp != nil && !data.DstEp.IsHostEndpoint() && data.DstEp.IsLocal() {

--- a/felix/collector/collector.go
+++ b/felix/collector/collector.go
@@ -47,6 +47,12 @@ const (
 	// policyEvalBatchDuration caps the wall-clock time spent re-evaluating policy in a single
 	// batch, so a large sweep does not starve the collector's other work sources.
 	policyEvalBatchDuration = 100 * time.Millisecond
+
+	// policyEvalDeadlineCheckInterval is how many flows the sweep pops between deadline checks
+	// when it is skipping rather than evaluating. Reading the clock costs several times more
+	// than deciding to skip a flow, so checking every flow would slow a skip-heavy sweep down
+	// more than the check protects against. 256 flows is a few microseconds either way.
+	policyEvalDeadlineCheckInterval = 256
 )
 
 // policyEvalReason is what prompted a pending-policy evaluation. It labels the evaluation counter,
@@ -965,7 +971,14 @@ func (c *collector) processRecalcBatch(budget time.Duration) bool {
 	deadline := now + budget
 	minLastEvalAt := now - c.policyEvalMinInterval
 
-	for len(c.recalcSnapshot) > 0 {
+	for popped := 0; len(c.recalcSnapshot) > 0; popped++ {
+		// Bound a run of flows that are all skipped: those never reach the post-evaluation
+		// deadline check below, so a whole snapshot of them would drain in one batch. Popping is
+		// what makes progress, so breaking here is safe once we have popped at least one flow.
+		if popped > 0 && popped%policyEvalDeadlineCheckInterval == 0 && monotime.Now() >= deadline {
+			break
+		}
+
 		data := c.popFlowForRecalc()
 
 		// Not due yet. Zero means never evaluated, which needs the explicit check: monotime
@@ -981,7 +994,7 @@ func (c *collector) processRecalcBatch(budget time.Duration) bool {
 
 		c.evaluatePendingRuleTraceForLocalEp(data, policyEvalRecalc)
 
-		// Checked last, so every batch evaluates at least one flow.
+		// Checked after the evaluation, so every batch evaluates at least one flow.
 		if monotime.Now() >= deadline {
 			break
 		}

--- a/felix/collector/collector.go
+++ b/felix/collector/collector.go
@@ -947,7 +947,9 @@ func (c *collector) processRecalcBatch(budget time.Duration) bool {
 	for len(c.recalcSnapshot) > 0 {
 		data := c.popFlowForRecalc()
 
-		// Not due yet.
+		// Not due yet. Zero means never evaluated, which needs the explicit check: monotime
+		// counts from boot, so within the first policyEvalMinInterval of uptime minLastEvalAt
+		// is negative and every unevaluated flow would look recent.
 		if data.lastPolicyEvalAt != 0 && data.lastPolicyEvalAt > minLastEvalAt {
 			continue
 		}

--- a/felix/collector/collector_test.go
+++ b/felix/collector/collector_test.go
@@ -26,6 +26,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	v3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	dto "github.com/prometheus/client_model/go"
 	kapiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -3746,6 +3748,215 @@ func TestRunPendingRuleTraceEvaluation(t *testing.T) {
 			validateRuleID(t, currentFlowData2.EgressPendingRuleIDs[0], defTierPolicy1AllowEgressRuleID, "Flow2 Egress After Endpoint Deletion")
 		}
 	})
+}
+
+// setupPolicyEvalCollector builds a collector with two flows and a populated policy store,
+// mirroring the fixture used by TestRunPendingRuleTraceEvaluation. It returns the collector and
+// the two flow tuples.
+func setupPolicyEvalCollector(t *testing.T) (*collector, tuple.Tuple, tuple.Tuple) {
+	t.Helper()
+
+	convertWorkloadId := func(key model.WorkloadEndpointKey) types.WorkloadEndpointID {
+		return types.WorkloadEndpointID{
+			OrchestratorId: key.OrchestratorID,
+			WorkloadId:     key.WorkloadID,
+			EndpointId:     key.EndpointID,
+		}
+	}
+
+	epMap := map[[16]byte]calc.EndpointData{
+		localIp1:  localEd1,
+		localIp2:  localEd2,
+		remoteIp1: remoteEd1,
+	}
+	lm := newMockLookupsCache(epMap, nil, nil, nil)
+	policyStoreManager := policystore.NewPolicyStoreManager()
+
+	c := newCollector(lm, &Config{
+		AgeTimeout:            10 * time.Second,
+		InitialReportingDelay: 5 * time.Second,
+		ExportingInterval:     time.Second,
+		FlowLogsFlushInterval: 100 * time.Second,
+		PolicyStoreManager:    policyStoreManager,
+	}).(*collector)
+
+	flowTuple1 := tuple.New(localIp1, localIp2, proto_tcp, 1000, 1000)
+	flowTuple2 := tuple.New(localIp2, remoteIp1, proto_tcp, 1000, 1000)
+
+	localWlEp1Proto := calc.ModelWorkloadEndpointToProto(localWlEp1, nil, nil, []*proto.TierInfo{{
+		Name:            "default",
+		IngressPolicies: []*proto.PolicyID{{Name: "policy1", Kind: v3.KindGlobalNetworkPolicy}},
+		EgressPolicies:  []*proto.PolicyID{{Name: "policy1", Kind: v3.KindGlobalNetworkPolicy}},
+	}})
+	localWlEp2Proto := calc.ModelWorkloadEndpointToProto(localWlEp2, nil, nil, []*proto.TierInfo{{
+		Name:            "default",
+		IngressPolicies: []*proto.PolicyID{{Name: "policy2", Kind: v3.KindGlobalNetworkPolicy}},
+		EgressPolicies:  []*proto.PolicyID{{Name: "policy2", Kind: v3.KindGlobalNetworkPolicy}},
+	}})
+	remoteWlEp1Proto := calc.ModelWorkloadEndpointToProto(remoteWlEp1, nil, nil, []*proto.TierInfo{})
+
+	policyStoreManager.DoWithLock(func(ps *policystore.PolicyStore) {
+		ps.Endpoints[convertWorkloadId(localWlEPKey1)] = localWlEp1Proto
+		ps.Endpoints[convertWorkloadId(localWlEPKey2)] = localWlEp2Proto
+		ps.Endpoints[convertWorkloadId(remoteWlEpKey1)] = remoteWlEp1Proto
+		ps.PolicyByID[types.PolicyID{Name: "policy1", Kind: v3.KindGlobalNetworkPolicy}] = &proto.Policy{
+			Tier:          "default",
+			InboundRules:  []*proto.Rule{{Action: "allow"}},
+			OutboundRules: []*proto.Rule{{Action: "allow"}},
+		}
+		ps.PolicyByID[types.PolicyID{Name: "policy2", Kind: v3.KindGlobalNetworkPolicy}] = &proto.Policy{
+			Tier:          "default",
+			InboundRules:  []*proto.Rule{{Action: "deny"}},
+			OutboundRules: []*proto.Rule{{Action: "deny"}},
+		}
+	})
+	policyStoreManager.OnInSync()
+
+	// Simulate packet processing to create flow data in epStats.
+	c.applyPacketInfo(clttypes.PacketInfo{
+		Tuple:     *flowTuple1,
+		Direction: rules.RuleDirIngress,
+		RuleHits:  []clttypes.RuleHit{{RuleID: calc.NewRuleID(v3.KindGlobalNetworkPolicy, "default", "policy1", "", 0, rules.RuleDirIngress, rules.RuleActionAllow), Hits: 1, Bytes: 100}},
+	})
+	c.applyPacketInfo(clttypes.PacketInfo{
+		Tuple:     *flowTuple1,
+		Direction: rules.RuleDirEgress,
+		RuleHits:  []clttypes.RuleHit{{RuleID: calc.NewRuleID(v3.KindGlobalNetworkPolicy, "default", "policy1", "", 0, rules.RuleDirEgress, rules.RuleActionAllow), Hits: 1, Bytes: 100}},
+	})
+	c.applyPacketInfo(clttypes.PacketInfo{
+		Tuple:     *flowTuple2,
+		Direction: rules.RuleDirEgress,
+		RuleHits:  []clttypes.RuleHit{{RuleID: calc.NewRuleID(v3.KindGlobalNetworkPolicy, "default", "policy2", "", 0, rules.RuleDirEgress, rules.RuleActionDeny), Hits: 1, Bytes: 100}},
+	})
+
+	return c, *flowTuple1, *flowTuple2
+}
+
+// pendingRuleIDs is a snapshot of both directions' pending rule IDs for the two test flows,
+// used to compare the batched sweep against the eager sweep.
+type pendingRuleIDs struct {
+	flow1Ingress, flow1Egress, flow2Ingress, flow2Egress []*calc.RuleID
+}
+
+func capturePendingRuleIDs(c *collector, ft1, ft2 tuple.Tuple) pendingRuleIDs {
+	return pendingRuleIDs{
+		flow1Ingress: c.epStats[ft1].IngressPendingRuleIDs,
+		flow1Egress:  c.epStats[ft1].EgressPendingRuleIDs,
+		flow2Ingress: c.epStats[ft2].IngressPendingRuleIDs,
+		flow2Egress:  c.epStats[ft2].EgressPendingRuleIDs,
+	}
+}
+
+func clearPendingRuleIDs(c *collector) {
+	for _, data := range c.epStats {
+		data.IngressPendingRuleIDs = nil
+		data.EgressPendingRuleIDs = nil
+	}
+}
+
+// TestBatchedPolicyEvalMatchesEagerSweep verifies that draining the snapshot in time-boxed batches
+// produces the same pending rule traces as the eager, single-shot sweep.
+func TestBatchedPolicyEvalMatchesEagerSweep(t *testing.T) {
+	RegisterTestingT(t)
+	c, ft1, ft2 := setupPolicyEvalCollector(t)
+
+	clearPendingRuleIDs(c)
+	c.updatePendingRuleTraces()
+	eager := capturePendingRuleIDs(c, ft1, ft2)
+
+	clearPendingRuleIDs(c)
+	c.snapshotFlowsForRecalc()
+	for !c.processRecalcBatch(time.Hour) { //nolint:revive // drain in one (large-budget) batch
+	}
+	batched := capturePendingRuleIDs(c, ft1, ft2)
+
+	Expect(batched).To(Equal(eager), "batched sweep should match eager sweep")
+	// Sanity: the fixture actually produced some pending rule IDs.
+	Expect(eager.flow1Ingress).ToNot(BeEmpty())
+}
+
+// TestProcessRecalcBatchTimeBoxes verifies that a small budget bounds each batch and that repeated
+// batches eventually drain the snapshot.
+func TestProcessRecalcBatchTimeBoxes(t *testing.T) {
+	RegisterTestingT(t)
+	c, _, _ := setupPolicyEvalCollector(t)
+
+	c.snapshotFlowsForRecalc()
+	total := len(c.recalcSnapshot)
+	Expect(total).To(BeNumerically(">", 1), "fixture should have more than one flow")
+
+	// A zero budget still makes forward progress: exactly one flow per batch, so it takes
+	// as many batches as there are flows to drain the snapshot.
+	batches := 0
+	remainingAfterFirst := -1
+	for {
+		drained := c.processRecalcBatch(0)
+		batches++
+		if remainingAfterFirst < 0 {
+			remainingAfterFirst = len(c.recalcSnapshot)
+		}
+		if drained {
+			break
+		}
+	}
+	Expect(remainingAfterFirst).To(Equal(total-1), "a zero-budget batch should process exactly one flow")
+	Expect(len(c.recalcSnapshot)).To(Equal(0), "snapshot should be fully drained")
+	Expect(batches).To(Equal(total), "zero-budget batches should drain one flow each")
+}
+
+// TestProcessRecalcBatchSkipsStaleFlows verifies that flows deleted from epStats after the snapshot
+// was taken are skipped rather than evaluated (no panic, not counted).
+func TestProcessRecalcBatchSkipsStaleFlows(t *testing.T) {
+	RegisterTestingT(t)
+	c, ft1, ft2 := setupPolicyEvalCollector(t)
+
+	c.snapshotFlowsForRecalc()
+	snapshotLen := len(c.recalcSnapshot)
+
+	// Delete one flow after the snapshot was taken, as another work source would.
+	c.deleteDataFromEpStats(c.epStats[ft1])
+
+	flowsBefore := testutil.ToFloat64(counterPolicyEvalFlows)
+	for !c.processRecalcBatch(time.Hour) {
+	}
+	flowsDelta := testutil.ToFloat64(counterPolicyEvalFlows) - flowsBefore
+
+	Expect(int(flowsDelta)).To(Equal(snapshotLen-1), "the deleted flow should be skipped, not evaluated")
+	// The surviving flow was still evaluated.
+	Expect(c.epStats[ft2].EgressPendingRuleIDs).ToNot(BeEmpty())
+}
+
+// TestPolicyEvalMetrics verifies the batch/flow counters and the sweep-duration histogram move as
+// expected across a full drain.
+func TestPolicyEvalMetrics(t *testing.T) {
+	RegisterTestingT(t)
+	c, _, _ := setupPolicyEvalCollector(t)
+
+	sweepSampleCount := func() uint64 {
+		var m dto.Metric
+		Expect(histogramPolicyEvalSweepDuration.Write(&m)).To(Succeed())
+		return m.GetHistogram().GetSampleCount()
+	}
+
+	batchesBefore := testutil.ToFloat64(counterPolicyEvalBatches)
+	flowsBefore := testutil.ToFloat64(counterPolicyEvalFlows)
+	sweepsBefore := sweepSampleCount()
+
+	c.snapshotFlowsForRecalc()
+	flows := len(c.recalcSnapshot)
+
+	batches := 0
+	for {
+		batches++
+		if c.processRecalcBatch(0) { // one flow per batch
+			break
+		}
+	}
+
+	Expect(int(testutil.ToFloat64(counterPolicyEvalBatches) - batchesBefore)).To(Equal(batches))
+	Expect(int(testutil.ToFloat64(counterPolicyEvalFlows) - flowsBefore)).To(Equal(flows))
+	// One completed sweep records exactly one histogram observation.
+	Expect(sweepSampleCount()).To(Equal(sweepsBefore + 1))
 }
 
 // Helper function to validate rule ID fields

--- a/felix/collector/collector_test.go
+++ b/felix/collector/collector_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gavv/monotime"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	v3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
@@ -3772,6 +3773,29 @@ func TestProcessRecalcBatchTimeBoxes(t *testing.T) {
 		batches++
 	}
 	Expect(batches).To(Equal(total), "zero-budget batches should drain one flow each")
+}
+
+// TestProcessRecalcBatchEvaluatesNeverEvaluatedFlows covers the early-uptime case: monotime counts
+// from boot, so when the freshness window exceeds the current uptime the "too recent" threshold is
+// negative. Flows that have never been evaluated must still be evaluated, not skipped.
+func TestProcessRecalcBatchEvaluatesNeverEvaluatedFlows(t *testing.T) {
+	RegisterTestingT(t)
+	c, _, _ := setupPolicyEvalCollector(t)
+
+	// A window longer than the machine has been up drives the threshold negative.
+	c.policyEvalMinInterval = 1000 * time.Hour
+	Expect(c.policyEvalMinInterval).To(BeNumerically(">", monotime.Now()),
+		"window must exceed uptime for this test to cover the negative-threshold case")
+	clearPendingRuleIDs(c)
+
+	before := testutil.ToFloat64(counterPolicyEvalFlows)
+	c.snapshotFlowsForRecalc()
+	flows := len(c.recalcSnapshot)
+	for !c.processRecalcBatch(time.Hour) {
+	}
+
+	Expect(int(testutil.ToFloat64(counterPolicyEvalFlows)-before)).To(Equal(flows),
+		"never-evaluated flows must not be skipped as too-recent")
 }
 
 // TestSnapshotRightSizesBuffer verifies the snapshot buffer stays proportional to the flow count,

--- a/felix/collector/collector_test.go
+++ b/felix/collector/collector_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/gavv/monotime"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	apiv3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
 	v3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	dto "github.com/prometheus/client_model/go"
@@ -3832,7 +3831,7 @@ func TestContinuousModeRunsSweepFromMainLoop(t *testing.T) {
 		// Short enough that a tick, and the following re-evaluation, land within the timeout
 		// below: the ticker fires at 8/10 of this and a flow becomes due again at 4/10.
 		FlowLogsFlushInterval: 100 * time.Millisecond,
-		PolicyEvaluationMode:  string(apiv3.FlowLogsPolicyEvaluationModeContinuous),
+		PolicyEvaluationMode:  string(v3.FlowLogsPolicyEvaluationModeContinuous),
 	}).(*collector)
 
 	Expect(c.tickerPolicyEval).ToNot(BeNil(), "continuous mode should arm the policy-eval ticker")

--- a/felix/collector/collector_test.go
+++ b/felix/collector/collector_test.go
@@ -3847,10 +3847,13 @@ func capturePendingRuleIDs(c *collector, ft1, ft2 tuple.Tuple) pendingRuleIDs {
 	}
 }
 
+// clearPendingRuleIDs resets the pending rule traces and the last-evaluated stamp for every flow,
+// so a test can drive a sweep from a clean state (the fixture stamps flows when it creates them).
 func clearPendingRuleIDs(c *collector) {
 	for _, data := range c.epStats {
 		data.IngressPendingRuleIDs = nil
 		data.EgressPendingRuleIDs = nil
+		data.lastPolicyEvalAt = 0
 	}
 }
 
@@ -3881,6 +3884,7 @@ func TestProcessRecalcBatchTimeBoxes(t *testing.T) {
 	RegisterTestingT(t)
 	c, _, _ := setupPolicyEvalCollector(t)
 
+	clearPendingRuleIDs(c) // reset the eval stamps the fixture set at flow creation.
 	c.snapshotFlowsForRecalc()
 	total := len(c.recalcSnapshot)
 	Expect(total).To(BeNumerically(">", 1), "fixture should have more than one flow")
@@ -3910,6 +3914,7 @@ func TestProcessRecalcBatchSkipsStaleFlows(t *testing.T) {
 	RegisterTestingT(t)
 	c, ft1, ft2 := setupPolicyEvalCollector(t)
 
+	clearPendingRuleIDs(c) // reset the eval stamps the fixture set at flow creation.
 	c.snapshotFlowsForRecalc()
 	snapshotLen := len(c.recalcSnapshot)
 
@@ -3942,6 +3947,7 @@ func TestPolicyEvalMetrics(t *testing.T) {
 	flowsBefore := testutil.ToFloat64(counterPolicyEvalFlows)
 	sweepsBefore := sweepSampleCount()
 
+	clearPendingRuleIDs(c) // reset the eval stamps the fixture set at flow creation.
 	c.snapshotFlowsForRecalc()
 	flows := len(c.recalcSnapshot)
 
@@ -3957,6 +3963,39 @@ func TestPolicyEvalMetrics(t *testing.T) {
 	Expect(int(testutil.ToFloat64(counterPolicyEvalFlows) - flowsBefore)).To(Equal(flows))
 	// One completed sweep records exactly one histogram observation.
 	Expect(sweepSampleCount()).To(Equal(sweepsBefore + 1))
+}
+
+// TestProcessRecalcBatchSkipsRecentlyEvaluatedFlows verifies that the sweep captures every flow but
+// skips (does not re-evaluate) flows evaluated within policyEvalMinInterval, so back-to-back sweeps
+// don't reprocess the same flows. Clearing the stamps makes every flow due again.
+func TestProcessRecalcBatchSkipsRecentlyEvaluatedFlows(t *testing.T) {
+	RegisterTestingT(t)
+	c, _, _ := setupPolicyEvalCollector(t)
+
+	Expect(c.policyEvalMinInterval).To(BeNumerically(">", 0))
+
+	// The fixture evaluated (and stamped) every flow when it created them, and the skip window
+	// is half the ticker interval (FlowLogsFlushInterval=100s => ~40s). The snapshot still
+	// captures every flow, but draining it re-evaluates none of them.
+	c.snapshotFlowsForRecalc()
+	total := len(c.recalcSnapshot)
+	Expect(total).To(BeNumerically(">", 1), "the snapshot should capture every flow")
+
+	before := testutil.ToFloat64(counterPolicyEvalFlows)
+	for !c.processRecalcBatch(time.Hour) {
+	}
+	Expect(int(testutil.ToFloat64(counterPolicyEvalFlows)-before)).To(Equal(0),
+		"recently-evaluated flows should be skipped at re-evaluation time")
+
+	// Once the stamps are cleared, every flow is due again.
+	clearPendingRuleIDs(c)
+	c.snapshotFlowsForRecalc()
+	Expect(len(c.recalcSnapshot)).To(Equal(total))
+	before = testutil.ToFloat64(counterPolicyEvalFlows)
+	for !c.processRecalcBatch(time.Hour) {
+	}
+	Expect(int(testutil.ToFloat64(counterPolicyEvalFlows)-before)).To(Equal(total),
+		"cleared flows should all be re-evaluated")
 }
 
 // Helper function to validate rule ID fields

--- a/felix/collector/collector_test.go
+++ b/felix/collector/collector_test.go
@@ -3774,6 +3774,34 @@ func TestProcessRecalcBatchTimeBoxes(t *testing.T) {
 	Expect(batches).To(Equal(total), "zero-budget batches should drain one flow each")
 }
 
+// TestSnapshotRightSizesBuffer verifies the snapshot buffer stays proportional to the flow count,
+// rather than re-allocating as it fills or holding a peak-sized array forever.
+func TestSnapshotRightSizesBuffer(t *testing.T) {
+	RegisterTestingT(t)
+	c, _, _ := setupPolicyEvalCollector(t)
+
+	inBand := func() {
+		Expect(cap(c.recalcSnapshot)).To(BeNumerically(">=", len(c.epStats)),
+			"buffer must hold every flow without growing mid-sweep")
+		Expect(cap(c.recalcSnapshot)).To(BeNumerically("<=", 2*len(c.epStats)),
+			"buffer must not hold on to much more than the current flow count")
+	}
+
+	c.snapshotFlowsForRecalc()
+	Expect(c.recalcSnapshot).To(HaveLen(len(c.epStats)))
+	inBand()
+
+	// Shrinking the flow count must release the larger array.
+	grown := cap(c.recalcSnapshot)
+	for tpl := range c.epStats {
+		c.deleteDataFromEpStats(c.epStats[tpl])
+		break
+	}
+	c.snapshotFlowsForRecalc()
+	inBand()
+	Expect(cap(c.recalcSnapshot)).To(BeNumerically("<", grown))
+}
+
 // TestProcessRecalcBatchSkipsStaleFlows verifies that flows deleted from epStats after the snapshot
 // was taken are skipped rather than evaluated (no panic, not counted).
 func TestProcessRecalcBatchSkipsStaleFlows(t *testing.T) {

--- a/felix/collector/collector_test.go
+++ b/felix/collector/collector_test.go
@@ -3378,117 +3378,10 @@ func TestLoopDataplaneInfoUpdates(t *testing.T) {
 func TestRunPendingRuleTraceEvaluation(t *testing.T) {
 	RegisterTestingT(t)
 
-	// Helper function to convert model workload endpoint key to protobuf endpoint ID
-	convertWorkloadId := func(key model.WorkloadEndpointKey) types.WorkloadEndpointID {
-		return types.WorkloadEndpointID{
-			OrchestratorId: key.OrchestratorID,
-			WorkloadId:     key.WorkloadID,
-			EndpointId:     key.EndpointID,
-		}
-	}
+	c, flowTuple1, flowTuple2 := setupPolicyEvalCollector(t)
 
-	// Setup test environment
-	epMap := map[[16]byte]calc.EndpointData{
-		localIp1:  localEd1,
-		localIp2:  localEd2,
-		remoteIp1: remoteEd1,
-	}
-
-	lm := newMockLookupsCache(epMap, nil, nil, nil)
-	policyStoreManager := policystore.NewPolicyStoreManager()
-
-	conf := &Config{
-		AgeTimeout:            time.Duration(10) * time.Second,
-		InitialReportingDelay: time.Duration(5) * time.Second,
-		ExportingInterval:     time.Duration(1) * time.Second,
-		FlowLogsFlushInterval: time.Duration(100) * time.Second,
-		DisplayDebugTraceLogs: true,
-		PolicyStoreManager:    policyStoreManager,
-	}
-	c := newCollector(lm, conf).(*collector)
-
-	// Create test flow tuples
-	// Flow 1: Local-to-local communication (localIp1 -> localIp2)
-	flowTuple1 := tuple.New(localIp1, localIp2, proto_tcp, 1000, 1000)
-
-	// Flow 2: Local-to-remote communication (localIp2 -> remoteIp1)
-	flowTuple2 := tuple.New(localIp2, remoteIp1, proto_tcp, 1000, 1000)
-
-	// Setup initial policy configuration
-	// localWlEp1 has policy1 for both ingress and egress
-	localWlEp1Proto := calc.ModelWorkloadEndpointToProto(localWlEp1, nil, nil, []*proto.TierInfo{
-		{
-			Name:            "default",
-			IngressPolicies: []*proto.PolicyID{{Name: "policy1", Kind: v3.KindGlobalNetworkPolicy}},
-			EgressPolicies:  []*proto.PolicyID{{Name: "policy1", Kind: v3.KindGlobalNetworkPolicy}},
-		},
-	})
-
-	// localWlEp2 initially has policy2 (deny) for both ingress and egress
-	localWlEp2Proto := calc.ModelWorkloadEndpointToProto(localWlEp2, nil, nil, []*proto.TierInfo{
-		{
-			Name:            "default",
-			IngressPolicies: []*proto.PolicyID{{Name: "policy2", Kind: v3.KindGlobalNetworkPolicy}},
-			EgressPolicies:  []*proto.PolicyID{{Name: "policy2", Kind: v3.KindGlobalNetworkPolicy}},
-		},
-	})
-
-	// remoteWlEp1 has no policies
-	remoteWlEp1Proto := calc.ModelWorkloadEndpointToProto(remoteWlEp1, nil, nil, []*proto.TierInfo{})
-
-	// Initialize policy store with endpoints and policies
-	policyStoreManager.DoWithLock(func(ps *policystore.PolicyStore) {
-		// Add endpoint configurations
-		ps.Endpoints[convertWorkloadId(localWlEPKey1)] = localWlEp1Proto
-		ps.Endpoints[convertWorkloadId(localWlEPKey2)] = localWlEp2Proto
-		ps.Endpoints[convertWorkloadId(remoteWlEpKey1)] = remoteWlEp1Proto
-
-		// Add policy definitions
-		// policy1: Allow all traffic
-		ps.PolicyByID[types.PolicyID{Name: "policy1", Kind: v3.KindGlobalNetworkPolicy}] = &proto.Policy{
-			Tier:          "default",
-			InboundRules:  []*proto.Rule{{Action: "allow"}},
-			OutboundRules: []*proto.Rule{{Action: "allow"}},
-		}
-
-		// policy2: Deny all traffic
-		ps.PolicyByID[types.PolicyID{Name: "policy2", Kind: v3.KindGlobalNetworkPolicy}] = &proto.Policy{
-			Tier:          "default",
-			InboundRules:  []*proto.Rule{{Action: "deny"}},
-			OutboundRules: []*proto.Rule{{Action: "deny"}},
-		}
-	})
-	policyStoreManager.OnInSync()
-
-	// Simulate packet processing to create flow data
-	ruleIDIngressPolicy1 := calc.NewRuleID(v3.KindGlobalNetworkPolicy, "default", "policy1", "", 0, rules.RuleDirIngress, rules.RuleActionAllow)
-	packetInfoIngress1 := clttypes.PacketInfo{
-		Tuple:     *flowTuple1,
-		Direction: rules.RuleDirIngress,
-		RuleHits:  []clttypes.RuleHit{{RuleID: ruleIDIngressPolicy1, Hits: 1, Bytes: 100}},
-	}
-	c.applyPacketInfo(packetInfoIngress1)
-
-	ruleIDEgressPolicy1 := calc.NewRuleID(v3.KindGlobalNetworkPolicy, "default", "policy1", "", 0, rules.RuleDirEgress, rules.RuleActionAllow)
-	packetInfoEgress1 := clttypes.PacketInfo{
-		Tuple:     *flowTuple1,
-		Direction: rules.RuleDirEgress,
-		RuleHits:  []clttypes.RuleHit{{RuleID: ruleIDEgressPolicy1, Hits: 1, Bytes: 100}},
-	}
-	c.applyPacketInfo(packetInfoEgress1)
-
-	// Process egress packet for flow 2 (localIp2 -> remoteIp1)
-	ruleIDEgressPolicy2 := calc.NewRuleID(v3.KindGlobalNetworkPolicy, "default", "policy2", "", 0, rules.RuleDirEgress, rules.RuleActionDeny)
-	packetInfoEgress2 := clttypes.PacketInfo{
-		Tuple:     *flowTuple2,
-		Direction: rules.RuleDirEgress,
-		RuleHits:  []clttypes.RuleHit{{RuleID: ruleIDEgressPolicy2, Hits: 1, Bytes: 100}},
-	}
-	c.applyPacketInfo(packetInfoEgress2)
-
-	// Retrieve flow data from collector
-	flowData1 := c.epStats[*flowTuple1]
-	flowData2 := c.epStats[*flowTuple2]
+	flowData1 := c.epStats[flowTuple1]
+	flowData2 := c.epStats[flowTuple2]
 
 	// Verify initial pending rule trace evaluation
 	testCases := []struct {
@@ -3547,16 +3440,16 @@ func TestRunPendingRuleTraceEvaluation(t *testing.T) {
 
 		// Update the policy store
 		c.policyStoreManager.DoWithLock(func(ps *policystore.PolicyStore) {
-			ps.Endpoints[convertWorkloadId(localWlEPKey2)] = updatedLocalWlEp2Proto
+			ps.Endpoints[workloadEndpointID(localWlEPKey2)] = updatedLocalWlEp2Proto
 		})
 		c.policyStoreManager.OnInSync()
 
 		// Trigger pending rule trace update
-		c.updatePendingRuleTraces()
+		drainRecalcSweep(c)
 
 		// Get updated flow data
-		updatedFlowData1 := c.epStats[*flowTuple1]
-		updatedFlowData2 := c.epStats[*flowTuple2]
+		updatedFlowData1 := c.epStats[flowTuple1]
+		updatedFlowData2 := c.epStats[flowTuple2]
 
 		// Verify updated policy evaluation
 		updatedTestCases := []struct {
@@ -3709,8 +3602,7 @@ func TestRunPendingRuleTraceEvaluation(t *testing.T) {
 			localIp2:  localEd2,
 			remoteIp1: remoteEd1,
 		}
-		lm = newMockLookupsCache(epMapWithoutLocalEd1, nil, nil, nil)
-		c.luc = lm
+		c.luc = newMockLookupsCache(epMapWithoutLocalEd1, nil, nil, nil)
 
 		// Make another policy change to trigger evaluation
 		localWlEp2Proto := calc.ModelWorkloadEndpointToProto(localWlEp2, nil, nil, []*proto.TierInfo{
@@ -3718,19 +3610,19 @@ func TestRunPendingRuleTraceEvaluation(t *testing.T) {
 		})
 
 		c.policyStoreManager.DoWithLock(func(ps *policystore.PolicyStore) {
-			ps.Endpoints[convertWorkloadId(localWlEPKey2)] = localWlEp2Proto
+			ps.Endpoints[workloadEndpointID(localWlEPKey2)] = localWlEp2Proto
 		})
 		c.policyStoreManager.OnInSync()
 
 		// Store original pending rule IDs before update
-		originalFlow1IngressRules := append([]*calc.RuleID(nil), c.epStats[*flowTuple1].IngressPendingRuleIDs...)
-		originalFlow1EgressRules := append([]*calc.RuleID(nil), c.epStats[*flowTuple1].EgressPendingRuleIDs...)
+		originalFlow1IngressRules := append([]*calc.RuleID(nil), c.epStats[flowTuple1].IngressPendingRuleIDs...)
+		originalFlow1EgressRules := append([]*calc.RuleID(nil), c.epStats[flowTuple1].EgressPendingRuleIDs...)
 
 		// Trigger update - should skip flow1 since localEd1 is deleted
-		c.updatePendingRuleTraces()
+		drainRecalcSweep(c)
 
-		currentFlowData1 := c.epStats[*flowTuple1]
-		currentFlowData2 := c.epStats[*flowTuple2]
+		currentFlowData1 := c.epStats[flowTuple1]
+		currentFlowData2 := c.epStats[flowTuple2]
 
 		// Verify that flow1 rules remain unchanged (endpoint deleted, so no update)
 		Expect(currentFlowData1.IngressPendingRuleIDs).To(Equal(originalFlow1IngressRules),
@@ -3750,19 +3642,20 @@ func TestRunPendingRuleTraceEvaluation(t *testing.T) {
 	})
 }
 
-// setupPolicyEvalCollector builds a collector with two flows and a populated policy store,
-// mirroring the fixture used by TestRunPendingRuleTraceEvaluation. It returns the collector and
-// the two flow tuples.
+// workloadEndpointID converts a model workload endpoint key to its protobuf endpoint ID.
+func workloadEndpointID(key model.WorkloadEndpointKey) types.WorkloadEndpointID {
+	return types.WorkloadEndpointID{
+		OrchestratorId: key.OrchestratorID,
+		WorkloadId:     key.WorkloadID,
+		EndpointId:     key.EndpointID,
+	}
+}
+
+// setupPolicyEvalCollector builds a collector holding two flows against a populated policy store:
+// flow1 is local-to-local (policy1 allow), flow2 is local-to-remote (policy2 deny). It returns the
+// collector and the two flow tuples.
 func setupPolicyEvalCollector(t *testing.T) (*collector, tuple.Tuple, tuple.Tuple) {
 	t.Helper()
-
-	convertWorkloadId := func(key model.WorkloadEndpointKey) types.WorkloadEndpointID {
-		return types.WorkloadEndpointID{
-			OrchestratorId: key.OrchestratorID,
-			WorkloadId:     key.WorkloadID,
-			EndpointId:     key.EndpointID,
-		}
-	}
 
 	epMap := map[[16]byte]calc.EndpointData{
 		localIp1:  localEd1,
@@ -3796,9 +3689,9 @@ func setupPolicyEvalCollector(t *testing.T) (*collector, tuple.Tuple, tuple.Tupl
 	remoteWlEp1Proto := calc.ModelWorkloadEndpointToProto(remoteWlEp1, nil, nil, []*proto.TierInfo{})
 
 	policyStoreManager.DoWithLock(func(ps *policystore.PolicyStore) {
-		ps.Endpoints[convertWorkloadId(localWlEPKey1)] = localWlEp1Proto
-		ps.Endpoints[convertWorkloadId(localWlEPKey2)] = localWlEp2Proto
-		ps.Endpoints[convertWorkloadId(remoteWlEpKey1)] = remoteWlEp1Proto
+		ps.Endpoints[workloadEndpointID(localWlEPKey1)] = localWlEp1Proto
+		ps.Endpoints[workloadEndpointID(localWlEPKey2)] = localWlEp2Proto
+		ps.Endpoints[workloadEndpointID(remoteWlEpKey1)] = remoteWlEp1Proto
 		ps.PolicyByID[types.PolicyID{Name: "policy1", Kind: v3.KindGlobalNetworkPolicy}] = &proto.Policy{
 			Tier:          "default",
 			InboundRules:  []*proto.Rule{{Action: "allow"}},
@@ -3832,50 +3725,30 @@ func setupPolicyEvalCollector(t *testing.T) (*collector, tuple.Tuple, tuple.Tupl
 	return c, *flowTuple1, *flowTuple2
 }
 
-// pendingRuleIDs is a snapshot of both directions' pending rule IDs for the two test flows,
-// used to compare the batched sweep against the eager sweep.
-type pendingRuleIDs struct {
-	flow1Ingress, flow1Egress, flow2Ingress, flow2Egress []*calc.RuleID
-}
-
-func capturePendingRuleIDs(c *collector, ft1, ft2 tuple.Tuple) pendingRuleIDs {
-	return pendingRuleIDs{
-		flow1Ingress: c.epStats[ft1].IngressPendingRuleIDs,
-		flow1Egress:  c.epStats[ft1].EgressPendingRuleIDs,
-		flow2Ingress: c.epStats[ft2].IngressPendingRuleIDs,
-		flow2Egress:  c.epStats[ft2].EgressPendingRuleIDs,
-	}
-}
-
-// clearPendingRuleIDs resets the pending rule traces and the last-evaluated stamp for every flow,
-// so a test can drive a sweep from a clean state (the fixture stamps flows when it creates them).
-func clearPendingRuleIDs(c *collector) {
+// makeAllFlowsDue zeroes the last-evaluated stamps so the next sweep re-evaluates every flow. The
+// fixture stamps flows as it creates them, which would otherwise be within the freshness window.
+func makeAllFlowsDue(c *collector) {
 	for _, data := range c.epStats {
-		data.IngressPendingRuleIDs = nil
-		data.EgressPendingRuleIDs = nil
 		data.lastPolicyEvalAt = 0
 	}
 }
 
-// TestBatchedPolicyEvalMatchesEagerSweep verifies that draining the snapshot in time-boxed batches
-// produces the same pending rule traces as the eager, single-shot sweep.
-func TestBatchedPolicyEvalMatchesEagerSweep(t *testing.T) {
-	RegisterTestingT(t)
-	c, ft1, ft2 := setupPolicyEvalCollector(t)
-
-	clearPendingRuleIDs(c)
-	c.updatePendingRuleTraces()
-	eager := capturePendingRuleIDs(c, ft1, ft2)
-
-	clearPendingRuleIDs(c)
-	c.snapshotFlowsForRecalc()
-	for !c.processRecalcBatch(time.Hour) { //nolint:revive // drain in one (large-budget) batch
+// clearPendingRuleIDs additionally discards the pending rule traces, for tests that need to
+// observe the sweep populating them from scratch.
+func clearPendingRuleIDs(c *collector) {
+	for _, data := range c.epStats {
+		data.IngressPendingRuleIDs = nil
+		data.EgressPendingRuleIDs = nil
 	}
-	batched := capturePendingRuleIDs(c, ft1, ft2)
+	makeAllFlowsDue(c)
+}
 
-	Expect(batched).To(Equal(eager), "batched sweep should match eager sweep")
-	// Sanity: the fixture actually produced some pending rule IDs.
-	Expect(eager.flow1Ingress).ToNot(BeEmpty())
+// drainRecalcSweep runs a full policy re-evaluation sweep to completion.
+func drainRecalcSweep(c *collector) {
+	makeAllFlowsDue(c)
+	c.snapshotFlowsForRecalc()
+	for !c.processRecalcBatch(time.Hour) {
+	}
 }
 
 // TestProcessRecalcBatchTimeBoxes verifies that a small budget bounds each batch and that repeated
@@ -3884,27 +3757,20 @@ func TestProcessRecalcBatchTimeBoxes(t *testing.T) {
 	RegisterTestingT(t)
 	c, _, _ := setupPolicyEvalCollector(t)
 
-	clearPendingRuleIDs(c) // reset the eval stamps the fixture set at flow creation.
+	clearPendingRuleIDs(c)
 	c.snapshotFlowsForRecalc()
 	total := len(c.recalcSnapshot)
 	Expect(total).To(BeNumerically(">", 1), "fixture should have more than one flow")
 
-	// A zero budget still makes forward progress: exactly one flow per batch, so it takes
-	// as many batches as there are flows to drain the snapshot.
-	batches := 0
-	remainingAfterFirst := -1
-	for {
-		drained := c.processRecalcBatch(0)
+	// A zero budget still makes forward progress: exactly one flow per batch.
+	Expect(c.processRecalcBatch(0)).To(BeFalse())
+	Expect(c.recalcSnapshot).To(HaveLen(total-1), "a zero-budget batch should process exactly one flow")
+
+	batches := 1
+	for len(c.recalcSnapshot) > 0 {
+		c.processRecalcBatch(0)
 		batches++
-		if remainingAfterFirst < 0 {
-			remainingAfterFirst = len(c.recalcSnapshot)
-		}
-		if drained {
-			break
-		}
 	}
-	Expect(remainingAfterFirst).To(Equal(total-1), "a zero-budget batch should process exactly one flow")
-	Expect(len(c.recalcSnapshot)).To(Equal(0), "snapshot should be fully drained")
 	Expect(batches).To(Equal(total), "zero-budget batches should drain one flow each")
 }
 
@@ -3914,11 +3780,11 @@ func TestProcessRecalcBatchSkipsStaleFlows(t *testing.T) {
 	RegisterTestingT(t)
 	c, ft1, ft2 := setupPolicyEvalCollector(t)
 
-	clearPendingRuleIDs(c) // reset the eval stamps the fixture set at flow creation.
+	clearPendingRuleIDs(c)
 	c.snapshotFlowsForRecalc()
 	snapshotLen := len(c.recalcSnapshot)
 
-	// Delete one flow after the snapshot was taken, as another work source would.
+	// Delete one flow after the snapshot was taken.
 	c.deleteDataFromEpStats(c.epStats[ft1])
 
 	flowsBefore := testutil.ToFloat64(counterPolicyEvalFlows)
@@ -3947,7 +3813,7 @@ func TestPolicyEvalMetrics(t *testing.T) {
 	flowsBefore := testutil.ToFloat64(counterPolicyEvalFlows)
 	sweepsBefore := sweepSampleCount()
 
-	clearPendingRuleIDs(c) // reset the eval stamps the fixture set at flow creation.
+	clearPendingRuleIDs(c)
 	c.snapshotFlowsForRecalc()
 	flows := len(c.recalcSnapshot)
 
@@ -3965,18 +3831,15 @@ func TestPolicyEvalMetrics(t *testing.T) {
 	Expect(sweepSampleCount()).To(Equal(sweepsBefore + 1))
 }
 
-// TestProcessRecalcBatchSkipsRecentlyEvaluatedFlows verifies that the sweep captures every flow but
-// skips (does not re-evaluate) flows evaluated within policyEvalMinInterval, so back-to-back sweeps
-// don't reprocess the same flows. Clearing the stamps makes every flow due again.
+// TestProcessRecalcBatchSkipsRecentlyEvaluatedFlows verifies the snapshot captures every flow but
+// only re-evaluates flows outside policyEvalMinInterval.
 func TestProcessRecalcBatchSkipsRecentlyEvaluatedFlows(t *testing.T) {
 	RegisterTestingT(t)
 	c, _, _ := setupPolicyEvalCollector(t)
 
 	Expect(c.policyEvalMinInterval).To(BeNumerically(">", 0))
 
-	// The fixture evaluated (and stamped) every flow when it created them, and the skip window
-	// is half the ticker interval (FlowLogsFlushInterval=100s => ~40s). The snapshot still
-	// captures every flow, but draining it re-evaluates none of them.
+	// The fixture stamped every flow as it created them, so none are due yet.
 	c.snapshotFlowsForRecalc()
 	total := len(c.recalcSnapshot)
 	Expect(total).To(BeNumerically(">", 1), "the snapshot should capture every flow")

--- a/felix/collector/collector_test.go
+++ b/felix/collector/collector_test.go
@@ -3776,6 +3776,41 @@ func TestProcessRecalcBatchTimeBoxes(t *testing.T) {
 	Expect(batches).To(Equal(total), "zero-budget batches should drain one flow each")
 }
 
+// TestProcessRecalcBatchYieldsWhenEveryFlowIsSkipped covers a snapshot in which nothing is due.
+// Skipped flows do not reach the post-evaluation deadline check, so without the amortised check the
+// batch would pop the whole snapshot in one go, re-introducing the stall the batching exists to
+// prevent. A sweep that overruns the ticker interval produces exactly this snapshot, because the
+// pending tick fires as soon as the sweep drains and every flow has just been stamped.
+func TestProcessRecalcBatchYieldsWhenEveryFlowIsSkipped(t *testing.T) {
+	RegisterTestingT(t)
+
+	const flows = 3 * policyEvalDeadlineCheckInterval
+	c := &collector{
+		epStats: make(map[tuple.Tuple]*Data, flows),
+		// Far longer than the test takes, so every flow reads as recently evaluated.
+		policyEvalMinInterval: time.Hour,
+	}
+	now := monotime.Now()
+	for i := range flows {
+		tup := *tuple.New([16]byte{byte(i), byte(i >> 8)}, [16]byte{1}, proto_tcp, i, 80)
+		data := NewData(tup, nil, nil)
+		data.lastPolicyEvalAt = now
+		c.epStats[tup] = data
+	}
+
+	c.snapshotFlowsForRecalc()
+	Expect(c.processRecalcBatch(0)).To(BeFalse(), "a snapshot of skipped flows should not drain in one batch")
+	Expect(c.recalcSnapshot).To(HaveLen(flows-policyEvalDeadlineCheckInterval),
+		"batch should yield after one deadline-check interval of skipped flows")
+
+	batches := 1
+	for len(c.recalcSnapshot) > 0 {
+		c.processRecalcBatch(0)
+		batches++
+	}
+	Expect(batches).To(Equal(flows / policyEvalDeadlineCheckInterval))
+}
+
 // TestContinuousModeRunsSweepFromMainLoop is the one test that exercises the sweep the way
 // production does: through the collector's own select loop, driven by the policy-eval ticker. Every
 // other policy-eval test calls snapshotFlowsForRecalc/processRecalcBatch directly, so nothing else

--- a/felix/collector/collector_test.go
+++ b/felix/collector/collector_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/gavv/monotime"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	apiv3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
 	v3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	dto "github.com/prometheus/client_model/go"
@@ -3775,6 +3776,61 @@ func TestProcessRecalcBatchTimeBoxes(t *testing.T) {
 	Expect(batches).To(Equal(total), "zero-budget batches should drain one flow each")
 }
 
+// TestContinuousModeRunsSweepFromMainLoop is the one test that exercises the sweep the way
+// production does: through the collector's own select loop, driven by the policy-eval ticker. Every
+// other policy-eval test calls snapshotFlowsForRecalc/processRecalcBatch directly, so nothing else
+// would notice if the ticker stopped firing or the batch path stopped being reached.
+//
+// It asserts on the counter rather than on Data fields, because epStats belongs to the collector
+// goroutine and reading it from the test would race.
+func TestContinuousModeRunsSweepFromMainLoop(t *testing.T) {
+	RegisterTestingT(t)
+
+	epMap := map[[16]byte]calc.EndpointData{
+		localIp1: localEd1,
+		localIp2: localEd2,
+	}
+	c := newCollector(newMockLookupsCache(epMap, nil, nil, nil), &Config{
+		AgeTimeout:            10 * time.Second,
+		InitialReportingDelay: 5 * time.Second,
+		ExportingInterval:     time.Second,
+		// Short enough that a tick, and the following re-evaluation, land within the timeout
+		// below: the ticker fires at 8/10 of this and a flow becomes due again at 4/10.
+		FlowLogsFlushInterval: 100 * time.Millisecond,
+		PolicyEvaluationMode:  string(apiv3.FlowLogsPolicyEvaluationModeContinuous),
+	}).(*collector)
+
+	Expect(c.tickerPolicyEval).ToNot(BeNil(), "continuous mode should arm the policy-eval ticker")
+
+	before := testutil.ToFloat64(counterPolicyEvalFlows.WithLabelValues(string(policyEvalRecalc)))
+	Expect(c.Start()).To(Succeed())
+
+	// Hand the flow to the collector over its reporting channel so that it is created on the
+	// collector's own goroutine.
+	c.ReportingChannel() <- &proto.DataplaneStats{
+		SrcIp:    localIp1Str,
+		DstIp:    localIp2Str,
+		SrcPort:  1000,
+		DstPort:  2000,
+		Protocol: &proto.Protocol{NumberOrName: &proto.Protocol_Number{Number: proto_tcp}},
+	}
+
+	Eventually(func() float64 {
+		return testutil.ToFloat64(counterPolicyEvalFlows.WithLabelValues(string(policyEvalRecalc)))
+	}, 5*time.Second, 20*time.Millisecond).Should(BeNumerically(">", before),
+		"the ticker should drive a re-evaluation sweep through the main loop")
+}
+
+// TestNonContinuousModeLeavesSweepIdle verifies the feature gate suppresses the work, not just the
+// log line: with pending policies disabled there is no ticker, so the sweep never runs.
+func TestNonContinuousModeLeavesSweepIdle(t *testing.T) {
+	RegisterTestingT(t)
+	c, _, _ := setupPolicyEvalCollector(t) // no PolicyEvaluationMode set
+
+	Expect(c.tickerPolicyEval).To(BeNil())
+	Expect(c.policyEvalTickChan()).To(BeNil(), "a nil channel masks the sweep out of the select")
+}
+
 // TestProcessRecalcBatchEvaluatesNeverEvaluatedFlows covers the early-uptime case: monotime counts
 // from boot, so when the freshness window exceeds the current uptime the "too recent" threshold is
 // negative. Flows that have never been evaluated must still be evaluated, not skipped.
@@ -3788,13 +3844,13 @@ func TestProcessRecalcBatchEvaluatesNeverEvaluatedFlows(t *testing.T) {
 		"window must exceed uptime for this test to cover the negative-threshold case")
 	clearPendingRuleIDs(c)
 
-	before := testutil.ToFloat64(counterPolicyEvalFlows)
+	before := testutil.ToFloat64(counterPolicyEvalFlows.WithLabelValues(string(policyEvalRecalc)))
 	c.snapshotFlowsForRecalc()
 	flows := len(c.recalcSnapshot)
 	for !c.processRecalcBatch(time.Hour) {
 	}
 
-	Expect(int(testutil.ToFloat64(counterPolicyEvalFlows)-before)).To(Equal(flows),
+	Expect(int(testutil.ToFloat64(counterPolicyEvalFlows.WithLabelValues(string(policyEvalRecalc)))-before)).To(Equal(flows),
 		"never-evaluated flows must not be skipped as too-recent")
 }
 
@@ -3839,10 +3895,10 @@ func TestProcessRecalcBatchSkipsStaleFlows(t *testing.T) {
 	// Delete one flow after the snapshot was taken.
 	c.deleteDataFromEpStats(c.epStats[ft1])
 
-	flowsBefore := testutil.ToFloat64(counterPolicyEvalFlows)
+	flowsBefore := testutil.ToFloat64(counterPolicyEvalFlows.WithLabelValues(string(policyEvalRecalc)))
 	for !c.processRecalcBatch(time.Hour) {
 	}
-	flowsDelta := testutil.ToFloat64(counterPolicyEvalFlows) - flowsBefore
+	flowsDelta := testutil.ToFloat64(counterPolicyEvalFlows.WithLabelValues(string(policyEvalRecalc))) - flowsBefore
 
 	Expect(int(flowsDelta)).To(Equal(snapshotLen-1), "the deleted flow should be skipped, not evaluated")
 	// The surviving flow was still evaluated.
@@ -3862,7 +3918,7 @@ func TestPolicyEvalMetrics(t *testing.T) {
 	}
 
 	batchesBefore := testutil.ToFloat64(counterPolicyEvalBatches)
-	flowsBefore := testutil.ToFloat64(counterPolicyEvalFlows)
+	flowsBefore := testutil.ToFloat64(counterPolicyEvalFlows.WithLabelValues(string(policyEvalRecalc)))
 	sweepsBefore := sweepSampleCount()
 
 	clearPendingRuleIDs(c)
@@ -3878,7 +3934,7 @@ func TestPolicyEvalMetrics(t *testing.T) {
 	}
 
 	Expect(int(testutil.ToFloat64(counterPolicyEvalBatches) - batchesBefore)).To(Equal(batches))
-	Expect(int(testutil.ToFloat64(counterPolicyEvalFlows) - flowsBefore)).To(Equal(flows))
+	Expect(int(testutil.ToFloat64(counterPolicyEvalFlows.WithLabelValues(string(policyEvalRecalc))) - flowsBefore)).To(Equal(flows))
 	// One completed sweep records exactly one histogram observation.
 	Expect(sweepSampleCount()).To(Equal(sweepsBefore + 1))
 }
@@ -3896,20 +3952,20 @@ func TestProcessRecalcBatchSkipsRecentlyEvaluatedFlows(t *testing.T) {
 	total := len(c.recalcSnapshot)
 	Expect(total).To(BeNumerically(">", 1), "the snapshot should capture every flow")
 
-	before := testutil.ToFloat64(counterPolicyEvalFlows)
+	before := testutil.ToFloat64(counterPolicyEvalFlows.WithLabelValues(string(policyEvalRecalc)))
 	for !c.processRecalcBatch(time.Hour) {
 	}
-	Expect(int(testutil.ToFloat64(counterPolicyEvalFlows)-before)).To(Equal(0),
+	Expect(int(testutil.ToFloat64(counterPolicyEvalFlows.WithLabelValues(string(policyEvalRecalc)))-before)).To(Equal(0),
 		"recently-evaluated flows should be skipped at re-evaluation time")
 
 	// Once the stamps are cleared, every flow is due again.
 	clearPendingRuleIDs(c)
 	c.snapshotFlowsForRecalc()
 	Expect(len(c.recalcSnapshot)).To(Equal(total))
-	before = testutil.ToFloat64(counterPolicyEvalFlows)
+	before = testutil.ToFloat64(counterPolicyEvalFlows.WithLabelValues(string(policyEvalRecalc)))
 	for !c.processRecalcBatch(time.Hour) {
 	}
-	Expect(int(testutil.ToFloat64(counterPolicyEvalFlows)-before)).To(Equal(total),
+	Expect(int(testutil.ToFloat64(counterPolicyEvalFlows.WithLabelValues(string(policyEvalRecalc)))-before)).To(Equal(total),
 		"cleared flows should all be re-evaluated")
 }
 

--- a/felix/collector/stats.go
+++ b/felix/collector/stats.go
@@ -353,9 +353,8 @@ type Data struct {
 
 	updatedAt     time.Duration
 	ruleUpdatedAt time.Duration
-	// lastPolicyEvalAt is the monotime of the last pending-rule-trace evaluation for this
-	// flow. The batched sweep uses it to skip flows evaluated too recently, so back-to-back
-	// sweeps do not reprocess the same flow. Zero means never evaluated.
+	// lastPolicyEvalAt is the monotime of this flow's last pending-rule-trace evaluation, used
+	// to skip flows a sweep re-reaches too soon. Zero means never evaluated.
 	lastPolicyEvalAt time.Duration
 
 	Reported             bool

--- a/felix/collector/stats.go
+++ b/felix/collector/stats.go
@@ -353,6 +353,10 @@ type Data struct {
 
 	updatedAt     time.Duration
 	ruleUpdatedAt time.Duration
+	// lastPolicyEvalAt is the monotime of the last pending-rule-trace evaluation for this
+	// flow. The batched sweep uses it to skip flows evaluated too recently, so back-to-back
+	// sweeps do not reprocess the same flow. Zero means never evaluated.
+	lastPolicyEvalAt time.Duration
 
 	Reported             bool
 	UnreportedPacketInfo bool


### PR DESCRIPTION
## Description

The collector's continuous policy re-evaluation (`updatePendingRuleTraces`) ran a
full `O(flows × tiers × policies)` sweep of `epStats` inline in the collector's
main `select` loop. For the entire duration of the sweep, the other four work
sources on that loop — conntrack batches, NFLOG packet info, the export/aging
ticker, and the dataplane-stats channel — were starved. On a busy node with many
flows this is head-of-line blocking.

This PR drives the sweep in time-boxed batches instead:

- When the policy-eval ticker fires, take a cheap pointer snapshot of the flows
  and **mask** the ticker channel so no new snapshot starts until this one drains.
- A pre-closed trigger channel then drives ~100 ms batches. Because a closed
  channel is always ready, it competes fairly with the other `select` cases, so
  each batch runs and then yields control back to the loop.
- When the snapshot drains, the trigger is re-masked and the ticker re-armed.

The sweep stays on the goroutine that owns `epStats`, so **no new locking** is
introduced — this is purely a `select`-loop restructuring. Batches always process
at least one flow (forward-progress guarantee), skip flows that interleaved work
has expired/deleted, and nil out popped slots so the reused snapshot backing array
does not pin freed `Data`.

New Prometheus metrics for monitoring the batching:
`felix_collector_policy_eval_batches_total`,
`felix_collector_policy_eval_flows_total`,
`felix_collector_policy_eval_sweep_duration_seconds`.

## Testing

New `go test` unit tests in `felix/collector/collector_test.go` cover
batched-vs-eager parity, time-boxing / forward progress, stale-flow skipping, and
the metrics. `go test ./felix/collector/` passes (existing Ginkgo specs + the new
tests); `go vet` is clean.

**Release note:**
```release-note
Fixed head-of-line blocking in the Felix flow-log collector by processing continuous policy re-evaluation in time-boxed batches, keeping conntrack, NFLOG, and dataplane-stats processing responsive.
```
