### PR TITLE
felixconfig: fix enum markers so config reference lists allowed values

### DIFF
--- a/api/config/crd/projectcalico.org_felixconfigurations.yaml
+++ b/api/config/crd/projectcalico.org_felixconfigurations.yaml
@@ -301,17 +301,13 @@ spec:
                     packets from external sources are dropped. [Default: true]
                   type: boolean
                 bpfJITHardening:
-                  allOf:
-                    - enum:
-                        - Auto
-                        - Strict
-                    - enum:
-                        - Auto
-                        - Strict
                   description: |-
                     BPFJITHardening controls BPF JIT hardening. When set to "Auto", Felix will set JIT hardening to 1
                     if it detects the current value is 2 (strict mode that hurts performance). When set to "Strict",
                     Felix will not modify the JIT hardening setting. [Default: Auto]
+                  enum:
+                    - Auto
+                    - Strict
                   type: string
                 bpfKubeProxyHealthzPort:
                   description: |-
@@ -1222,6 +1218,11 @@ spec:
                   description: |-
                     PrometheusMetricsClientAuth specifies the client authentication type for the /metrics endpoint.
                     This determines how the server validates client certificates. Default is "NoClientCert".
+                  enum:
+                    - RequireAndVerifyClientCert
+                    - RequireAnyClientCert
+                    - VerifyClientCertIfGiven
+                    - NoClientCert
                   type: string
                 prometheusMetricsEnabled:
                   description:

--- a/api/pkg/apis/projectcalico/v3/felixconfig.go
+++ b/api/pkg/apis/projectcalico/v3/felixconfig.go
@@ -181,7 +181,7 @@ const (
 	NATOutgoingExclusionsIPPoolsAndHostIPs NATOutgoingExclusionsType = "IPPoolsAndHostIPs"
 )
 
-// +kubebuilder:validation:enum=RequireAndVerifyClientCert;RequireAnyClientCert;VerifyClientCertIfGiven;NoClientCert
+// +kubebuilder:validation:Enum=RequireAndVerifyClientCert;RequireAnyClientCert;VerifyClientCertIfGiven;NoClientCert
 type PrometheusMetricsClientAuthType string
 
 const (
@@ -760,7 +760,6 @@ type FelixConfigurationSpec struct {
 	// BPFJITHardening controls BPF JIT hardening. When set to "Auto", Felix will set JIT hardening to 1
 	// if it detects the current value is 2 (strict mode that hurts performance). When set to "Strict",
 	// Felix will not modify the JIT hardening setting. [Default: Auto]
-	// +kubebuilder:validation:Enum=Auto;Strict
 	BPFJITHardening *BPFJITHardeningType `json:"bpfJITHardening,omitempty" validate:"omitempty,oneof=Auto Strict"`
 
 	// BPFLogLevel controls the log level of the BPF programs when in BPF dataplane mode.  One of "Off", "Info", or

--- a/felix/config/metadata.go
+++ b/felix/config/metadata.go
@@ -277,7 +277,57 @@ func CombinedFieldInfo() ([]*FieldInfo, error) {
 		return 0
 	})
 
+	if err := checkEnumMarkers(params); err != nil {
+		return nil, err
+	}
+
 	return params, nil
+}
+
+// fieldsAllowedWithoutYAMLEnum lists closed-set string parameters that
+// intentionally do not (yet) expose their values as a FelixConfiguration CRD
+// enum.  Keep this list as short as possible; each entry is a field whose docs
+// do not list its allowed values.
+var fieldsAllowedWithoutYAMLEnum = map[string]bool{
+	// The parser reports a single accepted value ("all") for bpfCTLBLogFilter,
+	// but it is unclear whether the field is genuinely a closed set or also
+	// accepts free-form filter strings.  Excluded until that is confirmed.
+	"bpfCTLBLogFilter": true,
+}
+
+// checkEnumMarkers fails the build if a parameter that Felix's parser restricts
+// to a closed set of string values ("One of: ...") does not expose those values
+// as a FelixConfiguration CRD enum.  When the enum is missing, the reference
+// docs show a bare "String." instead of the allowed values.  The usual cause is
+// a missing or mis-cased (`enum` instead of `Enum`) +kubebuilder:validation:Enum
+// marker on the Go type or field.
+func checkEnumMarkers(params []*FieldInfo) error {
+	var problems []string
+	for _, pm := range params {
+		if pm.NameYAML == "" {
+			continue // Not exposed in the FelixConfiguration CRD.
+		}
+		if !strings.HasPrefix(pm.StringSchema, "One of:") {
+			continue // Parser does not restrict to a closed set of strings.
+		}
+		if len(pm.YAMLEnumValues) > 0 {
+			continue // Values are correctly exposed as a CRD enum.
+		}
+		if fieldsAllowedWithoutYAMLEnum[pm.NameYAML] {
+			continue
+		}
+		problems = append(problems, fmt.Sprintf(
+			"%s: parser accepts a closed set of values (%s) but the "+
+				"FelixConfiguration CRD exposes no enum; check for a missing or "+
+				"mis-cased (`enum` vs `Enum`) +kubebuilder:validation:Enum marker "+
+				"on the %s type or field.",
+			pm.NameYAML, pm.StringSchema, pm.NameGoAPI))
+	}
+	if len(problems) > 0 {
+		return fmt.Errorf("FelixConfiguration enum marker problems detected:\n  - %s",
+			strings.Join(problems, "\n  - "))
+	}
+	return nil
 }
 
 var backtickRegex = regexp.MustCompile("`([^`]+)`")
@@ -451,6 +501,7 @@ func loadV3APIMetadata() (map[string]YAMLInfo, error) {
 		return nil, fmt.Errorf("not supported: CRD should have single version")
 	}
 	spec := crd.Spec.Versions[0].Schema.OpenAPIV3Schema.Properties["spec"]
+	var nestedEnumFields []string
 	for yamlName, prop := range spec.Properties {
 		si, ok := yamlNameToStructInfo[yamlName]
 		if !ok {
@@ -480,11 +531,44 @@ func loadV3APIMetadata() (map[string]YAMLInfo, error) {
 		}
 		info.Schema, info.EnumValues = v3TypesToDescription(si, prop)
 
+		if crdFieldHasNestedEnum(prop) {
+			nestedEnumFields = append(nestedEnumFields, yamlName)
+		}
+
 		out[info.V1Name] = info
 		out[yamlName] = info
 	}
 
+	if len(nestedEnumFields) > 0 {
+		sort.Strings(nestedEnumFields)
+		return nil, fmt.Errorf(
+			"FelixConfiguration CRD fields carry their enum nested under `allOf` "+
+				"instead of a single top-level `enum` (the config docs generator only "+
+				"reads a top-level enum, so the allowed values are dropped); this is "+
+				"usually a +kubebuilder:validation:Enum marker duplicated on both the Go "+
+				"type and the struct field, so put it on only one. Affected fields: %s",
+			strings.Join(nestedEnumFields, ", "))
+	}
+
 	return out, nil
+}
+
+// crdFieldHasNestedEnum reports whether a CRD property carries its enum values
+// nested under `allOf` rather than at the top level.  controller-gen emits this
+// shape (`allOf: [{enum: [...]}, {enum: [...]}]`) when a
+// +kubebuilder:validation:Enum marker is set on both the named Go type and the
+// struct field that uses it.  The docs generator only reads the top-level enum,
+// so such fields silently lose their allowed values.
+func crdFieldHasNestedEnum(prop v1.JSONSchemaProps) bool {
+	if len(prop.Enum) > 0 {
+		return false
+	}
+	for _, sub := range prop.AllOf {
+		if len(sub.Enum) > 0 {
+			return true
+		}
+	}
+	return false
 }
 
 // Regex to extract enum constants from the standard enum regex. Example: ^(?i)(Drop|Accept|Return)?$

--- a/felix/config/metadata_test.go
+++ b/felix/config/metadata_test.go
@@ -17,12 +17,63 @@ package config
 import (
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
+	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 )
 
 var _ = ginkgo.Describe("Docs metadata", func() {
 	ginkgo.It("should load the metadata", func() {
+		// This also exercises the enum-marker assertions against the real
+		// FelixConfiguration CRD, so it fails if a new field regresses.
 		params, err := CombinedFieldInfo()
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		gomega.Expect(params).NotTo(gomega.BeEmpty())
 	})
+})
+
+func enum(vals ...string) []v1.JSON {
+	var out []v1.JSON
+	for _, v := range vals {
+		out = append(out, v1.JSON{Raw: []byte(`"` + v + `"`)})
+	}
+	return out
+}
+
+var _ = ginkgo.Describe("Enum marker assertions", func() {
+	ginkgo.DescribeTable("crdFieldHasNestedEnum",
+		func(prop v1.JSONSchemaProps, expected bool) {
+			gomega.Expect(crdFieldHasNestedEnum(prop)).To(gomega.Equal(expected))
+		},
+		ginkgo.Entry("top-level enum is fine",
+			v1.JSONSchemaProps{Enum: enum("Auto", "Strict")}, false),
+		ginkgo.Entry("no enum at all is fine",
+			v1.JSONSchemaProps{Type: "string"}, false),
+		ginkgo.Entry("enum nested under allOf (duplicate marker) is flagged",
+			v1.JSONSchemaProps{AllOf: []v1.JSONSchemaProps{
+				{Enum: enum("Auto", "Strict")},
+				{Enum: enum("Auto", "Strict")},
+			}}, true),
+		ginkgo.Entry("allOf without any enum is fine",
+			v1.JSONSchemaProps{AllOf: []v1.JSONSchemaProps{{Type: "string"}}}, false),
+	)
+
+	ginkgo.DescribeTable("checkEnumMarkers",
+		func(field *FieldInfo, expectErr bool) {
+			err := checkEnumMarkers([]*FieldInfo{field})
+			if expectErr {
+				gomega.Expect(err).To(gomega.HaveOccurred())
+			} else {
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			}
+		},
+		ginkgo.Entry("closed set with CRD enum is fine",
+			&FieldInfo{NameYAML: "x", StringSchema: "One of: `A`, `B`", YAMLEnumValues: []string{"A", "B"}}, false),
+		ginkgo.Entry("closed set with no CRD enum is flagged",
+			&FieldInfo{NameYAML: "x", NameGoAPI: "X", StringSchema: "One of: `A`, `B`"}, true),
+		ginkgo.Entry("allow-listed closed set with no CRD enum is fine",
+			&FieldInfo{NameYAML: "bpfCTLBLogFilter", StringSchema: "One of: `all`"}, false),
+		ginkgo.Entry("non closed-set string is fine",
+			&FieldInfo{NameYAML: "x", StringSchema: "String."}, false),
+		ginkgo.Entry("field not exposed in the CRD is fine",
+			&FieldInfo{NameYAML: "", StringSchema: "One of: `A`, `B`"}, false),
+	)
 })

--- a/felix/docs/config-params.json
+++ b/felix/docs/config-params.json
@@ -1052,9 +1052,14 @@
           "ParsedDefaultJSON": "\"NoClientCert\"",
           "ParsedType": "string",
           "YAMLType": "string",
-          "YAMLSchema": "",
-          "YAMLEnumValues": null,
-          "YAMLSchemaHTML": "",
+          "YAMLSchema": "One of: `\"NoClientCert\"`, `\"RequireAndVerifyClientCert\"`, `\"RequireAnyClientCert\"`, `\"VerifyClientCertIfGiven\"`.",
+          "YAMLEnumValues": [
+            "`\"NoClientCert\"`",
+            "`\"RequireAndVerifyClientCert\"`",
+            "`\"RequireAnyClientCert\"`",
+            "`\"VerifyClientCertIfGiven\"`"
+          ],
+          "YAMLSchemaHTML": "One of: <code>\"NoClientCert\"</code>, <code>\"RequireAndVerifyClientCert\"</code>, <code>\"RequireAnyClientCert\"</code>, <code>\"VerifyClientCertIfGiven\"</code>.",
           "YAMLDefault": "NoClientCert",
           "Required": false,
           "OnParseFailure": "ReplaceWithDefault",
@@ -3682,9 +3687,12 @@
           "ParsedDefaultJSON": "\"Auto\"",
           "ParsedType": "string",
           "YAMLType": "string",
-          "YAMLSchema": "",
-          "YAMLEnumValues": null,
-          "YAMLSchemaHTML": "",
+          "YAMLSchema": "One of: `\"Auto\"`, `\"Strict\"`.",
+          "YAMLEnumValues": [
+            "`\"Auto\"`",
+            "`\"Strict\"`"
+          ],
+          "YAMLSchemaHTML": "One of: <code>\"Auto\"</code>, <code>\"Strict\"</code>.",
           "YAMLDefault": "Auto",
           "Required": true,
           "OnParseFailure": "ReplaceWithDefault",

--- a/felix/docs/config-params.md
+++ b/felix/docs/config-params.md
@@ -557,7 +557,7 @@ This determines how the server validates client certificates. Default is "NoClie
 | Encoding (env var/config file) | One of: <code>NoClientCert</code>, <code>RequireAndVerifyClientCert</code>, <code>RequireAnyClientCert</code>, <code>VerifyClientCertIfGiven</code> |
 | Default value (above encoding) | `NoClientCert` |
 | `FelixConfiguration` field | `prometheusMetricsClientAuth` (YAML) `PrometheusMetricsClientAuth` (Go API) |
-| `FelixConfiguration` schema | `string` |
+| `FelixConfiguration` schema | One of: <code>"NoClientCert"</code>, <code>"RequireAndVerifyClientCert"</code>, <code>"RequireAnyClientCert"</code>, <code>"VerifyClientCertIfGiven"</code>. |
 | Default value (YAML) | `NoClientCert` |
 
 ### `PrometheusMetricsEnabled` (config file) / `prometheusMetricsEnabled` (YAML)
@@ -2047,7 +2047,7 @@ Felix will not modify the JIT hardening setting.
 | Encoding (env var/config file) | One of: <code>Auto</code>, <code>Strict</code> |
 | Default value (above encoding) | `Auto` |
 | `FelixConfiguration` field | `bpfJITHardening` (YAML) `BPFJITHardening` (Go API) |
-| `FelixConfiguration` schema | `string` |
+| `FelixConfiguration` schema | One of: <code>"Auto"</code>, <code>"Strict"</code>. |
 | Default value (YAML) | `Auto` |
 | Notes | Required. | 
 

--- a/libcalico-go/config/crd/crd.projectcalico.org_felixconfigurations.yaml
+++ b/libcalico-go/config/crd/crd.projectcalico.org_felixconfigurations.yaml
@@ -302,17 +302,13 @@ spec:
                     packets from external sources are dropped. [Default: true]
                   type: boolean
                 bpfJITHardening:
-                  allOf:
-                    - enum:
-                        - Auto
-                        - Strict
-                    - enum:
-                        - Auto
-                        - Strict
                   description: |-
                     BPFJITHardening controls BPF JIT hardening. When set to "Auto", Felix will set JIT hardening to 1
                     if it detects the current value is 2 (strict mode that hurts performance). When set to "Strict",
                     Felix will not modify the JIT hardening setting. [Default: Auto]
+                  enum:
+                    - Auto
+                    - Strict
                   type: string
                 bpfKubeProxyHealthzPort:
                   description: |-
@@ -1223,6 +1219,11 @@ spec:
                   description: |-
                     PrometheusMetricsClientAuth specifies the client authentication type for the /metrics endpoint.
                     This determines how the server validates client certificates. Default is "NoClientCert".
+                  enum:
+                    - RequireAndVerifyClientCert
+                    - RequireAnyClientCert
+                    - VerifyClientCertIfGiven
+                    - NoClientCert
                   type: string
                 prometheusMetricsEnabled:
                   description:

--- a/manifests/calico-bpf.yaml
+++ b/manifests/calico-bpf.yaml
@@ -2321,17 +2321,13 @@ spec:
                     packets from external sources are dropped. [Default: true]
                   type: boolean
                 bpfJITHardening:
-                  allOf:
-                    - enum:
-                        - Auto
-                        - Strict
-                    - enum:
-                        - Auto
-                        - Strict
                   description: |-
                     BPFJITHardening controls BPF JIT hardening. When set to "Auto", Felix will set JIT hardening to 1
                     if it detects the current value is 2 (strict mode that hurts performance). When set to "Strict",
                     Felix will not modify the JIT hardening setting. [Default: Auto]
+                  enum:
+                    - Auto
+                    - Strict
                   type: string
                 bpfKubeProxyHealthzPort:
                   description: |-
@@ -3242,6 +3238,11 @@ spec:
                   description: |-
                     PrometheusMetricsClientAuth specifies the client authentication type for the /metrics endpoint.
                     This determines how the server validates client certificates. Default is "NoClientCert".
+                  enum:
+                    - RequireAndVerifyClientCert
+                    - RequireAnyClientCert
+                    - VerifyClientCertIfGiven
+                    - NoClientCert
                   type: string
                 prometheusMetricsEnabled:
                   description:

--- a/manifests/calico-policy-only.yaml
+++ b/manifests/calico-policy-only.yaml
@@ -2331,17 +2331,13 @@ spec:
                     packets from external sources are dropped. [Default: true]
                   type: boolean
                 bpfJITHardening:
-                  allOf:
-                    - enum:
-                        - Auto
-                        - Strict
-                    - enum:
-                        - Auto
-                        - Strict
                   description: |-
                     BPFJITHardening controls BPF JIT hardening. When set to "Auto", Felix will set JIT hardening to 1
                     if it detects the current value is 2 (strict mode that hurts performance). When set to "Strict",
                     Felix will not modify the JIT hardening setting. [Default: Auto]
+                  enum:
+                    - Auto
+                    - Strict
                   type: string
                 bpfKubeProxyHealthzPort:
                   description: |-
@@ -3252,6 +3248,11 @@ spec:
                   description: |-
                     PrometheusMetricsClientAuth specifies the client authentication type for the /metrics endpoint.
                     This determines how the server validates client certificates. Default is "NoClientCert".
+                  enum:
+                    - RequireAndVerifyClientCert
+                    - RequireAnyClientCert
+                    - VerifyClientCertIfGiven
+                    - NoClientCert
                   type: string
                 prometheusMetricsEnabled:
                   description:

--- a/manifests/calico-typha.yaml
+++ b/manifests/calico-typha.yaml
@@ -2332,17 +2332,13 @@ spec:
                     packets from external sources are dropped. [Default: true]
                   type: boolean
                 bpfJITHardening:
-                  allOf:
-                    - enum:
-                        - Auto
-                        - Strict
-                    - enum:
-                        - Auto
-                        - Strict
                   description: |-
                     BPFJITHardening controls BPF JIT hardening. When set to "Auto", Felix will set JIT hardening to 1
                     if it detects the current value is 2 (strict mode that hurts performance). When set to "Strict",
                     Felix will not modify the JIT hardening setting. [Default: Auto]
+                  enum:
+                    - Auto
+                    - Strict
                   type: string
                 bpfKubeProxyHealthzPort:
                   description: |-
@@ -3253,6 +3249,11 @@ spec:
                   description: |-
                     PrometheusMetricsClientAuth specifies the client authentication type for the /metrics endpoint.
                     This determines how the server validates client certificates. Default is "NoClientCert".
+                  enum:
+                    - RequireAndVerifyClientCert
+                    - RequireAnyClientCert
+                    - VerifyClientCertIfGiven
+                    - NoClientCert
                   type: string
                 prometheusMetricsEnabled:
                   description:

--- a/manifests/calico-v3-crds.yaml
+++ b/manifests/calico-v3-crds.yaml
@@ -2430,17 +2430,13 @@ spec:
                     packets from external sources are dropped. [Default: true]
                   type: boolean
                 bpfJITHardening:
-                  allOf:
-                    - enum:
-                        - Auto
-                        - Strict
-                    - enum:
-                        - Auto
-                        - Strict
                   description: |-
                     BPFJITHardening controls BPF JIT hardening. When set to "Auto", Felix will set JIT hardening to 1
                     if it detects the current value is 2 (strict mode that hurts performance). When set to "Strict",
                     Felix will not modify the JIT hardening setting. [Default: Auto]
+                  enum:
+                    - Auto
+                    - Strict
                   type: string
                 bpfKubeProxyHealthzPort:
                   description: |-
@@ -3351,6 +3347,11 @@ spec:
                   description: |-
                     PrometheusMetricsClientAuth specifies the client authentication type for the /metrics endpoint.
                     This determines how the server validates client certificates. Default is "NoClientCert".
+                  enum:
+                    - RequireAndVerifyClientCert
+                    - RequireAnyClientCert
+                    - VerifyClientCertIfGiven
+                    - NoClientCert
                   type: string
                 prometheusMetricsEnabled:
                   description:

--- a/manifests/calico-vxlan.yaml
+++ b/manifests/calico-vxlan.yaml
@@ -2316,17 +2316,13 @@ spec:
                     packets from external sources are dropped. [Default: true]
                   type: boolean
                 bpfJITHardening:
-                  allOf:
-                    - enum:
-                        - Auto
-                        - Strict
-                    - enum:
-                        - Auto
-                        - Strict
                   description: |-
                     BPFJITHardening controls BPF JIT hardening. When set to "Auto", Felix will set JIT hardening to 1
                     if it detects the current value is 2 (strict mode that hurts performance). When set to "Strict",
                     Felix will not modify the JIT hardening setting. [Default: Auto]
+                  enum:
+                    - Auto
+                    - Strict
                   type: string
                 bpfKubeProxyHealthzPort:
                   description: |-
@@ -3237,6 +3233,11 @@ spec:
                   description: |-
                     PrometheusMetricsClientAuth specifies the client authentication type for the /metrics endpoint.
                     This determines how the server validates client certificates. Default is "NoClientCert".
+                  enum:
+                    - RequireAndVerifyClientCert
+                    - RequireAnyClientCert
+                    - VerifyClientCertIfGiven
+                    - NoClientCert
                   type: string
                 prometheusMetricsEnabled:
                   description:

--- a/manifests/calico.yaml
+++ b/manifests/calico.yaml
@@ -2316,17 +2316,13 @@ spec:
                     packets from external sources are dropped. [Default: true]
                   type: boolean
                 bpfJITHardening:
-                  allOf:
-                    - enum:
-                        - Auto
-                        - Strict
-                    - enum:
-                        - Auto
-                        - Strict
                   description: |-
                     BPFJITHardening controls BPF JIT hardening. When set to "Auto", Felix will set JIT hardening to 1
                     if it detects the current value is 2 (strict mode that hurts performance). When set to "Strict",
                     Felix will not modify the JIT hardening setting. [Default: Auto]
+                  enum:
+                    - Auto
+                    - Strict
                   type: string
                 bpfKubeProxyHealthzPort:
                   description: |-
@@ -3237,6 +3233,11 @@ spec:
                   description: |-
                     PrometheusMetricsClientAuth specifies the client authentication type for the /metrics endpoint.
                     This determines how the server validates client certificates. Default is "NoClientCert".
+                  enum:
+                    - RequireAndVerifyClientCert
+                    - RequireAnyClientCert
+                    - VerifyClientCertIfGiven
+                    - NoClientCert
                   type: string
                 prometheusMetricsEnabled:
                   description:

--- a/manifests/canal.yaml
+++ b/manifests/canal.yaml
@@ -2333,17 +2333,13 @@ spec:
                     packets from external sources are dropped. [Default: true]
                   type: boolean
                 bpfJITHardening:
-                  allOf:
-                    - enum:
-                        - Auto
-                        - Strict
-                    - enum:
-                        - Auto
-                        - Strict
                   description: |-
                     BPFJITHardening controls BPF JIT hardening. When set to "Auto", Felix will set JIT hardening to 1
                     if it detects the current value is 2 (strict mode that hurts performance). When set to "Strict",
                     Felix will not modify the JIT hardening setting. [Default: Auto]
+                  enum:
+                    - Auto
+                    - Strict
                   type: string
                 bpfKubeProxyHealthzPort:
                   description: |-
@@ -3254,6 +3250,11 @@ spec:
                   description: |-
                     PrometheusMetricsClientAuth specifies the client authentication type for the /metrics endpoint.
                     This determines how the server validates client certificates. Default is "NoClientCert".
+                  enum:
+                    - RequireAndVerifyClientCert
+                    - RequireAnyClientCert
+                    - VerifyClientCertIfGiven
+                    - NoClientCert
                   type: string
                 prometheusMetricsEnabled:
                   description:

--- a/manifests/crds.yaml
+++ b/manifests/crds.yaml
@@ -2230,17 +2230,13 @@ spec:
                     packets from external sources are dropped. [Default: true]
                   type: boolean
                 bpfJITHardening:
-                  allOf:
-                    - enum:
-                        - Auto
-                        - Strict
-                    - enum:
-                        - Auto
-                        - Strict
                   description: |-
                     BPFJITHardening controls BPF JIT hardening. When set to "Auto", Felix will set JIT hardening to 1
                     if it detects the current value is 2 (strict mode that hurts performance). When set to "Strict",
                     Felix will not modify the JIT hardening setting. [Default: Auto]
+                  enum:
+                    - Auto
+                    - Strict
                   type: string
                 bpfKubeProxyHealthzPort:
                   description: |-
@@ -3151,6 +3147,11 @@ spec:
                   description: |-
                     PrometheusMetricsClientAuth specifies the client authentication type for the /metrics endpoint.
                     This determines how the server validates client certificates. Default is "NoClientCert".
+                  enum:
+                    - RequireAndVerifyClientCert
+                    - RequireAnyClientCert
+                    - VerifyClientCertIfGiven
+                    - NoClientCert
                   type: string
                 prometheusMetricsEnabled:
                   description:

--- a/manifests/flannel-migration/calico.yaml
+++ b/manifests/flannel-migration/calico.yaml
@@ -2316,17 +2316,13 @@ spec:
                     packets from external sources are dropped. [Default: true]
                   type: boolean
                 bpfJITHardening:
-                  allOf:
-                    - enum:
-                        - Auto
-                        - Strict
-                    - enum:
-                        - Auto
-                        - Strict
                   description: |-
                     BPFJITHardening controls BPF JIT hardening. When set to "Auto", Felix will set JIT hardening to 1
                     if it detects the current value is 2 (strict mode that hurts performance). When set to "Strict",
                     Felix will not modify the JIT hardening setting. [Default: Auto]
+                  enum:
+                    - Auto
+                    - Strict
                   type: string
                 bpfKubeProxyHealthzPort:
                   description: |-
@@ -3237,6 +3233,11 @@ spec:
                   description: |-
                     PrometheusMetricsClientAuth specifies the client authentication type for the /metrics endpoint.
                     This determines how the server validates client certificates. Default is "NoClientCert".
+                  enum:
+                    - RequireAndVerifyClientCert
+                    - RequireAnyClientCert
+                    - VerifyClientCertIfGiven
+                    - NoClientCert
                   type: string
                 prometheusMetricsEnabled:
                   description:

--- a/manifests/operator-crds.yaml
+++ b/manifests/operator-crds.yaml
@@ -37174,17 +37174,13 @@ spec:
                     packets from external sources are dropped. [Default: true]
                   type: boolean
                 bpfJITHardening:
-                  allOf:
-                    - enum:
-                        - Auto
-                        - Strict
-                    - enum:
-                        - Auto
-                        - Strict
                   description: |-
                     BPFJITHardening controls BPF JIT hardening. When set to "Auto", Felix will set JIT hardening to 1
                     if it detects the current value is 2 (strict mode that hurts performance). When set to "Strict",
                     Felix will not modify the JIT hardening setting. [Default: Auto]
+                  enum:
+                    - Auto
+                    - Strict
                   type: string
                 bpfKubeProxyHealthzPort:
                   description: |-
@@ -38095,6 +38091,11 @@ spec:
                   description: |-
                     PrometheusMetricsClientAuth specifies the client authentication type for the /metrics endpoint.
                     This determines how the server validates client certificates. Default is "NoClientCert".
+                  enum:
+                    - RequireAndVerifyClientCert
+                    - RequireAnyClientCert
+                    - VerifyClientCertIfGiven
+                    - NoClientCert
                   type: string
                 prometheusMetricsEnabled:
                   description:

--- a/manifests/v1_crd_projectcalico_org.yaml
+++ b/manifests/v1_crd_projectcalico_org.yaml
@@ -37174,17 +37174,13 @@ spec:
                     packets from external sources are dropped. [Default: true]
                   type: boolean
                 bpfJITHardening:
-                  allOf:
-                    - enum:
-                        - Auto
-                        - Strict
-                    - enum:
-                        - Auto
-                        - Strict
                   description: |-
                     BPFJITHardening controls BPF JIT hardening. When set to "Auto", Felix will set JIT hardening to 1
                     if it detects the current value is 2 (strict mode that hurts performance). When set to "Strict",
                     Felix will not modify the JIT hardening setting. [Default: Auto]
+                  enum:
+                    - Auto
+                    - Strict
                   type: string
                 bpfKubeProxyHealthzPort:
                   description: |-
@@ -38095,6 +38091,11 @@ spec:
                   description: |-
                     PrometheusMetricsClientAuth specifies the client authentication type for the /metrics endpoint.
                     This determines how the server validates client certificates. Default is "NoClientCert".
+                  enum:
+                    - RequireAndVerifyClientCert
+                    - RequireAnyClientCert
+                    - VerifyClientCertIfGiven
+                    - NoClientCert
                   type: string
                 prometheusMetricsEnabled:
                   description:

--- a/manifests/v3_projectcalico_org.yaml
+++ b/manifests/v3_projectcalico_org.yaml
@@ -37455,17 +37455,13 @@ spec:
                     packets from external sources are dropped. [Default: true]
                   type: boolean
                 bpfJITHardening:
-                  allOf:
-                    - enum:
-                        - Auto
-                        - Strict
-                    - enum:
-                        - Auto
-                        - Strict
                   description: |-
                     BPFJITHardening controls BPF JIT hardening. When set to "Auto", Felix will set JIT hardening to 1
                     if it detects the current value is 2 (strict mode that hurts performance). When set to "Strict",
                     Felix will not modify the JIT hardening setting. [Default: Auto]
+                  enum:
+                    - Auto
+                    - Strict
                   type: string
                 bpfKubeProxyHealthzPort:
                   description: |-
@@ -38376,6 +38372,11 @@ spec:
                   description: |-
                     PrometheusMetricsClientAuth specifies the client authentication type for the /metrics endpoint.
                     This determines how the server validates client certificates. Default is "NoClientCert".
+                  enum:
+                    - RequireAndVerifyClientCert
+                    - RequireAnyClientCert
+                    - VerifyClientCertIfGiven
+                    - NoClientCert
                   type: string
                 prometheusMetricsEnabled:
                   description:


### PR DESCRIPTION
### Description

Two `FelixConfiguration` fields show a generic `String.` schema in the generated config reference instead of their allowed values. The values are known to Felix's parser, but they never reach the API schema, so the reference table has nothing to list.

Root cause is in the `+kubebuilder:validation:Enum` markers:

- **`prometheusMetricsClientAuth`** — the marker was spelled lowercase (`enum=`). Markers are case-sensitive, so controller-gen ignored it and the CRD emitted a bare `type: string`. Fixed to `Enum=`.
- **`bpfJITHardening`** — the `Enum` marker was set on both the type and the field, so the CRD emitted `allOf: [enum, enum]`. The docs generator reads only a top-level `enum`, so it listed nothing. Removed the duplicate field-level marker; the type-level marker is kept. **Validation is unchanged** (two identical enums enforce the same set as one).

The regenerated `felix/docs/config-params.json` is included so the payoff is visible in the diff: `YAMLEnumValues` fills in for both fields, and the reference **Schema** row changes from `String.` to:
- `One of: NoClientCert, RequireAndVerifyClientCert, RequireAnyClientCert, VerifyClientCertIfGiven`
- `One of: Auto, Strict`

### Behavior note

For `prometheusMetricsClientAuth`, the CRD now enforces the value list on the resource path (case-sensitive). This matches the many enum fields that already behave this way (for example `logSeverityScreen`); the environment-variable and config-file paths remain case-insensitive via the parser. `bpfJITHardening` is behavior-neutral (marker dedupe only).

### Checklist

- [x] `PrometheusMetricsClientAuthType` marker changed from `enum` to `Enum`.
- [x] Duplicate `bpfJITHardening` field-level marker removed (type marker kept).
- [x] Regenerated CRDs (`make -C libcalico-go gen-crds`, `make -C api gen-files`).
- [x] Regenerated `felix/docs/config-params.json` and `.md`.
- [x] CRD shows a single top-level `enum:` for both fields; `config-params.json` has non-null `YAMLEnumValues`.
- [x] No diff for fields that already worked.

```release-note
Fix the FelixConfiguration API reference so it lists the allowed values for the prometheusMetricsClientAuth and bpfJITHardening settings.
```
