### PR TITLE
BPF: re-encapsulate overlay replies in HostAddress mode

### DIFF
--- a/felix/bpf-gpl/conntrack_types.h
+++ b/felix/bpf-gpl/conntrack_types.h
@@ -46,6 +46,7 @@ enum cali_ct_type {
 #define CALI_CT_FLAG_CONNLIMIT_INGRESS_REJECTED	0x80000 /* marks connections rejected by the ingress connection limit */
 #define CALI_CT_FLAG_CONNLIMIT_EGRESS	0x100000 /* marks connections counted against an egress connection limit */
 #define CALI_CT_FLAG_CONNLIMIT_DEC	0x200000 /* marks connections already decremented from connlimit counter */
+#define CALI_CT_FLAG_OVERLAY_REPLY	0x400000 /* reply of a host-originated overlay flow must be re-encapsulated (BPFOverlayHostSourceIP=HostAddress) */
 
 struct calico_ct_leg {
 	__u64 bytes;
@@ -102,6 +103,9 @@ struct calico_ct_value {
 			struct calico_ct_leg b_to_a;	// 48
 
 			// CALI_CT_TYPE_NAT_REV
+			// tun_ip is set only when a NodePort connection is forwarded to a
+			// backend on another node; it holds that node's IP so the reply can
+			// be tunneled back via the forwarding node (dnat_return_should_encap).
 			ipv46_addr_t tun_ip;	// 72
 			ipv46_addr_t orig_ip;	// 76
 			__u16 orig_port;	// 80
@@ -269,7 +273,8 @@ struct calico_ct_result {
 	ipv46_addr_t nat_sip;
 	__u16 nat_port;
 	__u16 nat_sport;
-	ipv46_addr_t tun_ip;
+	ipv46_addr_t tun_ip;   /* NodePort-forwarding node IP from the NAT_REV entry;
+				* a reply with tun_ip set must encap back to that node. */
 	__u32 ifindex_fwd; /* if set, the ifindex where the packet should be forwarded */
 	__u32 ifindex_created; /* For a CT state that was created by a packet ingressing
 				* through an interface towards the host, this is the

--- a/felix/bpf-gpl/fib_co_re.h
+++ b/felix/bpf-gpl/fib_co_re.h
@@ -247,7 +247,11 @@ skip_redir_ifindex:
 			if ((rc = try_redirect_to_peer(ctx)) == TC_ACT_REDIRECT) {
 				goto skip_fib;
 			}
-		} else if ((cali_rt_is_tunneled(dest_rt) && !cali_rt_is_same_subnet(dest_rt))) {
+		} else if ((cali_rt_is_tunneled(dest_rt) && !cali_rt_is_same_subnet(dest_rt)) ||
+				(state->ct_result.flags & CALI_CT_FLAG_OVERLAY_REPLY)) {
+			/* A remote tunneled workload, or the reply of a host-originated overlay
+			 * flow (BPFOverlayHostSourceIP=HostAddress) - tagged at ingress because
+			 * its destination node carries the node IP as its route next_hop. */
 			struct bpf_tunnel_key key = {
 				.tunnel_id = OVERLAY_TUNNEL_ID,
 			};

--- a/felix/bpf-gpl/fib_co_re.h
+++ b/felix/bpf-gpl/fib_co_re.h
@@ -250,7 +250,11 @@ skip_redir_ifindex:
 			if ((rc = try_redirect_to_peer(ctx)) == TC_ACT_REDIRECT) {
 				goto skip_fib;
 			}
-		} else if ((cali_rt_is_tunneled(dest_rt) && !cali_rt_is_same_subnet(dest_rt))) {
+		} else if ((cali_rt_is_tunneled(dest_rt) && !cali_rt_is_same_subnet(dest_rt)) ||
+				(state->ct_result.flags & CALI_CT_FLAG_OVERLAY_REPLY)) {
+			/* A remote tunneled workload, or the reply of a host-originated overlay
+			 * flow (BPFOverlayHostSourceIP=HostAddress) - tagged at ingress because
+			 * its destination node carries the node IP as its route next_hop. */
 			struct bpf_tunnel_key key = {
 				.tunnel_id = OVERLAY_TUNNEL_ID,
 			};

--- a/felix/bpf-gpl/tc.c
+++ b/felix/bpf-gpl/tc.c
@@ -1666,6 +1666,23 @@ int calico_tc_skb_new_flow_entrypoint(struct __sk_buff *skb)
 		}
 	}
 
+	/* In HostAddress mode (no tunnel-device IP) a host-networked client's request to a
+	 * local workload arrives over the overlay with the client node IP as inner source;
+	 * the reply targets a bare node IP (CALI_RT_HOST, not tunneled) and would leave
+	 * un-encapsulated with a pod source, which source-checking fabrics (e.g. GCP) drop.
+	 * Mark the flow so fib_co_re.h re-encapsulates the reply to that node.  Scoped to
+	 * the overlay tunnel-ingress programs (from_vxlan, and from_l3 for the IPIP L3
+	 * tunnel device) with a remote-host source.  ip_void(HOST_TUNNEL_IP) selects
+	 * HostAddress mode: it is void only for IPIP/VXLAN without a device IP, and set
+	 * for TunnelAddress and for WireGuard (which shares from_l3), so both are
+	 * excluded; the compile gate additionally excludes tunnel=none. */
+	if (ip_void(HOST_TUNNEL_IP) &&
+			((CALI_F_INGRESS && CALI_F_VXLAN) || CALI_F_L3_INGRESS) &&
+			rt_addr_is_remote_host(&state->ip_src)) {
+		ct_ctx_nat->flags |= CALI_CT_FLAG_OVERLAY_REPLY;
+		CALI_DEBUG("CALI_CT_FLAG_OVERLAY_REPLY");
+	}
+
 	if (state->ip_proto == IPPROTO_TCP) {
 		if (skb_refresh_validate_ptrs(ctx, TCP_SIZE)) {
 			deny_reason(ctx, CALI_REASON_SHORT);

--- a/felix/bpf-gpl/tc.c
+++ b/felix/bpf-gpl/tc.c
@@ -1680,6 +1680,23 @@ int calico_tc_skb_new_flow_entrypoint(struct __sk_buff *skb)
 		}
 	}
 
+	/* In HostAddress mode (no tunnel-device IP) a host-networked client's request to a
+	 * local workload arrives over the overlay with the client node IP as inner source;
+	 * the reply targets a bare node IP (CALI_RT_HOST, not tunneled) and would leave
+	 * un-encapsulated with a pod source, which source-checking fabrics (e.g. GCP) drop.
+	 * Mark the flow so fib_co_re.h re-encapsulates the reply to that node.  Scoped to
+	 * the overlay tunnel-ingress programs (from_vxlan, and from_l3 for the IPIP L3
+	 * tunnel device) with a remote-host source.  ip_void(HOST_TUNNEL_IP) selects
+	 * HostAddress mode: it is void only for IPIP/VXLAN without a device IP, and set
+	 * for TunnelAddress and for WireGuard (which shares from_l3), so both are
+	 * excluded; the compile gate additionally excludes tunnel=none. */
+	if (ip_void(HOST_TUNNEL_IP) &&
+			((CALI_F_INGRESS && CALI_F_VXLAN) || CALI_F_L3_INGRESS) &&
+			rt_addr_is_remote_host(&state->ip_src)) {
+		ct_ctx_nat->flags |= CALI_CT_FLAG_OVERLAY_REPLY;
+		CALI_DEBUG("CALI_CT_FLAG_OVERLAY_REPLY");
+	}
+
 	if (state->ip_proto == IPPROTO_TCP) {
 		if (skb_refresh_validate_ptrs(ctx, TCP_SIZE)) {
 			deny_reason(ctx, CALI_REASON_SHORT);

--- a/felix/dataplane/linux/bpf_ep_mgr.go
+++ b/felix/dataplane/linux/bpf_ep_mgr.go
@@ -1484,7 +1484,21 @@ func (m *bpfEndpointManager) onInterfaceUpdate(update *ifaceStateUpdate) {
 				}
 			default:
 				if m.v4 != nil {
-					if err := m.dp.setRPFilter(update.Name, 2); err != nil {
+					rpFilter := 2
+					if !m.bpfOverlayIPOnDevice &&
+						(iface.info.ifaceType == IfaceTypeIPIP || iface.info.ifaceType == IfaceTypeVXLAN) {
+						// In BPFOverlayHostSourceIP=HostAddress mode the overlay
+						// device has no IP address, and the kernel drops packets
+						// arriving on an address-less device unless their source
+						// routes back via that device, even in loose RPF mode.
+						// Replies of host-networked connections to remote service
+						// backends are reverse-NATted here on tunnel ingress, so
+						// their source is the service IP, routed via bpfin.cali.
+						// Turn kernel RPF off like on the bpfin/bpfout devices;
+						// BPF does the RPF on its own.
+						rpFilter = 0
+					}
+					if err := m.dp.setRPFilter(update.Name, rpFilter); err != nil {
 						logrus.WithError(err).Warnf("Failed to set rp_filter for %s.", update.Name)
 					}
 				}

--- a/felix/dataplane/linux/bpf_ep_mgr.go
+++ b/felix/dataplane/linux/bpf_ep_mgr.go
@@ -1531,7 +1531,21 @@ func (m *bpfEndpointManager) onInterfaceUpdate(update *ifaceStateUpdate) {
 				}
 			default:
 				if m.v4 != nil {
-					if err := m.dp.setRPFilter(update.Name, 2); err != nil {
+					rpFilter := 2
+					if !m.bpfOverlayIPOnDevice &&
+						(iface.info.ifaceType == IfaceTypeIPIP || iface.info.ifaceType == IfaceTypeVXLAN) {
+						// In BPFOverlayHostSourceIP=HostAddress mode the overlay
+						// device has no IP address, and the kernel drops packets
+						// arriving on an address-less device unless their source
+						// routes back via that device, even in loose RPF mode.
+						// Replies of host-networked connections to remote service
+						// backends are reverse-NATted here on tunnel ingress, so
+						// their source is the service IP, routed via bpfin.cali.
+						// Turn kernel RPF off like on the bpfin/bpfout devices;
+						// BPF does the RPF on its own.
+						rpFilter = 0
+					}
+					if err := m.dp.setRPFilter(update.Name, rpFilter); err != nil {
 						logrus.WithError(err).Warnf("Failed to set rp_filter for %s.", update.Name)
 					}
 				}

--- a/felix/dataplane/linux/bpf_ep_mgr_test.go
+++ b/felix/dataplane/linux/bpf_ep_mgr_test.go
@@ -76,6 +76,7 @@ type mockDataplane struct {
 	numAttaches          map[string]int
 	policy               map[string]polprog.Rules
 	routes               map[ip.CIDR]struct{}
+	rpFilter             map[string]int
 	netlinkShim          netlinkshim.Interface
 	natDevicesConfigured bool
 
@@ -101,6 +102,7 @@ func newMockDataplane() *mockDataplane {
 		numAttaches: map[string]int{},
 		policy:      map[string]polprog.Rules{},
 		routes:      map[ip.CIDR]struct{}{},
+		rpFilter:    map[string]int{},
 		netlinkShim: netlinkShim,
 	}
 }
@@ -207,7 +209,20 @@ func (m *mockDataplane) setAcceptLocal(iface string, val bool) error {
 }
 
 func (m *mockDataplane) setRPFilter(iface string, val int) error {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	m.rpFilter[iface] = val
 	return nil
+}
+
+func (m *mockDataplane) rpFilterLevel(iface string) int {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	val, seen := m.rpFilter[iface]
+	if !seen {
+		return -1
+	}
+	return val
 }
 
 func (m *mockDataplane) getIfaceLink(name string) (netlink.Link, error) {
@@ -386,6 +401,7 @@ var _ = Describe("BPF Endpoint Manager", func() {
 		dataIfacePattern     string
 		l3IfacePattern       string
 		workloadIfaceRegex   string
+		overlayIPOnDevice    bool
 		ipSetIDAllocatorV4   *idalloc.IDAllocator
 		ipSetIDAllocatorV6   *idalloc.IDAllocator
 		vxlanMTU             int
@@ -413,6 +429,7 @@ var _ = Describe("BPF Endpoint Manager", func() {
 		dataIfacePattern = "^eth0"
 		workloadIfaceRegex = "cali"
 		l3IfacePattern = "^l30"
+		overlayIPOnDevice = true // BPFOverlayHostSourceIP=TunnelAddress
 		ipSetIDAllocatorV4 = idalloc.New()
 		ipSetIDAllocatorV6 = idalloc.New()
 		vxlanMTU = 0
@@ -521,6 +538,7 @@ var _ = Describe("BPF Endpoint Manager", func() {
 				BPFHostNetworkedNAT:     "Enabled",
 				BPFPolicyDebugEnabled:   true,
 				BPFIpv6Enabled:          ipv6Enabled,
+				BPFOverlayIPOnDevice:    overlayIPOnDevice,
 			},
 			maps,
 			regexp.MustCompile(workloadIfaceRegex),
@@ -1196,6 +1214,40 @@ var _ = Describe("BPF Endpoint Manager", func() {
 			Expect(dp.programAttached("l30:ingress")).To(BeTrue())
 			Expect(dp.programAttached("l30:egress")).To(BeTrue())
 			checkIfState(14, "l30", ifstate.FlgIPv4Ready|ifstate.FlgL3)
+		})
+	})
+
+	Context("with overlay devices", func() {
+		JustBeforeEach(func() {
+			err := dp.createIface("vxlan.calico", 10, "vxlan")
+			Expect(err).NotTo(HaveOccurred())
+			err = dp.createIface("tunl0", 11, "ipip")
+			Expect(err).NotTo(HaveOccurred())
+			dataIfacePattern = "^(eth0|tunl0|vxlan.calico)"
+			newBpfEpMgr(false)
+			genIfaceUpdate("eth0", ifacemonitor.StateUp, 3)()
+			genIfaceUpdate("vxlan.calico", ifacemonitor.StateUp, 10)()
+			genIfaceUpdate("tunl0", ifacemonitor.StateUp, 11)()
+		})
+
+		Context("in BPFOverlayHostSourceIP=HostAddress mode", func() {
+			BeforeEach(func() {
+				overlayIPOnDevice = false
+			})
+
+			It("should turn rp_filter off on the address-less overlay devices only", func() {
+				Expect(dp.rpFilterLevel("tunl0")).To(Equal(0))
+				Expect(dp.rpFilterLevel("vxlan.calico")).To(Equal(0))
+				Expect(dp.rpFilterLevel("eth0")).To(Equal(2))
+			})
+		})
+
+		Context("in BPFOverlayHostSourceIP=TunnelAddress mode", func() {
+			It("should set loose rp_filter on all host devices", func() {
+				Expect(dp.rpFilterLevel("tunl0")).To(Equal(2))
+				Expect(dp.rpFilterLevel("vxlan.calico")).To(Equal(2))
+				Expect(dp.rpFilterLevel("eth0")).To(Equal(2))
+			})
 		})
 	})
 

--- a/felix/dataplane/linux/bpf_ep_mgr_test.go
+++ b/felix/dataplane/linux/bpf_ep_mgr_test.go
@@ -76,6 +76,7 @@ type mockDataplane struct {
 	numAttaches          map[string]int
 	policy               map[string]polprog.Rules
 	routes               map[ip.CIDR]struct{}
+	rpFilter             map[string]int
 	netlinkShim          netlinkshim.Interface
 	natDevicesConfigured bool
 
@@ -106,6 +107,7 @@ func newMockDataplane() *mockDataplane {
 		numAttaches: map[string]int{},
 		policy:      map[string]polprog.Rules{},
 		routes:      map[ip.CIDR]struct{}{},
+		rpFilter:    map[string]int{},
 		netlinkShim: netlinkShim,
 		netkitPins:  map[string]bool{},
 	}
@@ -213,7 +215,20 @@ func (m *mockDataplane) setAcceptLocal(iface string, val bool) error {
 }
 
 func (m *mockDataplane) setRPFilter(iface string, val int) error {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	m.rpFilter[iface] = val
 	return nil
+}
+
+func (m *mockDataplane) rpFilterLevel(iface string) int {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	val, seen := m.rpFilter[iface]
+	if !seen {
+		return -1
+	}
+	return val
 }
 
 func (m *mockDataplane) getIfaceLink(name string) (netlink.Link, error) {
@@ -415,6 +430,7 @@ var _ = Describe("BPF Endpoint Manager", func() {
 		dataIfacePattern     string
 		l3IfacePattern       string
 		workloadIfaceRegex   string
+		overlayIPOnDevice    bool
 		ipSetIDAllocatorV4   *idalloc.IDAllocator
 		ipSetIDAllocatorV6   *idalloc.IDAllocator
 		vxlanMTU             int
@@ -443,6 +459,7 @@ var _ = Describe("BPF Endpoint Manager", func() {
 		dataIfacePattern = "^eth0"
 		workloadIfaceRegex = "cali"
 		l3IfacePattern = "^l30"
+		overlayIPOnDevice = true // BPFOverlayHostSourceIP=TunnelAddress
 		ipSetIDAllocatorV4 = idalloc.New()
 		ipSetIDAllocatorV6 = idalloc.New()
 		vxlanMTU = 0
@@ -555,6 +572,7 @@ var _ = Describe("BPF Endpoint Manager", func() {
 				BPFPolicyDebugEnabled:   true,
 				BPFIpv6Enabled:          ipv6Enabled,
 				BPFAttachType:           bpfAttachType,
+				BPFOverlayIPOnDevice:    overlayIPOnDevice,
 			},
 			maps,
 			regexp.MustCompile(workloadIfaceRegex),
@@ -1377,6 +1395,40 @@ var _ = Describe("BPF Endpoint Manager", func() {
 			Expect(dp.programAttached("l30:ingress")).To(BeTrue())
 			Expect(dp.programAttached("l30:egress")).To(BeTrue())
 			checkIfState(14, "l30", ifstate.FlgIPv4Ready|ifstate.FlgL3)
+		})
+	})
+
+	Context("with overlay devices", func() {
+		JustBeforeEach(func() {
+			err := dp.createIface("vxlan.calico", 10, "vxlan")
+			Expect(err).NotTo(HaveOccurred())
+			err = dp.createIface("tunl0", 11, "ipip")
+			Expect(err).NotTo(HaveOccurred())
+			dataIfacePattern = "^(eth0|tunl0|vxlan.calico)"
+			newBpfEpMgr(false)
+			genIfaceUpdate("eth0", ifacemonitor.StateUp, 3)()
+			genIfaceUpdate("vxlan.calico", ifacemonitor.StateUp, 10)()
+			genIfaceUpdate("tunl0", ifacemonitor.StateUp, 11)()
+		})
+
+		Context("in BPFOverlayHostSourceIP=HostAddress mode", func() {
+			BeforeEach(func() {
+				overlayIPOnDevice = false
+			})
+
+			It("should turn rp_filter off on the address-less overlay devices only", func() {
+				Expect(dp.rpFilterLevel("tunl0")).To(Equal(0))
+				Expect(dp.rpFilterLevel("vxlan.calico")).To(Equal(0))
+				Expect(dp.rpFilterLevel("eth0")).To(Equal(2))
+			})
+		})
+
+		Context("in BPFOverlayHostSourceIP=TunnelAddress mode", func() {
+			It("should set loose rp_filter on all host devices", func() {
+				Expect(dp.rpFilterLevel("tunl0")).To(Equal(2))
+				Expect(dp.rpFilterLevel("vxlan.calico")).To(Equal(2))
+				Expect(dp.rpFilterLevel("eth0")).To(Equal(2))
+			})
 		})
 	})
 

--- a/felix/design/bpf-conntrack-flowstate.md
+++ b/felix/design/bpf-conntrack-flowstate.md
@@ -90,6 +90,18 @@ bpfnat feature is enabled; per-interface sysctls are set to loose
 (`2`) on interfaces where Calico forwards packets that may appear
 misrouted to the kernel. BPF does the real check.
 
+Loose is not relaxed enough on a device with **no IPv4 address**: the
+kernel's `__fib_validate_source()` short-circuits on such devices
+(`no_addr`) and drops any packet whose source does not route back out
+that device, for *any* non-zero `rp_filter` — the loose-mode fallback
+lookup is never reached. This bites the overlay device in
+`BPFOverlayHostSourceIP=HostAddress` mode (the tunnel deliberately has
+no IP): replies of host-networked connections to remote service
+backends are reverse-NATted on tunnel ingress, so they enter the stack
+with the service IP as source, which routes via `bpfin.cali`, not the
+tunnel. Felix therefore sets `rp_filter = 0` (like on the bpfnat veths)
+on IPIP/VXLAN devices in that mode.
+
 ### Review notes for this section
 
 - A change that makes a new interface type Calico-managed must decide

--- a/felix/design/bpf-conntrack-flowstate.md
+++ b/felix/design/bpf-conntrack-flowstate.md
@@ -129,6 +129,45 @@ Creating a NAT'd flow means creating both. Destroying a NAT'd flow
 means destroying both — atomically enough that BPF never sees only
 one side. The cleanup pipeline is built around this requirement.
 
+#### Tunnel return address and overlay-reply re-encap
+
+Two mechanisms let a node send a reply back through the overlay,
+and it is important not to conflate them:
+
+- **`tun_ip` (NAT-reverse entries only).** The reverse entry of a
+  service/NodePort flow that crossed nodes stores the peer node's
+  address in `tun_ip`. On the forwarding node it is the backend
+  node to tunnel *to* (`CALI_CT_FLAG_NP_FWD`); on the backend node
+  it is the node the request came *from*, so the reply is tunneled
+  back the way it arrived. It is written only for
+  `CALI_CT_TYPE_NAT_REV` (`conntrack.h`) and consumed only by the
+  service/NodePort return-encap paths
+  (`dnat_return_should_encap()`). Normal (non-NAT) entries never
+  populate it.
+
+- **`CALI_CT_FLAG_OVERLAY_REPLY` (normal entries).** With
+  `BPFOverlayHostSourceIP=HostAddress` the tunnel device has no IP,
+  so a host-networked client's request arrives over the overlay
+  with the node IP as its inner source. The workload's reply then
+  targets a bare remote node IP — a `CALI_RT_HOST` route, which is
+  *not* tunneled — and would leave the node un-encapsulated with a
+  pod-CIDR source, which a source-checking fabric (e.g. GCP) drops.
+  The flag is set at conntrack creation on the overlay tunnel-ingress
+  programs — `from_vxlan` (`CALI_F_VXLAN`) for VXLAN, and `from_l3`
+  (`CALI_F_L3_DEV`) for the IPIP tunnel device, which is an L3 device
+  the kernel decaps onto. Gating on those compile flags scopes the flag
+  to overlay ingress and excludes `tunnel=none` (host→pod arrives on the
+  main host endpoint, with no tunnel to re-encapsulate into). It is
+  further gated on HostAddress mode (absent tunnel IP) and a remote-host
+  inner source, which restricts it to host-originated flows. It is read
+  on the reply's workload-egress path, where it forces the overlay encap
+  even though the destination route is a bare host. It carries no
+  address: a remote-host route already holds the node IP as its
+  `next_hop`, which is the tunnel endpoint (equivalently, the reply
+  re-encaps to its own destination). This is deliberately *not*
+  `tun_ip` — that field's meaning is NodePort/service-specific and must
+  stay so.
+
 ### Cleanup: three layers
 
 #### 1. Userspace scanners

--- a/felix/design/bpf-conntrack-flowstate.md
+++ b/felix/design/bpf-conntrack-flowstate.md
@@ -165,9 +165,9 @@ and it is important not to conflate them:
   *not* tunneled — and would leave the node un-encapsulated with a
   pod-CIDR source, which a source-checking fabric (e.g. GCP) drops.
   The flag is set at conntrack creation on the overlay tunnel-ingress
-  programs — `from_vxlan` (`CALI_F_VXLAN`) for VXLAN, and `from_l3`
-  (`CALI_F_L3_DEV`) for the IPIP tunnel device, which is an L3 device
-  the kernel decaps onto. Gating on those compile flags scopes the flag
+  programs — `from_vxlan` (`CALI_F_INGRESS && CALI_F_VXLAN`) for VXLAN,
+  and `from_l3` (`CALI_F_L3_INGRESS`) for the IPIP tunnel device, which
+  is an L3 device the kernel decaps onto. Gating on those flags scopes the flag
   to overlay ingress and excludes `tunnel=none` (host→pod arrives on the
   main host endpoint, with no tunnel to re-encapsulate into). It is
   further gated on HostAddress mode (absent tunnel IP) and a remote-host

--- a/felix/design/bpf-conntrack-flowstate.md
+++ b/felix/design/bpf-conntrack-flowstate.md
@@ -175,9 +175,9 @@ and it is important not to conflate them:
   *not* tunneled — and would leave the node un-encapsulated with a
   pod-CIDR source, which a source-checking fabric (e.g. GCP) drops.
   The flag is set at conntrack creation on the overlay tunnel-ingress
-  programs — `from_vxlan` (`CALI_F_VXLAN`) for VXLAN, and `from_l3`
-  (`CALI_F_L3_DEV`) for the IPIP tunnel device, which is an L3 device
-  the kernel decaps onto. Gating on those compile flags scopes the flag
+  programs — `from_vxlan` (`CALI_F_INGRESS && CALI_F_VXLAN`) for VXLAN,
+  and `from_l3` (`CALI_F_L3_INGRESS`) for the IPIP tunnel device, which
+  is an L3 device the kernel decaps onto. Gating on those flags scopes the flag
   to overlay ingress and excludes `tunnel=none` (host→pod arrives on the
   main host endpoint, with no tunnel to re-encapsulate into). It is
   further gated on HostAddress mode (absent tunnel IP) and a remote-host

--- a/felix/design/bpf-conntrack-flowstate.md
+++ b/felix/design/bpf-conntrack-flowstate.md
@@ -139,6 +139,45 @@ Readers and writers alike have to reach it: a `NAT_FWD` hit gives
 `src_to_dst`/`dst_to_src` into the tracking entry's legs and uses
 `tracking_v` for the fields hanging off the value itself.
 
+#### Tunnel return address and overlay-reply re-encap
+
+Two mechanisms let a node send a reply back through the overlay,
+and it is important not to conflate them:
+
+- **`tun_ip` (NAT-reverse entries only).** The reverse entry of a
+  service/NodePort flow that crossed nodes stores the peer node's
+  address in `tun_ip`. On the forwarding node it is the backend
+  node to tunnel *to* (`CALI_CT_FLAG_NP_FWD`); on the backend node
+  it is the node the request came *from*, so the reply is tunneled
+  back the way it arrived. It is written only for
+  `CALI_CT_TYPE_NAT_REV` (`conntrack.h`) and consumed only by the
+  service/NodePort return-encap paths
+  (`dnat_return_should_encap()`). Normal (non-NAT) entries never
+  populate it.
+
+- **`CALI_CT_FLAG_OVERLAY_REPLY` (normal entries).** With
+  `BPFOverlayHostSourceIP=HostAddress` the tunnel device has no IP,
+  so a host-networked client's request arrives over the overlay
+  with the node IP as its inner source. The workload's reply then
+  targets a bare remote node IP — a `CALI_RT_HOST` route, which is
+  *not* tunneled — and would leave the node un-encapsulated with a
+  pod-CIDR source, which a source-checking fabric (e.g. GCP) drops.
+  The flag is set at conntrack creation on the overlay tunnel-ingress
+  programs — `from_vxlan` (`CALI_F_VXLAN`) for VXLAN, and `from_l3`
+  (`CALI_F_L3_DEV`) for the IPIP tunnel device, which is an L3 device
+  the kernel decaps onto. Gating on those compile flags scopes the flag
+  to overlay ingress and excludes `tunnel=none` (host→pod arrives on the
+  main host endpoint, with no tunnel to re-encapsulate into). It is
+  further gated on HostAddress mode (absent tunnel IP) and a remote-host
+  inner source, which restricts it to host-originated flows. It is read
+  on the reply's workload-egress path, where it forces the overlay encap
+  even though the destination route is a bare host. It carries no
+  address: a remote-host route already holds the node IP as its
+  `next_hop`, which is the tunnel endpoint (equivalently, the reply
+  re-encaps to its own destination). This is deliberately *not*
+  `tun_ip` — that field's meaning is NodePort/service-specific and must
+  stay so.
+
 ### Cleanup: three layers
 
 #### 1. Userspace scanners

--- a/felix/design/bpf-services.md
+++ b/felix/design/bpf-services.md
@@ -182,7 +182,9 @@ backend's veth.
 
 On return, the backend's WEP program sees a packet whose destination
 is the external client, and whose conntrack entry records that the
-ingress came from a specific ingress node. The program wraps the
+ingress came from a specific ingress node — the `tun_ip` field of the
+`NAT_REV` entry, which is set only by this NodePort-forwarding path
+(`dnat_return_should_encap()` keys off it). The program wraps the
 return packet back in VXLAN, destined for the node that originally
 received the connection, and lets the host stack route it out. That
 node decapsulates and routes the packet to the client.

--- a/felix/fv/bpf_overlay_ip_test.go
+++ b/felix/fv/bpf_overlay_ip_test.go
@@ -159,11 +159,10 @@ func describeBPFOverlayTests(tunnel, hostSourceIP string) bool {
 			cc.CheckConnectivity(conntrackChecks(tc.Felixes)...)
 		})
 
-		itTunnelAddr := It
-		if hostSourceIP != "TunnelAddress" {
-			itTunnelAddr = PIt
-		}
-		itTunnelAddr("should use the host IP, not the tunnel IP, as the overlay underlay source", func() {
+		It("should use the host IP, not the tunnel IP, as the overlay underlay source", func() {
+			if hostSourceIP != "TunnelAddress" {
+				Skip("tunnel-IP-as-source check only applies to TunnelAddress mode")
+			}
 			// The outer (underlay) source of encapsulated host-networked traffic must be
 			// the node's own IP.  The overlay tunnel-device IP is not underlay-routable; a
 			// fabric that checks source addresses (e.g. GCP) drops packets carrying it.
@@ -208,11 +207,10 @@ func describeBPFOverlayTests(tunnel, hostSourceIP string) bool {
 				fmt.Sprintf("overlay outer source must never be the tunnel IP %s", tunnelAddr))
 		})
 
-		itHostAddr := It
-		if hostSourceIP != "HostAddress" {
-			itHostAddr = PIt
-		}
-		itHostAddr("should re-encapsulate a workload's reply to a host-networked client", func() {
+		It("should re-encapsulate a workload's reply to a host-networked client", func() {
+			if hostSourceIP != "HostAddress" {
+				Skip("reply re-encap check only applies to HostAddress mode")
+			}
 			// In HostAddress mode the tunnel device has no IP, so a host-networked client's
 			// encapsulated request carries the node IP as its inner source.  The workload's
 			// reply therefore targets a bare node IP, which has no overlay route: without

--- a/felix/fv/bpf_overlay_ip_test.go
+++ b/felix/fv/bpf_overlay_ip_test.go
@@ -30,19 +30,22 @@ import (
 	client "github.com/projectcalico/calico/libcalico-go/lib/clientv3"
 )
 
-// Standalone tests for BPFOverlayHostSourceIP=TunnelAddress — verifies that overlay connectivity
-// works when the tunnel device is assigned an IP address (the legacy behaviour).  The primary
-// scenario is host-networked traffic to/from remote tunneled workloads, which is where
-// HOST_TUNNEL_IP and the SNAT conflict resolution logic come into play.
-var _ = describeBPFOverlayTunnelAddrTests("ipip")
-var _ = describeBPFOverlayTunnelAddrTests("vxlan")
+// Standalone tests for BPFOverlayHostSourceIP.  In TunnelAddress mode the tunnel device is
+// assigned an IP and host-networked traffic to a remote workload is SNATed to it (the legacy
+// behaviour, exercising HOST_TUNNEL_IP and the SNAT conflict resolution).  In HostAddress mode
+// the tunnel device has no IP, so the inner source is the node IP and the workload's reply must
+// be re-encapsulated back to the node rather than leaking un-encapsulated with a pod-CIDR source.
+var _ = describeBPFOverlayTests("ipip", "TunnelAddress")
+var _ = describeBPFOverlayTests("vxlan", "TunnelAddress")
+var _ = describeBPFOverlayTests("ipip", "HostAddress")
+var _ = describeBPFOverlayTests("vxlan", "HostAddress")
 
-func describeBPFOverlayTunnelAddrTests(tunnel string) bool {
+func describeBPFOverlayTests(tunnel, hostSourceIP string) bool {
 	if !BPFMode() {
 		return true
 	}
 
-	desc := fmt.Sprintf("_BPF_ _BPF-SAFE_ BPF overlay host source IP tunnel address (%s)", tunnel)
+	desc := fmt.Sprintf("_BPF_ _BPF-SAFE_ BPF overlay host source IP %s (%s)", hostSourceIP, tunnel)
 	return infrastructure.DatastoreDescribe(desc, []apiconfig.DatastoreType{apiconfig.Kubernetes}, func(getInfra infrastructure.InfraFactory) {
 		const numNodes = 2
 		var (
@@ -81,7 +84,7 @@ func describeBPFOverlayTunnelAddrTests(tunnel string) bool {
 			options.ExtraEnvVars["FELIX_BPFConnectTimeLoadBalancing"] = string(api.BPFConnectTimeLBEnabled)
 			options.ExtraEnvVars["FELIX_BPFHostNetworkedNATWithoutCTLB"] = string(api.BPFHostNetworkedNATDisabled)
 			options.ExtraEnvVars["FELIX_DefaultEndpointToHostAction"] = "ACCEPT"
-			options.ExtraEnvVars["FELIX_BPFOverlayHostSourceIP"] = "TunnelAddress"
+			options.ExtraEnvVars["FELIX_BPFOverlayHostSourceIP"] = hostSourceIP
 
 			cc = &Checker{}
 			cc.Protocol = "tcp"
@@ -156,7 +159,11 @@ func describeBPFOverlayTunnelAddrTests(tunnel string) bool {
 			cc.CheckConnectivity(conntrackChecks(tc.Felixes)...)
 		})
 
-		It("should use the host IP, not the tunnel IP, as the overlay underlay source", func() {
+		itTunnelAddr := It
+		if hostSourceIP != "TunnelAddress" {
+			itTunnelAddr = PIt
+		}
+		itTunnelAddr("should use the host IP, not the tunnel IP, as the overlay underlay source", func() {
 			// The outer (underlay) source of encapsulated host-networked traffic must be
 			// the node's own IP.  The overlay tunnel-device IP is not underlay-routable; a
 			// fabric that checks source addresses (e.g. GCP) drops packets carrying it.
@@ -199,6 +206,54 @@ func describeBPFOverlayTunnelAddrTests(tunnel string) bool {
 				fmt.Sprintf("overlay outer source should be the node IP %s", tc.Felixes[0].IP))
 			Consistently(fromTunnel.MatchCountFn("pkt"), "2s", "100ms").Should(BeZero(),
 				fmt.Sprintf("overlay outer source must never be the tunnel IP %s", tunnelAddr))
+		})
+
+		itHostAddr := It
+		if hostSourceIP != "HostAddress" {
+			itHostAddr = PIt
+		}
+		itHostAddr("should re-encapsulate a workload's reply to a host-networked client", func() {
+			// In HostAddress mode the tunnel device has no IP, so a host-networked client's
+			// encapsulated request carries the node IP as its inner source.  The workload's
+			// reply therefore targets a bare node IP, which has no overlay route: without
+			// re-encapsulation it leaves the node un-encapsulated with a pod-CIDR source,
+			// which a source-checking fabric (e.g. GCP) drops.  Connectivity still succeeds on
+			// a permissive FV underlay, so assert on the wire: the reply must leave the
+			// workload's node encapsulated (outer source = that node IP) and must never appear
+			// with the pod IP as its outer source.  Selection uses tcpdump's own source-host
+			// filter, not text parsing.
+			var encap []string
+			switch tunnel {
+			case "vxlan":
+				encap = []string{"udp", "and", "port", "4789"}
+			case "ipip":
+				encap = []string{"ip", "proto", "4"}
+			}
+
+			// Any captured packet line contains " > "; the tcpdump banner does not.
+			pkt := regexp.MustCompile(" > ")
+			podNode := tc.Felixes[1]
+
+			// The reply leaves the workload's node encapsulated, outer source = that node (correct).
+			encapReply := podNode.AttachTCPDump("eth0")
+			encapReply.SetLogEnabled(true)
+			encapReply.AddMatcher("pkt", pkt)
+			encapReply.Start(infra, append(append([]string{"-n"}, encap...), "and", "src", "host", podNode.IP)...)
+
+			// The reply leaves the node un-encapsulated with the pod IP as its outer source (the bug).
+			bareReply := podNode.AttachTCPDump("eth0")
+			bareReply.SetLogEnabled(true)
+			bareReply.AddMatcher("pkt", pkt)
+			bareReply.Start(infra, "-n", "src", "host", w[1].IP)
+
+			// Host-networked client on nodeA -> workload on nodeB; its reply is the flow under test.
+			cc.ExpectSome(hostW[0], w[1])
+			cc.CheckConnectivity(conntrackChecks(tc.Felixes)...)
+
+			Eventually(encapReply.MatchCountFn("pkt"), "5s", "100ms").Should(BeNumerically(">", 0),
+				fmt.Sprintf("workload reply should leave node %s encapsulated", podNode.IP))
+			Consistently(bareReply.MatchCountFn("pkt"), "2s", "100ms").Should(BeZero(),
+				fmt.Sprintf("workload reply must never leave the node un-encapsulated with pod source %s", w[1].IP))
 		})
 	})
 }


### PR DESCRIPTION
### Description

With `BPFOverlayHostSourceIP=HostAddress` the tunnel device has no IP, so a host-networked client's request to a remote workload travels the overlay with the **node IP** as its inner source. The workload's reply therefore targets a bare remote **node IP**, whose route is `CALI_RT_HOST` (not tunneled) — so the reply left the workload's node **un-encapsulated with a pod-CIDR source**. A source-checking fabric (e.g. GCP anti-spoof) drops that, so the host↔pod handshake never completes. `TunnelAddress` mode avoids this because the reply targets the overlay-routable tunnel IP instead.

This is a pre-existing bug in #11919 (which introduced HostAddress mode), independent of and complementary to the outbound-source fix in #13291.

**Fix (backend node):** mark host-originated overlay flows at ingress with a new conntrack flag `CALI_CT_FLAG_OVERLAY_REPLY`, and on the reply's workload-egress path force the overlay encap even though the destination route is a bare host. A remote-host route already carries the node IP as its `next_hop`, so no address is stored on the entry.

The regular pod overlay (`OVERLAY_TUNNEL_ID`) is decapped by the kernel tunnel device, so the flag is set on the resulting **tunnel-ingress program** — `from_vxlan` (`CALI_F_VXLAN`) for VXLAN, and `from_l3` (`CALI_F_L3_INGRESS`) for the IPIP tunnel device — scoped to `ip_void(HOST_TUNNEL_IP)` (true only for IPIP/VXLAN without a device IP, i.e. HostAddress mode; WireGuard always has a tunnel IP) and a remote-host inner source so only host-originated flows are tagged (a pod source resolves to a workload route). `state->tun_ip` is deliberately not used: it is only set for the BPF-to-BPF NodePort tunnel (`CALI_VXLAN_VNI`, decapped in BPF), not the regular overlay, and the reply needs no stored address anyway.

Deliberately **not** the NAT-reverse `tun_ip` mechanism, whose meaning is NodePort/service-specific (now documented in `conntrack_types.h` and the design docs).

**Fix (client node):** re-encapsulating the reply exposed a second issue — host → service → remote-pod with `BPFHostNetworkedNATWithoutCTLB` broke, because the reply now arrives decapped on the client's tunnel device, where it is reverse-NATted to the service IP before entering the host stack. The kernel's `__fib_validate_source()` short-circuits on an **address-less** device (`no_addr`): with *any* non-zero `rp_filter` — including the loose (2) that felix sets on host interfaces — it drops every packet whose source does not route back out that device, and the loose-mode fallback is never reached. The service-IP source routes via `bpfin.cali`, so the reply was dropped as a martian (`SKB_DROP_REASON_IP_RPFILTER`). In TunnelAddress mode the same packet is accepted only because the tunnel device has an IP. Felix now sets `rp_filter=0` on IPIP/VXLAN devices in HostAddress mode — the same treatment the equally address-less `bpfin.cali`/`bpfout.cali` already get.

This does not relax the real anti-spoof check: `hep_rpf_check()` (`rpf.h`, governed by `BPFEnforceRPF`) still runs on the tunnel-ingress programs, and it validates the packet **pre-reverse-DNAT** — i.e. the genuine on-wire source (the backend pod IP, which does route back via the tunnel). The kernel check being disabled here would have judged the **post-reverse-DNAT** source, a service IP synthesized locally by the same program a moment earlier — on an address-less device that is a tautological drop, not a spoof check.

### Tests

- Parameterized the BPF overlay-host-source-IP FV by mode and added a HostAddress case asserting the workload's reply leaves its node **encapsulated** (outer source = node IP) and **never** un-encapsulated with a pod-CIDR source (VXLAN + IPIP). Verified on the wire because a permissive FV underlay would let the buggy reply through.
- The existing host → service → workload FV matrix (which runs in HostAddress mode) covers the client-node return path that regressed during development.
- UT: `bpf_ep_mgr` sets `rp_filter=0` on IPIP/VXLAN devices in HostAddress mode and keeps loose (2) in TunnelAddress mode.

### Release Note

```release-note
None
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)