### PR TITLE
Move IPReservation CIDR format marker onto the list items [release-v3.32]

### DIFF
--- a/api/config/crd/projectcalico.org_ipreservations.yaml
+++ b/api/config/crd/projectcalico.org_ipreservations.yaml
@@ -27,8 +27,8 @@ spec:
             spec:
               properties:
                 reservedCIDRs:
-                  format: cidr
                   items:
+                    format: cidr
                     type: string
                   type: array
                   x-kubernetes-list-type: set

--- a/api/pkg/apis/projectcalico/v3/ipreservation.go
+++ b/api/pkg/apis/projectcalico/v3/ipreservation.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017, 2021 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017-2026 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -56,7 +56,7 @@ type IPReservation struct {
 type IPReservationSpec struct {
 	// ReservedCIDRs is a list of CIDRs and/or IP addresses that Calico IPAM will exclude from new allocations.
 	// +listType=set
-	// +kubebuilder:validation:Format=cidr
+	// +kubebuilder:validation:items:Format=cidr
 	ReservedCIDRs []string `json:"reservedCIDRs,omitempty" validate:"cidrs,omitempty"`
 }
 

--- a/libcalico-go/config/crd/crd.projectcalico.org_ipreservations.yaml
+++ b/libcalico-go/config/crd/crd.projectcalico.org_ipreservations.yaml
@@ -27,8 +27,8 @@ spec:
             spec:
               properties:
                 reservedCIDRs:
-                  format: cidr
                   items:
+                    format: cidr
                     type: string
                   type: array
                   x-kubernetes-list-type: set

--- a/manifests/calico-bpf.yaml
+++ b/manifests/calico-bpf.yaml
@@ -3634,8 +3634,8 @@ spec:
             spec:
               properties:
                 reservedCIDRs:
-                  format: cidr
                   items:
+                    format: cidr
                     type: string
                   type: array
                   x-kubernetes-list-type: set

--- a/manifests/calico-policy-only.yaml
+++ b/manifests/calico-policy-only.yaml
@@ -3644,8 +3644,8 @@ spec:
             spec:
               properties:
                 reservedCIDRs:
-                  format: cidr
                   items:
+                    format: cidr
                     type: string
                   type: array
                   x-kubernetes-list-type: set

--- a/manifests/calico-typha.yaml
+++ b/manifests/calico-typha.yaml
@@ -3645,8 +3645,8 @@ spec:
             spec:
               properties:
                 reservedCIDRs:
-                  format: cidr
                   items:
+                    format: cidr
                     type: string
                   type: array
                   x-kubernetes-list-type: set

--- a/manifests/calico-v3-crds.yaml
+++ b/manifests/calico-v3-crds.yaml
@@ -3116,8 +3116,8 @@ spec:
             spec:
               properties:
                 reservedCIDRs:
-                  format: cidr
                   items:
+                    format: cidr
                     type: string
                   type: array
                   x-kubernetes-list-type: set

--- a/manifests/calico-vxlan.yaml
+++ b/manifests/calico-vxlan.yaml
@@ -3629,8 +3629,8 @@ spec:
             spec:
               properties:
                 reservedCIDRs:
-                  format: cidr
                   items:
+                    format: cidr
                     type: string
                   type: array
                   x-kubernetes-list-type: set

--- a/manifests/calico.yaml
+++ b/manifests/calico.yaml
@@ -3629,8 +3629,8 @@ spec:
             spec:
               properties:
                 reservedCIDRs:
-                  format: cidr
                   items:
+                    format: cidr
                     type: string
                   type: array
                   x-kubernetes-list-type: set

--- a/manifests/canal.yaml
+++ b/manifests/canal.yaml
@@ -3646,8 +3646,8 @@ spec:
             spec:
               properties:
                 reservedCIDRs:
-                  format: cidr
                   items:
+                    format: cidr
                     type: string
                   type: array
                   x-kubernetes-list-type: set

--- a/manifests/crds.yaml
+++ b/manifests/crds.yaml
@@ -3543,8 +3543,8 @@ spec:
             spec:
               properties:
                 reservedCIDRs:
-                  format: cidr
                   items:
+                    format: cidr
                     type: string
                   type: array
                   x-kubernetes-list-type: set

--- a/manifests/flannel-migration/calico.yaml
+++ b/manifests/flannel-migration/calico.yaml
@@ -3629,8 +3629,8 @@ spec:
             spec:
               properties:
                 reservedCIDRs:
-                  format: cidr
                   items:
+                    format: cidr
                     type: string
                   type: array
                   x-kubernetes-list-type: set

--- a/manifests/operator-crds.yaml
+++ b/manifests/operator-crds.yaml
@@ -36837,8 +36837,8 @@ spec:
             spec:
               properties:
                 reservedCIDRs:
-                  format: cidr
                   items:
+                    format: cidr
                     type: string
                   type: array
                   x-kubernetes-list-type: set

--- a/manifests/v1_crd_projectcalico_org.yaml
+++ b/manifests/v1_crd_projectcalico_org.yaml
@@ -36837,8 +36837,8 @@ spec:
             spec:
               properties:
                 reservedCIDRs:
-                  format: cidr
                   items:
+                    format: cidr
                     type: string
                   type: array
                   x-kubernetes-list-type: set

--- a/manifests/v3_projectcalico_org.yaml
+++ b/manifests/v3_projectcalico_org.yaml
@@ -36317,8 +36317,8 @@ spec:
             spec:
               properties:
                 reservedCIDRs:
-                  format: cidr
                   items:
+                    format: cidr
                     type: string
                   type: array
                   x-kubernetes-list-type: set


### PR DESCRIPTION
Cherry-pick of #13338 onto `release-v3.32`.

The manifests conflicted (master has a doc comment on the field that this branch doesn't), so the generated files were regenerated here rather than taken from master. The resulting diff is the same one-line move in each file.

Original PR: https://github.com/projectcalico/calico/pull/13338

```release-note
Fixes an "unrecognized format" warning printed by Kubernetes 1.36 when applying the IPReservation CRD.
```
