### PR TITLE
Prune nftables flowtable devices against kernel truth

### DIFF
--- a/felix/nftables/fake_test.go
+++ b/felix/nftables/fake_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Tigera, Inc. All rights reserved.
+// Copyright (c) 2024-2026 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -109,6 +109,14 @@ func (f *fakeNFT) NewTransaction() *knftables.Transaction {
 func (f *fakeNFT) Run(ctx context.Context, tx *knftables.Transaction) error {
 	f.preRun(tx)
 	return f.fake.Run(ctx, tx)
+}
+
+// Transactions returns a copy of the transactions Run has seen, for test assertions.
+func (f *fakeNFT) Transactions() []knftables.Transaction {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+
+	return append([]knftables.Transaction(nil), f.transactions...)
 }
 
 func (f *fakeNFT) preRun(tx *knftables.Transaction) {

--- a/felix/nftables/table.go
+++ b/felix/nftables/table.go
@@ -55,8 +55,8 @@ const (
 	// row we'll do it before falling back to the refresh timer. A device that is merely slow to
 	// appear is back within a retry or two; one that never appears - a workload endpoint whose
 	// veth is gone for good - mustn't keep us reprogramming forever.
-	flowtablePruneRetryDelay = 5 * time.Second
-	maxFlowtablePruneRetries = 5
+	FlowtablePruneRetryDelay = 5 * time.Second
+	MaxFlowtablePruneRetries = 5
 )
 
 type FlowTableHandler interface {
@@ -194,6 +194,10 @@ var (
 		Name: "felix_nft_flowtable_devices",
 		Help: "Number of devices attached to the Calico nftables flowtable.",
 	}, []string{"ip_version"})
+	gaugeNumFlowtableMissingDevices = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "felix_nft_flowtable_missing_devices",
+		Help: "Number of desired Calico nftables flowtable devices that do not exist in the kernel.",
+	}, []string{"ip_version"})
 )
 
 func init() {
@@ -204,6 +208,7 @@ func init() {
 	prometheus.MustRegister(gaugeNumChains)
 	prometheus.MustRegister(gaugeNumRules)
 	prometheus.MustRegister(gaugeNumFlowtableDevices)
+	prometheus.MustRegister(gaugeNumFlowtableMissingDevices)
 }
 
 // NftablesTable is an implementation of the generictables.Table interface that programs nftables. It represents a
@@ -280,7 +285,7 @@ type NftablesTable struct {
 	flowtableDirty bool
 
 	// flowtablePruneRetries counts consecutive Applies that left the flowtable dirty because
-	// pruning dropped a device. Bounded by maxFlowtablePruneRetries.
+	// pruning dropped a device. Bounded by MaxFlowtablePruneRetries.
 	flowtablePruneRetries int
 
 	// chainToDataplaneHashes contains the rule hashes that we think are in the dataplane.
@@ -308,9 +313,10 @@ type NftablesTable struct {
 	logCxt               *logrus.Entry
 	updateRateLimitedLog *logutilslc.RateLimitedLogger
 
-	gaugeNumChains           prometheus.Gauge
-	gaugeNumRules            prometheus.Gauge
-	gaugeNumFlowtableDevices prometheus.Gauge
+	gaugeNumChains                  prometheus.Gauge
+	gaugeNumRules                   prometheus.Gauge
+	gaugeNumFlowtableDevices        prometheus.Gauge
+	gaugeNumFlowtableMissingDevices prometheus.Gauge
 
 	// Factory for making commands, used by UTs to shim exec.Command().
 	newCmd cmdshim.CmdFactory
@@ -523,10 +529,11 @@ func newTable(
 
 		listInterfaces: listInterfaces,
 
-		gaugeNumChains:           gaugeNumChains.WithLabelValues(gaugeLabel),
-		gaugeNumRules:            gaugeNumRules.WithLabelValues(gaugeLabel),
-		gaugeNumFlowtableDevices: gaugeNumFlowtableDevices.WithLabelValues(gaugeLabel),
-		opReporter:               options.OpRecorder,
+		gaugeNumChains:                  gaugeNumChains.WithLabelValues(gaugeLabel),
+		gaugeNumRules:                   gaugeNumRules.WithLabelValues(gaugeLabel),
+		gaugeNumFlowtableDevices:        gaugeNumFlowtableDevices.WithLabelValues(gaugeLabel),
+		gaugeNumFlowtableMissingDevices: gaugeNumFlowtableMissingDevices.WithLabelValues(gaugeLabel),
+		opReporter:                      options.OpRecorder,
 
 		disabled: options.Disabled,
 
@@ -583,6 +590,11 @@ func (t *NftablesTable) SetExternalDevices(ifces []string) {
 // use by tests outside this package.
 func (t *NftablesTable) GaugeNumFlowtableDevices() prometheus.Gauge {
 	return t.gaugeNumFlowtableDevices
+}
+
+// GaugeNumFlowtableMissingDevices exposes the felix_nft_flowtable_missing_devices gauge for tests.
+func (t *NftablesTable) GaugeNumFlowtableMissingDevices() prometheus.Gauge {
+	return t.gaugeNumFlowtableMissingDevices
 }
 
 // enableFlowtable turns on offload and recalculates the device list. The first enable marks
@@ -1177,8 +1189,8 @@ func (t *NftablesTable) Apply() (rescheduleAfter time.Duration) {
 
 	// A flowtable left dirty is waiting on a device to appear, so come back for it promptly
 	// instead of waiting out the refresh interval (which may be disabled entirely).
-	if t.flowtableDirty && (rescheduleAfter == 0 || rescheduleAfter > flowtablePruneRetryDelay) {
-		rescheduleAfter = flowtablePruneRetryDelay
+	if t.flowtableDirty && (rescheduleAfter == 0 || rescheduleAfter > FlowtablePruneRetryDelay) {
+		rescheduleAfter = FlowtablePruneRetryDelay
 	}
 	return
 }
@@ -1242,16 +1254,15 @@ func (t *NftablesTable) applyUpdates() error {
 			Devices:  devices,
 		})
 		t.gaugeNumFlowtableDevices.Set(float64(len(devices)))
+		t.gaugeNumFlowtableMissingDevices.Set(float64(len(t.flowtableDevices) - len(devices)))
 
 		// Pruning is symmetric: it also drops a device that hasn't appeared yet, which happens
 		// when we learn about a workload before its veth is created. Nothing re-dirties the
 		// flowtable when the device does show up - the desired list never changed - so stay dirty
 		// and re-assert shortly rather than leaving the device unoffloaded until the next resync.
-		if dropped && t.flowtablePruneRetries < maxFlowtablePruneRetries {
+		if dropped && t.flowtablePruneRetries < MaxFlowtablePruneRetries {
 			t.flowtablePruneRetries++
 			keepFlowtableDirty = true
-		} else {
-			t.flowtablePruneRetries = 0
 		}
 	}
 
@@ -1392,6 +1403,7 @@ func (t *NftablesTable) applyUpdates() error {
 	if t.flowtableDirty && !t.flowtableEnabled {
 		tx.Delete(&knftables.Flowtable{Name: dataplanedefs.FlowtableName})
 		t.gaugeNumFlowtableDevices.Set(0)
+		t.gaugeNumFlowtableMissingDevices.Set(0)
 	}
 
 	if t.disabled && len(t.chainToDataplaneHashes) != 0 {
@@ -1427,6 +1439,9 @@ func (t *NftablesTable) applyUpdates() error {
 	t.dirtyBaseChains = set.New[string]()
 	if !keepFlowtableDirty {
 		t.flowtableDirty = false
+
+		// A stale count would shorten the retry budget of the next prune.
+		t.flowtablePruneRetries = 0
 	}
 
 	// Store off the updates.

--- a/felix/nftables/table.go
+++ b/felix/nftables/table.go
@@ -50,6 +50,13 @@ const (
 	objectTypeChain     = "chain"
 	objectTypeMap       = "map"
 	objectTypeFlowtable = "flowtable"
+
+	// How soon to re-assert the flowtable after pruning dropped a device, and how many times in a
+	// row we'll do it before falling back to the refresh timer. A device that is merely slow to
+	// appear is back within a retry or two; one that never appears - a workload endpoint whose
+	// veth is gone for good - mustn't keep us reprogramming forever.
+	flowtablePruneRetryDelay = 5 * time.Second
+	maxFlowtablePruneRetries = 5
 )
 
 type FlowTableHandler interface {
@@ -271,6 +278,10 @@ type NftablesTable struct {
 	// flowtableDirty is true when the flowtable needs reconciling: created or updated when offload
 	// is enabled, or deleted when it is disabled but a flowtable lingers from a previous run.
 	flowtableDirty bool
+
+	// flowtablePruneRetries counts consecutive Applies that left the flowtable dirty because
+	// pruning dropped a device. Bounded by maxFlowtablePruneRetries.
+	flowtablePruneRetries int
 
 	// chainToDataplaneHashes contains the rule hashes that we think are in the dataplane.
 	// it is updated when we write to the dataplane but it can also be read back and compared
@@ -614,28 +625,43 @@ func realInterfaceNames() ([]string, error) {
 	return names, nil
 }
 
-// pruneToExistingDevices drops any device that the kernel no longer has. The workload and
-// overlay lists are fed asynchronously (endpoint manager, ifacemonitor), so they can still
-// name a veth that CNI already deleted; a flowtable that references a missing device fails the
-// whole nft transaction. On a listing error we fall open and return the list unchanged - a
-// transient failure to read interfaces shouldn't wipe offload from every device.
-func (t *NftablesTable) pruneToExistingDevices(devices []string) []string {
+// pruneToExistingDevices drops any device that the kernel no longer has, and reports whether it
+// dropped anything. A flowtable that references a missing device fails the whole nft
+// transaction, and the device lists we're given are fed asynchronously (endpoint manager,
+// ifacemonitor), so they can still name a veth that CNI already deleted.
+//
+// We deliberately ask the kernel rather than reusing ifacemonitor's cache: that cache is exactly
+// what's stale during this race - it hasn't processed the RTM_DELLINK yet - so consulting it
+// would tell us what we already believe. One netlink dump per programming pass is cheap next to
+// the transaction it protects, and it beats a per-device lookup once a node has a few hundred
+// workloads.
+//
+// On a listing error we fall open and return the list unchanged: a transient failure to read
+// interfaces shouldn't wipe offload from every device.
+func (t *NftablesTable) pruneToExistingDevices(devices []string) ([]string, bool) {
 	if len(devices) == 0 {
-		return devices
+		return devices, false
 	}
 	names, err := t.listInterfaces()
 	if err != nil {
 		t.logCxt.WithError(err).Warn("Failed to list interfaces while pruning flowtable devices; keeping cached list")
-		return devices
+		return devices, false
 	}
+
 	existing := set.FromArray(names)
 	pruned := make([]string, 0, len(devices))
+	var dropped []string
 	for _, d := range devices {
 		if existing.Contains(d) {
 			pruned = append(pruned, d)
+		} else {
+			dropped = append(dropped, d)
 		}
 	}
-	return pruned
+	if len(dropped) > 0 {
+		t.logCxt.WithField("devices", dropped).Info("Pruned flowtable devices that no longer exist in the kernel")
+	}
+	return pruned, len(dropped) > 0
 }
 
 // InsertOrAppendRules sets the rules that should be inserted into or appended
@@ -1148,6 +1174,12 @@ func (t *NftablesTable) Apply() (rescheduleAfter time.Duration) {
 		}).Debug("Calculating reschedule time")
 		rescheduleAfter = t.refreshInterval - lastReadToNow
 	}
+
+	// A flowtable left dirty is waiting on a device to appear, so come back for it promptly
+	// instead of waiting out the refresh interval (which may be disabled entirely).
+	if t.flowtableDirty && (rescheduleAfter == 0 || rescheduleAfter > flowtablePruneRetryDelay) {
+		rescheduleAfter = flowtablePruneRetryDelay
+	}
 	return
 }
 
@@ -1157,6 +1189,10 @@ func (t *NftablesTable) applyUpdates() error {
 
 	// Start a new nftables transaction.
 	tx := t.nft.NewTransaction()
+
+	// Set when the flowtable needs another pass, so the dirty-clear at the end of this function
+	// leaves flowtableDirty set for the next Apply.
+	keepFlowtableDirty := false
 
 	// Get the set of map updates we need to make. We'll interleave these with the chain updates.
 	// in the correct order. Namely:
@@ -1198,7 +1234,7 @@ func (t *NftablesTable) applyUpdates() error {
 	// even with no devices). The delete for the disabled case is deferred to the end of the
 	// transaction, after the referencing rule has been flushed away.
 	if t.flowtableDirty && t.flowtableEnabled {
-		devices := t.pruneToExistingDevices(t.flowtableDevices)
+		devices, dropped := t.pruneToExistingDevices(t.flowtableDevices)
 		prio := knftables.FilterIngressPriority
 		tx.Add(&knftables.Flowtable{
 			Name:     dataplanedefs.FlowtableName,
@@ -1206,6 +1242,17 @@ func (t *NftablesTable) applyUpdates() error {
 			Devices:  devices,
 		})
 		t.gaugeNumFlowtableDevices.Set(float64(len(devices)))
+
+		// Pruning is symmetric: it also drops a device that hasn't appeared yet, which happens
+		// when we learn about a workload before its veth is created. Nothing re-dirties the
+		// flowtable when the device does show up - the desired list never changed - so stay dirty
+		// and re-assert shortly rather than leaving the device unoffloaded until the next resync.
+		if dropped && t.flowtablePruneRetries < maxFlowtablePruneRetries {
+			t.flowtablePruneRetries++
+			keepFlowtableDirty = true
+		} else {
+			t.flowtablePruneRetries = 0
+		}
 	}
 
 	// Make a pass over the dirty chains and generate a forward reference for any that we're about to update.
@@ -1378,7 +1425,9 @@ func (t *NftablesTable) applyUpdates() error {
 	// was actually a no-op update.
 	t.dirtyChains = set.New[string]()
 	t.dirtyBaseChains = set.New[string]()
-	t.flowtableDirty = false
+	if !keepFlowtableDirty {
+		t.flowtableDirty = false
+	}
 
 	// Store off the updates.
 	for chainName, hashes := range newHashes {

--- a/felix/nftables/table.go
+++ b/felix/nftables/table.go
@@ -17,6 +17,7 @@ package nftables
 import (
 	"context"
 	"fmt"
+	"net"
 	"os/exec"
 	"reflect"
 	"regexp"
@@ -307,6 +308,10 @@ type NftablesTable struct {
 	timeSleep func(d time.Duration)
 	timeNow   func() time.Time
 
+	// listInterfaces returns the names of interfaces that currently exist in the kernel.
+	// Defaults to net.Interfaces(); overridable in tests.
+	listInterfaces func() ([]string, error)
+
 	onStillAlive func()
 	opReporter   logutils.OpRecorder
 	reason       string
@@ -333,6 +338,10 @@ type TableOptions struct {
 
 	// LookPathOverride for tests, if non-nil, replacement for exec.LookPath()
 	LookPathOverride func(file string) (string, error)
+
+	// ListInterfacesOverride for tests, if non-nil, replaces the net.Interfaces()-based
+	// lister used to prune the flowtable device list against kernel truth.
+	ListInterfacesOverride func() ([]string, error)
 
 	// Thunk to call periodically when doing a long-running operation.
 	OnStillAlive func()
@@ -451,6 +460,10 @@ func newTable(
 	if options.NowOverride != nil {
 		now = options.NowOverride
 	}
+	listInterfaces := realInterfaceNames
+	if options.ListInterfacesOverride != nil {
+		listInterfaces = options.ListInterfacesOverride
+	}
 
 	if options.NewDataplane == nil {
 		options.NewDataplane = knftables.New
@@ -496,6 +509,8 @@ func newTable(
 		newCmd:    newCmd,
 		timeSleep: sleep,
 		timeNow:   now,
+
+		listInterfaces: listInterfaces,
 
 		gaugeNumChains:           gaugeNumChains.WithLabelValues(gaugeLabel),
 		gaugeNumRules:            gaugeNumRules.WithLabelValues(gaugeLabel),
@@ -583,6 +598,44 @@ func (t *NftablesTable) recalcFlowtableDevices() {
 		t.flowtableDevices = combined
 		t.flowtableDirty = true
 	}
+}
+
+// realInterfaceNames returns the names of every network interface currently present in the
+// kernel, via a single netlink dump.
+func realInterfaceNames() ([]string, error) {
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return nil, err
+	}
+	names := make([]string, 0, len(ifaces))
+	for _, iface := range ifaces {
+		names = append(names, iface.Name)
+	}
+	return names, nil
+}
+
+// pruneToExistingDevices drops any device that the kernel no longer has. The workload and
+// overlay lists are fed asynchronously (endpoint manager, ifacemonitor), so they can still
+// name a veth that CNI already deleted; a flowtable that references a missing device fails the
+// whole nft transaction. On a listing error we fall open and return the list unchanged - a
+// transient failure to read interfaces shouldn't wipe offload from every device.
+func (t *NftablesTable) pruneToExistingDevices(devices []string) []string {
+	if len(devices) == 0 {
+		return devices
+	}
+	names, err := t.listInterfaces()
+	if err != nil {
+		t.logCxt.WithError(err).Warn("Failed to list interfaces while pruning flowtable devices; keeping cached list")
+		return devices
+	}
+	existing := set.FromArray(names)
+	pruned := make([]string, 0, len(devices))
+	for _, d := range devices {
+		if existing.Contains(d) {
+			pruned = append(pruned, d)
+		}
+	}
+	return pruned
 }
 
 // InsertOrAppendRules sets the rules that should be inserted into or appended
@@ -1145,13 +1198,14 @@ func (t *NftablesTable) applyUpdates() error {
 	// even with no devices). The delete for the disabled case is deferred to the end of the
 	// transaction, after the referencing rule has been flushed away.
 	if t.flowtableDirty && t.flowtableEnabled {
+		devices := t.pruneToExistingDevices(t.flowtableDevices)
 		prio := knftables.FilterIngressPriority
 		tx.Add(&knftables.Flowtable{
 			Name:     dataplanedefs.FlowtableName,
 			Priority: &prio,
-			Devices:  t.flowtableDevices,
+			Devices:  devices,
 		})
-		t.gaugeNumFlowtableDevices.Set(float64(len(t.flowtableDevices)))
+		t.gaugeNumFlowtableDevices.Set(float64(len(devices)))
 	}
 
 	// Make a pass over the dirty chains and generate a forward reference for any that we're about to update.

--- a/felix/nftables/table_test.go
+++ b/felix/nftables/table_test.go
@@ -1299,11 +1299,44 @@ var _ = Describe("Table with flowtable offload enabled", func() {
 		table.SetWorkloadInterfaces([]string{"cali1234", "caliDEAD"})
 
 		// Dropping a device asks for a prompt retry, in case it was on its way up rather than gone.
-		Expect(table.Apply()).To(Equal(5 * time.Second))
+		Expect(table.Apply()).To(Equal(nftables.FlowtablePruneRetryDelay))
 
 		// caliDEAD is dropped; only the surviving devices are programmed.
 		Expect(f.Fake().Dump()).To(ContainSubstring("devices = { cali1234, vxlan.calico }"))
 		Expect(testutil.ToFloat64(table.GaugeNumFlowtableDevices())).To(Equal(float64(2)))
+		Expect(testutil.ToFloat64(table.GaugeNumFlowtableMissingDevices())).To(Equal(float64(1)))
+	})
+
+	// A failure to read the kernel's interfaces must not wipe offload from every device.
+	It("should keep the cached device list when listing interfaces fails", func() {
+		newDataplane := func(fam knftables.Family, name string, options ...knftables.Option) (knftables.Interface, error) {
+			f = NewFake(fam, name)
+			return f, nil
+		}
+		table = nftables.NewTable(
+			"calico",
+			4,
+			rules.RuleHashPrefix,
+			environment.NewFeatureDetector(nil),
+			nftables.TableOptions{
+				NewDataplane:     newDataplane,
+				LookPathOverride: testutils.LookPathNoLegacy,
+				OpRecorder:       logutils.NewSummarizer("test loop"),
+				ListInterfacesOverride: func() ([]string, error) {
+					return nil, errors.New("netlink is having a bad day")
+				},
+			},
+			true,
+		)
+
+		table.SetOverlayDevices([]string{"vxlan.calico"})
+		table.SetWorkloadInterfaces([]string{"cali1234"})
+
+		// Nothing was pruned, so there's nothing to retry for either.
+		Expect(table.Apply()).To(BeZero())
+		Expect(f.Fake().Dump()).To(ContainSubstring("devices = { cali1234, vxlan.calico }"))
+		Expect(testutil.ToFloat64(table.GaugeNumFlowtableDevices())).To(Equal(float64(2)))
+		Expect(testutil.ToFloat64(table.GaugeNumFlowtableMissingDevices())).To(BeZero())
 	})
 
 	// A device can be missing because it's still being created, not because it's gone. The desired
@@ -1333,13 +1366,14 @@ var _ = Describe("Table with flowtable offload enabled", func() {
 
 		table.SetOverlayDevices([]string{"vxlan.calico"})
 		table.SetWorkloadInterfaces([]string{"cali1234"})
-		Expect(table.Apply()).To(Equal(5 * time.Second))
+		Expect(table.Apply()).To(Equal(nftables.FlowtablePruneRetryDelay))
 		Expect(f.Fake().Dump()).To(ContainSubstring("devices = { vxlan.calico }"))
 
 		// The veth lands. Nothing tells the table about it, so the retry has to notice.
 		present = append(present, "cali1234")
 		Expect(table.Apply()).To(BeZero())
 		Expect(testutil.ToFloat64(table.GaugeNumFlowtableDevices())).To(Equal(float64(2)))
+		Expect(testutil.ToFloat64(table.GaugeNumFlowtableMissingDevices())).To(BeZero())
 
 		// knftables' fake ignores an "add flowtable" for a flowtable that already exists, where
 		// real nft treats it as create-or-update, so the device list in Dump() is stuck at what
@@ -1353,8 +1387,8 @@ var _ = Describe("Table with flowtable offload enabled", func() {
 		table.SetOverlayDevices([]string{"vxlan.calico"})
 		table.SetWorkloadInterfaces([]string{"caliGHOST"})
 
-		for i := 0; i < 5; i++ {
-			Expect(table.Apply()).To(Equal(5*time.Second), "expected a retry on attempt %d", i+1)
+		for i := 0; i < nftables.MaxFlowtablePruneRetries; i++ {
+			Expect(table.Apply()).To(Equal(nftables.FlowtablePruneRetryDelay), "expected a retry on attempt %d", i+1)
 		}
 		Expect(table.Apply()).To(BeZero())
 	})

--- a/felix/nftables/table_test.go
+++ b/felix/nftables/table_test.go
@@ -1187,6 +1187,11 @@ var _ = Describe("Table with flowtable offload enabled", func() {
 				NewDataplane:     newDataplane,
 				LookPathOverride: testutils.LookPathNoLegacy,
 				OpRecorder:       logutils.NewSummarizer("test loop"),
+				ListInterfacesOverride: func() ([]string, error) {
+					// Everything the flowtable specs program is treated as present by default;
+					// the prune spec overrides this with its own narrower lister.
+					return []string{"cali1234", "vxlan.calico", "eth0", "lo"}, nil
+				},
 			},
 			true,
 		)
@@ -1265,5 +1270,36 @@ var _ = Describe("Table with flowtable offload enabled", func() {
 		table.InvalidateDataplaneCache("test")
 		Expect(table.Apply()).To(BeNumerically("<", 100*time.Millisecond))
 		Expect(f.List(context.TODO(), "flowtable")).To(BeEmpty())
+	})
+
+	It("should prune flowtable devices that no longer exist in the kernel", func() {
+		// net.Interfaces() reports cali1234 and vxlan.calico exist, but not the dead veth.
+		newDataplane := func(fam knftables.Family, name string, options ...knftables.Option) (knftables.Interface, error) {
+			f = NewFake(fam, name)
+			return f, nil
+		}
+		table = nftables.NewTable(
+			"calico",
+			4,
+			rules.RuleHashPrefix,
+			environment.NewFeatureDetector(nil),
+			nftables.TableOptions{
+				NewDataplane:     newDataplane,
+				LookPathOverride: testutils.LookPathNoLegacy,
+				OpRecorder:       logutils.NewSummarizer("test loop"),
+				ListInterfacesOverride: func() ([]string, error) {
+					return []string{"cali1234", "vxlan.calico", "lo"}, nil
+				},
+			},
+			true,
+		)
+
+		table.SetOverlayDevices([]string{"vxlan.calico"})
+		table.SetWorkloadInterfaces([]string{"cali1234", "caliDEAD"})
+		Expect(table.Apply()).To(BeNumerically("<", 100*time.Millisecond))
+
+		// caliDEAD is dropped; only the surviving devices are programmed.
+		Expect(f.Fake().Dump()).To(ContainSubstring("devices = { cali1234, vxlan.calico }"))
+		Expect(testutil.ToFloat64(table.GaugeNumFlowtableDevices())).To(Equal(float64(2)))
 	})
 })

--- a/felix/nftables/table_test.go
+++ b/felix/nftables/table_test.go
@@ -17,6 +17,7 @@ package nftables_test
 import (
 	"context"
 	"errors"
+	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -1296,10 +1297,89 @@ var _ = Describe("Table with flowtable offload enabled", func() {
 
 		table.SetOverlayDevices([]string{"vxlan.calico"})
 		table.SetWorkloadInterfaces([]string{"cali1234", "caliDEAD"})
-		Expect(table.Apply()).To(BeNumerically("<", 100*time.Millisecond))
+
+		// Dropping a device asks for a prompt retry, in case it was on its way up rather than gone.
+		Expect(table.Apply()).To(Equal(5 * time.Second))
 
 		// caliDEAD is dropped; only the surviving devices are programmed.
 		Expect(f.Fake().Dump()).To(ContainSubstring("devices = { cali1234, vxlan.calico }"))
 		Expect(testutil.ToFloat64(table.GaugeNumFlowtableDevices())).To(Equal(float64(2)))
 	})
+
+	// A device can be missing because it's still being created, not because it's gone. The desired
+	// list doesn't change when it finally appears, so without the retry the device would go
+	// unoffloaded until the next resync.
+	It("should re-assert the flowtable once a pruned device appears", func() {
+		present := []string{"vxlan.calico", "lo"}
+		newDataplane := func(fam knftables.Family, name string, options ...knftables.Option) (knftables.Interface, error) {
+			f = NewFake(fam, name)
+			return f, nil
+		}
+		table = nftables.NewTable(
+			"calico",
+			4,
+			rules.RuleHashPrefix,
+			environment.NewFeatureDetector(nil),
+			nftables.TableOptions{
+				NewDataplane:     newDataplane,
+				LookPathOverride: testutils.LookPathNoLegacy,
+				OpRecorder:       logutils.NewSummarizer("test loop"),
+				ListInterfacesOverride: func() ([]string, error) {
+					return present, nil
+				},
+			},
+			true,
+		)
+
+		table.SetOverlayDevices([]string{"vxlan.calico"})
+		table.SetWorkloadInterfaces([]string{"cali1234"})
+		Expect(table.Apply()).To(Equal(5 * time.Second))
+		Expect(f.Fake().Dump()).To(ContainSubstring("devices = { vxlan.calico }"))
+
+		// The veth lands. Nothing tells the table about it, so the retry has to notice.
+		present = append(present, "cali1234")
+		Expect(table.Apply()).To(BeZero())
+		Expect(testutil.ToFloat64(table.GaugeNumFlowtableDevices())).To(Equal(float64(2)))
+
+		// knftables' fake ignores an "add flowtable" for a flowtable that already exists, where
+		// real nft treats it as create-or-update, so the device list in Dump() is stuck at what
+		// the first Apply wrote. Assert on what we asked nft to do instead.
+		Expect(flowtableDevicesProgrammed(f)).To(ContainElement("devices = { cali1234, vxlan.calico }"))
+	})
+
+	// A workload endpoint whose veth is gone for good would otherwise keep us re-asserting the
+	// flowtable every few seconds forever.
+	It("should stop retrying a pruned device that never appears", func() {
+		table.SetOverlayDevices([]string{"vxlan.calico"})
+		table.SetWorkloadInterfaces([]string{"caliGHOST"})
+
+		for i := 0; i < 5; i++ {
+			Expect(table.Apply()).To(Equal(5*time.Second), "expected a retry on attempt %d", i+1)
+		}
+		Expect(table.Apply()).To(BeZero())
+	})
 })
+
+// flowtableDevicesProgrammed returns the "devices = { ... }" clause of every "add flowtable"
+// operation the table has sent to nft, oldest first.
+func flowtableDevicesProgrammed(f *fakeNFT) []string {
+	var clauses []string
+	for _, tx := range f.Transactions() {
+		for _, line := range strings.Split(tx.String(), "\n") {
+			if !strings.Contains(line, "add flowtable") {
+				continue
+			}
+
+			start := strings.Index(line, "devices = {")
+			if start < 0 {
+				continue
+			}
+			end := strings.Index(line[start:], "}")
+			if end < 0 {
+				continue
+			}
+			clauses = append(clauses, line[start:start+end+1])
+		}
+	}
+	return clauses
+}


### PR DESCRIPTION
Felix could restart when a workload interface was removed while nftables flowtable offload was enabled. On pod teardown CNI deletes the veth immediately, but Felix only learns about it a moment later, so flowtable programming still references the dead device and nft rejects the whole transaction. The retry loop kept rebuilding the same dead device and, if the interface-down event didn't arrive in time, eventually panicked.

This prunes the device list against the interfaces that actually exist in the kernel at programming time, so the common case self-heals on the next attempt. Pruning also drops a device we've heard about before its veth exists, so we re-assert the flowtable a few seconds later (up to five times) rather than leaving it unoffloaded until the next resync.

Follow-on to #9458. Tracked by CORE-13187.

```release-note
Fixes a Felix restart that could occur when a workload interface is removed while nftables flowtable offload is enabled.
```
