### PR TITLE
Move IPReservation CIDR format marker onto the list items

### DIFF
--- a/api/config/crd/projectcalico.org_ipreservations.yaml
+++ b/api/config/crd/projectcalico.org_ipreservations.yaml
@@ -49,8 +49,8 @@ spec:
                   description: |-
                     ReservedCIDRs is a list of CIDRs that Calico IPAM will exclude from new allocations.
                     Each entry must be in CIDR notation (e.g., "10.0.0.0/24" or "10.0.0.1/32" for a single IP).
-                  format: cidr
                   items:
+                    format: cidr
                     type: string
                   type: array
                   x-kubernetes-list-type: set

--- a/api/pkg/apis/projectcalico/v3/ipreservation.go
+++ b/api/pkg/apis/projectcalico/v3/ipreservation.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017, 2021 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017-2026 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -57,7 +57,7 @@ type IPReservationSpec struct {
 	// ReservedCIDRs is a list of CIDRs that Calico IPAM will exclude from new allocations.
 	// Each entry must be in CIDR notation (e.g., "10.0.0.0/24" or "10.0.0.1/32" for a single IP).
 	// +listType=set
-	// +kubebuilder:validation:Format=cidr
+	// +kubebuilder:validation:items:Format=cidr
 	ReservedCIDRs []string `json:"reservedCIDRs,omitempty" validate:"cidrs,omitempty"`
 }
 

--- a/libcalico-go/config/crd/crd.projectcalico.org_ipreservations.yaml
+++ b/libcalico-go/config/crd/crd.projectcalico.org_ipreservations.yaml
@@ -43,8 +43,8 @@ spec:
                   description: |-
                     ReservedCIDRs is a list of CIDRs that Calico IPAM will exclude from new allocations.
                     Each entry must be in CIDR notation (e.g., "10.0.0.0/24" or "10.0.0.1/32" for a single IP).
-                  format: cidr
                   items:
+                    format: cidr
                     type: string
                   type: array
                   x-kubernetes-list-type: set

--- a/manifests/calico-bpf.yaml
+++ b/manifests/calico-bpf.yaml
@@ -5620,8 +5620,8 @@ spec:
                   description: |-
                     ReservedCIDRs is a list of CIDRs that Calico IPAM will exclude from new allocations.
                     Each entry must be in CIDR notation (e.g., "10.0.0.0/24" or "10.0.0.1/32" for a single IP).
-                  format: cidr
                   items:
+                    format: cidr
                     type: string
                   type: array
                   x-kubernetes-list-type: set

--- a/manifests/calico-policy-only.yaml
+++ b/manifests/calico-policy-only.yaml
@@ -5630,8 +5630,8 @@ spec:
                   description: |-
                     ReservedCIDRs is a list of CIDRs that Calico IPAM will exclude from new allocations.
                     Each entry must be in CIDR notation (e.g., "10.0.0.0/24" or "10.0.0.1/32" for a single IP).
-                  format: cidr
                   items:
+                    format: cidr
                     type: string
                   type: array
                   x-kubernetes-list-type: set

--- a/manifests/calico-typha.yaml
+++ b/manifests/calico-typha.yaml
@@ -5631,8 +5631,8 @@ spec:
                   description: |-
                     ReservedCIDRs is a list of CIDRs that Calico IPAM will exclude from new allocations.
                     Each entry must be in CIDR notation (e.g., "10.0.0.0/24" or "10.0.0.1/32" for a single IP).
-                  format: cidr
                   items:
+                    format: cidr
                     type: string
                   type: array
                   x-kubernetes-list-type: set

--- a/manifests/calico-v3-crds.yaml
+++ b/manifests/calico-v3-crds.yaml
@@ -5887,8 +5887,8 @@ spec:
                   description: |-
                     ReservedCIDRs is a list of CIDRs that Calico IPAM will exclude from new allocations.
                     Each entry must be in CIDR notation (e.g., "10.0.0.0/24" or "10.0.0.1/32" for a single IP).
-                  format: cidr
                   items:
+                    format: cidr
                     type: string
                   type: array
                   x-kubernetes-list-type: set

--- a/manifests/calico-vxlan.yaml
+++ b/manifests/calico-vxlan.yaml
@@ -5615,8 +5615,8 @@ spec:
                   description: |-
                     ReservedCIDRs is a list of CIDRs that Calico IPAM will exclude from new allocations.
                     Each entry must be in CIDR notation (e.g., "10.0.0.0/24" or "10.0.0.1/32" for a single IP).
-                  format: cidr
                   items:
+                    format: cidr
                     type: string
                   type: array
                   x-kubernetes-list-type: set

--- a/manifests/calico.yaml
+++ b/manifests/calico.yaml
@@ -5615,8 +5615,8 @@ spec:
                   description: |-
                     ReservedCIDRs is a list of CIDRs that Calico IPAM will exclude from new allocations.
                     Each entry must be in CIDR notation (e.g., "10.0.0.0/24" or "10.0.0.1/32" for a single IP).
-                  format: cidr
                   items:
+                    format: cidr
                     type: string
                   type: array
                   x-kubernetes-list-type: set

--- a/manifests/canal.yaml
+++ b/manifests/canal.yaml
@@ -5632,8 +5632,8 @@ spec:
                   description: |-
                     ReservedCIDRs is a list of CIDRs that Calico IPAM will exclude from new allocations.
                     Each entry must be in CIDR notation (e.g., "10.0.0.0/24" or "10.0.0.1/32" for a single IP).
-                  format: cidr
                   items:
+                    format: cidr
                     type: string
                   type: array
                   x-kubernetes-list-type: set

--- a/manifests/crds.yaml
+++ b/manifests/crds.yaml
@@ -5529,8 +5529,8 @@ spec:
                   description: |-
                     ReservedCIDRs is a list of CIDRs that Calico IPAM will exclude from new allocations.
                     Each entry must be in CIDR notation (e.g., "10.0.0.0/24" or "10.0.0.1/32" for a single IP).
-                  format: cidr
                   items:
+                    format: cidr
                     type: string
                   type: array
                   x-kubernetes-list-type: set

--- a/manifests/flannel-migration/calico.yaml
+++ b/manifests/flannel-migration/calico.yaml
@@ -5615,8 +5615,8 @@ spec:
                   description: |-
                     ReservedCIDRs is a list of CIDRs that Calico IPAM will exclude from new allocations.
                     Each entry must be in CIDR notation (e.g., "10.0.0.0/24" or "10.0.0.1/32" for a single IP).
-                  format: cidr
                   items:
+                    format: cidr
                     type: string
                   type: array
                   x-kubernetes-list-type: set

--- a/manifests/operator-crds.yaml
+++ b/manifests/operator-crds.yaml
@@ -40473,8 +40473,8 @@ spec:
                   description: |-
                     ReservedCIDRs is a list of CIDRs that Calico IPAM will exclude from new allocations.
                     Each entry must be in CIDR notation (e.g., "10.0.0.0/24" or "10.0.0.1/32" for a single IP).
-                  format: cidr
                   items:
+                    format: cidr
                     type: string
                   type: array
                   x-kubernetes-list-type: set

--- a/manifests/v1_crd_projectcalico_org.yaml
+++ b/manifests/v1_crd_projectcalico_org.yaml
@@ -40473,8 +40473,8 @@ spec:
                   description: |-
                     ReservedCIDRs is a list of CIDRs that Calico IPAM will exclude from new allocations.
                     Each entry must be in CIDR notation (e.g., "10.0.0.0/24" or "10.0.0.1/32" for a single IP).
-                  format: cidr
                   items:
+                    format: cidr
                     type: string
                   type: array
                   x-kubernetes-list-type: set

--- a/manifests/v3_projectcalico_org.yaml
+++ b/manifests/v3_projectcalico_org.yaml
@@ -40912,8 +40912,8 @@ spec:
                   description: |-
                     ReservedCIDRs is a list of CIDRs that Calico IPAM will exclude from new allocations.
                     Each entry must be in CIDR notation (e.g., "10.0.0.0/24" or "10.0.0.1/32" for a single IP).
-                  format: cidr
                   items:
+                    format: cidr
                     type: string
                   type: array
                   x-kubernetes-list-type: set


### PR DESCRIPTION
Applying the Calico CRDs to a Kubernetes 1.36 cluster prints `Warning: unrecognized format "cidr"`. The IPReservation CRD had the CIDR format sitting on the list itself instead of on the strings inside it, and 1.36 started warning about formats on anything that isn't a string, integer or number.

No behaviour change, since the format was being ignored where it was.

```release-note
Fixes an "unrecognized format" warning printed by Kubernetes 1.36 when applying the IPReservation CRD.
```
