### PR TITLE
Fix named port matching in the app-policy checker

### DIFF
--- a/app-policy/checker/match.go
+++ b/app-policy/checker/match.go
@@ -30,10 +30,13 @@ import (
 	"github.com/projectcalico/calico/libcalico-go/lib/selector"
 )
 
+// protocolMapL4 maps IP protocol numbers to the lower-case names Felix uses when
+// rendering IP_AND_PORT IP set members ("<IP>,<protocol>:<port>").
 var protocolMapL4 = map[int32]string{
-	1:  "icmp",
-	6:  "tcp",
-	17: "udp",
+	1:   "icmp",
+	6:   "tcp",
+	17:  "udp",
+	132: "sctp",
 }
 
 type namespaceMatch struct {
@@ -548,20 +551,20 @@ func matchIPSetsNotAny(ids []string, ipsSetFunc func(string) policystore.IPSet, 
 // matchDstPort checks if the destination port is within the port ranges and named port sets. It
 // also checks if the destination port is not within the not port ranges and named port sets.
 func matchDstPort(r *proto.Rule, req *requestCache) bool {
-	return matchPort("dst", r.GetDstPorts(), r.GetDstNamedPortIpSetIds(), req.getIPSet, req.GetDestPort()) &&
-		matchNotPort("dst", r.GetNotDstPorts(), r.GetNotDstNamedPortIpSetIds(), req.getIPSet, req.GetDestPort())
+	return matchPort("dst", r.GetDstPorts(), r.GetDstNamedPortIpSetIds(), req.getIPSet, req.GetDestPort(), req.getDstIPProtoPortStr) &&
+		matchNotPort("dst", r.GetNotDstPorts(), r.GetNotDstNamedPortIpSetIds(), req.getIPSet, req.GetDestPort(), req.getDstIPProtoPortStr)
 }
 
 // matchSrcPort checks if the source port is within the port ranges and named port sets. It also
 // checks if the source port is not within the not port ranges and named port sets.
 func matchSrcPort(r *proto.Rule, req *requestCache) bool {
-	return matchPort("src", r.GetSrcPorts(), r.GetSrcNamedPortIpSetIds(), req.getIPSet, req.GetSourcePort()) &&
-		matchNotPort("src", r.GetNotSrcPorts(), r.GetNotSrcNamedPortIpSetIds(), req.getIPSet, req.GetSourcePort())
+	return matchPort("src", r.GetSrcPorts(), r.GetSrcNamedPortIpSetIds(), req.getIPSet, req.GetSourcePort(), req.getSrcIPProtoPortStr) &&
+		matchNotPort("src", r.GetNotSrcPorts(), r.GetNotSrcNamedPortIpSetIds(), req.getIPSet, req.GetSourcePort(), req.getSrcIPProtoPortStr)
 }
 
 // matchPort checks if the port is within the port ranges and named port sets. It returns true if
 // the port matches, false otherwise.
-func matchPort(dir string, ranges []*proto.PortRange, namedPortSets []string, ipsSetFunc func(string) policystore.IPSet, port int) bool {
+func matchPort(dir string, ranges []*proto.PortRange, namedPortSets []string, ipsSetFunc func(string) policystore.IPSet, port int, ipProtoPortFunc func() string) bool {
 	if log.IsLevelEnabled(log.DebugLevel) {
 		log.WithFields(log.Fields{
 			"ranges":        ranges,
@@ -579,18 +582,12 @@ func matchPort(dir string, ranges []*proto.PortRange, namedPortSets []string, ip
 			return true
 		}
 	}
-	for _, id := range namedPortSets {
-		portStr := fmt.Sprintf("%d", port)
-		if s := ipsSetFunc(id); s != nil && s.Contains(portStr) {
-			return true
-		}
-	}
-	return false
+	return matchNamedPortSetsAny(namedPortSets, ipsSetFunc, ipProtoPortFunc)
 }
 
 // matchNotPort checks if the port is not within the port ranges and named port sets. It returns
 // true if the port matches, false otherwise.
-func matchNotPort(dir string, ranges []*proto.PortRange, namedPortSets []string, ipsSetFunc func(string) policystore.IPSet, port int) bool {
+func matchNotPort(dir string, ranges []*proto.PortRange, namedPortSets []string, ipsSetFunc func(string) policystore.IPSet, port int, ipProtoPortFunc func() string) bool {
 	if log.IsLevelEnabled(log.DebugLevel) {
 		log.WithFields(log.Fields{
 			"ranges":        ranges,
@@ -608,13 +605,28 @@ func matchNotPort(dir string, ranges []*proto.PortRange, namedPortSets []string,
 			return false
 		}
 	}
+	return !matchNamedPortSetsAny(namedPortSets, ipsSetFunc, ipProtoPortFunc)
+}
+
+// matchNamedPortSetsAny returns true if the flow's endpoint is a member of any of the named port
+// IP sets.
+//
+// A named port resolves, in the calc graph, to an IP set of type IP_AND_PORT whose members are
+// "<IP>,<protocol>:<port>" — one entry per (endpoint IP, resolved port number) pair for the
+// endpoints matched by the rule's selector. So the membership test has to use the whole
+// IP/protocol/port tuple for the direction the rule applies to, not the port number alone. The
+// tuple is built lazily because most rules carry no named port reference at all.
+func matchNamedPortSetsAny(namedPortSets []string, ipsSetFunc func(string) policystore.IPSet, ipProtoPortFunc func() string) bool {
+	if len(namedPortSets) == 0 {
+		return false
+	}
+	member := ipProtoPortFunc()
 	for _, id := range namedPortSets {
-		portStr := fmt.Sprintf("%d", port)
-		if s := ipsSetFunc(id); s != nil && s.Contains(portStr) {
-			return false
+		if s := ipsSetFunc(id); s != nil && s.Contains(member) {
+			return true
 		}
 	}
-	return true
+	return false
 }
 
 // matchDstNet checks if the destination IP is within the CIDRs and not in the not CIDRs.

--- a/app-policy/checker/match_test.go
+++ b/app-policy/checker/match_test.go
@@ -1226,3 +1226,192 @@ func TestMatchDstIPPortSetIds(t *testing.T) {
 		})
 	}
 }
+
+// Named ports resolve, in the calc graph, to IP sets of type IP_AND_PORT whose members are
+// "<IP>,<protocol>:<port>". The checker must test membership using the whole tuple for the
+// direction the rule applies to; using the bare port number never matches.
+func TestMatchNamedPorts(t *testing.T) {
+	// "http" named port on two endpoints, resolving to 8080/tcp.
+	httpSet := policystore.NewIPSet(proto.IPSetUpdate_IP_AND_PORT)
+	httpSet.AddString("10.0.0.1,tcp:8080")
+	httpSet.AddString("10.0.0.2,tcp:8080")
+	// "dns" named port, resolving to 53/udp.
+	dnsSet := policystore.NewIPSet(proto.IPSetUpdate_IP_AND_PORT)
+	dnsSet.AddString("10.0.0.1,udp:53")
+	// "sig" named port, resolving to 2905/sctp.
+	sctpSet := policystore.NewIPSet(proto.IPSetUpdate_IP_AND_PORT)
+	sctpSet.AddString("10.0.0.1,sctp:2905")
+	// IPv6 endpoint with the "http" named port.
+	v6Set := policystore.NewIPSet(proto.IPSetUpdate_IP_AND_PORT)
+	v6Set.AddString("fc00:fe11::1,tcp:8080")
+
+	store := policystore.NewPolicyStore()
+	store.IPSetByID["http"] = httpSet
+	store.IPSetByID["dns"] = dnsSet
+	store.IPSetByID["sig"] = sctpSet
+	store.IPSetByID["httpv6"] = v6Set
+
+	const (
+		protoTCP  = 6
+		protoUDP  = 17
+		protoSCTP = 132
+	)
+
+	testCases := []struct {
+		title     string
+		rule      *proto.Rule
+		srcIP     string
+		srcPort   int
+		dstIP     string
+		dstPort   int
+		protocol  int
+		srcResult bool
+		dstResult bool
+	}{
+		{
+			title:     "named port matches the endpoint's resolved port",
+			rule:      &proto.Rule{DstNamedPortIpSetIds: []string{"http"}, SrcNamedPortIpSetIds: []string{"http"}},
+			srcIP:     "10.0.0.2",
+			srcPort:   8080,
+			dstIP:     "10.0.0.1",
+			dstPort:   8080,
+			protocol:  protoTCP,
+			srcResult: true,
+			dstResult: true,
+		},
+		{
+			title:     "named port does not match a different port on a member IP",
+			rule:      &proto.Rule{DstNamedPortIpSetIds: []string{"http"}, SrcNamedPortIpSetIds: []string{"http"}},
+			srcIP:     "10.0.0.2",
+			srcPort:   9090,
+			dstIP:     "10.0.0.1",
+			dstPort:   9090,
+			protocol:  protoTCP,
+			srcResult: false,
+			dstResult: false,
+		},
+		{
+			title:     "named port does not match an IP outside the set",
+			rule:      &proto.Rule{DstNamedPortIpSetIds: []string{"http"}, SrcNamedPortIpSetIds: []string{"http"}},
+			srcIP:     "10.0.0.9",
+			srcPort:   8080,
+			dstIP:     "10.0.0.9",
+			dstPort:   8080,
+			protocol:  protoTCP,
+			srcResult: false,
+			dstResult: false,
+		},
+		{
+			title:     "named port does not match a different protocol",
+			rule:      &proto.Rule{DstNamedPortIpSetIds: []string{"http"}, SrcNamedPortIpSetIds: []string{"http"}},
+			srcIP:     "10.0.0.2",
+			srcPort:   8080,
+			dstIP:     "10.0.0.1",
+			dstPort:   8080,
+			protocol:  protoUDP,
+			srcResult: false,
+			dstResult: false,
+		},
+		{
+			title:     "UDP named port matches",
+			rule:      &proto.Rule{DstNamedPortIpSetIds: []string{"dns"}, SrcNamedPortIpSetIds: []string{"dns"}},
+			srcIP:     "10.0.0.1",
+			srcPort:   53,
+			dstIP:     "10.0.0.1",
+			dstPort:   53,
+			protocol:  protoUDP,
+			srcResult: true,
+			dstResult: true,
+		},
+		{
+			title:     "SCTP named port matches",
+			rule:      &proto.Rule{DstNamedPortIpSetIds: []string{"sig"}, SrcNamedPortIpSetIds: []string{"sig"}},
+			srcIP:     "10.0.0.1",
+			srcPort:   2905,
+			dstIP:     "10.0.0.1",
+			dstPort:   2905,
+			protocol:  protoSCTP,
+			srcResult: true,
+			dstResult: true,
+		},
+		{
+			title:     "IPv6 named port matches",
+			rule:      &proto.Rule{DstNamedPortIpSetIds: []string{"httpv6"}, SrcNamedPortIpSetIds: []string{"httpv6"}},
+			srcIP:     "fc00:fe11::1",
+			srcPort:   8080,
+			dstIP:     "fc00:fe11::1",
+			dstPort:   8080,
+			protocol:  protoTCP,
+			srcResult: true,
+			dstResult: true,
+		},
+		{
+			title: "numeric range matches even when the named port set does not",
+			rule: &proto.Rule{
+				DstNamedPortIpSetIds: []string{"http"},
+				DstPorts:             []*proto.PortRange{{First: 9090, Last: 9090}},
+				SrcNamedPortIpSetIds: []string{"http"},
+				SrcPorts:             []*proto.PortRange{{First: 9090, Last: 9090}},
+			},
+			srcIP:     "10.0.0.1",
+			srcPort:   9090,
+			dstIP:     "10.0.0.1",
+			dstPort:   9090,
+			protocol:  protoTCP,
+			srcResult: true,
+			dstResult: true,
+		},
+		{
+			title:     "unknown named port set does not match",
+			rule:      &proto.Rule{DstNamedPortIpSetIds: []string{"missing"}, SrcNamedPortIpSetIds: []string{"missing"}},
+			srcIP:     "10.0.0.1",
+			srcPort:   8080,
+			dstIP:     "10.0.0.1",
+			dstPort:   8080,
+			protocol:  protoTCP,
+			srcResult: false,
+			dstResult: false,
+		},
+		{
+			title:     "negated named port excludes a member",
+			rule:      &proto.Rule{NotDstNamedPortIpSetIds: []string{"http"}, NotSrcNamedPortIpSetIds: []string{"http"}},
+			srcIP:     "10.0.0.2",
+			srcPort:   8080,
+			dstIP:     "10.0.0.1",
+			dstPort:   8080,
+			protocol:  protoTCP,
+			srcResult: false,
+			dstResult: false,
+		},
+		{
+			title:     "negated named port permits a non-member",
+			rule:      &proto.Rule{NotDstNamedPortIpSetIds: []string{"http"}, NotSrcNamedPortIpSetIds: []string{"http"}},
+			srcIP:     "10.0.0.9",
+			srcPort:   8080,
+			dstIP:     "10.0.0.9",
+			dstPort:   8080,
+			protocol:  protoTCP,
+			srcResult: true,
+			dstResult: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.title, func(t *testing.T) {
+			g := NewWithT(t)
+			fl := &mocks.Flow{}
+			fl.On("GetSourceIP").Return(libnet.ParseIP(tc.srcIP).IP)
+			fl.On("GetSourcePort").Return(tc.srcPort)
+			fl.On("GetDestIP").Return(libnet.ParseIP(tc.dstIP).IP)
+			fl.On("GetDestPort").Return(tc.dstPort)
+			fl.On("GetProtocol").Return(tc.protocol)
+
+			// A fresh cache per direction: the IP/protocol/port string is memoized.
+			srcReq := &requestCache{Flow: fl, store: store}
+			dstReq := &requestCache{Flow: fl, store: store}
+
+			g.Expect(matchSrcPort(tc.rule, srcReq)).To(Equal(tc.srcResult), "src")
+			g.Expect(matchDstPort(tc.rule, dstReq)).To(Equal(tc.dstResult), "dst")
+		})
+	}
+}

--- a/app-policy/checker/requestcache.go
+++ b/app-policy/checker/requestcache.go
@@ -49,6 +49,7 @@ type requestCache struct {
 	// allocation when many policies apply to an endpoint.
 	srcIPStr       string
 	dstIPStr       string
+	srcIPProtoPort string
 	dstIPProtoPort string
 }
 
@@ -127,10 +128,30 @@ func (r *requestCache) getDstIPStr() string {
 // IP+port set matching, memoized across the request.
 func (r *requestCache) getDstIPProtoPortStr() string {
 	if r.dstIPProtoPort == "" {
-		protocolStr := protocolMapL4[int32(r.GetProtocol())]
-		r.dstIPProtoPort = fmt.Sprintf("%s,%s:%d", r.getDstIPStr(), protocolStr, r.GetDestPort())
+		r.dstIPProtoPort = ipProtoPortStr(r.getDstIPStr(), r.GetProtocol(), r.GetDestPort())
 	}
 	return r.dstIPProtoPort
+}
+
+// getSrcIPProtoPortStr returns the source "<IP>,<protocol>:<port>" key used for IP+port
+// set matching, memoized across the request.
+func (r *requestCache) getSrcIPProtoPortStr() string {
+	if r.srcIPProtoPort == "" {
+		r.srcIPProtoPort = ipProtoPortStr(r.getSrcIPStr(), r.GetProtocol(), r.GetSourcePort())
+	}
+	return r.srcIPProtoPort
+}
+
+// ipProtoPortStr builds the "<IP>,<protocol>:<port>" member format that Felix uses for
+// IP_AND_PORT IP sets (named port sets and service IP+port sets).
+func ipProtoPortStr(ipStr string, protocol, port int) string {
+	protocolStr, ok := protocolMapL4[int32(protocol)]
+	if !ok {
+		// The set members only ever carry tcp/udp/sctp, so a flow on any other
+		// protocol cannot be a member. Log and let the lookup miss.
+		log.WithField("protocol", protocol).Debug("No IP/port set member format for protocol")
+	}
+	return fmt.Sprintf("%s,%s:%d", ipStr, protocolStr, port)
 }
 
 // getIPSet returns the IPSet with the given ID.


### PR DESCRIPTION
Fixes #13174.

## Problem

A named port in a policy rule is resolved by Felix's calc graph into an IP set of type `IP_AND_PORT`, whose members are `"<IP>,<protocol>:<port>"` — one entry per (endpoint IP, resolved port number) pair for the endpoints matched by the rule's selector. The rule then references that set via `{Src,Dst}NamedPortIpSetIds`.

The app-policy checker tested membership using the bare port number:

```go
portStr := fmt.Sprintf("%d", port)
if s := ipsSetFunc(id); s != nil && s.Contains(portStr) { ... }
```

`"8080"` is never a member of a set containing `"10.0.0.1,tcp:8080"`, so a rule referencing a named port **never matched**. An `Allow` rule fell through to the default deny, and a `Deny` rule silently did nothing — while the main dataplanes allowed the same flow.

## Fix

- Named-port membership is now tested using the whole IP/protocol/port tuple for the direction the rule applies to: destination IP and port for `Dst*` references, source IP and port for `Src*`. This matches how the iptables dataplane renders these sets (`--match-set <set> dst,dst` / `src,src`).
- The tuple is built lazily and memoized per request (`getSrcIPProtoPortStr` alongside the existing `getDstIPProtoPortStr`), since most rules carry no named-port reference at all.
- The shared lookup is extracted into `matchNamedPortSetsAny`, so `matchPort` and `matchNotPort` no longer duplicate it.
- Added `132: "sctp"` to `protocolMapL4`. Named ports and service IP+port sets can both be SCTP; without an entry the tuple came out as `"10.0.0.1,:2905"` and could never match. This additionally fixes `matchDstIPPortSetIds` for SCTP service ports.

## Testing

New `TestMatchNamedPorts` in `app-policy/checker/match_test.go` — a table test run over both directions covering: positive match, wrong port on a member IP, non-member IP, wrong protocol, UDP, SCTP, IPv6, a numeric range alongside a non-matching named port, an unknown set ID, and both negated cases.

Confirmed the test reproduces the bug: with the source change reverted, the five positive-match cases fail; with it applied, all pass.

```
go test ./app-policy/...          # all packages ok
golangci-lint run ./app-policy/... # clean
```

No `DESIGN.md` covers the app-policy matcher, and this restores documented behaviour, so no design doc update is required.

**Release note:**
```release-note
Fix Application Layer Policy (Dikastes) so that policy rules referencing a named port are evaluated correctly instead of never matching.
```
