### PR TITLE
Add DOCKER_MEMORY knob to cap build container memory

### DIFF
--- a/lib.Makefile
+++ b/lib.Makefile
@@ -319,6 +319,13 @@ EXTRA_DOCKER_ARGS += -v $(GOMOD_CACHE):/go/pkg/mod:rw
 #   DOCKER_CPUSET_CPUS=0-3  Pin container to specific cores (true affinity).
 #   GOMAXPROCS=N            Cap goroutine parallelism inside each go invocation
 #                           (linker, vet, etc.); complements -p=N from GOFLAGS.
+#   DOCKER_MEMORY=8g        Hard cap on container memory. The kernel OOM-kills
+#                           the container at this limit, so a runaway compile or
+#                           link fails the build ("signal: killed") rather than
+#                           driving the whole host into swap thrash.
+#   DOCKER_MEMORY_SWAP=8g   Cap on memory and swap combined. Defaults to
+#                           DOCKER_MEMORY, which denies the container swap
+#                           entirely and keeps it off the host swap device.
 ifneq ($(DOCKER_CPUS),)
 EXTRA_DOCKER_ARGS += --cpus=$(DOCKER_CPUS)
 endif
@@ -327,6 +334,9 @@ EXTRA_DOCKER_ARGS += --cpuset-cpus=$(DOCKER_CPUSET_CPUS)
 endif
 ifneq ($(GOMAXPROCS),)
 EXTRA_DOCKER_ARGS += -e GOMAXPROCS=$(GOMAXPROCS)
+endif
+ifneq ($(DOCKER_MEMORY),)
+EXTRA_DOCKER_ARGS += --memory=$(DOCKER_MEMORY) --memory-swap=$(if $(DOCKER_MEMORY_SWAP),$(DOCKER_MEMORY_SWAP),$(DOCKER_MEMORY))
 endif
 
 # Define go architecture flags

--- a/lib.Makefile
+++ b/lib.Makefile
@@ -323,9 +323,9 @@ EXTRA_DOCKER_ARGS += -v $(GOMOD_CACHE):/go/pkg/mod:rw
 #                           the container at this limit, so a runaway compile or
 #                           link fails the build ("signal: killed") rather than
 #                           driving the whole host into swap thrash.
-#   DOCKER_MEMORY_SWAP=8g   Cap on memory and swap combined. Defaults to
-#                           DOCKER_MEMORY, which denies the container swap
-#                           entirely and keeps it off the host swap device.
+#   DOCKER_MEMORY_SWAP=8g   Cap on memory+swap combined (requires DOCKER_MEMORY).
+#                           Must be >= DOCKER_MEMORY or -1; defaults to DOCKER_MEMORY
+#                           (denies container swap entirely, keeps it off host swap).
 ifneq ($(DOCKER_CPUS),)
 EXTRA_DOCKER_ARGS += --cpus=$(DOCKER_CPUS)
 endif


### PR DESCRIPTION
Adds `DOCKER_MEMORY` and `DOCKER_MEMORY_SWAP` to the optional per-build resource caps in `lib.Makefile`, completing the set alongside the existing `DOCKER_CPUS`, `DOCKER_CPUSET_CPUS` and `GOMAXPROCS`.

### Why

Build containers run with no memory limit, and they land in `system.slice`, where `systemd-oomd` cannot see them because it only manages `user.slice`. On a workstation, a `make` target that forks a Go compile and link per parallel job can exhaust RAM and livelock the host. The kernel OOM killer never fires, because reclaim keeps technically succeeding, so the machine crawls indefinitely instead of failing. Capping the container turns that into a clean `signal: killed` build failure.

`DOCKER_MEMORY_SWAP` defaults to `DOCKER_MEMORY`, which denies the container swap entirely and so keeps a runaway build off the host swap device.

### Type of change

Build-system improvement. No change to default behaviour: both variables are unset by default and add no docker flags, matching the existing caps.

### Testing

Verified with `make -C felix -n build` dry runs:

| Invocation | Flags emitted |
|---|---|
| `DOCKER_MEMORY=6g` | `--memory=6g --memory-swap=6g` |
| `DOCKER_MEMORY=6g DOCKER_MEMORY_SWAP=8g` | `--memory=6g --memory-swap=8g` |
| neither set | none |

No test accompanies this change. It is infrastructure-only plumbing of Makefile variables into `EXTRA_DOCKER_ARGS`, with no reachable code path to assert against, and it follows the precedent of the adjacent CPU and `GOMAXPROCS` caps.

**Release note:**
```release-note
Added optional DOCKER_MEMORY and DOCKER_MEMORY_SWAP make variables to cap memory usage of Docker-based builds.
```

