### PR TITLE
docs: trim and correct the agent guidance files

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -2,127 +2,64 @@
 
 This file is **operational guidance** for agents working in this repo: build commands, test invocation, debugging, conventions, and the process rules every PR follows. For **architecture, invariants, and review criteria**, see [`DESIGN.md`](../DESIGN.md) at the repo root, and the per-component `DESIGN.md` files it links to. Do not look here for architecture; look there.
 
-## Repository Overview
-
-Project Calico is a large monorepo providing container networking and security 
-for Kubernetes. The codebase contains ~2000 Go files across 30+ components, 
-supporting multiple dataplanes (eBPF, iptables, nftables, Windows, VPP).
-
-**Primary language:** Go (also C/eBPF, Python, Shell, TypeScript/React)
-**Build system:** Make + Docker-based reproducible builds
-**CI/CD:** Semaphore CI (configuration in `.semaphore/`)
-**Default branch:** `master` (not `main`)
-**Separate docs repo**  https://github.com/tigera/docs/
-
 ## Gotchas
 
-- **NEVER** run `make ci` or `make cd` locally — destructive CI-only targets
+- **NEVER** run `make ci` or `make cd` — in any component or at the root.
+  Destructive CI-only targets.
 - **NEVER** run `make test` at root — takes hours. Always test components individually.
-- **NEVER**, include customer names in code comments, commit
-  messages, or PR descriptions. If you must reference, refer to the ticket only (GitHub issue number/JIRA key).
-- **ALWAYS** remove `FIt`/`FDescribe` before committing — pre-commit hook rejects Ginkgo focused tests
-- **ALWAYS** commit generated files alongside source changes
+- **NEVER** include customer names in code comments, commit messages, or PR
+  descriptions. Refer to the ticket instead (GitHub issue number/JIRA key).
+- **ALWAYS** remove `FIt`/`FDescribe` before committing. Nothing in the repo
+  catches these for you — check your own diff.
+- **ALWAYS** commit generated files alongside source changes.
 
 ## Essential Build Commands
 
-**Prerequisites:** Docker, Make, Go, Git, Linux environment (Ubuntu 24.04+ recommended)
-
-### Building Components
+Builds run in Docker via `calico/go-build`; tool and base-image versions are
+pinned in `metadata.mk`. Run `make help` for the full target list.
 
 ```bash
-# Build specific component (2-5 minutes, RECOMMENDED)
-make -C felix build
-make -C typha build
-make -C node build
-make -C calicoctl build
-make -C kube-controllers build
-
-# Build all images (WARNING: 30+ minutes)
-make image
-
-# Build for specific architecture
-make -C felix build ARCH=arm64
+make -C <component> build   # 2-5 minutes — the usual way to build
+make image                  # ALL images — 30+ minutes
 ```
-
-### Docker Build System
-
-- All builds run inside Docker containers using `calico/go-build` (version pinned in `metadata.mk`)
-- Base images configured in `metadata.mk`
-- Build cache in `.go-pkg-cache/` (speeds up rebuilds)
-- Supported architectures: amd64, arm64, ppc64le, s390x (plus Windows builds)
-- Cross-compilation via `ARCH=<target>` and binfmt registration (`calico/binfmt`)
 
 ### Running Tests
 
 ```bash
-# Unit tests for a component via Make (runs in Docker, rebuilds tooling)
+# Per component, in Docker (rebuilds tooling)
 make -C felix ut
-make -C calicoctl test
-make -C typha test
 
-# Unit tests via go test (faster, no Docker overhead — use for quick iteration)
+# Faster iteration, no Docker overhead
 go test ./felix/calc/...
-go test ./libcalico-go/lib/...
 
-# Components with separate go.mod (must cd first)
+# Components with their own go.mod must be entered first
 cd api && go test ./...
 cd lib/std && go test ./...
 cd lib/httpmachinery && go test ./...
-
-# Felix FV (functional verification) tests
-# IMPORTANT: Always use Makefile targets — they build required tooling and set up permissions
-make -C felix fv GINKGO_ARGS="-ginkgo.v"
-
-# Run specific FV tests by pattern
-make -C felix fv GINKGO_FOCUS="TestName" GINKGO_ARGS="-ginkgo.v"
-
-# Felix FV in eBPF mode (BPF-SAFE tests only)
-make -C felix fv-bpf GINKGO_FOCUS="TestName" GINKGO_ARGS="-ginkgo.v"
-
-# Felix FV in nftables mode
-make -C felix fv GINKGO_ARGS="-ginkgo.v" FELIX_FV_NFTABLES=Enabled
 ```
 
-### Felix Testing Notes
-
-- Felix FV tests are in `felix/fv/`, using **Ginkgo v2** (`github.com/onsi/ginkgo/v2`)
-- Test IDs include all nested Context/Describe headings
-- **Always run FVs via Makefile** — builds required tooling and sets up permissions
-- Use `GINKGO_FOCUS="regex"` to target specific tests, `GINKGO_ARGS` for extra flags
-- Useful flags: `-ginkgo.dryRun` (list tests), `-ginkgo.v` (verbose), `FV_FELIX_LOG_LEVEL=debug`
-- **Prefer vanilla `go test` for new packages.** Only use Ginkgo if established pattern exists.
-- Felix "brain" is the calculation graph in `felix/calc/` — changes require calc graph "FV" tests (`felix/calc/calc_graph_fv_test.go`)
+**Always run FV tests via Makefile targets** — they build the required tooling
+and set up permissions. See [`felix/CLAUDE.md`](../felix/CLAUDE.md) for the
+Felix FV, BPF, and nftables invocations.
 
 ### Validation and Formatting
 
 ```bash
-make yaml-lint              # Quick YAML validation (~30 seconds)
-make check-go-mod           # Go module validation
-make check-dockerfiles      # Dockerfile linting
-make check-language         # Language/content checks
-make go-vet                 # Go static analysis (requires: make -C felix clone-libbpf)
-make verify-go-mods         # Cross-component module check
-make golangci-lint          # Run golangci-lint (--timeout 8m)
-make fix-changed            # Auto-fix formatting for changed files (RECOMMENDED)
-make pre-commit             # Run pre-commit checks in Docker
+make fix-changed    # Auto-fix formatting for changed files — prefer this
+make static-checks  # golangci-lint
+make yaml-lint      # ~30 seconds
 ```
 
 ### Code Generation
 
 ```bash
-# Regenerate all generated files (APIs, protobuf, manifests, CI config, etc.)
-make generate
-
-# Individual generation targets
-make protobuf               # Regenerate protobuf files
-make gen-manifests          # Update manifests/ from helm charts
-make gen-semaphore-yaml     # Regenerate .semaphore/semaphore.yml from templates
-make gen-deps-files         # Regenerate deps.txt files after adding new imports to a component; used to trigger downstream CI.
+make generate        # Everything: APIs, protobuf, manifests, CI config. Runs fix-changed itself.
+make gen-deps-files  # After adding imports to a component — deps.txt drives downstream CI triggers.
 ```
 
-**After modifying API types** (e.g., `api/pkg/apis/projectcalico/v3/felixconfig.go`), 
-run `make generate` — it regenerates OpenAPI specs, CRDs, deep copy, Felix 
-config docs, manifests, and runs `fix-changed`. See also `hack/docs/adding-an-api.md`.
+**After modifying API types** (e.g. `api/pkg/apis/projectcalico/v3/felixconfig.go`),
+run `make generate` — it regenerates OpenAPI specs, CRDs, deep copy, Felix
+config docs, and manifests. See also `hack/docs/adding-an-api.md`.
 
 ## Generated Files (DO NOT edit directly)
 
@@ -136,21 +73,12 @@ After regenerating, commit the generated files alongside your source changes.
 
 ## Code Conventions
 
-### Go Import Order
+### Formatting
 
-Three groups separated by blank lines: stdlib, external, calico-internal:
-```go
-import (
-	"fmt"
-	"net"
-
-	"k8s.io/api/core/v1"
-
-	"github.com/projectcalico/calico/libcalico-go/lib/apis"
-)
-```
-
-A repo-scoped PostToolUse hook (`.claude/settings.json`) re-formats `.go` files automatically after every Edit/Write/MultiEdit.
+A repo-scoped PostToolUse hook (`.claude/settings.json`) runs
+`hack/cmd/format-go-file` after every Edit/Write/MultiEdit, which fixes gofmt
+and import grouping (stdlib, external, calico-internal). Don't hand-format
+imports.
 
 ### Copyright Headers
 
@@ -162,7 +90,8 @@ All new `.go` files require:
 // ...
 ```
 
-eBPF files in `felix/bpf-gpl/` require dual Apache/GPL headers with SPDX identifiers. The pre-commit hook validates license headers.
+eBPF files in `felix/bpf-gpl/` require dual Apache/GPL headers with SPDX
+identifiers. Nothing enforces this automatically — add the header yourself.
 
 ### File layout
 
@@ -181,179 +110,63 @@ eBPF files in `felix/bpf-gpl/` require dual Apache/GPL headers with SPDX identif
 
 ## Documentation map
 
-This repo carries an extensive corpus of architecture and review
-guidance. **Consult it first, instead of reverse-engineering from
-the code** — it captures invariants, design rationale, and review
-criteria that are hard to recover from the source alone.
+This repo carries an extensive corpus of architecture and review guidance.
+**Consult it first, instead of reverse-engineering from the code** — it captures
+invariants, design rationale, and review criteria that are hard to recover from
+the source alone.
 
-Where it lives:
+- [`DESIGN.md`](../DESIGN.md) at the repo root — cross-cutting architecture, and
+  the authoritative starting point for *what the repo is*.
+- `<component>/DESIGN.md` — per-component architecture, invariants, and
+  per-section review notes. A coding agent writing a PR and a reviewer checking
+  one read the same file and apply the same embedded review notes.
+- `design/<topic>/` — designs for subsystems spanning several components (e.g.
+  IPAM). Pointer stubs may sit in consumer subdirectories, but the canonical
+  content lives here.
+- `<component>/CLAUDE.md` — operational guidance only. Not architecture.
 
-- **[`DESIGN.md`](../DESIGN.md) at the repo root** — Calico's
-  cross-cutting architecture: the component dependency tables,
-  the combined `calico` binary pattern, health reporting, Go
-  module structure, build system, and entry points. The
-  authoritative starting point for *what the repo is*.
-- **`<component>/DESIGN.md`** — per-component architecture,
-  invariants, and per-section review notes. Authoritative source
-  for "what does this code promise?". A coding agent writing a PR
-  and a reviewer checking one read the same file and apply the
-  same embedded review notes.
-- **Complex components have an index.** Felix has
-  [`felix/DESIGN.md`](../felix/DESIGN.md) at its root listing
-  per-topic sub-designs under
-  [`felix/design/`](../felix/design/) with an "applies to" glob
-  per topic. A PR touching multiple globs must load every matching
-  sub-design. This pattern applies to any component that grows
-  more than one design topic.
-- **`<component>/CLAUDE.md`** (or `AGENTS.md`) — operational
-  agent guidance: build commands, test invocation, debugging,
-  in-repo conventions. **Not** for architecture. If you are looking
-  for invariants or design rationale, look for a `DESIGN.md`, not
-  here.
-- **`design/<topic>/`** — cross-component designs for
-  subsystems that span multiple components (e.g. IPAM spans
-  `libcalico-go/lib/ipam`, `cni-plugin`, `kube-controllers`,
-  `node`). Same shape as a component design index: a `DESIGN.md`
-  plus per-topic sub-files with `applies to` globs. Use this when
-  no single component owns the subsystem. Discoverability pointer
-  stubs may live in consumer subdirectories (see e.g.
-  `libcalico-go/lib/ipam/DESIGN.md`,
-  `cni-plugin/pkg/ipamplugin/DESIGN.md`,
-  `kube-controllers/pkg/controllers/node/DESIGN.md`) but the
-  canonical content lives under `design/<topic>/`.
-- **[`.github/copilot-instructions.md`](../.github/copilot-instructions.md)**
-  and
-  **[`.github/instructions/*.instructions.md`](../.github/instructions/)**
-  — repo-wide and path-scoped Copilot configuration. The
-  path-scoped files are thin pointers to the relevant `DESIGN.md`
-  plus meta-rules (update rule, `@copilot` invocation pattern).
-  They do not restate design content.
+Complex components split their design across a directory with an "applies to"
+glob per topic — Felix uses [`felix/DESIGN.md`](../felix/DESIGN.md) as an index
+over [`felix/design/`](../felix/design/). A PR touching multiple globs must load
+every matching sub-design.
 
 **Rules for agents reading this repo:**
 
-1. Before writing or reviewing code in a component, read that
-   component's `DESIGN.md` (or, for Felix, the topic sub-designs
-   that match the paths you're touching).
-2. Follow links. A sub-design may reference sibling docs, other
-   components' designs, or external references. Load them — a
-   design is a graph, not a single node.
-3. A PR that changes how a component works — its behaviour,
-   data model, configuration surface, or any invariant the
-   design doc records — must update the relevant `DESIGN.md` in
-   the same PR. For components with a design directory (Felix
-   uses `felix/design/`), this means updating the relevant file
-   under that directory — the sub-design covering the area —
-   and/or the index itself when the sub-design table or scope
-   changes. Exemptions: bug fix restoring documented behaviour,
-   mechanical refactor, comment or log-message edits, dependency
+1. Before writing or reviewing code in a component, read that component's
+   `DESIGN.md` (or, for Felix, the sub-designs matching the paths you touch).
+2. Follow links. A design is a graph, not a single node.
+3. A PR that changes how a component works — its behaviour, data model,
+   configuration surface, or any invariant the design records — must update the
+   relevant `DESIGN.md` in the same PR. Exemptions: bug fix restoring documented
+   behaviour, mechanical refactor, comment or log-message edits, dependency
    bumps. If in doubt, update the doc.
 
 ## Tests required for code changes
 
-A PR that fixes a bug must include a test in the same PR that
-reproduces the bug. A PR that adds a feature must include tests
-that exercise the feature. A change without a corresponding test
-is the exception, not the default, and requires explicit
-justification (untestable interface boundary, infrastructure-only
-change).
+A PR that fixes a bug must include a test that reproduces the bug. A PR that
+adds a feature must include tests that exercise it. A change without a
+corresponding test is the exception, and requires explicit justification
+(untestable interface boundary, infrastructure-only change).
 
-Prefer the lowest test level that meaningfully exercises the
-change:
+Prefer the lowest test level that meaningfully exercises the change:
 
-1. **Unit tests** — deterministic, fast, hermetic. Always the
-   first choice when the behaviour can be reached without real
-   infrastructure. UT failures point at the change directly.
-2. **Functional verification (FV) tests** — real binary against
-   real infrastructure (containers, dataplane, kernel). Catch
-   integration bugs UT cannot, but slower, harder to write, and
-   can flake. Use FV when the integration *is* the thing being
-   tested.
-3. **End-to-end / Kubernetes tests** — full stack against a real
-   cluster. Reserve for behaviour that genuinely requires it.
+1. **Unit tests** — deterministic, fast, hermetic. Always the first choice when
+   the behaviour is reachable without real infrastructure.
+2. **Functional verification (FV)** — real binary against real infrastructure.
+   Use when the integration *is* the thing being tested.
+3. **End-to-end / Kubernetes** — reserve for behaviour that genuinely needs a
+   full cluster.
 
-Tests-only follow-ups are an anti-pattern: by the time they land,
-the change has shipped untested. A reviewer who sees "I tested it
-manually" or "tests in a follow-up PR" should push back.
+Tests-only follow-ups are an anti-pattern: by the time they land, the change has
+shipped untested. A reviewer who sees "I tested it manually" or "tests in a
+follow-up PR" should push back.
 
-Per-area sub-designs carry the area-specific test conventions on
-top of this general rule (e.g.
-[`felix/design/bpf-tests.md`](../felix/design/bpf-tests.md) for
-the BPF dataplane).
-
-## Common Development Workflows
-
-### Making Code Changes
-
-1. Create feature branch from `master`
-2. Make changes to relevant component(s)
-3. Run component-specific tests: `make -C <component> test` or `go test ./...`
-4. Run validation: `make yaml-lint` (if YAML changed)
-5. If APIs/config/CI changed: `make generate` (formats regenerated files itself)
-6. Commit changes (generated files must be included)
-7. Push and create PR
-
-### Updating Helm Charts and Manifests
-
-- Charts are in `charts/`
-- After editing chart templates: `make gen-manifests`
-- This regenerates `manifests/` directory (mostly auto-generated)
-- Commit both chart changes and regenerated manifests
-- The install/upgrade instructions in `charts/tigera-operator/README.md` and `charts/crd.projectcalico.org.v1/README.md` are hand-written and drift silently. A chart change that alters how a user installs or upgrades Calico via Helm (moving resources between charts, adding/removing a manual step, renaming a chart, changing a documented values key or example command) must update the matching README in the same PR. See [`.github/instructions/helm-charts.instructions.md`](../.github/instructions/helm-charts.instructions.md).
-
-### Working with eBPF Code
-
-- eBPF programs: `felix/bpf-gpl/` (GPL v2.0 license for Linux compatibility)
-- Apache licensed BPF code: `felix/bpf-apache/`
-- Before building: `make -C felix clone-libbpf`
-- BPF tooling configured in `metadata.mk` (LIBBPF_VERSION, BPFTOOL_IMAGE)
-
-### Kind Cluster Development
-
-Kind cluster targets are defined in `lib.Makefile` and orchestrated from the root `Makefile`. Scripts and infrastructure live in `hack/test/kind/`.
-
-```bash
-make kind-up                # Build all images + create cluster + deploy Calico (full bringup)
-make kind-cluster-create    # Create the kind cluster (no images, no Calico)
-make kind-build-images      # Build all container images needed for the kind cluster
-make kind-deploy            # Load images + install Calico via Helm + wait for readiness
-make kind-reload            # Reload only changed images onto an existing cluster (incremental)
-make kind-cluster-destroy   # Tear down the kind cluster
-make kind-down              # Alias for kind-cluster-destroy
-```
-
-Image loading is incremental — `kind-reload` and `kind-deploy` compare local Docker image IDs against what's on the cluster and only transfer changed images. Override the cluster name with `KIND_NAME=<name>`.
-
-### Cherry-picking to Release Branches
-
-1. Merge PR to master first
-2. Use `hack/cherry-pick-pull` to create the cherry-pick PR:
-   ```bash
-   SRC_UPSTREAM_REMOTE=origin DST_UPSTREAM_REMOTE=origin FORK_REMOTE=<your-remote> CHERRY_PICK=1 \
-     ./hack/cherry-pick-pull origin/release-vX.YY <PR_NUMBER>
-   ```
-
-## Critical Files and Locations
-
-**Build Configuration:**
-- `metadata.mk` - Version pins, tool versions, registry config (all tool/image versions pinned here)
-- `lib.Makefile` - Shared Makefile logic for all components
-- `Makefile` - Root orchestration
-
-For component entry points and architectural code paths, see [`DESIGN.md`](../DESIGN.md) §5.
-
-**Kind Cluster Infrastructure:**
-- `hack/test/kind/` - Kind cluster scripts (creation, image loading, deployment, teardown)
-- `hack/test/kind/infra/` - Kind cluster config, Helm values, supporting manifests
-
-**Testing:**
-- `felix/fv/` - Felix functional verification tests (Ginkgo v2-based)
-- Component unit tests co-located with source code
-- Felix FV supports batching: `FV_NUM_BATCHES` / `FV_BATCHES_TO_RUN` to split across CI jobs
-- Race detector enabled by default on amd64/arm64 (`FV_RACE_DETECTOR_ENABLED`)
+Per-area sub-designs carry area-specific test conventions on top of this rule
+(e.g. [`felix/design/bpf-tests.md`](../felix/design/bpf-tests.md)).
 
 ## PR Requirements
 
-**ALWAYS** use the PR template (`.github/PULL_REQUEST_TEMPLATE.md`) when submitting pull requests. The only mandatory section is the **Release Note** — fill it in with a one-line summary of the user-facing impact of the change. Take a broad view of "user-facing": bug fixes, new features, performance improvements, and behavioral changes all qualify. If there is genuinely no user-facing impact, write "None".
+**ALWAYS** use the PR template (`.github/PULL_REQUEST_TEMPLATE.md`). The only mandatory section is the **Release Note** — fill it in with a one-line summary of the user-facing impact of the change. Take a broad view of "user-facing": bug fixes, new features, performance improvements, and behavioral changes all qualify. If there is genuinely no user-facing impact, write "None".
 
 Every PR needs one docs label (`docs-pr-required`, `docs-completed`, or `docs-not-required`) and one release note label (`release-note-required` or `release-note-not-required`). Optional: `cherry-pick-candidate` (bug fix backports), `needs-operator-pr` (requires operator change).
 
@@ -362,4 +175,5 @@ Every PR needs one docs label (`docs-pr-required`, `docs-completed`, or `docs-no
 - **Developer Guide:** `DEVELOPER_GUIDE.md`
 - **Contributing Guide:** `CONTRIBUTING.md`
 - **User Documentation:** https://docs.tigera.io/calico/latest/about
+- **Docs repo:** https://github.com/tigera/docs/
 - **Hack docs:** `hack/docs/`

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -8,7 +8,9 @@ This file is **operational guidance** for agents working in this repo: build com
   Destructive CI-only targets.
 - **NEVER** run `make test` at root — takes hours. Always test components individually.
 - **NEVER** include customer names in code comments, commit messages, or PR
-  descriptions. Refer to the ticket instead (GitHub issue number/JIRA key).
+  descriptions — this repo is public. Cite a dev ticket (`CORE-1234`, `EV-1234`)
+  or a GitHub issue instead; JIRA picks those keys up and links the ticket to
+  the PR. Avoid `CI-1234` keys here — they track customer escalations.
 - **ALWAYS** remove `FIt`/`FDescribe` before committing. Nothing in the repo
   catches these for you — check your own diff.
 - **ALWAYS** commit generated files alongside source changes.

--- a/.claude/skills/cherry-pick-release/SKILL.md
+++ b/.claude/skills/cherry-pick-release/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: cherry-pick-release
+description: Cherry-pick a merged PR onto a Calico release branch using hack/cherry-pick-pull. Use when the user wants to backport a fix to a release-vX.YY branch or asks about the cherry-pick process.
+---
+
+# Cherry-picking to Release Branches
+
+**Merge the PR to `master` first.** Cherry-picks are made from the merged
+commit, so a PR that is still open has nothing to pick.
+
+Then run `hack/cherry-pick-pull` from the repo root:
+
+```bash
+SRC_UPSTREAM_REMOTE=origin DST_UPSTREAM_REMOTE=origin FORK_REMOTE=<your-remote> CHERRY_PICK=1 \
+  ./hack/cherry-pick-pull origin/release-vX.YY <PR_NUMBER>
+```
+
+`FORK_REMOTE` is the remote for your personal fork — the script pushes the
+cherry-pick branch there and opens the PR from it.
+
+Bug fixes that should be backported are marked on the original PR with the
+`cherry-pick-candidate` label.

--- a/.claude/skills/kind-cluster/SKILL.md
+++ b/.claude/skills/kind-cluster/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: kind-cluster
+description: Create, deploy to, reload, and tear down a local kind cluster running Calico from locally-built images. Use when the user wants to bring up a test cluster, try a change on a real cluster, reload a rebuilt image onto kind, or destroy the cluster.
+---
+
+# Kind Cluster Development
+
+Kind targets are defined in `lib.Makefile` and orchestrated from the root
+`Makefile`. Scripts and infrastructure live in `hack/test/kind/`, with cluster
+config, Helm values, and supporting manifests under `hack/test/kind/infra/`.
+
+Run all of these from the repo root.
+
+```bash
+make kind-up                # Build all images + create cluster + deploy Calico (full bringup)
+make kind-cluster-create    # Create the kind cluster (no images, no Calico)
+make kind-build-images      # Build all container images needed for the kind cluster
+make kind-deploy            # Load images + install Calico via Helm + wait for readiness
+make kind-reload            # Reload only changed images onto an existing cluster (incremental)
+make kind-cluster-destroy   # Tear down the kind cluster
+make kind-down              # Alias for kind-cluster-destroy
+```
+
+Image loading is incremental: `kind-reload` and `kind-deploy` compare local
+Docker image IDs against what is already on the cluster and only transfer the
+ones that changed. So the normal edit/test loop is `make -C <component> build`
+followed by `make kind-reload`, not a full `kind-up`.
+
+Override the cluster name with `KIND_NAME=<name>` if you need more than one
+cluster at a time.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -18,7 +18,7 @@ This is the main **Project Calico** repository - an open-source container networ
 - **Docker** - Required for all builds (validated: Docker Engine 28.0.4+)
 - **Make** - Primary build orchestration
 - **git** - Repository management
-- **Linux** - Required build environment (Ubuntu 16.04+ recommended)
+- **Linux** - Required build environment (Ubuntu 24.04+ recommended)
 
 ### Core Build Commands
 

--- a/charts/CLAUDE.md
+++ b/charts/CLAUDE.md
@@ -1,0 +1,20 @@
+# Helm Charts — Operational Guide
+
+After editing chart templates, run `make gen-manifests` from the repo root. It
+regenerates the `manifests/` directory, which is otherwise entirely generated —
+never hand-edit it. Commit the chart change and the regenerated manifests
+together.
+
+## The READMEs drift silently
+
+The install and upgrade instructions in
+[`tigera-operator/README.md`](./tigera-operator/README.md) and
+[`crd.projectcalico.org.v1/README.md`](./crd.projectcalico.org.v1/README.md) are
+hand-written, so nothing catches them going stale.
+
+A chart change that alters how a user installs or upgrades Calico via Helm must
+update the matching README in the same PR. That includes: moving resources
+between charts, adding or removing a manual step, renaming a chart, and changing
+a documented values key or example command.
+
+See [`.github/instructions/helm-charts.instructions.md`](../.github/instructions/helm-charts.instructions.md).

--- a/felix/CLAUDE.md
+++ b/felix/CLAUDE.md
@@ -14,15 +14,28 @@ make ut
 
 Runs all Go unit tests (via Ginkgo with coverage). Skips `fv/`, `k8sfv/`, and `bpf/ut/` packages. Pass `GINKGO_ARGS` for extra flags (e.g., `GINKGO_ARGS="-focus=TestName"`).
 
+**Prefer vanilla `go test` for new packages.** Only reach for Ginkgo where an established pattern already exists.
+
+Felix's "brain" is the calculation graph in `calc/`. Changes there require calc graph "FV" tests in [`calc/calc_graph_fv_test.go`](./calc/calc_graph_fv_test.go).
+
 ### Functional Tests
 
 ```bash
 make fv GINKGO_FOCUS="TestName"
 ```
 
-Runs functional tests from `fv/`. Requires container images to be built first. `GINKGO_FOCUS` filters by test name (supports regex). Can be parallelized with `FV_NUM_BATCHES` and `FV_BATCHES_TO_RUN`.
+Runs functional tests from `fv/`, using **Ginkgo v2**. Requires container images to be built first. `GINKGO_FOCUS` filters by test name (supports regex). Can be parallelized with `FV_NUM_BATCHES` and `FV_BATCHES_TO_RUN`; the race detector is on by default on amd64/arm64 (`FV_RACE_DETECTOR_ENABLED`).
+
+A test's ID is the concatenation of all its nested `Context`/`Describe` headings, so `GINKGO_FOCUS` can match on any enclosing heading. Other useful flags: `-ginkgo.dryRun` (list tests without running them), `-ginkgo.v` (verbose), and `FV_FELIX_LOG_LEVEL=debug`.
 
 ### BPF-Specific Tests
+
+#### Where the BPF code lives
+
+- `bpf-gpl/` — eBPF programs, GPL v2.0 licensed for Linux kernel compatibility.
+- `bpf-apache/` — Apache-licensed BPF code.
+- `make clone-libbpf` — run before your first BPF build; fetches libbpf.
+- BPF tooling versions (`LIBBPF_VERSION`, `BPFTOOL_IMAGE`) are pinned in [`metadata.mk`](../metadata.mk).
 
 #### Building BPF Programs
 

--- a/felix/CLAUDE.md
+++ b/felix/CLAUDE.md
@@ -24,7 +24,9 @@ Felix's "brain" is the calculation graph in `calc/`. Changes there require calc 
 make fv GINKGO_FOCUS="TestName"
 ```
 
-Runs functional tests from `fv/`, using **Ginkgo v2**. Requires container images to be built first. `GINKGO_FOCUS` filters by test name (supports regex). Can be parallelized with `FV_NUM_BATCHES` and `FV_BATCHES_TO_RUN`; the race detector is on by default on amd64/arm64 (`FV_RACE_DETECTOR_ENABLED`).
+Runs functional tests from `fv/`, using **Ginkgo v2**. `make fv` builds everything it needs first, and detects which images are already fresh so it does not rebuild them. `GINKGO_FOCUS` filters by test name (supports regex). Can be parallelized with `FV_NUM_BATCHES` and `FV_BATCHES_TO_RUN`; the race detector is on by default on amd64/arm64 (`FV_RACE_DETECTOR_ENABLED`).
+
+`fv-no-prereqs` skips that build step. It exists for CI, which builds separately and wants no accidental rebuilds — don't use it locally.
 
 A test's ID is the concatenation of all its nested `Context`/`Describe` headings, so `GINKGO_FOCUS` can match on any enclosing heading. Other useful flags: `-ginkgo.dryRun` (list tests without running them), `-ginkgo.v` (verbose), and `FV_FELIX_LOG_LEVEL=debug`.
 
@@ -32,7 +34,7 @@ A test's ID is the concatenation of all its nested `Context`/`Describe` headings
 
 #### Where the BPF code lives
 
-- `bpf-gpl/` — eBPF programs, GPL v2.0 licensed for Linux kernel compatibility.
+- `bpf-gpl/` — eBPF programs, GPL v2.0/Apache dual licensed for Linux kernel compatibility.
 - `bpf-apache/` — Apache-licensed BPF code.
 - `make clone-libbpf` — run before your first BPF build; fetches libbpf.
 - BPF tooling versions (`LIBBPF_VERSION`, `BPFTOOL_IMAGE`) are pinned in [`metadata.mk`](../metadata.mk).

--- a/goldmane/CLAUDE.md
+++ b/goldmane/CLAUDE.md
@@ -14,9 +14,6 @@ configuration surface, and Prometheus metric reference, see
 # Build binaries
 make build
 
-# Build Docker image
-make image
-
 # Run unit tests
 make ut
 


### PR DESCRIPTION
`.claude/CLAUDE.md` loads into every agent session. It had grown to 16k chars, about half of which an agent could work out for itself, and it carried three statements that were simply false.

**Correct the false claims first**, since they matter more than the size:

| Claim | Reality |
|---|---|
| "pre-commit hook rejects Ginkgo focused tests" | `git-hooks/` does not exist in this repo. Nothing catches `FIt`/`FDescribe`. |
| "The pre-commit hook validates license headers" | Same — nothing enforces copyright headers. |
| `make pre-commit` listed as a validation command | Broken: `lib.Makefile:893` runs `git-hooks/pre-commit-in-container`, which is missing. |
| "NEVER run `make ci` or `make cd`" | `cd` has no root target, only per-component ones (`node/Makefile:422` etc.). |

Both rules stay — they are now stated as the agent's own responsibility rather than as something a hook catches, which is the part that mattered.

**Then cut what the codebase already answers**: the repo-stats overview, the Docker build-system bullets, the workflow for making a code change, the file-location tour, and the derivable half of the command blocks (`make help` lists the targets). The Go import-order section goes too — the repo's own PostToolUse hook runs goimports and `coalesce-imports` on every edit, so the rule cannot be violated by hand. The documentation map and the test-required policy are compressed without losing their substance.

**Finally, move guidance that is not universal** out of the always-loaded file, so it arrives when it is relevant instead of every session:

| From | To |
|---|---|
| Felix FV/testing notes, eBPF build notes | `felix/CLAUDE.md` |
| Helm chart README drift rule | new `charts/CLAUDE.md` |
| Kind cluster workflow | new `.claude/skills/kind-cluster/SKILL.md` |
| Cherry-pick workflow | new `.claude/skills/cherry-pick-release/SKILL.md` |

Every "NEVER"/"ALWAYS" gotcha, the generated-files table, copyright headers, file layout, and PR requirements stay in the always-loaded file. Safety prohibitions do not move into lazily-loaded files.

Net: 16.4k → 7.9k chars, and what remains is guidance an agent could not have derived.

Also drops `make image` from `goldmane/CLAUDE.md` (no such target — Goldmane has no Dockerfile and ships in the mono `calico` image), and fixes a stale Ubuntu version in the Copilot instructions.

## Testing

Documentation only; no code paths change. Verified mechanically:

- Every `make` target still referenced exists in the relevant Makefile.
- Every relative link resolves from its new location.
- Every referenced file path exists.
- The removed claims were checked against the tree: no `git-hooks/` in `origin/master`, no installed `.git/hooks/pre-commit`, no `make image` in `goldmane/`.

**Release note:**
```release-note
None
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
