### PR TITLE
Add nftables dataplane benchmark and perf-publishing infra

### DIFF
--- a/.semaphore/semaphore-scheduled-builds.yml
+++ b/.semaphore/semaphore-scheduled-builds.yml
@@ -1685,6 +1685,44 @@ blocks:
             - mkdir logs
             - sudo journalctl > logs/journalctl.txt
             - artifact push job logs
+  - name: "Felix: dataplane benchmark"
+    run:
+      when: "true"
+    dependencies:
+      - Prerequisites
+    task:
+      agent:
+        machine:
+          type: f1-standard-2
+          os_image: ubuntu2204
+      secrets:
+        - name: banzai-secrets
+      jobs:
+        - name: "Felix: dataplane benchmark"
+          execution_time_limit:
+            minutes: 30
+          commands:
+            # The benchmark programs a real nftables table, which the go-build
+            # image can't do (it has no nft binary), so run it on the host. Build
+            # the benchmark and the Lens publisher as static binaries in go-build,
+            # then run them here.
+            - sudo apt-get update -y && sudo apt-get install -y nftables
+            - make -C felix bin/nft.test
+            - make bin/send-perf-results
+            - mkdir -p artifacts/perf
+            # Run as root so the benchmark can program the kernel. A few iterations
+            # is enough for a stable steady-state number; this is trend tracking,
+            # not a per-PR gate.
+            - sudo env NFT_BENCH_PERF_ARTIFACTS_DIR="$(pwd)/artifacts/perf" felix/bin/nft.test -test.run='^$' -test.bench=. -test.benchmem -test.benchtime=6x
+            # Publish to Lens. send-perf-results no-ops if the creds are unset.
+            - export ELASTICSEARCH_URL=https://banzai-lens-es.dev-tools.tigera.net:9200
+            - export ELASTICSEARCH_USER=elastic
+            - export ELASTICSEARCH_TOKEN=${LENS_ELASTICSEARCH_TOKEN}
+            - ./bin/send-perf-results --dir artifacts/perf
+      epilogue:
+        always:
+          commands:
+            - artifact push job artifacts/perf || true
   - name: Mock node
     run:
       when: "true"

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -1685,6 +1685,44 @@ blocks:
             - mkdir logs
             - sudo journalctl > logs/journalctl.txt
             - artifact push job logs
+  - name: "Felix: dataplane benchmark"
+    run:
+      when: "change_in(['/.semaphore/semaphore.yml.d/01-preamble.yml','/.semaphore/semaphore.yml.d/02-global_job_config.yml','/.semaphore/semaphore.yml.d/03-promotions.yml','/.semaphore/semaphore.yml.d/09-blocks.yml','/.semaphore/semaphore.yml.d/99-after_pipeline.yml','/.semaphore/semaphore.yml.d/blocks/45-nft-bench.yml','/api/pkg/apis/projectcalico/v3/*.go','/api/pkg/defaults/*.go','/api/pkg/lib/numorstring/*.go','/crypto/pkg/tls/*.go','/felix/config/*.go','/felix/dataplane/ipsets/*.go','/felix/deltatracker/*.go','/felix/environment/*.go','/felix/generictables/*.go','/felix/idalloc/*.go','/felix/ip/*.go','/felix/ipsets/*.go','/felix/iptables/cmdshim/*.go','/felix/labelindex/ipsetmember/*.go','/felix/logutils/*.go','/felix/netlinkshim/*.go','/felix/nftables/**','/felix/proto/*.go','/felix/stringutils/*.go','/hack/perf/','/hack/test/certs/','/lib.Makefile','/lib/std/uniquelabels/*.go','/lib/std/uniquestr/*.go','/libcalico-go/config/*.go','/libcalico-go/lib/apiconfig/*.go','/libcalico-go/lib/apis/crd.projectcalico.org/v1/scheme/*.go','/libcalico-go/lib/apis/internalapi/*.go','/libcalico-go/lib/backend/*.go','/libcalico-go/lib/backend/api/*.go','/libcalico-go/lib/backend/encap/*.go','/libcalico-go/lib/backend/etcdv3/*.go','/libcalico-go/lib/backend/k8s/*.go','/libcalico-go/lib/backend/k8s/conversion/*.go','/libcalico-go/lib/backend/k8s/resources/*.go','/libcalico-go/lib/backend/model/*.go','/libcalico-go/lib/clientv3/*.go','/libcalico-go/lib/consistenthash/*.go','/libcalico-go/lib/errors/*.go','/libcalico-go/lib/hash/*.go','/libcalico-go/lib/json/*.go','/libcalico-go/lib/logutils/*.go','/libcalico-go/lib/names/*.go','/libcalico-go/lib/namespace/*.go','/libcalico-go/lib/net/*.go','/libcalico-go/lib/options/*.go','/libcalico-go/lib/prometheus/*.go','/libcalico-go/lib/resources/*.go','/libcalico-go/lib/selector/*.go','/libcalico-go/lib/selector/parser/*.go','/libcalico-go/lib/selector/tokenizer/*.go','/libcalico-go/lib/set/*.go','/libcalico-go/lib/validator/v3/*.go','/libcalico-go/lib/watch/*.go','/libcalico-go/lib/winutils/*.go','/metadata.mk','/node/pkg/lifecycle/utils/*.go'], {pipeline_file: 'ignore', exclude: ['/**/*.md','/**/.gitignore','/**/AUTHORS*','/**/CONTRIBUTING*','/**/DEVELOPER_GUIDE*','/**/LICENSE*','/**/README*','/**/SECURITY.md','/api/**/*_test.go','/crypto/**/*_test.go','/felix/**/*_test.go','/lib/**/*_test.go','/libcalico-go/**/*_test.go','/node/**/*_test.go'], default_branch: 'release-v3.32'})"
+    dependencies:
+      - Prerequisites
+    task:
+      agent:
+        machine:
+          type: f1-standard-2
+          os_image: ubuntu2204
+      secrets:
+        - name: banzai-secrets
+      jobs:
+        - name: "Felix: dataplane benchmark"
+          execution_time_limit:
+            minutes: 30
+          commands:
+            # The benchmark programs a real nftables table, which the go-build
+            # image can't do (it has no nft binary), so run it on the host. Build
+            # the benchmark and the Lens publisher as static binaries in go-build,
+            # then run them here.
+            - sudo apt-get update -y && sudo apt-get install -y nftables
+            - make -C felix bin/nft.test
+            - make bin/send-perf-results
+            - mkdir -p artifacts/perf
+            # Run as root so the benchmark can program the kernel. A few iterations
+            # is enough for a stable steady-state number; this is trend tracking,
+            # not a per-PR gate.
+            - sudo env NFT_BENCH_PERF_ARTIFACTS_DIR="$(pwd)/artifacts/perf" felix/bin/nft.test -test.run='^$' -test.bench=. -test.benchmem -test.benchtime=6x
+            # Publish to Lens. send-perf-results no-ops if the creds are unset.
+            - export ELASTICSEARCH_URL=https://banzai-lens-es.dev-tools.tigera.net:9200
+            - export ELASTICSEARCH_USER=elastic
+            - export ELASTICSEARCH_TOKEN=${LENS_ELASTICSEARCH_TOKEN}
+            - ./bin/send-perf-results --dir artifacts/perf
+      epilogue:
+        always:
+          commands:
+            - artifact push job artifacts/perf || true
   - name: Mock node
     run:
       when: "change_in(['/.semaphore/semaphore.yml.d/01-preamble.yml','/.semaphore/semaphore.yml.d/02-global_job_config.yml','/.semaphore/semaphore.yml.d/03-promotions.yml','/.semaphore/semaphore.yml.d/09-blocks.yml','/.semaphore/semaphore.yml.d/99-after_pipeline.yml','/.semaphore/semaphore.yml.d/blocks/60-mock-node.yml','/api/pkg/apis/projectcalico/v3/*.go','/api/pkg/lib/numorstring/*.go','/crypto/pkg/tls/*.go','/hack/test/certs/','/lib.Makefile','/lib/std/uniquelabels/*.go','/lib/std/uniquestr/*.go','/libcalico-go/lib/apis/internalapi/*.go','/libcalico-go/lib/backend/api/*.go','/libcalico-go/lib/backend/encap/*.go','/libcalico-go/lib/backend/model/*.go','/libcalico-go/lib/errors/*.go','/libcalico-go/lib/json/*.go','/libcalico-go/lib/logutils/*.go','/libcalico-go/lib/names/*.go','/libcalico-go/lib/namespace/*.go','/libcalico-go/lib/net/*.go','/libcalico-go/lib/readlogger/*.go','/libcalico-go/lib/winutils/*.go','/metadata.mk','/pkg/buildinfo/*.go','/test-tools/mocknode/**','/typha/pkg/discovery/*.go','/typha/pkg/syncclient/*.go','/typha/pkg/syncproto/*.go','/typha/pkg/tlsutils/*.go'], {pipeline_file: 'ignore', exclude: ['/**/*.md','/**/.gitignore','/**/AUTHORS*','/**/CONTRIBUTING*','/**/DEVELOPER_GUIDE*','/**/LICENSE*','/**/README*','/**/SECURITY.md','/api/**/*_test.go','/crypto/**/*_test.go','/lib/**/*_test.go','/libcalico-go/**/*_test.go','/pkg/**/*_test.go','/typha/**/*_test.go'], default_branch: 'release-v3.32'})"

--- a/.semaphore/semaphore.yml.d/blocks/45-nft-bench.yml
+++ b/.semaphore/semaphore.yml.d/blocks/45-nft-bench.yml
@@ -1,0 +1,38 @@
+- name: "Felix: dataplane benchmark"
+  run:
+    when: "${CHANGE_IN(felix/nftables,non-go:/hack/perf/)}"
+  dependencies:
+    - Prerequisites
+  task:
+    agent:
+      machine:
+        type: f1-standard-2
+        os_image: ubuntu2204
+    secrets:
+      - name: banzai-secrets
+    jobs:
+      - name: "Felix: dataplane benchmark"
+        execution_time_limit:
+          minutes: 30
+        commands:
+          # The benchmark programs a real nftables table, which the go-build
+          # image can't do (it has no nft binary), so run it on the host. Build
+          # the benchmark and the Lens publisher as static binaries in go-build,
+          # then run them here.
+          - sudo apt-get update -y && sudo apt-get install -y nftables
+          - make -C felix bin/nft.test
+          - make bin/send-perf-results
+          - mkdir -p artifacts/perf
+          # Run as root so the benchmark can program the kernel. A few iterations
+          # is enough for a stable steady-state number; this is trend tracking,
+          # not a per-PR gate.
+          - sudo env NFT_BENCH_PERF_ARTIFACTS_DIR="$(pwd)/artifacts/perf" felix/bin/nft.test -test.run='^$' -test.bench=. -test.benchmem -test.benchtime=6x
+          # Publish to Lens. send-perf-results no-ops if the creds are unset.
+          - export ELASTICSEARCH_URL=https://banzai-lens-es.dev-tools.tigera.net:9200
+          - export ELASTICSEARCH_USER=elastic
+          - export ELASTICSEARCH_TOKEN=${LENS_ELASTICSEARCH_TOKEN}
+          - ./bin/send-perf-results --dir artifacts/perf
+    epilogue:
+      always:
+        commands:
+          - artifact push job artifacts/perf || true

--- a/Makefile
+++ b/Makefile
@@ -136,6 +136,13 @@ $(DEP_FILES): go.mod go.sum $(shell find . -name '*.go') Makefile hack/cmd/deps/
 	  $(DOCKER_GO_BUILD) sh -c "go run ./hack/cmd/deps combined $(patsubst %/,%,$(dir $@))"; \
 	} > $@
 
+# bin/send-perf-results is the tool that pushes hack/perf JSON docs to the Lens
+# Elasticsearch cluster (see hack/perf/README.md). Built statically so CI jobs
+# that produce perf artifacts on the host (e.g. the nftables dataplane benchmark)
+# can run it without the go-build container.
+bin/send-perf-results: $(shell find ./hack/perf -name '*.go')
+	$(DOCKER_GO_BUILD) sh -c "CGO_ENABLED=0 go build -o $@ ./hack/perf/cmd/send-perf-results"
+
 CHART_DESTINATION ?= ./bin
 
 # Build helm charts.

--- a/felix/Makefile
+++ b/felix/Makefile
@@ -552,6 +552,14 @@ ut-watch: $(SRC_FILES) $(LIBBPF_A) $(BPF_APACHE_O_FILES)
 	@echo Watching go UTs for changes...
 	$(DOCKER_GO_BUILD) ginkgo2 watch -r -skip-package $(UT_PACKAGES_TO_SKIP) $(GINKGO_ARGS)
 
+# bin/nft.test is the compiled felix/nftables test binary. The "Felix: nftables
+# dataplane benchmark" CI job runs it on the host (as root, against a real nft)
+# to publish the dataplane-programming benchmarks to Lens. Built statically (no
+# CGO) so it runs outside the go-build container.
+.PHONY: bin/nft.test
+bin/nft.test: $(shell find nftables -name '*.go')
+	$(DOCKER_GO_BUILD) sh -c "CGO_ENABLED=0 go test ./nftables -c -o $@"
+
 .PHONY: bin/bpf.test
 bin/bpf.test: $(GENERATED_FILES) $(shell find bpf/ -name '*.go')
 	$(DOCKER_GO_BUILD_CGO) go test ./bpf/ -c -o $@

--- a/felix/nftables/bench_test.go
+++ b/felix/nftables/bench_test.go
@@ -1,0 +1,373 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nftables_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/prometheus/procfs"
+	"github.com/sirupsen/logrus"
+
+	"github.com/projectcalico/calico/felix/environment"
+	"github.com/projectcalico/calico/felix/generictables"
+	"github.com/projectcalico/calico/felix/ipsets"
+	"github.com/projectcalico/calico/felix/logutils"
+	"github.com/projectcalico/calico/felix/nftables"
+	"github.com/projectcalico/calico/felix/rules"
+)
+
+// These benchmarks isolate the nftables programming path - render plus the nft
+// transaction to the kernel - so we can measure the cost of a change without
+// standing up a cluster.  They program a real "calico" table in the host's
+// network namespace, so they must run as root (CAP_NET_ADMIN), same as the
+// routetable benchmarks.
+//
+// The scale knobs (IP sets, members per set, policy chains, rules per chain)
+// map onto the dimensions the higher-level k8sfv scale runs drive from real
+// policy, so a finding here is reproducible there.  Felix's IP sets come from
+// policy selectors (label selectors over pods/namespaces, network sets, named
+// ports), not from Kubernetes services - those are kube-proxy's job and live in
+// its own table.  So the large specs below model policies that select across
+// many endpoints, which is where Felix's IP set and rule load actually comes
+// from.
+
+type scaleSpec struct {
+	name string
+
+	numIPSets     int
+	membersPerSet int
+	numPolicies   int
+	rulesPerChain int
+}
+
+// scaleSpecs is a deliberately modest first sweep.  The dimensions can be
+// turned up towards the k8sfv headline scales (10k+ policies, 250k members)
+// once we trust the numbers; start small so the suite stays runnable.
+var scaleSpecs = []scaleSpec{
+	{name: "100sets_100chains", numIPSets: 100, membersPerSet: 20, numPolicies: 100, rulesPerChain: 10},
+	{name: "500sets_500chains", numIPSets: 500, membersPerSet: 50, numPolicies: 500, rulesPerChain: 10},
+	{name: "2000sets_2000chains", numIPSets: 2000, membersPerSet: 100, numPolicies: 2000, rulesPerChain: 10},
+}
+
+// BenchmarkResync measures the cost of a full resync against an already-correct
+// dataplane: read the current state back, diff it against the desired state,
+// and reconcile.  This is the periodic-refresh cost and the analogue of
+// BenchmarkResync in felix/routetable.
+func BenchmarkResync(b *testing.B) {
+	for _, s := range scaleSpecs {
+		b.Run(s.name, func(b *testing.B) {
+			table, ipv := newRealTable(b)
+			buildState(table, ipv, s)
+			table.ApplyUpdates(nil)
+			table.Apply()
+
+			b.ReportAllocs()
+			rec := record(b, s, "resync")
+			b.ResetTimer()
+
+			for range b.N {
+				table.InvalidateDataplaneCache("bench")
+				table.QueueResync()
+				table.ApplyUpdates(nil)
+				table.Apply()
+			}
+
+			b.StopTimer()
+			rec.finish()
+		})
+	}
+}
+
+// BenchmarkDeltaUpdate measures the incremental write cost: each iteration
+// churns a single IP set's membership and reprograms.  This is the steady-state
+// case - a pod coming or going - rather than a full resync.
+func BenchmarkDeltaUpdate(b *testing.B) {
+	for _, s := range scaleSpecs {
+		b.Run(s.name, func(b *testing.B) {
+			table, ipv := newRealTable(b)
+			buildState(table, ipv, s)
+			table.ApplyUpdates(nil)
+			table.Apply()
+			// The first Apply() programs the whole table, which invalidates the
+			// dataplane cache. Apply once more so the cache is settled before we
+			// start timing - we want the steady-state delta cost, not the one-off
+			// reload that follows the initial program.
+			table.Apply()
+
+			b.ReportAllocs()
+			rec := record(b, s, "delta")
+			b.ResetTimer()
+
+			// Toggle one member of set 0 in and out so each iteration is a real
+			// add or remove rather than a no-op.
+			churn := intToIP(172<<24 | 16<<16)
+			for i := range b.N {
+				if i%2 == 0 {
+					table.AddMembers("s000000", []string{churn})
+				} else {
+					table.RemoveMembers("s000000", []string{churn})
+				}
+				table.ApplyUpdates(nil)
+				table.Apply()
+			}
+
+			b.StopTimer()
+			rec.finish()
+		})
+	}
+}
+
+// BenchmarkChainUpdate measures the incremental cost of changing a single policy
+// chain's rules and reprogramming, in steady state (no forced resync).
+func BenchmarkChainUpdate(b *testing.B) {
+	for _, s := range scaleSpecs {
+		b.Run(s.name, func(b *testing.B) {
+			table, ipv := newRealTable(b)
+			buildState(table, ipv, s)
+			table.ApplyUpdates(nil)
+			table.Apply()
+			// Settle the cache before timing (see BenchmarkDeltaUpdate).
+			table.Apply()
+
+			b.ReportAllocs()
+			rec := record(b, s, "chain_update")
+			b.ResetTimer()
+
+			// Toggle one rule's destination port on a single chain so each
+			// iteration is a real change to that chain and nothing else.
+			chainName := "cali-pi-000000"
+			setName := ipv.NameForMainIPSet("s000000")
+			for i := range b.N {
+				port := uint16(2000 + i%2)
+				table.UpdateChain(&generictables.Chain{
+					Name: chainName,
+					Rules: []generictables.Rule{
+						{
+							Match:  nftables.Match().Protocol("tcp").SourceIPSet(setName).DestPorts(port),
+							Action: nftables.ReturnAction{},
+						},
+					},
+				})
+				table.Apply()
+			}
+
+			b.StopTimer()
+			rec.finish()
+		})
+	}
+}
+
+// benchTableName is a dedicated, benchmark-only table. We deliberately avoid
+// "calico" so a run can never touch a real Calico dataplane on this host.
+const benchTableName = "calico-bench"
+
+// newRealTable builds an NftablesTable wired to the real kernel via knftables.
+// It skips (rather than fails) when its prerequisites aren't met (not root, or
+// no nft binary) so a plain "go test" on a dev box doesn't error - the benchmark
+// is only meaningful with kernel access.
+func newRealTable(b *testing.B) (*nftables.NftablesTable, *ipsets.IPVersionConfig) {
+	if os.Getuid() != 0 {
+		b.Skip("Must run as root: programs the real nftables dataplane.")
+	}
+	if _, err := exec.LookPath("nft"); err != nil {
+		b.Skip("nft binary not found; skipping nftables dataplane benchmark.")
+	}
+	logutils.ConfigureEarlyLogging()
+	logrus.SetLevel(logrus.WarnLevel)
+
+	// Start clean and tidy up after ourselves - we program a real table in the
+	// host's network namespace.
+	deleteBenchTable()
+	b.Cleanup(deleteBenchTable)
+
+	// required=false so we return nil (and skip) rather than panic if the
+	// knftables client can't be created, e.g. the kernel lacks nftables support.
+	table := nftables.NewTable(
+		benchTableName,
+		4,
+		rules.RuleHashPrefix,
+		environment.NewFeatureDetector(nil),
+		nftables.TableOptions{
+			OpRecorder: logutils.NewSummarizer("bench"),
+		},
+		false,
+	)
+	if table == nil {
+		b.Skip("nftables not available on this host; skipping benchmark.")
+	}
+	ipv := ipsets.NewIPVersionConfig(ipsets.IPFamilyV4, ipsets.IPSetNamePrefix, nil, nil)
+	return table, ipv
+}
+
+func deleteBenchTable() {
+	// May not exist yet on the first call; ignore the error.
+	_ = exec.Command("nft", "delete", "table", "ip", benchTableName).Run()
+}
+
+// buildState queues the desired state onto the table: numIPSets hash:ip sets,
+// and numPolicies chains each holding rulesPerChain rules that match on a source
+// IP set and TCP destination port.  Each chain is jumped to from filter-FORWARD
+// so it is referenced and therefore programmed.
+func buildState(table *nftables.NftablesTable, ipv *ipsets.IPVersionConfig, s scaleSpec) {
+	ipCounter := uint32(10 << 24)
+	setNames := make([]string, s.numIPSets)
+	for i := range s.numIPSets {
+		setID := fmt.Sprintf("s%06d", i)
+		setNames[i] = ipv.NameForMainIPSet(setID)
+		members := make([]string, s.membersPerSet)
+		for j := range s.membersPerSet {
+			members[j] = intToIP(ipCounter)
+			ipCounter++
+		}
+		table.AddOrReplaceIPSet(
+			ipsets.IPSetMetadata{
+				SetID:   setID,
+				Type:    ipsets.IPSetTypeHashIP,
+				MaxSize: 1 << 20,
+			},
+			members,
+		)
+	}
+
+	jumps := make([]generictables.Rule, s.numPolicies)
+	for p := range s.numPolicies {
+		chainName := fmt.Sprintf("cali-pi-%06d", p)
+		policyRules := make([]generictables.Rule, s.rulesPerChain)
+		for r := range s.rulesPerChain {
+			setName := setNames[(p*s.rulesPerChain+r)%s.numIPSets]
+			policyRules[r] = generictables.Rule{
+				Match: nftables.Match().
+					Protocol("tcp").
+					SourceIPSet(setName).
+					DestPorts(uint16(1000 + r)),
+				Action: nftables.ReturnAction{},
+			}
+		}
+		table.UpdateChain(&generictables.Chain{Name: chainName, Rules: policyRules})
+		jumps[p] = generictables.Rule{
+			Match:  nftables.Match(),
+			Action: nftables.JumpAction{Target: chainName},
+		}
+	}
+	table.InsertOrAppendRules("filter-FORWARD", jumps)
+}
+
+func intToIP(v uint32) string {
+	return fmt.Sprintf("%d.%d.%d.%d", byte(v>>24), byte(v>>16), byte(v>>8), byte(v))
+}
+
+// perfArtifactsEnvVar names a directory to write per-measurement results into,
+// as hack/perf JSON docs (see hack/perf/README.md). It is unset for ordinary
+// `go test` runs - we only emit when a CI job asks for it, which keeps dev runs
+// out of the long-term trend store. The CI job then runs send-perf-results
+// against the directory to push the docs to Lens.
+const (
+	perfArtifactsEnvVar = "NFT_BENCH_PERF_ARTIFACTS_DIR"
+	perfFamily          = "benchmark_data_nft_dataplane"
+)
+
+// recorder measures a benchmark loop and, on finish, reports per-op metrics to
+// testing.B and (if enabled) writes a hack/perf doc for it. Start it immediately
+// before b.ResetTimer() and finish it immediately after b.StopTimer().
+type recorder struct {
+	b     *testing.B
+	spec  scaleSpec
+	phase string
+
+	proc      procfs.Proc
+	startCPU  float64
+	startWall time.Time
+	startMem  runtime.MemStats
+}
+
+func record(b *testing.B, s scaleSpec, phase string) *recorder {
+	proc, _ := procfs.NewProc(os.Getpid())
+	stat, _ := proc.Stat()
+	r := &recorder{
+		b:         b,
+		spec:      s,
+		phase:     phase,
+		proc:      proc,
+		startCPU:  stat.CPUTime(),
+		startWall: time.Now(),
+	}
+	runtime.ReadMemStats(&r.startMem)
+	return r
+}
+
+func (r *recorder) finish() {
+	wallNsPerOp := float64(time.Since(r.startWall).Nanoseconds()) / float64(r.b.N)
+
+	var endMem runtime.MemStats
+	runtime.ReadMemStats(&endMem)
+	bytesPerOp := float64(endMem.TotalAlloc-r.startMem.TotalAlloc) / float64(r.b.N)
+	allocsPerOp := float64(endMem.Mallocs-r.startMem.Mallocs) / float64(r.b.N)
+
+	// CPU time diverges from wall-clock once the nft path blocks on the kernel,
+	// so report both.
+	runtime.GC()
+	stat, _ := r.proc.Stat()
+	cpuNsPerOp := (stat.CPUTime() - r.startCPU) / float64(r.b.N) * 1e9
+
+	r.b.ReportMetric(float64(r.spec.numIPSets), "ipsets")
+	r.b.ReportMetric(float64(r.spec.numIPSets*r.spec.membersPerSet), "members")
+	r.b.ReportMetric(float64(r.spec.numPolicies), "chains")
+	r.b.ReportMetric(float64(r.spec.numPolicies*r.spec.rulesPerChain), "rules")
+	r.b.ReportMetric(cpuNsPerOp, "ncpu/op")
+
+	r.writePerfDoc(wallNsPerOp, cpuNsPerOp, bytesPerOp, allocsPerOp)
+}
+
+func (r *recorder) writePerfDoc(wallNsPerOp, cpuNsPerOp, bytesPerOp, allocsPerOp float64) {
+	dir := os.Getenv(perfArtifactsEnvVar)
+	if dir == "" {
+		return
+	}
+	doc := map[string]any{
+		"test_name":         "nft_dataplane",
+		"dataplane":         "nftables",
+		"phase":             r.phase,
+		"scale_ipsets":      r.spec.numIPSets,
+		"scale_set_members": r.spec.numIPSets * r.spec.membersPerSet,
+		"scale_chains":      r.spec.numPolicies,
+		"scale_rules":       r.spec.numPolicies * r.spec.rulesPerChain,
+		"wall_ns_per_op":    wallNsPerOp,
+		"cpu_ns_per_op":     cpuNsPerOp,
+		"bytes_per_op":      bytesPerOp,
+		"allocs_per_op":     allocsPerOp,
+		"ok":                true,
+	}
+	familyDir := filepath.Join(dir, perfFamily)
+	if err := os.MkdirAll(familyDir, 0o755); err != nil {
+		r.b.Logf("perf: failed to create %s: %v", familyDir, err)
+		return
+	}
+	data, err := json.MarshalIndent(doc, "", "  ")
+	if err != nil {
+		r.b.Logf("perf: failed to marshal doc: %v", err)
+		return
+	}
+	path := filepath.Join(familyDir, fmt.Sprintf("%s_%s.json", r.phase, r.spec.name))
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		r.b.Logf("perf: failed to write %s: %v", path, err)
+	}
+}

--- a/hack/deps.txt
+++ b/hack/deps.txt
@@ -116,6 +116,7 @@ local:hack/cmd/coalesce-imports
 local:hack/cmd/deps
 local:hack/cmd/gomodder
 local:hack/cmd/ipam-hammer
+local:hack/perf/cmd/send-perf-results
 local:hack/test/spider
 local:lib/std/uniquelabels
 local:lib/std/uniquestr

--- a/hack/perf/README.md
+++ b/hack/perf/README.md
@@ -1,0 +1,439 @@
+# Cross-monorepo performance-result publishing
+
+This directory is the canonical home for plumbing that gets perf-test
+measurements into the Lens Elasticsearch cluster, where they can be tracked
+over time.
+
+## Why this exists
+
+The monorepo has a growing collection of perf tests -- tiger-bench,
+`felix/k8sfv`, OpenStack Neutron→etcd resync timings, and others -- but
+historically their results have been ephemeral: printed to a CI log, then lost
+when the log rotates.  That makes it impossible to answer questions like "did
+this PR slow down endpoint programming?" or "has Felix memory occupancy been
+creeping up over the last quarter?"
+
+The Lens ES/Kibana stack at `banzai-lens.dev-tools.tigera.net` gives us a
+place to land structured perf data and visualise it over time.  This README
+covers how to wire a new test into it.  Tiger-bench's
+`pkg/elasticsearch/elasticsearch.go` is prior art and worth reading if you're
+curious about the lower-level ES client side; this directory abstracts that
+away behind a producer-side "write JSON files" contract.
+
+This is **not** about per-PR perf gating (synchronous, blocks merges).  It's
+about long-term trend visibility: spotting gradual regressions, validating
+performance work, and comparing dataplanes/branches over time.
+
+## The Lens store
+
+- **ES + Kibana**: <https://banzai-lens.dev-tools.tigera.net>
+- **Existing dashboards**: tiger-bench results live at
+  `/app/dashboards#/view/856d49ee-c097-4c58-a6e7-1433475698fc`.
+- **Credentials and endpoint**: ask in `#banzai` (or whoever owns the Lens
+  cluster) for the ES endpoint URL (set as `ELASTICSEARCH_URL` -- typically
+  on port 9200, distinct from the Kibana URL above) plus *one* of:
+  - `ELASTICSEARCH_USER` + `ELASTICSEARCH_TOKEN` (basic auth), or
+  - `ELASTICSEARCH_KEY` (API key -- preferred).
+- **In CI**: wire these as Semaphore secrets attached to the pipeline that
+  runs your test.
+- **Locally**: same env vars work, but see [Operational hygiene](#operational-hygiene)
+  -- don't pollute trend data with dev runs.
+
+## What lives here
+
+```
+hack/perf/
+├── cmd/send-perf-results/main.go     The tool that pushes JSON docs to ES.
+├── index-templates/<family>.json     One ES index template per family.
+└── README.md                         (this file)
+```
+
+## How a test publishes a measurement
+
+A test producing perf data does **two** things:
+
+1. Write one JSON file per measurement to
+   `artifacts/perf/<index_family>/<descriptive_name>.json`.  Each file is a
+   single ES document containing **only the scenario-specific scalars** --
+   scale dimensions, metrics, test_name, and so on.  CI metadata
+   (`git_commit`, `ci_run_id`, etc.) is NOT the producer's job.  See
+   [Schema](#schema-what-makes-a-good-datapoint) below for what counts as
+   scenario-specific.
+
+2. Arrange for `send-perf-results` to run once at the end of the producing
+   Semaphore job.  The simplest pattern is to add a line near the end of the
+   job's commands:
+
+   ```sh
+   go run ./hack/perf/cmd/send-perf-results --dir artifacts/perf
+   ```
+
+   (or invoke a pre-built binary).  Calling it exactly once per job is the
+   only operational discipline required -- see [Idempotency](#idempotency).
+
+`artifacts/perf/` lives under the existing `artifacts/` upload, so the
+per-measurement JSON files are also automatically captured as Semaphore
+artifacts -- useful for post-mortem when a number looks off.
+
+## What `send-perf-results` does
+
+On each invocation, in order:
+
+1. **Apply index templates.**  For every `hack/perf/index-templates/<family>.json`,
+   PUT it to `/_index_template/<family>` in ES.  Idempotent upsert -- see
+   [When does the PUT have effect?](#when-does-the-put-have-effect) for what
+   this is and isn't buying.
+2. **Walk `artifacts/perf/<family>/*.json`** for every `<family>` subdirectory.
+3. **Augment each doc** with CI metadata (`@timestamp`, `git_commit`,
+   `git_branch`, `code_version`, `ci_run_id`, `pr_number`, `env`) unless the
+   producer already supplied that field -- producer values win.  Picked up
+   from `SEMAPHORE_GIT_SHA`, `SEMAPHORE_GIT_BRANCH`, `SEMAPHORE_JOB_ID`,
+   `SEMAPHORE_GIT_PR_NUMBER`.
+4. **POST to `<family>_<UTC year>/_doc`.**  The year suffix is computed at
+   send time; producer side stays date-free.  ES auto-creates the dated
+   index on first write using the template applied in step 1.
+5. Exit 0.
+
+"Lens is observability, not a critical path": the tool only returns non-zero
+in genuinely unrecoverable cases.  Missing credentials, unreachable ES,
+malformed JSON, mapping conflicts -- all log a warning and continue.  A
+`--require-creds` flag flips the missing-creds case to a hard failure, for
+places that want a strict gate on the publish step.
+
+### When does the PUT have effect?
+
+Index templates in Elasticsearch apply at *index-creation* time, not to live
+indices.  Once `benchmark_data_<family>_2026` exists, its mapping is fixed;
+PUTing the template again does not modify that index.  So the PUT-every-time
+behaviour is meaningful in four narrow cases:
+
+1. **First-ever run for a family** -- creates the template before the first
+   doc lands, so the first auto-created index gets pinned types instead of
+   ES's dynamic inference.
+2. **Year rollover** -- the next `benchmark_data_<family>_<YYYY>` is
+   auto-created on the first write of the new year, using whatever template
+   is in cluster state at that moment.
+3. **Cluster rebuild or migration** -- equivalent to case (1).
+4. **Defensive replay** -- if anything ever deletes the template (master
+   failover edge cases have been known to lose entries), the next run puts
+   it back.
+
+In normal steady-state operation -- template already in place, mid-year --
+the PUT is a no-op.  We do it on every run anyway because (a) it's a single
+HTTP per family per CI job, effectively free, and (b) the self-heal property
+in case (4) is worth more than the cost.
+
+Mid-year template *edits* (adding/removing/renaming a field, changing a type)
+do not affect the live index.  An added field gets dynamic-mapping inference
+on first sight; a removed field still appears in old docs' `_source` and the
+live index's mapping; a type change risks a write rejection (mapping
+conflict) until the next year's index rolls over with the new template.  For
+type changes that need to take effect mid-year, reindex into a renamed index
+(`_2026_v2`) rather than fighting the existing mapping.
+
+## Schema: what makes a good datapoint
+
+**One measurement = one document.**  Don't push your test's whole raw output
+as a single deeply-nested doc; decompose it into individual scalar
+measurements first.
+
+**Flat scalars only.**  Every field should be a scalar (string, number,
+boolean) or a flat array of scalars.  Avoid:
+
+- **Nested objects** (e.g. `cold.phases.endpoints.compare_ms`).  They
+  technically work, but they're harder to discover in Kibana and they make
+  visualisations clunkier than they need to be.
+- **Arrays of objects** (e.g. `steady: [{phases: ...}, {phases: ...}]`).
+  ES's default mapping flattens these into parallel arrays-of-scalars,
+  losing per-element correlation.  Lens can't chart them; the proper fix
+  (mapping the field as `nested` type) makes them queryable but Lens *still*
+  won't chart them -- you'd have to drop down to TSVB or Vega.
+
+If your test produces multiple sub-measurements (e.g. a "cold" run plus
+three "steady" iterations), explode them into separate documents
+distinguished by `phase` / `iter` / `test_step` fields.  See
+[Patterns for tricky cases](#patterns-for-tricky-cases).
+
+### Producer-supplied fields
+
+Scenario-specific scalars are the producer's responsibility:
+
+- **`test_name`** -- a stable string identifying the scenario family,
+  distinct from the index name (e.g. `neutron_resync`).
+- **Scale parameters** -- e.g. `scale_endpoints: 10000`, `scale_policies:
+  100`, `scale_hosts: 10`.  Field names should be specific to your scenario,
+  but consistent within a test.
+- **The measured metrics**, flattened (e.g. `endpoints_total_ms`, not
+  `endpoints.total_ms`).
+- **`phase` / `iter` / `test_step` keywords** if the doc is one of several
+  related sub-measurements.
+- **`ok: bool`** and optional **`error: string`** if the test can partially
+  succeed.
+- **Scenario context** when applicable: `dataplane` (`iptables`,
+  `nftables`, `ebpf`), `encap` (`vxlan`, `ipip`, `none`), `k8s_version`,
+  `cloud` (`gcp`, `aws`, `azure`, `kind`), `node_type`, `node_count`.
+
+### Tool-injected fields (don't set these)
+
+`send-perf-results` adds these from the CI environment unless the producer
+already supplied a value (producer wins):
+
+- **`@timestamp`** -- ISO-8601 UTC; Kibana's time field.
+- **`git_commit`** -- from `SEMAPHORE_GIT_SHA`.
+- **`git_branch`** -- from `SEMAPHORE_GIT_BRANCH`.
+- **`code_version`** -- short SHA derived from `git_commit`.
+- **`ci_run_id`** -- from `SEMAPHORE_JOB_ID`.
+- **`pr_number`** -- from `SEMAPHORE_GIT_PR_NUMBER`, if set.
+- **`env`** -- `ci` if `SEMAPHORE_JOB_ID` is set, else `dev`.  Filter
+  dashboards to `env: ci` to keep dev runs out of trend data.
+
+### `phase` vs `iter` vs `test_step`
+
+- **`iter`** *(integer)*: index of a repeated whole-test iteration
+  (e.g. `0` for cold, `1..N` for steady runs).
+- **`phase`** *(keyword)*: tag for distinct phases of a test (`cold`,
+  `steady`, `setup`, `teardown`).  Use alongside `iter` when each phase is
+  run multiple times.
+- **`test_step`** *(keyword)*: label for snapshots *within* a single test
+  run (e.g. `snap_0`, `snap_1`, ... in `felix/k8sfv`'s memory-leak
+  scenario).  Use this for in-test time series; use `iter` for repeated
+  whole-test runs.  All three can coexist: a test running three steady
+  iterations of twenty heap snapshots would have `iter ∈ {1,2,3}`,
+  `phase = "steady"`, `test_step ∈ {"snap_0", ..., "snap_19"}`.
+
+## Index naming convention
+
+Indices are named `<family>_<period-suffix>`, where:
+
+- **`<family>`** is `benchmark_data_<test>` (e.g. `benchmark_data_neutron_resync`).
+- **`<period-suffix>`** is either `YYYY` (yearly) or `YYYY-MM` (monthly).
+  **Don't use daily.**
+
+`send-perf-results` writes to a yearly suffix.  For most monorepo perf
+tests, **yearly is the right default** -- it minimises shard count, keeps
+cluster-state overhead lowest, and the data volumes leave plenty of
+headroom.  Pick monthly only if:
+
+- **High document volume.**  A year's worth could plausibly exceed 10 GB in
+  a single index.  ES wants primary shards in the 10–50 GB range; at ~500
+  bytes per doc a yearly index can fit ~20M docs comfortably.  None of our
+  current tests come close.
+- **Sub-yearly retention.**  Yearly forces you to wait until the year rolls
+  over before shedding any data.
+- **Frequent schema evolution.**  Monthly gives you a natural reset point.
+
+In Kibana, create a single index pattern per family with a wildcard
+(`benchmark_data_<test>_*`).  That picks up both yearly and monthly so you
+can switch granularity later without losing continuity.
+
+**Why not daily?**  Daily indices over-fragment intrinsically low-volume
+perf data: hundreds of nearly-empty shards waste heap, cluster state
+balloons, query fan-out gets expensive, and dynamic mapping inference (see
+[ES schema gotchas](#es-schema-gotchas)) gets 365 chances per year to drift
+instead of 1.  Tiger-bench's existing indices predate this convention and
+can stay where they are; new test families should follow it.
+
+## Adding a new index family
+
+1. Pick a family name following `benchmark_data_<test>`.
+2. Add `hack/perf/index-templates/<family>.json` covering at least the
+   metadata fields plus your scenario-specific numeric metrics.  See the
+   [starter template](#starter-index-template) below.
+3. Have your test write to `artifacts/perf/<family>/*.json`.
+4. Add a `send-perf-results` invocation to the end of the producing
+   Semaphore job (if not already there from a previous family).
+5. After the first CI run, [verify the data landed](#verifying-data-landed).
+
+### Starter index template
+
+A minimal template covering the metadata fields and a `total_ms` metric.
+Drop it at `hack/perf/index-templates/benchmark_data_<test>.json` and add
+your scenario-specific numeric fields alongside `total_ms`:
+
+```json
+{
+  "index_patterns": ["benchmark_data_<test>_*"],
+  "template": {
+    "mappings": {
+      "properties": {
+        "@timestamp":   {"type": "date"},
+        "git_commit":   {"type": "keyword"},
+        "git_branch":   {"type": "keyword"},
+        "ci_run_id":    {"type": "keyword"},
+        "code_version": {"type": "keyword"},
+        "pr_number":    {"type": "keyword"},
+        "test_name":    {"type": "keyword"},
+        "dataplane":    {"type": "keyword"},
+        "encap":        {"type": "keyword"},
+        "k8s_version":  {"type": "keyword"},
+        "cloud":        {"type": "keyword"},
+        "node_type":    {"type": "keyword"},
+        "env":          {"type": "keyword"},
+        "phase":        {"type": "keyword"},
+        "test_step":    {"type": "keyword"},
+        "iter":         {"type": "integer"},
+        "ok":           {"type": "boolean"},
+        "error":        {"type": "keyword"},
+        "total_ms":     {"type": "double"}
+      }
+    }
+  }
+}
+```
+
+Replace `<test>` in `index_patterns` with your family suffix.  Pin every
+numeric metric you care about as `double` if there's any chance it'll go
+fractional (see "Numeric type widening" below).
+
+## ES schema gotchas
+
+- **Dynamic mapping inference.**  ES infers field types from the *first*
+  document indexed into each new index.  If the first doc in one period
+  has `error: null` and the first doc in the next has `error: "timeout"`,
+  you get mapping inconsistency across the index pattern and Kibana shows
+  "conflict" warnings.  **Fix:** rely on the index template
+  (`send-perf-results` applies them on every invocation, so a template
+  change auto-propagates).  Even pinning a handful of known fields
+  prevents most surprises.
+- **`text` vs `keyword`.**  ES's default dynamic mapping maps strings as
+  `text` (full-text searchable, **not aggregatable**) with a `.keyword`
+  subfield.  To filter or group by `git_branch` in Kibana, you'd then have
+  to use `git_branch.keyword`.  Less awkward to pin string fields as
+  `keyword` in the template.
+- **Field count limit.**  ES caps an index at 1000 fields by default.  You
+  won't hit this with a flat doc; you can hit it surprisingly fast with a
+  deeply-nested one.
+- **Numeric type widening.**  If your first doc has `total_ms: 100` (mapped
+  as `long`) and a later doc has `total_ms: 100.5`, the later push fails
+  the mapping.  Pin numeric metrics as `double` in the template if there's
+  any chance they'll go fractional.
+
+## Kibana visualisation gotchas
+
+- **Lens, the default visualiser, doesn't chart `nested`-typed fields.**
+  TSVB and Vega can, but you'd rather not be writing Vega.  Avoid nested
+  fields.
+- **Time field required.**  Kibana index patterns need a date field to
+  enable time-series views.  Use `@timestamp`.
+- **Index pattern wildcards.**  One per test family:
+  `benchmark_data_neutron_resync_*` covers yearly and monthly suffixes.
+
+## Patterns for tricky cases
+
+### Multiple iterations per run (cold + N steady)
+
+Push one document per iteration.  Distinguish via `phase` and `iter`:
+
+```
+{ phase: "cold",   iter: 0, total_ms: 6798, ... }
+{ phase: "steady", iter: 1, total_ms: 4769, ... }
+{ phase: "steady", iter: 2, total_ms: 4730, ... }
+{ phase: "steady", iter: 3, total_ms: 4672, ... }
+```
+
+In Kibana, chart median of `total_ms` filtered by `phase: "steady"`, or
+compare cold vs steady side-by-side.
+
+### Time-series within a single run
+
+For tests like `felix/k8sfv`'s memory-leak scenario -- heap snapshots
+throughout a long-running test -- push one doc per snapshot with a
+`test_step` label:
+
+```
+{ test_step: "snap_0",  heap_alloc_bytes: 12345678, ... }
+{ test_step: "snap_1",  heap_alloc_bytes: 13456789, ... }
+...
+{ test_step: "snap_19", heap_alloc_bytes: 25678901, ... }
+```
+
+Each doc still gets the full metadata (commit, branch, ci_run_id) -- those
+are repeated across docs in the run.  ES handles this fine and Kibana lets
+you chart `heap_alloc_bytes` over `test_step`, with `git_commit` as a
+series breakdown for cross-run comparison.
+
+### Pass/fail alongside continuous metrics
+
+Just include `ok: true|false` (and optional `error: "<message>"`) on the
+same doc as the timing.  Kibana can chart failure rate per scenario as a
+separate visualisation in the same dashboard.
+
+### Test failure or partial results
+
+If your test crashes partway through:
+
+- **Partial metrics available**: write the file you have with `ok: false`
+  and `error: "<reason>"`.  A "test failed at scale=1000" data point is
+  itself useful trend information.
+- **Nothing usable** (e.g. infra failed before the test started): don't
+  write a file.  A doc with `null` everywhere just creates noise -- use
+  the CI log for the failure record instead.
+
+## Operational hygiene
+
+- **Don't push from local dev runs.**  Most developers won't have Lens
+  creds anyway -- `send-perf-results` already skips silently when
+  `ELASTICSEARCH_URL` is unset.  If you *do* push locally (e.g. for
+  testing the tool itself), the injected `env: dev` lets dashboards
+  filter dev runs out.
+- **Index retention.**  Check with the Lens cluster owners whether ILM
+  (Index Lifecycle Management) is configured for `benchmark_data_*`.  If
+  not, indices accumulate forever.  Worth setting up an ILM policy that
+  rolls older indices to a cheaper tier.
+- **Schema evolution.**  If you need to change the *meaning* of a field,
+  don't try to patch the existing family in place -- start a new one
+  (`benchmark_data_neutron_resync_v2_*`) and update dashboards.  Fighting
+  type drift across periods is more pain than starting fresh.
+
+## Verifying data landed
+
+After your first CI run, confirm the doc made it into ES before going
+further.  From Kibana → **Dev Tools**:
+
+```
+GET benchmark_data_<test>_*/_search
+{
+  "size": 5,
+  "sort": [{"@timestamp": "desc"}]
+}
+```
+
+You should see your most recent docs with the expected fields and types.
+If a field shows up as `text` when you wanted `keyword`, your index
+template didn't take effect -- check that the template's `index_patterns`
+matches your actual index name.
+
+From the shell:
+
+```bash
+curl -s "$ELASTICSEARCH_URL/benchmark_data_<test>_*/_search?size=5&sort=@timestamp:desc" \
+  -H "Authorization: ApiKey $ELASTICSEARCH_KEY" | jq '.hits.hits'
+```
+
+To see the inferred mapping for a specific index:
+
+```
+GET benchmark_data_<test>_2026/_mapping
+```
+
+## Next steps once you've pushed data
+
+1. **Create a Kibana index pattern.**  Stack Management → Index Patterns →
+   Create.  Pattern: `benchmark_data_<your_test>_*`.  Time field: `@timestamp`.
+2. **Build a starter Lens visualisation.**  Drag your primary metric onto
+   Y, `@timestamp` onto X.  Break out by `dataplane` or `git_branch` as a
+   series.
+3. **Save it to a dashboard.**  Add filters for `env: ci` and any baseline
+   scenario settings.
+4. **Share the dashboard URL.**  Add it next to your test's documentation
+   so others can see how the test has trended.
+
+## Local development
+
+To test the tool itself against a local files-only flow:
+
+```sh
+go run ./hack/perf/cmd/send-perf-results --dry-run --dir /tmp/some/perf
+```
+
+`--dry-run` prints what would be POSTed without contacting ES.

--- a/hack/perf/cmd/send-perf-results/main.go
+++ b/hack/perf/cmd/send-perf-results/main.go
@@ -1,0 +1,278 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// send-perf-results scans a directory of per-test JSON measurement files,
+// augments each with CI metadata, and POSTs them to the Lens Elasticsearch
+// cluster.  See hack/perf/README.md for the convention.
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const (
+	// Field names injected into every doc unless the producer already
+	// supplied them.  Keep in sync with hack/perf/README.md.
+	fieldTimestamp   = "@timestamp"
+	fieldGitCommit   = "git_commit"
+	fieldGitBranch   = "git_branch"
+	fieldCodeVersion = "code_version"
+	fieldCIRunID     = "ci_run_id"
+	fieldPRNumber    = "pr_number"
+	fieldEnv         = "env"
+)
+
+func main() {
+	dir := flag.String("dir", "artifacts/perf", "Directory to scan for per-family subdirectories of JSON docs.")
+	tmplDir := flag.String("templates", "hack/perf/index-templates", "Directory containing one <family>.json template per index family.")
+	dryRun := flag.Bool("dry-run", false, "Parse and augment but do not POST.  Prints each doc to stdout.")
+	requireCreds := flag.Bool("require-creds", false, "Exit non-zero if Elasticsearch credentials are not configured.")
+	flag.Parse()
+
+	esURL := os.Getenv("ELASTICSEARCH_URL")
+	auth, authOK := buildAuthHeader()
+	if esURL == "" || !authOK {
+		// "Lens is observability, not a critical path" -- see
+		// hack/perf/README.md.  Missing creds in a local dev run is normal;
+		// in CI it usually means the pipeline secret wasn't attached, which
+		// a --require-creds caller can turn into a hard failure.
+		msg := "ELASTICSEARCH_URL or credentials unset; skipping send"
+		if *requireCreds {
+			log.Fatalf("%s (--require-creds set)", msg)
+		}
+		log.Printf("%s", msg)
+		if *dryRun {
+			// Continue so the dry-run prints can still be useful.
+		} else {
+			return
+		}
+	}
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	metadata := ciMetadata()
+
+	// Apply index templates first.  ES treats PUT _index_template/<name>
+	// as an upsert, so committing template changes auto-propagates the next
+	// time the tool runs.  Failures here are warnings -- a missing template
+	// means new fields will get default mappings, which is a Kibana
+	// inconvenience, not a data-loss event.
+	if !*dryRun {
+		if err := applyTemplates(client, esURL, auth, *tmplDir); err != nil {
+			log.Printf("warning: applying templates failed: %v", err)
+		}
+	}
+
+	if err := walkAndSend(client, esURL, auth, *dir, metadata, *dryRun); err != nil {
+		// Observability failures should not propagate into CI (see README).
+		log.Printf("warning: walkAndSend returned an error: %v", err)
+	}
+}
+
+// buildAuthHeader returns the value for the Authorization header constructed
+// from environment variables, plus a bool reporting whether credentials are
+// configured at all.  Prefers an API key over basic auth.
+func buildAuthHeader() (string, bool) {
+	if key := os.Getenv("ELASTICSEARCH_KEY"); key != "" {
+		return "ApiKey " + key, true
+	}
+	user := os.Getenv("ELASTICSEARCH_USER")
+	token := os.Getenv("ELASTICSEARCH_TOKEN")
+	if user != "" && token != "" {
+		return basicAuthHeader(user, token), true
+	}
+	return "", false
+}
+
+// basicAuthHeader assembles a Basic auth header value the same way
+// net/http does in (*Request).SetBasicAuth, without importing encoding/base64
+// directly.
+func basicAuthHeader(user, password string) string {
+	r, _ := http.NewRequest("GET", "http://x/", nil)
+	r.SetBasicAuth(user, password)
+	return r.Header.Get("Authorization")
+}
+
+// ciMetadata gathers the fields the tool injects into every doc whose
+// producer hasn't already set them.
+func ciMetadata() map[string]any {
+	sha := os.Getenv("SEMAPHORE_GIT_SHA")
+	codeVer := sha
+	if len(codeVer) > 12 {
+		codeVer = codeVer[:12]
+	}
+	env := "dev"
+	if os.Getenv("SEMAPHORE_JOB_ID") != "" {
+		env = "ci"
+	}
+	m := map[string]any{
+		fieldTimestamp:   time.Now().UTC().Format(time.RFC3339),
+		fieldGitCommit:   sha,
+		fieldGitBranch:   os.Getenv("SEMAPHORE_GIT_BRANCH"),
+		fieldCodeVersion: codeVer,
+		fieldCIRunID:     os.Getenv("SEMAPHORE_JOB_ID"),
+		fieldEnv:         env,
+	}
+	if pr := os.Getenv("SEMAPHORE_GIT_PR_NUMBER"); pr != "" {
+		m[fieldPRNumber] = pr
+	}
+	return m
+}
+
+// applyTemplates PUTs each <family>.json in tmplDir to ES at
+// /_index_template/<family>.
+func applyTemplates(client *http.Client, esURL, auth, tmplDir string) error {
+	entries, err := os.ReadDir(tmplDir)
+	if err != nil {
+		// A missing templates directory is not fatal: a deployment might
+		// rely entirely on dynamic mapping inference.  Just warn.
+		if os.IsNotExist(err) {
+			log.Printf("templates directory %s does not exist; no templates applied", tmplDir)
+			return nil
+		}
+		return fmt.Errorf("read templates dir %s: %w", tmplDir, err)
+	}
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
+			continue
+		}
+		family := strings.TrimSuffix(e.Name(), ".json")
+		path := filepath.Join(tmplDir, e.Name())
+		body, err := os.ReadFile(path)
+		if err != nil {
+			log.Printf("warning: read %s: %v", path, err)
+			continue
+		}
+		endpoint := fmt.Sprintf("%s/_index_template/%s", strings.TrimRight(esURL, "/"), url.PathEscape(family))
+		if err := esRequest(client, "PUT", endpoint, auth, body); err != nil {
+			log.Printf("warning: PUT template %s: %v", family, err)
+			continue
+		}
+		log.Printf("applied template %s", family)
+	}
+	return nil
+}
+
+// walkAndSend processes every <dir>/<family>/*.json file, augmenting and
+// POSTing to <family>_<UTC year>.
+func walkAndSend(client *http.Client, esURL, auth, dir string, metadata map[string]any, dryRun bool) error {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			log.Printf("perf-results directory %s does not exist; nothing to send", dir)
+			return nil
+		}
+		return fmt.Errorf("read dir %s: %w", dir, err)
+	}
+	year := time.Now().UTC().Format("2006")
+	for _, e := range entries {
+		if !e.IsDir() {
+			// Stray files at the top level are not part of the convention.
+			// Warn and skip rather than silently dropping; that way a
+			// producer that writes to the wrong place gets a visible cue.
+			log.Printf("warning: skipping %s (not a family subdirectory)", e.Name())
+			continue
+		}
+		family := e.Name()
+		familyDir := filepath.Join(dir, family)
+		sent, failed, err := sendFamily(client, esURL, auth, familyDir, family, year, metadata, dryRun)
+		if err != nil {
+			log.Printf("warning: family %s: %v", family, err)
+		}
+		log.Printf("family %s: sent %d, failed %d", family, sent, failed)
+	}
+	return nil
+}
+
+// sendFamily handles one <family> subdirectory: walks all *.json under it,
+// augments with metadata, and POSTs to <family>_<year>.
+func sendFamily(client *http.Client, esURL, auth, familyDir, family, year string, metadata map[string]any, dryRun bool) (sent, failed int, err error) {
+	files, err := filepath.Glob(filepath.Join(familyDir, "*.json"))
+	if err != nil {
+		return 0, 0, fmt.Errorf("glob %s: %w", familyDir, err)
+	}
+	endpoint := fmt.Sprintf("%s/%s_%s/_doc",
+		strings.TrimRight(esURL, "/"),
+		url.PathEscape(family),
+		year,
+	)
+	for _, f := range files {
+		raw, rerr := os.ReadFile(f)
+		if rerr != nil {
+			log.Printf("warning: read %s: %v", f, rerr)
+			failed++
+			continue
+		}
+		var doc map[string]any
+		if jerr := json.Unmarshal(raw, &doc); jerr != nil {
+			log.Printf("warning: parse %s: %v", f, jerr)
+			failed++
+			continue
+		}
+		// Producer-supplied values win.  Inject only what isn't already set.
+		for k, v := range metadata {
+			if _, present := doc[k]; !present {
+				doc[k] = v
+			}
+		}
+		body, _ := json.Marshal(doc)
+		if dryRun {
+			log.Printf("dry-run: would POST %s\n  %s", endpoint, string(body))
+			sent++
+			continue
+		}
+		if perr := esRequest(client, "POST", endpoint, auth, body); perr != nil {
+			log.Printf("warning: POST %s (%s): %v", f, family, perr)
+			failed++
+			continue
+		}
+		sent++
+	}
+	return sent, failed, nil
+}
+
+// esRequest performs a single HTTP request to ES with the given method,
+// endpoint, auth header, and JSON body.  Returns an error on transport
+// failure or any non-2xx response.
+func esRequest(client *http.Client, method, endpoint, auth string, body []byte) error {
+	req, err := http.NewRequest(method, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if auth != "" {
+		req.Header.Set("Authorization", auth)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return fmt.Errorf("%s %s: HTTP %d: %s", method, endpoint, resp.StatusCode, strings.TrimSpace(string(respBody)))
+	}
+	_, _ = io.Copy(io.Discard, resp.Body)
+	return nil
+}

--- a/hack/perf/index-templates/benchmark_data_neutron_resync.json
+++ b/hack/perf/index-templates/benchmark_data_neutron_resync.json
@@ -1,0 +1,68 @@
+{
+  "index_patterns": ["benchmark_data_neutron_resync_*"],
+  "template": {
+    "mappings": {
+      "properties": {
+        "@timestamp":       {"type": "date"},
+        "git_commit":       {"type": "keyword"},
+        "git_branch":       {"type": "keyword"},
+        "code_version":     {"type": "keyword"},
+        "ci_run_id":        {"type": "keyword"},
+        "pr_number":        {"type": "keyword"},
+        "test_name":        {"type": "keyword"},
+        "env":              {"type": "keyword"},
+        "phase":            {"type": "keyword"},
+        "iter":             {"type": "integer"},
+        "ok":               {"type": "boolean"},
+        "error":            {"type": "keyword"},
+
+        "scale_ports":      {"type": "integer"},
+        "scale_networks":   {"type": "integer"},
+        "scale_sgs":        {"type": "integer"},
+        "scale_hosts":      {"type": "integer"},
+
+        "total_ms":         {"type": "double"},
+
+        "expand_total_ms":         {"type": "double"},
+
+        "subnets_total_ms":        {"type": "double"},
+        "subnets_compare_ms":      {"type": "double"},
+        "subnets_etcd_read_ms":    {"type": "double"},
+        "subnets_neutron_read_ms": {"type": "double"},
+        "subnets_create_ms":       {"type": "double"},
+        "subnets_etcd_items":      {"type": "integer"},
+        "subnets_neutron_items":   {"type": "integer"},
+        "subnets_correct":         {"type": "integer"},
+        "subnets_updated":         {"type": "integer"},
+        "subnets_deleted":         {"type": "integer"},
+        "subnets_created":         {"type": "integer"},
+
+        "policy_total_ms":         {"type": "double"},
+        "policy_compare_ms":       {"type": "double"},
+        "policy_etcd_read_ms":     {"type": "double"},
+        "policy_neutron_read_ms":  {"type": "double"},
+        "policy_create_ms":        {"type": "double"},
+        "policy_etcd_items":       {"type": "integer"},
+        "policy_neutron_items":    {"type": "integer"},
+        "policy_correct":          {"type": "integer"},
+        "policy_updated":          {"type": "integer"},
+        "policy_deleted":          {"type": "integer"},
+        "policy_created":          {"type": "integer"},
+
+        "endpoints_total_ms":         {"type": "double"},
+        "endpoints_compare_ms":       {"type": "double"},
+        "endpoints_etcd_read_ms":     {"type": "double"},
+        "endpoints_neutron_read_ms":  {"type": "double"},
+        "endpoints_create_ms":        {"type": "double"},
+        "endpoints_etcd_items":       {"type": "integer"},
+        "endpoints_neutron_items":    {"type": "integer"},
+        "endpoints_correct":          {"type": "integer"},
+        "endpoints_updated":          {"type": "integer"},
+        "endpoints_deleted":          {"type": "integer"},
+        "endpoints_created":          {"type": "integer"},
+
+        "felix_config_total_ms":      {"type": "double"}
+      }
+    }
+  }
+}

--- a/hack/perf/index-templates/benchmark_data_nft_dataplane.json
+++ b/hack/perf/index-templates/benchmark_data_nft_dataplane.json
@@ -1,0 +1,32 @@
+{
+  "index_patterns": ["benchmark_data_nft_dataplane_*"],
+  "template": {
+    "mappings": {
+      "properties": {
+        "@timestamp":        {"type": "date"},
+        "git_commit":        {"type": "keyword"},
+        "git_branch":        {"type": "keyword"},
+        "code_version":      {"type": "keyword"},
+        "ci_run_id":         {"type": "keyword"},
+        "pr_number":         {"type": "keyword"},
+        "test_name":         {"type": "keyword"},
+        "dataplane":         {"type": "keyword"},
+        "env":               {"type": "keyword"},
+        "phase":             {"type": "keyword"},
+        "iter":              {"type": "integer"},
+        "ok":                {"type": "boolean"},
+        "error":             {"type": "keyword"},
+
+        "scale_ipsets":      {"type": "integer"},
+        "scale_set_members": {"type": "integer"},
+        "scale_chains":      {"type": "integer"},
+        "scale_rules":       {"type": "integer"},
+
+        "wall_ns_per_op":    {"type": "double"},
+        "cpu_ns_per_op":     {"type": "double"},
+        "bytes_per_op":      {"type": "double"},
+        "allocs_per_op":     {"type": "double"}
+      }
+    }
+  }
+}


### PR DESCRIPTION
Backports the felix/nftables dataplane benchmark and the hack/perf Lens publisher from master (#12770, #12984), without the table.go optimization that shipped alongside the benchmark in #12984. Leaving the optimization out is deliberate - it lets this branch benchmark its own pre-optimization dataplane code, so the numbers landing in Lens form a baseline to compare the master series against.

The benchmark only uses stable public API, so it compiles against this branch's nftables code unchanged. Data flows via the scheduled build (the CHANGE_IN trigger rarely fires on a release branch); publishing needs the banzai-secrets / LENS_ELASTICSEARCH_TOKEN secret on this pipeline, and send-perf-results no-ops if it's unset.\

Once we have some data flowing, we can backport the optimization.
