### PR TITLE
ci: DM the PR author on Slack when their PR is approved

### DIFF
--- a/.github/workflows/ci-notify.yml
+++ b/.github/workflows/ci-notify.yml
@@ -1,4 +1,5 @@
-# DMs a PR author on Slack when their PR's Semaphore CI finishes.
+# DMs a PR author on Slack when their PR's Semaphore CI finishes, and when
+# someone approves their PR.
 #
 # Opt-in is a repo *variable* (not a secret — Slack member IDs aren't
 # sensitive): CI_NOTIFY_MAP, a comma-separated list of
@@ -16,15 +17,21 @@
 # The workflow is a no-op (never fails noisily) if the variable/secret
 # are unset, the author hasn't opted in, or Slack is unreachable.
 
-name: CI finished Slack notify
+name: PR Slack notify
 
 on:
   status: {}
-  # Manual test path: simulate a finished-CI status for a given PR, so the
-  # full chain (resolve -> opt-in lookup -> DM) can be exercised on demand
-  # without waiting for real CI. Dispatchable only once this file is on the
-  # default branch (a GitHub limitation), so it's for post-merge sanity
-  # checks, not pre-merge testing.
+  # Approval path. Like `status`, this event runs the workflow file from the
+  # base branch, so a fork PR cannot alter it and the Slack secret is
+  # available. Each submitted review is a single event — no duplicate burst
+  # — so the approval path needs no dedup marker.
+  pull_request_review:
+    types: [submitted]
+  # Manual test path: simulate a finished-CI status (or an approval) for a
+  # given PR, so the full chain (resolve -> opt-in lookup -> DM) can be
+  # exercised on demand without waiting for real CI. Dispatchable only once
+  # this file is on the default branch (a GitHub limitation), so it's for
+  # post-merge sanity checks, not pre-merge testing.
   workflow_dispatch:
     inputs:
       pr_number:
@@ -32,11 +39,11 @@ on:
         required: true
         type: string
       state:
-        description: "Simulated CI outcome"
+        description: "Simulated CI outcome, or 'approved' for the review path"
         required: false
         default: success
         type: choice
-        options: [success, failure, error]
+        options: [success, failure, error, approved]
 
 # Semaphore re-posts the same terminal status several times per commit.
 # Dedup claims a git ref named after (commit, state) atomically — see "Claim
@@ -46,6 +53,7 @@ on:
 # a double-send race. Markers only matter for the duplicate-event burst
 # (minutes), so each run opportunistically prunes markers older than 2 days
 # — see "Prune stale dedup markers" — keeping refs/ci-notify/* bounded.
+# This applies to the `status` path only; see the trigger comments above.
 
 permissions:
   pull-requests: read
@@ -61,13 +69,18 @@ jobs:
   notify:
     # Fire once when the aggregate Semaphore status reaches a terminal
     # state. Skip 'pending' — that's CI starting/running, not finishing.
+    # Reviews fire only on an approval: 'commented' and 'changes_requested'
+    # already reach the author by GitHub's own notifications, and a comment
+    # review would be a firehose.
     # Manual workflow_dispatch runs always proceed (state comes from input).
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (github.event.context == 'ci/semaphoreci/pr: Calico' &&
        (github.event.state == 'success' ||
         github.event.state == 'failure' ||
-        github.event.state == 'error'))
+        github.event.state == 'error')) ||
+      (github.event_name == 'pull_request_review' &&
+       github.event.review.state == 'approved')
     runs-on: ubuntu-latest
     timeout-minutes: 5
     env:
@@ -75,10 +88,18 @@ jobs:
       REPO: ${{ github.repository }}
       CI_NOTIFY_MAP: ${{ vars.CI_NOTIFY_MAP }}
       SLACK_BOT_TOKEN: ${{ secrets.GH_PR_MONITOR_BOT_TOKEN }}
-      # On a status event these come from the event; on workflow_dispatch
-      # STATE falls through to the input and SHA is empty.
-      STATE: ${{ github.event.state || inputs.state }}
+      # STATE drives everything downstream: 'success'/'failure'/'error' mean
+      # the CI path, 'approved' the review path. It comes from the status
+      # event, the review, or the dispatch input, in that order (a missing
+      # property evaluates to empty, so the fallbacks pick the live one).
+      STATE: ${{ github.event.state || github.event.review.state || inputs.state }}
+      # Status events only — it names the commit the dedup marker claims.
+      # Empty on a review or a manual run, which is what disables dedup and
+      # marker pruning on those paths.
       SHA: ${{ github.event.sha }}
+      # Review path: who approved. A GitHub login, and passed as an env value
+      # rather than interpolated into a script, so it can't inject.
+      REVIEWER: ${{ github.event.review.user.login }}
     steps:
       - name: Skip if not configured
         id: gate
@@ -95,6 +116,8 @@ jobs:
         if: steps.gate.outputs.skip != 'true'
         env:
           INPUT_PR: ${{ inputs.pr_number }}
+          # Review event: the PR number is right there in the payload.
+          EVENT_PR: ${{ github.event.pull_request.number }}
         run: |
           if [[ -n "$INPUT_PR" ]]; then
             # Manual run: trust only a numeric PR number (guards against
@@ -104,6 +127,8 @@ jobs:
               exit 1
             fi
             PR="$INPUT_PR"
+          elif [[ -n "$EVENT_PR" ]]; then
+            PR="$EVENT_PR"
           else
             # Status event: resolve PR from SHA. Use the search API rather
             # than repos/$REPO/commits/$SHA/pulls — the latter does not
@@ -154,11 +179,13 @@ jobs:
       # status events race to create the same ref and exactly one wins —
       # no concurrency group or serialization required. A non-"already
       # exists" failure fails OPEN (proceeds to send) rather than silently
-      # swallowing a real notification on an API hiccup. Status events only
-      # (SHA non-empty); manual workflow_dispatch runs always proceed.
+      # swallowing a real notification on an API hiccup. Status events only:
+      # a review is a single event, and keying a marker on (sha, 'approved')
+      # would wrongly swallow a second reviewer's approval of the same
+      # commit. Manual workflow_dispatch runs always proceed too.
       - name: Claim dedup marker (atomic)
         id: claim
-        if: steps.gate.outputs.skip != 'true' && steps.resolve.outputs.skip != 'true' && steps.lookup.outputs.skip != 'true' && env.SHA != ''
+        if: steps.gate.outputs.skip != 'true' && steps.resolve.outputs.skip != 'true' && steps.lookup.outputs.skip != 'true' && github.event_name == 'status'
         run: |
           set +e
           ERR=$(gh api "repos/$REPO/git/refs" --method POST \
@@ -178,8 +205,9 @@ jobs:
       # On failure/error, sem-ai-ci-triage posts a failure-analysis comment
       # — but it runs concurrently on the same status event and only after
       # its LLM backend responds, so the comment usually isn't there yet.
-      # Poll briefly for it so the DM can deep-link to the analysis. Success
-      # never gets a triage comment, so we skip the poll entirely there.
+      # Poll briefly for it so the DM can deep-link to the analysis. A pass
+      # and an approval never get a triage comment, so the poll is skipped
+      # on every state but failure/error.
       - name: Wait for sem-ai-triage comment
         id: triage
         if: >-
@@ -187,7 +215,7 @@ jobs:
           steps.resolve.outputs.skip != 'true' &&
           steps.lookup.outputs.skip != 'true' &&
           steps.claim.outputs.claimed != 'false' &&
-          env.STATE != 'success'
+          (env.STATE == 'failure' || env.STATE == 'error')
         env:
           PR: ${{ steps.resolve.outputs.pr }}
           # When CI finished, per GitHub (status events only; empty on a
@@ -246,21 +274,26 @@ jobs:
           TITLE=$(jq -r .title pr.json)
           URL=$(jq -r .url pr.json)
 
-          case "$STATE" in
-            success) EMOJI=":white_check_mark:" WORD="passed" ;;
-            failure) EMOJI=":x:"                WORD="failed" ;;
-            error)   EMOJI=":warning:"          WORD="errored" ;;
-            *)       EMOJI=":grey_question:"     WORD="$STATE" ;;
-          esac
-
           # Slack mrkdwn link: <url|text> renders "PR #N" as a hyperlink.
-          TEXT="$EMOJI CI $WORD on your <$URL|PR #$PR>: $TITLE"
-          # On failure/error, point at the sem-ai triage analysis on the PR
-          # (which itself links the run), when triage actually posted one (it
-          # skips on PASS or backend hiccups). No raw CI-run link on any
-          # outcome — the PR link above is the lead.
-          if [[ "$STATE" != "success" && -n "$TRIAGE_COMMENT_URL" ]]; then
-            TEXT="$TEXT"$'\n'":mag: Failure analysis: $TRIAGE_COMMENT_URL"
+          if [[ "$STATE" == "approved" ]]; then
+            # REVIEWER is empty on a manual run (no review payload), so name
+            # the reviewer only when the event supplied one.
+            TEXT=":+1: Your <$URL|PR #$PR> was approved${REVIEWER:+ by $REVIEWER}: $TITLE"
+          else
+            case "$STATE" in
+              success) EMOJI=":white_check_mark:" WORD="passed" ;;
+              failure) EMOJI=":x:"                WORD="failed" ;;
+              error)   EMOJI=":warning:"          WORD="errored" ;;
+              *)       EMOJI=":grey_question:"     WORD="$STATE" ;;
+            esac
+            TEXT="$EMOJI CI $WORD on your <$URL|PR #$PR>: $TITLE"
+            # On failure/error, point at the sem-ai triage analysis on the PR
+            # (which itself links the run), when triage actually posted one (it
+            # skips on PASS or backend hiccups). No raw CI-run link on any
+            # outcome — the PR link above is the lead.
+            if [[ "$STATE" != "success" && -n "$TRIAGE_COMMENT_URL" ]]; then
+              TEXT="$TEXT"$'\n'":mag: Failure analysis: $TRIAGE_COMMENT_URL"
+            fi
           fi
 
           # Resolve the member ID to a DM channel with conversations.open

--- a/.github/workflows/ci-notify.yml
+++ b/.github/workflows/ci-notify.yml
@@ -72,7 +72,11 @@ jobs:
     # state. Skip 'pending' — that's CI starting/running, not finishing.
     # Reviews fire only on an approval: 'commented' and 'changes_requested'
     # already reach the author by GitHub's own notifications, and a comment
-    # review would be a firehose.
+    # review would be a firehose. The approval must also come from someone
+    # with write access — on a public repo any account can submit an
+    # approving review, so without this any number of drive-by approvals
+    # would each DM the author (the review path claims no dedup marker), and
+    # an untrusted actor could start runs holding the Slack token at will.
     # Manual workflow_dispatch runs always proceed (state comes from input).
     if: >-
       github.event_name == 'workflow_dispatch' ||
@@ -81,7 +85,9 @@ jobs:
         github.event.state == 'failure' ||
         github.event.state == 'error')) ||
       (github.event_name == 'pull_request_review' &&
-       github.event.review.state == 'approved')
+       github.event.review.state == 'approved' &&
+       contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'),
+                github.event.review.author_association))
     runs-on: ubuntu-latest
     timeout-minutes: 5
     env:
@@ -94,11 +100,13 @@ jobs:
       # event, the review, or the dispatch input, in that order (a missing
       # property evaluates to empty, so the fallbacks pick the live one).
       STATE: ${{ github.event.state || github.event.review.state || inputs.state }}
-      # Status events only — it names the commit the dedup marker claims.
-      # Empty on a review or a manual run, which is what disables dedup and
-      # marker pruning on those paths.
+      # Status events only — names the commit the dedup marker claims. Empty
+      # on the review and manual paths, which claim no marker at all: see the
+      # event-name gate on the claim step.
       SHA: ${{ github.event.sha }}
-      # Review path: who approved. A GitHub login passed via env (not via `${{ }}` interpolation inside the `run:` script), so it can't affect shell parsing.
+      # Review path: who approved. A GitHub login passed via env (not via
+      # `${{ }}` interpolation inside the `run:` script), so it can't affect
+      # shell parsing.
       REVIEWER: ${{ github.event.review.user.login }}
     steps:
       - name: Skip if not configured
@@ -299,14 +307,17 @@ jobs:
               success) EMOJI=":white_check_mark:" WORD="passed" ;;
               failure) EMOJI=":x:"                WORD="failed" ;;
               error)   EMOJI=":warning:"          WORD="errored" ;;
+              # Unreachable via the job's `if`; keeps a state added later
+              # from rendering as a blank word.
               *)       EMOJI=":grey_question:"     WORD="$STATE" ;;
             esac
             TEXT="$EMOJI CI $WORD on your <$URL|PR #$PR>: $TITLE"
-            # On failure/error, point at the sem-ai triage analysis on the PR
-            # (which itself links the run), when triage actually posted one (it
-            # skips on PASS or backend hiccups). No raw CI-run link on any
+            # Point at the sem-ai triage analysis on the PR (which itself
+            # links the run) when triage actually posted one — the poll only
+            # runs on failure/error, and triage skips on backend hiccups, so
+            # a URL here is the whole condition. No raw CI-run link on any
             # outcome — the PR link above is the lead.
-            if [[ "$STATE" != "success" && -n "$TRIAGE_COMMENT_URL" ]]; then
+            if [[ -n "$TRIAGE_COMMENT_URL" ]]; then
               TEXT="$TEXT"$'\n'":mag: Failure analysis: $TRIAGE_COMMENT_URL"
             fi
           fi
@@ -381,13 +392,17 @@ jobs:
               NAME=${REF#refs/ci-notify/}
               DATE=${NAME%%-*}
               if [[ ! "$DATE" =~ ^[0-9]{8}$ ]]; then
-                # A marker with no date prefix predates this naming scheme
-                # and cannot be aged, so retire it on sight. Worst case it
+                # A <40-hex>-<state> name predates this naming scheme and
+                # cannot be aged, so retire it on sight. Worst case it
                 # belonged to a burst still in flight during the rollout and
-                # that burst sends one extra DM.
-                gh api "repos/$REPO/git/$REF" --method DELETE \
-                  && echo "pruned undated $REF" \
-                  || echo "::notice::could not prune $REF"
+                # that burst sends one extra DM. Anything else under this
+                # namespace was put there by hand — leave it alone rather
+                # than delete someone's debugging marker.
+                if [[ "$NAME" =~ ^[0-9a-f]{40}- ]]; then
+                  gh api "repos/$REPO/git/$REF" --method DELETE \
+                    && echo "pruned legacy $REF" \
+                    || echo "::notice::could not prune $REF"
+                fi
                 continue
               fi
               # yyyymmdd sorts lexicographically, so '<' compares dates.

--- a/.github/workflows/ci-notify.yml
+++ b/.github/workflows/ci-notify.yml
@@ -97,8 +97,7 @@ jobs:
       # Empty on a review or a manual run, which is what disables dedup and
       # marker pruning on those paths.
       SHA: ${{ github.event.sha }}
-      # Review path: who approved. A GitHub login, and passed as an env value
-      # rather than interpolated into a script, so it can't inject.
+      # Review path: who approved. A GitHub login passed via env (not via `${{ }}` interpolation inside the `run:` script), so it can't affect shell parsing.
       REVIEWER: ${{ github.event.review.user.login }}
     steps:
       - name: Skip if not configured

--- a/.github/workflows/ci-notify.yml
+++ b/.github/workflows/ci-notify.yml
@@ -46,13 +46,14 @@ on:
         options: [success, failure, error, approved]
 
 # Semaphore re-posts the same terminal status several times per commit.
-# Dedup claims a git ref named after (commit, state) atomically — see "Claim
-# dedup marker" below — so concurrent duplicate events race to create the
-# same ref and exactly one wins. No concurrency group is needed: the claim
-# is atomic on GitHub's side, so runs don't need to be serialized to avoid
-# a double-send race. Markers only matter for the duplicate-event burst
-# (minutes), so each run opportunistically prunes markers older than 2 days
-# — see "Prune stale dedup markers" — keeping refs/ci-notify/* bounded.
+# Dedup claims a git ref named refs/ci-notify/<yyyymmdd>-<commit>-<state>
+# atomically — see "Claim dedup marker" below — so concurrent duplicate
+# events race to create the same ref and exactly one wins. No concurrency
+# group is needed: the claim is atomic on GitHub's side, so runs don't need
+# to be serialized to avoid a double-send race. Markers only matter for the
+# duplicate-event burst (minutes), so each run opportunistically prunes
+# markers whose date prefix is more than 2 days old — see "Prune stale dedup
+# markers" — keeping refs/ci-notify/* bounded.
 # This applies to the `status` path only; see the trigger comments above.
 
 permissions:
@@ -186,9 +187,24 @@ jobs:
         id: claim
         if: steps.gate.outputs.skip != 'true' && steps.resolve.outputs.skip != 'true' && steps.lookup.outputs.skip != 'true' && github.event_name == 'status'
         run: |
+          # The marker name carries everything dedup and pruning need: the
+          # claim date, then the (commit, state) this DM is for. Duplicates
+          # that straddle midnight UTC compute different names and so both
+          # send — one extra DM at most, once a day, in exchange for keeping
+          # age in the name.
+          REF="refs/ci-notify/$(date -u +%Y%m%d)-${SHA}-${STATE}"
+          echo "ref=$REF" >> "$GITHUB_OUTPUT"
+          # The ref *target* is GITHUB_SHA — the default-branch tip this run
+          # was resolved from — deliberately not the status sha. A status sha
+          # is a PR head commit living in a fork, and creating a ref that
+          # points at one is not reliably permitted here: freshly pushed fork
+          # commits have been observed to 403 ("Resource not accessible by
+          # integration") while a day-old one succeeded, and that failure
+          # takes the fail-open branch below and re-sends the DM. Nothing
+          # reads the target, so a commit that is certainly local is enough.
           set +e
           ERR=$(gh api "repos/$REPO/git/refs" --method POST \
-            -f ref="refs/ci-notify/${SHA}-${STATE}" -f sha="$SHA" 2>&1 >/dev/null)
+            -f ref="$REF" -f sha="$GITHUB_SHA" 2>&1 >/dev/null)
           RC=$?
           set -e
           if [[ $RC -eq 0 ]]; then
@@ -341,14 +357,17 @@ jobs:
       - name: Release dedup marker if send failed
         if: steps.claim.outputs.claimed == 'true' && steps.send.outputs.sent != 'true'
         continue-on-error: true
-        run: gh api "repos/$REPO/git/refs/ci-notify/${SHA}-${STATE}" --method DELETE
+        env:
+          MARKER: ${{ steps.claim.outputs.ref }}
+        run: gh api "repos/$REPO/git/$MARKER" --method DELETE
 
       # Housekeeping: markers are dead weight once the duplicate-event burst
       # (minutes) has passed, so prune any older than 2 days here rather than
       # in a separate scheduled workflow — keeps the whole mechanism in this
-      # file and refs/ci-notify/* from growing without bound. Age proxy is
-      # the committer date of the ref's target commit (the marker is created
-      # moments after that commit's CI finishes). Best-effort throughout: a
+      # file and refs/ci-notify/* from growing without bound. Age is the
+      # yyyymmdd prefix of the marker name, so the whole sweep costs one list
+      # call and no per-ref lookups. This run's own marker carries today's
+      # date and so can never precede the cutoff. Best-effort throughout: a
       # failed prune must never fail the notifier, and a missed one just
       # waits for the next run. Duplicate runs may race to delete the same
       # ref — the loser's 422 is swallowed.
@@ -356,20 +375,25 @@ jobs:
         if: steps.claim.outcome == 'success'
         continue-on-error: true
         run: |
-          CUTOFF=$(date -u -d '2 days ago' +%Y-%m-%dT%H:%M:%SZ)
-          gh api "repos/$REPO/git/matching-refs/ci-notify/" --paginate \
-            --jq '.[] | "\(.ref) \(.object.sha)"' \
-          | while read -r REF OBJ; do
-              # Never prune this run's own marker: a push can carry an old
-              # committer date (e.g. an untouched branch pushed late), and
-              # deleting our own marker would re-open the dedup window while
-              # duplicate events are still arriving.
-              [[ "$REF" == "refs/ci-notify/${SHA}-${STATE}" ]] && continue
-              DATE=$(gh api "repos/$REPO/commits/$OBJ" --jq .commit.committer.date) || continue
-              # ISO-8601 UTC sorts lexicographically, so '<' compares times.
+          CUTOFF=$(date -u -d '2 days ago' +%Y%m%d)
+          gh api "repos/$REPO/git/matching-refs/ci-notify/" --paginate --jq '.[].ref' \
+          | while read -r REF; do
+              NAME=${REF#refs/ci-notify/}
+              DATE=${NAME%%-*}
+              if [[ ! "$DATE" =~ ^[0-9]{8}$ ]]; then
+                # A marker with no date prefix predates this naming scheme
+                # and cannot be aged, so retire it on sight. Worst case it
+                # belonged to a burst still in flight during the rollout and
+                # that burst sends one extra DM.
+                gh api "repos/$REPO/git/$REF" --method DELETE \
+                  && echo "pruned undated $REF" \
+                  || echo "::notice::could not prune $REF"
+                continue
+              fi
+              # yyyymmdd sorts lexicographically, so '<' compares dates.
               if [[ "$DATE" < "$CUTOFF" ]]; then
                 gh api "repos/$REPO/git/$REF" --method DELETE \
-                  && echo "pruned $REF (target committed $DATE)" \
+                  && echo "pruned $REF (claimed $DATE)" \
                   || echo "::notice::could not prune $REF"
               fi
             done


### PR DESCRIPTION
Extends the Slack notifier (`.github/workflows/ci-notify.yml`) so an opted-in PR author is also DM'd when someone **approves** their PR, not only when Semaphore CI finishes. Opt-in is unchanged: the `CI_NOTIFY_MAP` repo variable plus the `GH_PR_MONITOR_BOT_TOKEN` secret; the workflow stays a silent no-op for anyone not in the map.

New trigger `pull_request_review: [submitted]`. One job serves both paths, told apart by `STATE` — `success`/`failure`/`error` is the CI path, `approved` the review path.

Review-path specifics:

- The PR number comes straight from the event payload, so no SHA-to-PR search.
- **No dedup marker.** A submitted review is a single event, and keying a marker on `(sha, 'approved')` would wrongly swallow a second reviewer's approval of the same commit. `SHA` is empty on this path, which also keeps the marker-prune step out.
- **No sem-ai-triage poll.** That gate is now `failure`/`error` only — previously "anything but success", which would have made every approval wait out the 120s poll for a comment that never comes.
- Fires on `approved` only. `commented` and `changes_requested` already reach the author through GitHub's own notifications.
- The reviewer's login is passed as an `env` value, never interpolated into a script, and the review body is not used at all.

`workflow_dispatch` gains an `approved` state option so the review path can be exercised on demand, and the workflow is renamed `CI finished Slack notify` -> `PR Slack notify` now that it covers both. Nothing else in the repo references the old name.

Like `status`, `pull_request_review` runs the workflow file from the base branch, so this path cannot fire until the file is on master — the post-merge check is a `workflow_dispatch` run with `state=approved`.

Verification: `actionlint` and the repo's `yamllint` config are clean on the file, and all four message branches (approved with and without a reviewer, CI pass, CI fail plus analysis link) were exercised locally. There is no test harness for GitHub Actions workflows in this repo, so this is infrastructure-only with no accompanying automated test.

Second commit, `ci: point the dedup marker at a commit that is certainly in this repo`, fixes an unrelated live bug found while this PR was open: the duplicate-status dedup keeps failing open, so a burst still sends one DM per event.

The claim pointed the marker ref at the status event's sha — a PR head commit that lives in a fork. Creating a ref at one is not reliably permitted: on this repo the claim returned 403 `Resource not accessible by integration` for two commits pushed minutes earlier (21:12 and 21:26 UTC on 2026-07-27, two DMs each) and succeeded for a day-old commit at 22:21, same trigger, same token, same workflow file. Ruled out along the way: the endpoint, the custom ref namespace and the rulesets (a PAT creates and deletes `refs/ci-notify/*` here, and a second create returns the exact `Reference already exists` the claim matches on), repo config (default workflow permissions are `write`), and any blanket write ban on `status` runs (sem-ai-ci-triage comments from the same trigger).

Nothing reads the marker's target, so it now points at `GITHUB_SHA` — the default-branch tip the run was resolved from, always local — with the dedup key in the ref name. That removes pruning's age signal (it read the target commit's committer date), so the claim date moves into the name, `refs/ci-notify/<yyyymmdd>-<commit>-<state>`, and pruning reads the prefix: one list call, no per-ref lookup, and this run's own marker can no longer look stale, so the self-skip guard goes away. Markers in the old naming cannot be aged and are retired on sight.

Verified against the real API on a fork: claim creates, a duplicate claim returns `Reference already exists` (so `claimed=false`), prune deletes a stale dated marker and an undated legacy one while leaving today's marker alone, and the release path deletes by the claimed name.

Third commit, `ci: restrict approval DMs to collaborators; narrow the prune sweep`, carries review follow-ups: the approval must come from someone with write access (`review.author_association` in OWNER/MEMBER/COLLABORATOR), since any account can approve a public repo's PR and the review path claims no dedup marker; pruning now retires only legacy `<40-hex>-<state>` markers rather than every undated ref, so a marker created by hand while debugging survives.

Post-merge verification, in two parts. The review path: 

```
gh workflow run "PR Slack notify" --repo projectcalico/calico -f pr_number=<n> -f state=approved
```

The dedup fix is not covered by that dispatch — it skips the claim step entirely — and cannot be exercised against this repo before the file is on master, so it was verified on a fork. Confirm it on the next real Semaphore status burst: exactly one DM per burst, and `gh api repos/projectcalico/calico/git/matching-refs/ci-notify/` showing date-prefixed names.

**Release note:**
```release-note
TBD
```
