### PR TITLE
[DE-4442] Pin ASO install to the kind kubeconfig and default namespace

### DIFF
--- a/process/testing/aso/Makefile
+++ b/process/testing/aso/Makefile
@@ -29,6 +29,7 @@ else
 	@echo "ASO kind cluster will now be deleted"
 	-$(BINDIR)/kind delete cluster --name $(KIND_CLUSTER_NAME)
 	-rm -f kubeconfig
+	-rm -f kind-kubeconfig
 	-rm -f $(ASO_INSTALLED_MARKER)
 endif
 

--- a/process/testing/aso/Makefile
+++ b/process/testing/aso/Makefile
@@ -29,7 +29,7 @@ else
 	@echo "ASO kind cluster will now be deleted"
 	-$(BINDIR)/kind delete cluster --name $(KIND_CLUSTER_NAME)
 	-rm -f kubeconfig
-	-rm -f kind-kubeconfig
+	-rm -f $(CURDIR)/kind-kubeconfig
 	-rm -f $(ASO_INSTALLED_MARKER)
 endif
 

--- a/process/testing/aso/install-aso.sh
+++ b/process/testing/aso/install-aso.sh
@@ -44,6 +44,12 @@ trap 'exit_code=$?; if [ $exit_code -ne 0 ]; then echo ""; echo "===============
 # Create management cluster
 ${KIND} create cluster --image "kindest/node:${KINDEST_NODE_VERSION}" --name "${KIND_CLUSTER_NAME}" --verbosity 5
 ${KIND} get kubeconfig --name "${KIND_CLUSTER_NAME}" > "${ASO_DIR}/kind-kubeconfig"
+
+# Pin every kubectl/cmctl/helm call below to this cluster rather than the ambient
+# kubeconfig, whose default namespace on a CI pod is the pod's own (e.g. argoci).
+export KUBECONFIG="${ASO_DIR}/kind-kubeconfig"
+${KUBECTL} config set-context --current --namespace=default
+
 ${KUBECTL} wait node "${KIND_CLUSTER_NAME}-control-plane" --for=condition=ready --timeout=90s
 
 # Install cert-manager


### PR DESCRIPTION
`process/testing/aso/install-aso.sh` writes `${ASO_DIR}/kind-kubeconfig` and then never uses it — every `kubectl` / `cmctl` / `helm` call after that runs against whatever kubeconfig happens to be ambient. On a Semaphore VM that is harmless, because the ambient kubeconfig *is* the kind cluster kind just created. Inside a pod it is not.

kind's generated context carries no `namespace:` field, so client-go resolves an *implicit* `"default"`. `DeferredLoadingClientConfig.Namespace()` treats an implicit `"default"` as "no namespace configured" and, when in-cluster config is possible, falls back to the pod's service account namespace (`/var/run/secrets/kubernetes.io/serviceaccount/namespace`). The result is a mixed config: API server from the kubeconfig, namespace from the pod. `cmctl check api` then dry-run-creates its probe Certificate in that namespace on the kind cluster and dies with:

```
Error from server (NotFound): namespaces "argoci" not found
make: *** [Makefile:21: .aso-installed] Error 124
```

The fix is two lines: export `KUBECONFIG` to the file the script already generates, and write an **explicit** namespace into the context. A non-empty `namespace` on the current context short-circuits the in-cluster fallback ([`merged_client_builder.go:145-160`](https://github.com/kubernetes/client-go/blob/master/tools/clientcmd/merged_client_builder.go)).

**Effect on Semaphore FVs**

None. The Windows FV blocks in `.semaphore/semaphore.yml.d/blocks/20-felix.yml` and `20-cni-plugin.yml` are gated on `CHANGE_IN(non-go:/process/testing/aso, ...)`, so they will run on this PR, but the change is a no-op there:

- `export KUBECONFIG` is process-local to `install-aso.sh`; make runs each recipe line in its own shell, so nothing downstream of the target inherits it.
- `kind create cluster` still writes the ambient kubeconfig exactly as before, so the ambient-config consumers (`vmss.sh`, `install-kubeadm.sh`) are unaffected.
- `install-calico.sh` sets its own `KUBECONFIG` for the target cluster.
- The only durable side effect is that `kind-kubeconfig` now carries `namespace: default` on its context — which is what it already resolved to on a VM.

**Testing**

Verified against a live kind cluster: before the change the resolved namespace under a simulated in-cluster environment is the pod's namespace and a namespaced create fails; after `kubectl config set-context --current --namespace=default` it resolves to `default` and the create succeeds. `bash -n` clean.

Jira: DE-4442

**Release note:**
```release-note
NONE
```
