### PR TITLE
Bump default CNI config cniVersion to 1.0.0

### DIFF
--- a/charts/calico/templates/calico-config.yaml
+++ b/charts/calico/templates/calico-config.yaml
@@ -69,7 +69,7 @@ data:
   cni_network_config: |-
     {
         "name": "canal",
-        "cniVersion": "0.3.1",
+        "cniVersion": "1.0.0",
         "plugins": [
             {
                 "type": "flannel",
@@ -103,7 +103,7 @@ data:
   cni_network_config: |-
     {
       "name": "k8s-pod-network",
-      "cniVersion": "0.3.1",
+      "cniVersion": "1.0.0",
       "plugins": [
         {
           "type": "calico",

--- a/cni-plugin/pkg/install/install_linux.go
+++ b/cni-plugin/pkg/install/install_linux.go
@@ -19,7 +19,7 @@ package install
 func defaultNetConf() string {
 	netconf := `{
   "name": "k8s-pod-network",
-  "cniVersion": "0.3.1",
+  "cniVersion": "1.0.0",
   "plugins": [
     {
       "type": "calico",

--- a/cni-plugin/pkg/install/install_test.go
+++ b/cni-plugin/pkg/install/install_test.go
@@ -24,7 +24,7 @@ import (
 
 var expectedDefaultConfig string = `{
   "name": "k8s-pod-network",
-  "cniVersion": "0.3.1",
+  "cniVersion": "1.0.0",
   "plugins": [
     {
       "type": "calico",

--- a/cni-plugin/pkg/install/install_windows.go
+++ b/cni-plugin/pkg/install/install_windows.go
@@ -31,7 +31,7 @@ import (
 func defaultNetConf() string {
 	netconf := `{
   "name": "Calico",
-  "cniVersion": "0.3.1",
+  "cniVersion": "1.0.0",
   "plugins": [
     {
       "type": "calico",

--- a/manifests/calico-bpf.yaml
+++ b/manifests/calico-bpf.yaml
@@ -64,7 +64,7 @@ data:
   cni_network_config: |-
     {
       "name": "k8s-pod-network",
-      "cniVersion": "0.3.1",
+      "cniVersion": "1.0.0",
       "plugins": [
         {
           "type": "calico",

--- a/manifests/calico-etcd.yaml
+++ b/manifests/calico-etcd.yaml
@@ -85,7 +85,7 @@ data:
   cni_network_config: |-
     {
       "name": "k8s-pod-network",
-      "cniVersion": "0.3.1",
+      "cniVersion": "1.0.0",
       "plugins": [
         {
           "type": "calico",

--- a/manifests/calico-policy-only.yaml
+++ b/manifests/calico-policy-only.yaml
@@ -73,7 +73,7 @@ data:
   cni_network_config: |-
     {
       "name": "k8s-pod-network",
-      "cniVersion": "0.3.1",
+      "cniVersion": "1.0.0",
       "plugins": [
         {
           "type": "calico",

--- a/manifests/calico-typha.yaml
+++ b/manifests/calico-typha.yaml
@@ -75,7 +75,7 @@ data:
   cni_network_config: |-
     {
       "name": "k8s-pod-network",
-      "cniVersion": "0.3.1",
+      "cniVersion": "1.0.0",
       "plugins": [
         {
           "type": "calico",

--- a/manifests/calico-v3-crds.yaml
+++ b/manifests/calico-v3-crds.yaml
@@ -66,7 +66,7 @@ data:
   cni_network_config: |-
     {
       "name": "k8s-pod-network",
-      "cniVersion": "0.3.1",
+      "cniVersion": "1.0.0",
       "plugins": [
         {
           "type": "calico",

--- a/manifests/calico-vxlan.yaml
+++ b/manifests/calico-vxlan.yaml
@@ -59,7 +59,7 @@ data:
   cni_network_config: |-
     {
       "name": "k8s-pod-network",
-      "cniVersion": "0.3.1",
+      "cniVersion": "1.0.0",
       "plugins": [
         {
           "type": "calico",

--- a/manifests/calico.yaml
+++ b/manifests/calico.yaml
@@ -59,7 +59,7 @@ data:
   cni_network_config: |-
     {
       "name": "k8s-pod-network",
-      "cniVersion": "0.3.1",
+      "cniVersion": "1.0.0",
       "plugins": [
         {
           "type": "calico",

--- a/manifests/canal-etcd.yaml
+++ b/manifests/canal-etcd.yaml
@@ -92,7 +92,7 @@ data:
   cni_network_config: |-
     {
         "name": "canal",
-        "cniVersion": "0.3.1",
+        "cniVersion": "1.0.0",
         "plugins": [
             {
                 "type": "flannel",

--- a/manifests/canal.yaml
+++ b/manifests/canal.yaml
@@ -66,7 +66,7 @@ data:
   cni_network_config: |-
     {
       "name": "k8s-pod-network",
-      "cniVersion": "0.3.1",
+      "cniVersion": "1.0.0",
       "plugins": [
         {
           "type": "calico",

--- a/manifests/flannel-migration/calico.yaml
+++ b/manifests/flannel-migration/calico.yaml
@@ -59,7 +59,7 @@ data:
   cni_network_config: |-
     {
       "name": "k8s-pod-network",
-      "cniVersion": "0.3.1",
+      "cniVersion": "1.0.0",
       "plugins": [
         {
           "type": "calico",


### PR DESCRIPTION
Part of the fix for #12965 (Calico delegate breaks after multus cniVersion bumped to 1.1.0). Companion operator change (merged): tigera/operator#5090, which defaults the operator-generated CNI config to 1.0.0 and adds `spec.cni.specVersion` to the Installation API.

## What

Raise the `cniVersion` declared in the default CNI configuration from `0.3.1` to `1.0.0`:

- the manifest-install template (`calico-config` ConfigMap in `charts/calico`, regenerated `manifests/`)
- the `install-cni` fallback template used when `CNI_NETWORK_CONFIG` is not provided (`cni-plugin/pkg/install`, Linux + Windows)

This brings manifest installs in line with the operator default and satisfies multus's delegate requirement (≥ 0.4.0) on OpenShift 4.23+.

## Why it's safe

- Every supported container runtime accepts 1.0.0 configs (containerd ≥ 1.6 / CRI-O ≥ 1.24 — below Calico's supported minimum).
- Calico and the bundled chained plugins (portmap) have supported spec 1.0.0 for years; the KDD UT lane runs `CNI_SPEC_VERSION=1.0.0` permanently.
- Existing attachments are unaffected on upgrade: the runtime caches each attachment's config and replays the original `cniVersion` at DEL, so pods networked at 0.3.1 tear down at 0.3.1.
- Manifest users who need the old value can still set it directly in the `calico-config` ConfigMap (`cni_network_config` is fully user-controlled).

## Testing

- `make -C cni-plugin test-install-cni`: 22/22 pass; `manifests/` verified reproducible from `charts/` on current master.
- Validated live on OpenShift 5.0.0-ec.3 (multus top-level 1.1.0): config at 0.3.1 reproduces the multus crash from #12965; at 1.0.0 (stock images) multus recovers, nodes go Ready, install completes. On GA OpenShift 4.18 and GCP/kubeadm: no regression, hostPort (portmap chain) verified, upgrade path 0.3.1 → 1.0.0 exercised with no disruption.

**Release note:**
```release-note
The default CNI configuration now declares cniVersion 1.0.0 (previously 0.3.1), enabling Calico as a multus delegate on OpenShift 4.23+. Requires containerd v1.6+ or CRI-O v1.24+.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)