### PR TITLE
felix: remove obsolete action marker fields

### DIFF
--- a/felix/iptables/actions.go
+++ b/felix/iptables/actions.go
@@ -141,8 +141,7 @@ type Referrer interface {
 }
 
 type GotoAction struct {
-	Target   string
-	TypeGoto struct{}
+	Target string
 }
 
 func (g GotoAction) ToFragment(features *environment.Features) string {
@@ -160,8 +159,7 @@ func (g GotoAction) ReferencedChain() string {
 var _ Referrer = GotoAction{}
 
 type JumpAction struct {
-	Target   string
-	TypeJump struct{}
+	Target string
 }
 
 func (g JumpAction) ToFragment(features *environment.Features) string {
@@ -181,9 +179,7 @@ var (
 	_ generictables.ReturnActionMarker = ReturnAction{}
 )
 
-type ReturnAction struct {
-	TypeReturn struct{}
-}
+type ReturnAction struct{}
 
 func (r ReturnAction) IsReturnAction() {
 }
@@ -196,9 +192,7 @@ func (r ReturnAction) String() string {
 	return "Return"
 }
 
-type DropAction struct {
-	TypeDrop struct{}
-}
+type DropAction struct{}
 
 func (g DropAction) ToFragment(features *environment.Features) string {
 	return "--jump DROP"
@@ -209,8 +203,7 @@ func (g DropAction) String() string {
 }
 
 type RejectAction struct {
-	TypeReject struct{}
-	With       generictables.RejectWith
+	With generictables.RejectWith
 }
 
 func (g RejectAction) ToFragment(features *environment.Features) string {
@@ -225,8 +218,7 @@ func (g RejectAction) String() string {
 }
 
 type LogAction struct {
-	Prefix  string
-	TypeLog struct{}
+	Prefix string
 }
 
 func (g LogAction) ToFragment(features *environment.Features) string {
@@ -237,9 +229,7 @@ func (g LogAction) String() string {
 	return "Log"
 }
 
-type AcceptAction struct {
-	TypeAccept struct{}
-}
+type AcceptAction struct{}
 
 func (g AcceptAction) ToFragment(features *environment.Features) string {
 	return "--jump ACCEPT"
@@ -276,7 +266,6 @@ func (n NflogAction) String() string {
 type DNATAction struct {
 	DestAddr string
 	DestPort uint16
-	TypeDNAT struct{}
 }
 
 func (g DNATAction) ToFragment(features *environment.Features) string {
@@ -292,8 +281,7 @@ func (g DNATAction) String() string {
 }
 
 type SNATAction struct {
-	ToAddr   string
-	TypeSNAT struct{}
+	ToAddr string
 }
 
 func (g SNATAction) ToFragment(features *environment.Features) string {
@@ -309,8 +297,7 @@ func (g SNATAction) String() string {
 }
 
 type MasqAction struct {
-	ToPorts  string
-	TypeMasq struct{}
+	ToPorts string
 }
 
 func (g MasqAction) ToFragment(features *environment.Features) string {
@@ -329,8 +316,7 @@ func (g MasqAction) String() string {
 }
 
 type ClearMarkAction struct {
-	Mark          uint32
-	TypeClearMark struct{}
+	Mark uint32
 }
 
 func (c ClearMarkAction) ToFragment(features *environment.Features) string {
@@ -342,8 +328,7 @@ func (c ClearMarkAction) String() string {
 }
 
 type SetMarkAction struct {
-	Mark        uint32
-	TypeSetMark struct{}
+	Mark uint32
 }
 
 func (c SetMarkAction) ToFragment(features *environment.Features) string {
@@ -355,9 +340,8 @@ func (c SetMarkAction) String() string {
 }
 
 type SetMaskedMarkAction struct {
-	Mark              uint32
-	Mask              uint32
-	TypeSetMaskedMark struct{}
+	Mark uint32
+	Mask uint32
 }
 
 func (c SetMaskedMarkAction) ToFragment(features *environment.Features) string {
@@ -368,9 +352,7 @@ func (c SetMaskedMarkAction) String() string {
 	return fmt.Sprintf("Set:%#x", c.Mark)
 }
 
-type NoTrackAction struct {
-	TypeNoTrack struct{}
-}
+type NoTrackAction struct{}
 
 func (g NoTrackAction) ToFragment(features *environment.Features) string {
 	return "--jump NOTRACK"
@@ -381,8 +363,7 @@ func (g NoTrackAction) String() string {
 }
 
 type SaveConnMarkAction struct {
-	SaveMask     uint32
-	TypeConnMark struct{}
+	SaveMask uint32
 }
 
 func (c SaveConnMarkAction) ToFragment(features *environment.Features) string {
@@ -401,8 +382,7 @@ func (c SaveConnMarkAction) String() string {
 }
 
 type RestoreConnMarkAction struct {
-	RestoreMask  uint32
-	TypeConnMark struct{}
+	RestoreMask uint32
 }
 
 func (c RestoreConnMarkAction) ToFragment(features *environment.Features) string {
@@ -421,9 +401,8 @@ func (c RestoreConnMarkAction) String() string {
 }
 
 type SetConnMarkAction struct {
-	Mark         uint32
-	Mask         uint32
-	TypeConnMark struct{}
+	Mark uint32
+	Mask uint32
 }
 
 func (c SetConnMarkAction) ToFragment(features *environment.Features) string {
@@ -442,10 +421,9 @@ func (c SetConnMarkAction) String() string {
 }
 
 type LimitPacketRateAction struct {
-	Rate                int64
-	Burst               int64
-	Mark                uint32
-	TypeLimitPacketRate struct{}
+	Rate  int64
+	Burst int64
+	Mark  uint32
 }
 
 func (a LimitPacketRateAction) ToFragment(features *environment.Features) string {
@@ -468,9 +446,8 @@ func (a LimitPacketRateAction) String() string {
 }
 
 type LimitNumConnectionsAction struct {
-	Num                     int64
-	RejectWith              generictables.RejectWith
-	TypeLimitNumConnections struct{}
+	Num        int64
+	RejectWith generictables.RejectWith
 }
 
 func (a LimitNumConnectionsAction) ToFragment(features *environment.Features) string {

--- a/felix/nftables/actions.go
+++ b/felix/nftables/actions.go
@@ -156,8 +156,7 @@ type Referrer interface {
 }
 
 type GotoAction struct {
-	Target   string
-	TypeGoto struct{}
+	Target string
 }
 
 func (g GotoAction) ToFragment(features *environment.Features) string {
@@ -188,8 +187,7 @@ var (
 )
 
 type JumpAction struct {
-	Target   string
-	TypeJump struct{}
+	Target string
 }
 
 func (g JumpAction) ToFragment(features *environment.Features) string {
@@ -221,9 +219,7 @@ var (
 	_ generictables.ReturnActionMarker = ReturnAction{}
 )
 
-type ReturnAction struct {
-	TypeReturn struct{}
-}
+type ReturnAction struct{}
 
 func (r ReturnAction) IsReturnAction() {
 }
@@ -236,9 +232,7 @@ func (r ReturnAction) String() string {
 	return "Return"
 }
 
-type DropAction struct {
-	TypeDrop struct{}
-}
+type DropAction struct{}
 
 func (g DropAction) ToFragment(features *environment.Features) string {
 	return "drop"
@@ -249,8 +243,7 @@ func (g DropAction) String() string {
 }
 
 type RejectAction struct {
-	TypeReject struct{}
-	With       string
+	With string
 }
 
 func (g RejectAction) ToFragment(features *environment.Features) string {
@@ -265,8 +258,7 @@ func (g RejectAction) String() string {
 }
 
 type LogAction struct {
-	Prefix  string
-	TypeLog struct{}
+	Prefix string
 }
 
 func (g LogAction) ToFragment(features *environment.Features) string {
@@ -277,9 +269,7 @@ func (g LogAction) String() string {
 	return "Log"
 }
 
-type AcceptAction struct {
-	TypeAccept struct{}
-}
+type AcceptAction struct{}
 
 func (g AcceptAction) ToFragment(features *environment.Features) string {
 	return "accept"
@@ -292,7 +282,6 @@ func (g AcceptAction) String() string {
 type DNATAction struct {
 	DestAddr string
 	DestPort uint16
-	TypeDNAT struct{}
 }
 
 func (g DNATAction) ToFragment(features *environment.Features) string {
@@ -308,8 +297,7 @@ func (g DNATAction) String() string {
 }
 
 type SNATAction struct {
-	ToAddr   string
-	TypeSNAT struct{}
+	ToAddr string
 }
 
 func (g SNATAction) ToFragment(features *environment.Features) string {
@@ -325,8 +313,7 @@ func (g SNATAction) String() string {
 }
 
 type MasqAction struct {
-	ToPorts  string
-	TypeMasq struct{}
+	ToPorts string
 }
 
 func (g MasqAction) ToFragment(features *environment.Features) string {
@@ -346,8 +333,7 @@ func (g MasqAction) String() string {
 }
 
 type ClearMarkAction struct {
-	Mark          uint32
-	TypeClearMark struct{}
+	Mark uint32
 }
 
 func (c ClearMarkAction) ToFragment(features *environment.Features) string {
@@ -359,8 +345,7 @@ func (c ClearMarkAction) String() string {
 }
 
 type SetMarkAction struct {
-	Mark        uint32
-	TypeSetMark struct{}
+	Mark uint32
 }
 
 func (c SetMarkAction) ToFragment(features *environment.Features) string {
@@ -372,9 +357,8 @@ func (c SetMarkAction) String() string {
 }
 
 type SetMaskedMarkAction struct {
-	Mark              uint32
-	Mask              uint32
-	TypeSetMaskedMark struct{}
+	Mark uint32
+	Mask uint32
 }
 
 func (c SetMaskedMarkAction) ToFragment(features *environment.Features) string {
@@ -385,9 +369,7 @@ func (c SetMaskedMarkAction) String() string {
 	return fmt.Sprintf("Set:%#x", c.Mark)
 }
 
-type NoTrackAction struct {
-	TypeNoTrack struct{}
-}
+type NoTrackAction struct{}
 
 func (g NoTrackAction) ToFragment(features *environment.Features) string {
 	return "notrack"
@@ -398,8 +380,7 @@ func (g NoTrackAction) String() string {
 }
 
 type SaveConnMarkAction struct {
-	SaveMask     uint32
-	TypeConnMark struct{}
+	SaveMask uint32
 }
 
 func (c SaveConnMarkAction) ToFragment(features *environment.Features) string {
@@ -414,8 +395,7 @@ func (c SaveConnMarkAction) String() string {
 }
 
 type RestoreConnMarkAction struct {
-	RestoreMask  uint32
-	TypeConnMark struct{}
+	RestoreMask uint32
 }
 
 func (c RestoreConnMarkAction) ToFragment(features *environment.Features) string {
@@ -431,9 +411,8 @@ func (c RestoreConnMarkAction) String() string {
 }
 
 type SetConnMarkAction struct {
-	Mark         uint32
-	Mask         uint32
-	TypeConnMark struct{}
+	Mark uint32
+	Mask uint32
 }
 
 func (c SetConnMarkAction) ToFragment(features *environment.Features) string {
@@ -474,7 +453,6 @@ type LimitPacketRateAction struct {
 	Rate  int64
 	Burst int64
 	// Mark is not used on nftables mode
-	TypeLimitPacketRate struct{}
 }
 
 func (a LimitPacketRateAction) ToFragment(features *environment.Features) string {
@@ -494,9 +472,8 @@ func (a LimitPacketRateAction) String() string {
 }
 
 type LimitNumConnectionsAction struct {
-	Num                     int64
-	RejectWith              generictables.RejectWith
-	TypeLimitNumConnections struct{}
+	Num        int64
+	RejectWith generictables.RejectWith
 }
 
 func (a LimitNumConnectionsAction) ToFragment(features *environment.Features) string {
@@ -531,9 +508,7 @@ func (a DSCPAction) String() string {
 	return fmt.Sprintf("DSCP %d", a.Value)
 }
 
-type FlowOffloadAction struct {
-	TypeFlowOffload struct{}
-}
+type FlowOffloadAction struct{}
 
 func (c FlowOffloadAction) ToFragment(features *environment.Features) string {
 	return fmt.Sprintf("flow offload @%s", dataplanedefs.FlowtableName)


### PR DESCRIPTION
## Description

The iptables and nftables `Action` structs each carried an empty, zero-size marker field (`TypeGoto`, `TypeJump`, `TypeDNAT`, ... — 39 in total across `felix/iptables/actions.go` and `felix/nftables/actions.go`).

These were introduced in 2017 (commit `9d80eca285`, *"Add marker fields so that action types get traced out in UT output."*) for a single reason: so an action's concrete type would be distinguishable in Gomega unit-test failure output. Empty structs such as `DropAction{}` and `ReturnAction{}` otherwise rendered identically as `{}`, making a failing rule-chain diff ambiguous.

Current Gomega (v1.42.0) already prints the concrete type name of an interface value's dynamic type in its failure diffs, e.g.:

```
Action: <iptables.DropAction>{},
```

so `DropAction{}` and `ReturnAction{}` are already distinguishable without the marker. The fields are never read or assigned anywhere in the tree (`grep` confirms declarations only), so they are now pure noise that repeatedly puzzles readers.

This PR removes them. The change is purely mechanical — no behavior change. Structs left with no remaining fields collapse to `struct{}`.

## Testing

Unit tests pass unchanged:

```
ok  github.com/projectcalico/calico/felix/iptables
ok  github.com/projectcalico/calico/felix/nftables
ok  github.com/projectcalico/calico/felix/rules
```

`go build` and `go vet` clean for both packages.

## Release Note

```release-note
None
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)