### PR TITLE
argoci: pass GITHUB_ACCESS_TOKEN via header, not URL

### DIFF
--- a/.argoci/scripts/global_prologue.sh
+++ b/.argoci/scripts/global_prologue.sh
@@ -153,7 +153,7 @@ export BZ_GLOBAL_BIN="${BZ_GLOBAL_BIN:-${HOME}/.local/bin}"
 mkdir -p "${BZ_GLOBAL_BIN}"
 export PATH="${BZ_GLOBAL_BIN}:${PATH}"
 if ! command -v bz >/dev/null 2>&1; then
-  echo "[INFO] bz not on PATH; BZ_REPO=${BZ_REPO:-<UNSET>} GITHUB_ACCESS_TOKEN=$( [ -n "${GITHUB_ACCESS_TOKEN:-}" ] && echo SET || echo EMPTY ) jq=$(command -v jq || echo none) wget=$(command -v wget || echo none)"
+  echo "[INFO] bz not on PATH; BZ_REPO=${BZ_REPO:-<UNSET>} GITHUB_ACCESS_TOKEN=$( [ -n "${GITHUB_ACCESS_TOKEN:-}" ] && echo SET || echo EMPTY ) jq=$(command -v jq || echo none) curl=$(command -v curl || echo none)"
   : "${BZ_REPO:?BZ_REPO not set (expected from banzai-secrets)}"
   : "${GITHUB_ACCESS_TOKEN:?GITHUB_ACCESS_TOKEN not set (expected from banzai-secrets)}"
   [[ -n "${BZ_VERSION:-}" ]] && BZ_RELEASE="tags/${BZ_VERSION}" || BZ_RELEASE="latest"
@@ -170,9 +170,14 @@ if ! command -v bz >/dev/null 2>&1; then
             -H "Accept: application/vnd.github+json" \
             "https://api.github.com/repos/${BZ_REPO}/releases/${BZ_RELEASE}" 2>/dev/null || true)
     BZ_ASSET_ID=$(printf '%s' "${api}" | jq -r 'if (type=="object" and (.assets|type)=="array") then (.assets[]|select(.name|test("^bz.*linux-amd64"))|.id) else empty end' 2>/dev/null | head -1)
+    # wget forwards in-URL creds across the 302 to the signed asset host (token leak,
+    # and S3 400s on double auth); curl drops the header cross-host.
     if [[ "${BZ_ASSET_ID}" =~ ^[0-9]+$ ]] \
-       && wget -q --tries=3 --waitretry=5 --auth-no-challenge --header='Accept:application/octet-stream' \
-            "https://${GITHUB_ACCESS_TOKEN}:@api.github.com/repos/${BZ_REPO}/releases/assets/${BZ_ASSET_ID}" -O "${BZ_GLOBAL_BIN}/bz" \
+       && curl -fsSL --retry 3 --retry-delay 5 --retry-all-errors \
+            -H "Authorization: token ${GITHUB_ACCESS_TOKEN}" \
+            -H "Accept: application/octet-stream" \
+            -o "${BZ_GLOBAL_BIN}/bz" \
+            "https://api.github.com/repos/${BZ_REPO}/releases/assets/${BZ_ASSET_ID}" \
        && [[ $(stat -c%s "${BZ_GLOBAL_BIN}/bz" 2>/dev/null || echo 0) -gt 1000000 ]]; then
       chmod +x "${BZ_GLOBAL_BIN}/bz"
       echo "[INFO] bz installed (asset id=${BZ_ASSET_ID}, attempt ${attempt})"


### PR DESCRIPTION
## Problem

`.argoci/scripts/global_prologue.sh` downloads the `bz` asset with the token embedded in the URL:

```
wget -q --auth-no-challenge ... "https://${GITHUB_ACCESS_TOKEN}:@api.github.com/repos/${BZ_REPO}/releases/assets/${BZ_ASSET_ID}"
```

Two problems:

1. **The token is handed to a third party.** The assets endpoint 302-redirects to a signed host. `wget` forwards the in-URL credentials across that redirect; S3 then sees two auth mechanisms and can 400.
2. **The token is in a URL**, so `-v`, a future `set -x`, or the process arg list puts it into step logs — which ArgoCI archives to `gs://argoci-artifacts` and serves through the viewer.

It's also inconsistent: the API call five lines above, in the same retry loop, already uses `-H "Authorization: token ..."`, as does `global_epilogue.sh`. This was the last token-in-URL in `.argoci`.

## Fix

Use `curl` with an `Authorization` header, matching the call above it. `curl` drops the header on cross-host redirect, so the signed host never sees the token.

Also updates the adjacent `[INFO]` diagnostic to report `curl` rather than `wget`, since the block no longer uses `wget`.

No functional change to what gets downloaded. The 8-attempt retry loop and the size sanity check are deliberately left alone — if the redirect/double-auth 400 was contributing to the flakiness that loop exists to absorb, that becomes measurable separately.

## Note on scope

This PR originally made the same change in `.semaphore/end-to-end/`. That has been dropped as obsolete following the move to ArgoCI. The token-in-URL pattern does still exist in `.semaphore/end-to-end/` on master (3 occurrences) — left as-is on the basis that the Semaphore e2e path is being retired.