### PR TITLE
argoci: suspend all e2e crons on release-v3.30

### DIFF
--- a/.argoci/README.md
+++ b/.argoci/README.md
@@ -19,6 +19,13 @@ migrated off Semaphore's scheduled e2e builds.
 These crons and scripts are maintained **by hand** going forward: edit the
 YAML (or the scripts) directly to change a suite's jobs, env, or schedule.
 
+## All suites are suspended on this branch
+
+v3.30 is EOL, so every `cron/*.yaml` here carries `suspend: true` and nothing
+runs on a schedule. The suites stay in place, with their real schedules intact,
+so a short-notice patch release has working e2e: drop the `suspend` lines and
+merge to this branch, and `cc-argoci-handler` re-applies the CronWorkflows.
+
 ## Layout is flat (no `end-to-end/` subdir)
 
 Unlike `.semaphore/end-to-end/`, e2e lives at the top of `.argoci/`. ArgoCI's

--- a/.argoci/cron/e2e-benchmarking.yaml
+++ b/.argoci/cron/e2e-benchmarking.yaml
@@ -3,6 +3,8 @@
 version: condensed
 generateName: e2e-benchmarking-
 schedule: 0 19 * * 0
+# v3.30 is EOL: e2e stays suspended until a patch release needs it.
+suspend: true
 globalPrologue: |
   cd "${CI_HOME}/${CI_GIT_DIR}"
   export ARGO_WORKFLOW_NAME="{{workflow.name}}"

--- a/.argoci/cron/e2e-bpf.yaml
+++ b/.argoci/cron/e2e-bpf.yaml
@@ -3,6 +3,8 @@
 version: condensed
 generateName: e2e-bpf-
 schedule: 10 19 * * 2
+# v3.30 is EOL: e2e stays suspended until a patch release needs it.
+suspend: true
 globalPrologue: |
   cd "${CI_HOME}/${CI_GIT_DIR}"
   export ARGO_WORKFLOW_NAME="{{workflow.name}}"

--- a/.argoci/cron/e2e-certification.yaml
+++ b/.argoci/cron/e2e-certification.yaml
@@ -3,6 +3,8 @@
 version: condensed
 generateName: e2e-certification-
 schedule: 0 0 31 2 *
+# v3.30 is EOL: e2e stays suspended until a patch release needs it.
+suspend: true
 globalPrologue: |
   cd "${CI_HOME}/${CI_GIT_DIR}"
   export ARGO_WORKFLOW_NAME="{{workflow.name}}"

--- a/.argoci/cron/e2e-iptables.yaml
+++ b/.argoci/cron/e2e-iptables.yaml
@@ -3,6 +3,8 @@
 version: condensed
 generateName: e2e-iptables-
 schedule: 10 19 * * 4
+# v3.30 is EOL: e2e stays suspended until a patch release needs it.
+suspend: true
 globalPrologue: |
   cd "${CI_HOME}/${CI_GIT_DIR}"
   export ARGO_WORKFLOW_NAME="{{workflow.name}}"

--- a/.argoci/cron/e2e-nftables.yaml
+++ b/.argoci/cron/e2e-nftables.yaml
@@ -3,6 +3,8 @@
 version: condensed
 generateName: e2e-nftables-
 schedule: 10 19 * * 1
+# v3.30 is EOL: e2e stays suspended until a patch release needs it.
+suspend: true
 globalPrologue: |
   cd "${CI_HOME}/${CI_GIT_DIR}"
   export ARGO_WORKFLOW_NAME="{{workflow.name}}"

--- a/.argoci/cron/e2e-patch-verification.yaml
+++ b/.argoci/cron/e2e-patch-verification.yaml
@@ -3,6 +3,8 @@
 version: condensed
 generateName: e2e-patch-verification-
 schedule: 10 19 * * 3
+# v3.30 is EOL: e2e stays suspended until a patch release needs it.
+suspend: true
 globalPrologue: |
   cd "${CI_HOME}/${CI_GIT_DIR}"
   export ARGO_WORKFLOW_NAME="{{workflow.name}}"

--- a/.argoci/cron/e2e-test.yaml
+++ b/.argoci/cron/e2e-test.yaml
@@ -3,6 +3,8 @@
 version: condensed
 generateName: e2e-test-
 schedule: 0 0 31 2 *
+# v3.30 is EOL: e2e stays suspended until a patch release needs it.
+suspend: true
 globalPrologue: |
   cd "${CI_HOME}/${CI_GIT_DIR}"
   export ARGO_WORKFLOW_NAME="{{workflow.name}}"

--- a/.argoci/cron/e2e-upgrade.yaml
+++ b/.argoci/cron/e2e-upgrade.yaml
@@ -3,6 +3,8 @@
 version: condensed
 generateName: e2e-upgrade-
 schedule: 10 19 * * 3
+# v3.30 is EOL: e2e stays suspended until a patch release needs it.
+suspend: true
 globalPrologue: |
   cd "${CI_HOME}/${CI_GIT_DIR}"
   export ARGO_WORKFLOW_NAME="{{workflow.name}}"

--- a/.argoci/cron/e2e-windows.yaml
+++ b/.argoci/cron/e2e-windows.yaml
@@ -3,6 +3,8 @@
 version: condensed
 generateName: e2e-windows-
 schedule: 10 19 * * 5
+# v3.30 is EOL: e2e stays suspended until a patch release needs it.
+suspend: true
 globalPrologue: |
   cd "${CI_HOME}/${CI_GIT_DIR}"
   export ARGO_WORKFLOW_NAME="{{workflow.name}}"


### PR DESCRIPTION
## Description

Stops scheduled e2e on `release-v3.30`. Every `.argoci/cron/*.yaml` gets
`suspend: true`, which `cc-argoci-handler` maps to the CronWorkflow's
`spec.suspend` when it re-applies the branch-qualified crons
(`e2e-*-release-v3-30`) on merge.

v3.30 is EOL. The suites and their real schedules stay in the branch so a
short-notice patch release still has working e2e — dropping the `suspend` lines
and merging is enough to resume.

Seven suites were actually firing (benchmarking Sun, nftables Mon, bpf Tue,
patch-verification + upgrade Wed, iptables Thu, windows Fri); `e2e-test` and
`e2e-certification` were already parked on the never-fires schedule. Suspending
all nine keeps the branch uniform.

No CI to run — verified locally that each file still parses and that `suspend`
lands as a top-level key the condensed schema recognises.

Note for whoever picks this up: Semaphore's e2e Tasks on the
`calico-monorepo-v3.30` project are a separate scheduler and are not touched by
this PR. If they're still active they need deactivating in the Semaphore UI too.

## Related issues/PRs

Follows the ArgoCI e2e migration backport (#13211).

## Todos

- [ ] Tests
- [ ] Documentation
- [x] Release note

## Release Note

```release-note
None
```
