### PR TITLE
[DO NOT MERGE] Run openstack e2es against the pr-11008 PPA

### DIFF
--- a/.argoci/cron/e2e-openstack.yaml
+++ b/.argoci/cron/e2e-openstack.yaml
@@ -29,6 +29,10 @@ globalPrologue: |
   export INSTALLER="${INSTALLER:-packaged}"
   export PROVISIONER="${PROVISIONER:-gcp-openstack}"
 
+  # TEMPORARY (this PR is for cron-ci testing only, not for merging):
+  # install Calico packages from the pr-11008 PPA instead of master.
+  export INSTALL_SOURCE="${INSTALL_SOURCE:-ppa:project-calico/pr-11008}"
+
   # Run the whole pytest suite (banzai's default selects only the smoke
   # subset).  The multi-region tests within it self-activate on the jobs
   # whose cluster has a second region — see MULTI_REGION below.


### PR DESCRIPTION
**Test-harness PR — not for merging.**  Uses the `cron-ci` label to run the full openstack e2e matrix (all four jobs, `full-fv`) with Calico packages from `ppa:project-calico/pr-11008` instead of `ppa:project-calico/master`.  Will be closed once the run has answered its question.

Note: the run's GitHub statuses won't appear here (tigera/cc-utils#173); watch it in the ArgoCI viewer instead.

**Release note:**
```release-note
None
```