### PR TITLE
OpenStack: fix DHCP agent handling of subnet CIDR re-use

### DIFF
--- a/networking-calico/devstack/qos_responsiveness_tests.py
+++ b/networking-calico/devstack/qos_responsiveness_tests.py
@@ -90,8 +90,6 @@ class QoSResponsivenessTest(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.next_subnet_byte = 0
-
         # Set up OpenStack connection
         cls.conn = openstack.connection.Connection(
             auth_url=os.environ.get("OS_AUTH_URL", "http://localhost/identity"),
@@ -452,17 +450,15 @@ class QoSResponsivenessTest(unittest.TestCase):
         subnet = self.conn.network.create_subnet(
             name=f"{name}-subnet",
             network_id=network.id,
-            cidr="10.63.%d.0/24" % self.next_subnet_byte,
+            cidr="192.168.100.0/24",
             ip_version=4,
             enable_dhcp=True,
         )
+
         logger.info(
             f"Created network: {name}"
             f" {'with QoS policy' if qos_policy_id else 'without QoS policy'}"
         )
-        self.next_subnet_byte += 1
-        self.assertLess(self.next_subnet_byte, 256)
-
         return network, subnet
 
     def _apply_change(self, current, nxt):

--- a/networking-calico/networking_calico/agent/dhcp_agent.py
+++ b/networking-calico/networking_calico/agent/dhcp_agent.py
@@ -39,6 +39,7 @@ import eventlet
 from eventlet.event import Event
 from eventlet.queue import Empty
 from eventlet.queue import LightQueue
+from eventlet.semaphore import Semaphore
 
 import netaddr
 
@@ -268,6 +269,19 @@ class MTUWatcher(object):
 
 
 class DnsmasqUpdater(object):
+
+    # How long to wait before retrying, after a Dnsmasq driver call has
+    # failed.  (On top of any retrying that the driver itself does
+    # internally.)
+    FAILED_CALL_RETRY_SECS = 10
+
+    # Limit on how many Dnsmasq driver calls may run concurrently, so that a
+    # flood of updates - e.g. following an etcd snapshot - cannot spawn an
+    # unbounded number of dnsmasq processes at the same moment.  (The
+    # reference Neutron DHCP agent similarly bounds its driver calls, with a
+    # green pool of up to 32 workers.)
+    MAX_CONCURRENT_DRIVER_CALLS = 16
+
     def __init__(self, agent):
         self.agent = agent
         self.updates_needed = LightQueue()
@@ -276,32 +290,78 @@ class DnsmasqUpdater(object):
         # network ID.
         self._last_dnsmasq_ports = {}
 
+        # Queues for the networks that currently have a worker thread; see
+        # start().
+        self._worker_queues = {}
+
+        self._driver_semaphore = Semaphore(self.MAX_CONCURRENT_DRIVER_CALLS)
+
     def update_network(self, network_id):
         self.updates_needed.put(network_id)
 
     def start(self):
+        # Dispatch each requested update to a worker thread for the network
+        # concerned.  Updates for the same network are serialized on that
+        # network's worker, but a driver call that blocks for one network
+        # then cannot delay processing for any other network.  That matters
+        # because a dnsmasq start blocks, inside the driver, for as long as
+        # dnsmasq fails to bind its listen address - which is exactly what
+        # happens when the address is still held by the dnsmasq of a
+        # deleted network with the same subnet CIDR, and the driver call
+        # that would stop that dnsmasq is still pending.
         while True:
             LOG.debug("DnsmasqUpdater: wait until updates needed")
-            dirty_network_ids = set()
-            dirty_network_ids.add(self.updates_needed.get())
+            network_id = self.updates_needed.get()
+            worker_queue = self._worker_queues.get(network_id)
+            if worker_queue is None:
+                worker_queue = LightQueue()
+                self._worker_queues[network_id] = worker_queue
+                eventlet.spawn(self._worker, network_id, worker_queue)
+            worker_queue.put(network_id)
+
+    def _worker(self, network_id, worker_queue):
+        while True:
+            worker_queue.get()
+
+            # Coalesce any further updates already requested for this
+            # network; a single really_update_dnsmasq call covers them all,
+            # because it recomputes what is needed from the current cache
+            # state.
             try:
                 while True:
-                    dirty_network_ids.add(self.updates_needed.get_nowait())
+                    worker_queue.get_nowait()
             except Empty:
                 pass
-            LOG.debug("DnsmasqUpdater: updating now for %r", dirty_network_ids)
-            for network_id in dirty_network_ids:
-                # Handle any exceptions here so that the dnsmasq updater thread
-                # doesn't die.  There aren't any expected exception scenarios,
-                # but better to be more resilient here.
-                try:
+            LOG.debug("DnsmasqUpdater: updating now for %s", network_id)
+
+            # Handle any exceptions here so that the worker thread doesn't
+            # die.  There aren't any expected exception scenarios, but better
+            # to be more resilient here.
+            try:
+                with self._driver_semaphore:
                     self.really_update_dnsmasq(network_id)
-                except Exception:
-                    LOG.exception("really_update_dnsmasq")
+            except Exception:
+                LOG.exception("really_update_dnsmasq")
+
+            # If no further update has been requested for this network, this
+            # worker is finished.  There is no yield point between the
+            # emptiness check here and the removal from _worker_queues, so
+            # the dispatcher in start() cannot deliver an update into a
+            # queue that no worker is serving.
+            if worker_queue.empty():
+                del self._worker_queues[network_id]
+                return
 
     def really_update_dnsmasq(self, network_id):
         # Get NetModel for that network ID.
         net = self.agent.cache.get_network_by_id(network_id)
+        net_in_cache = net is not None
+        if not net_in_cache:
+            # The network is no longer in the cache - this update can have
+            # been requested before the network's removal - but its dnsmasq
+            # could still be running; carry on with a synthetic empty network
+            # model, so as to ensure that it is stopped.
+            net = empty_network(network_id)
         LOG.debug("Net: %s", net)
 
         # Compute the set of ports that we need Dnsmasq to handle for this
@@ -340,16 +400,34 @@ class DnsmasqUpdater(object):
                     network_id,
                     len(ports_needed),
                 )
-                self.agent.call_driver("restart", net)
+                success = self.agent.call_driver("restart", net)
             else:
                 # No ports left, so also remove this network from the cache.
-                _fix_network_cache_port_lookup(self.agent, net.id)
-                self.agent.cache.remove(net)
+                if net_in_cache:
+                    _fix_network_cache_port_lookup(self.agent, net.id)
+                    self.agent.cache.remove(net)
                 LOG.info("Disable dnsmasq for network %s", network_id)
-                self.agent.call_driver("disable", net)
+                success = self.agent.call_driver("disable", net)
 
-            # Remember what we've asked Dnsmasq for.
-            self._last_dnsmasq_ports[network_id] = ports_needed_as_string
+            if success:
+                # Remember what we've asked Dnsmasq for.
+                self._last_dnsmasq_ports[network_id] = ports_needed_as_string
+            else:
+                # The driver call failed, so what dnsmasq is actually now
+                # handling for this network is unknown; a failed restart, in
+                # particular, can have stopped the previous dnsmasq without
+                # starting a new one.  Forget our record for this network, so
+                # that the retry cannot be skipped as "no change", and
+                # schedule that retry.
+                LOG.warning(
+                    "Driver call failed for network %s; will retry in %ss",
+                    network_id,
+                    self.FAILED_CALL_RETRY_SECS,
+                )
+                self._last_dnsmasq_ports.pop(network_id, None)
+                eventlet.spawn_after(
+                    self.FAILED_CALL_RETRY_SECS, self.update_network, network_id
+                )
         else:
             LOG.debug("No change")
 

--- a/networking-calico/networking_calico/etcdv3.py
+++ b/networking-calico/networking_calico/etcdv3.py
@@ -13,14 +13,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import array
+import fcntl
 import functools
 from importlib.metadata import version
+import queue
+import termios
+import time
 
+from etcd3gw import watch as etcd3gw_watch
 from etcd3gw.client import Etcd3Client
 from etcd3gw.exceptions import Etcd3Exception
 from etcd3gw.lease import Lease
 from etcd3gw.utils import _encode
 from etcd3gw.utils import _increment_last_byte
+
+import eventlet
 
 from oslo_config import cfg
 
@@ -549,6 +557,67 @@ class Etcd3AuthClient(Etcd3Client):
 
             # Otherwise re-raise.
             raise
+
+    def watch(self, key, **kwargs):
+        """Watch a key or range of keys, with drain-then-cancel semantics.
+
+        This reimplements etcd3gw's Client.watch, differing only in what
+        happens on cancellation.  etcd3gw's version discards events that the
+        server has already delivered but that have not yet been consumed -
+        both events parsed and queued by its reader thread, and bytes still
+        unread in the watch socket - because its cancel thunk marks the
+        iterator as cancelled before anything drains.  Our EtcdWatcher
+        (etcdutils) cancels any watch that goes WATCH_TIMEOUT_SECS without
+        delivering an event, so whenever this process stalls past that
+        deadline - e.g. under load - with an event in flight, that discard
+        loses the event.  In the DHCP agent this was observed to lose
+        WorkloadEndpoint deletions, leaving stale dnsmasq instances running.
+
+        Here, instead, cancel() first waits briefly for the reader to drain
+        any bytes already received on the watch socket, then puts the
+        end-of-stream sentinel *behind* whatever the reader has queued.  The
+        events iterator yields everything up to the sentinel, so
+        already-delivered events are processed rather than thrown away.
+        """
+        event_queue = queue.Queue()
+
+        def callback(event):
+            event_queue.put(event)
+
+        watcher = etcd3gw_watch.Watcher(self, key, callback, **kwargs)
+
+        def cancel():
+            # Drain phase: while the watch socket still has unread bytes,
+            # yield so that the reader thread can consume them and queue the
+            # corresponding events.  Bounded, so that a steady inbound flood
+            # cannot postpone cancellation indefinitely.
+            deadline = time.monotonic() + 2
+            while time.monotonic() < deadline:
+                try:
+                    fd = watcher._response.raw._fp.fileno()
+                    pending = array.array("i", [0])
+                    fcntl.ioctl(fd, termios.FIONREAD, pending)
+                except Exception:
+                    # Response or socket already closed, or otherwise
+                    # unreadable; nothing more can be drained.
+                    break
+                if pending[0] == 0:
+                    break
+                eventlet.sleep(0.05)
+
+            # Add the end-of-stream sentinel, behind any queued events; then
+            # stop the reader and close the connection.
+            event_queue.put(None)
+            watcher.stop()
+
+        def iterator():
+            while True:
+                event = event_queue.get()
+                if event is None:
+                    return
+                yield event
+
+        return iterator(), cancel
 
 
 def _get_client():

--- a/networking-calico/networking_calico/etcdv3.py
+++ b/networking-calico/networking_calico/etcdv3.py
@@ -605,10 +605,13 @@ class Etcd3AuthClient(Etcd3Client):
                     break
                 eventlet.sleep(0.05)
 
-            # Add the end-of-stream sentinel, behind any queued events; then
-            # stop the reader and close the connection.
-            event_queue.put(None)
+            # Stop the reader and close the connection; then add the
+            # end-of-stream sentinel behind any queued events.  This order
+            # means that any events that the reader manages to parse and
+            # queue while the connection is being torn down still land ahead
+            # of the sentinel and so are delivered.
             watcher.stop()
+            event_queue.put(None)
 
         def iterator():
             while True:

--- a/networking-calico/networking_calico/tests/test_fv_dhcp_agent.py
+++ b/networking-calico/networking_calico/tests/test_fv_dhcp_agent.py
@@ -1,0 +1,364 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2026 Tigera, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+test_fv_dhcp_agent
+~~~~~~~~~~~~~~~~~~
+
+Tests for the Calico DHCP agent with a real etcd server, focussing on subnet
+CIDR re-use.
+
+When a Neutron network is deleted and another network is then created with the
+same subnet CIDR, the new network's dnsmasq cannot bind its listening socket
+until the old network's dnsmasq has been stopped, because both want to listen
+on the same gateway IP.  The real dnsmasq driver reacts to that bind failure
+by retrying the spawn, inside the driver call, for several minutes; and the
+agent's DnsmasqUpdater processes all driver calls in series on a single
+thread.  So if the start of the new dnsmasq is attempted before the stop of
+the old one, the stop is queued behind a driver call that can only fail, and
+DHCP service is lost for all networks until the driver call times out.  These
+tests reproduce that scenario with a fake driver that models just the
+address-conflict and blocking-retry behaviours.
+"""
+
+from __future__ import print_function
+
+# These are functional-verification tests: they need a real etcd binary on
+# disk and use eventlet's cooperative I/O.  As for test_fv_etcdutils.py, the
+# whole file is opt-in via the CALICO_RUN_FV_TESTS=1 environment variable, so
+# that importing it under the standard tox / subunit unit-test discovery does
+# not monkey-patch that test process.
+import os
+
+_FV_ENABLED = os.environ.get("CALICO_RUN_FV_TESTS") == "1"
+
+import eventlet
+
+if _FV_ENABLED:
+    eventlet.monkey_patch()
+
+import json  # noqa: I100
+import logging
+import shutil
+import socket
+import subprocess
+import time
+import unittest
+
+import mock
+
+from oslo_config import cfg
+
+from networking_calico import datamodel_v2
+from networking_calico import datamodel_v3
+from networking_calico import etcdv3
+from networking_calico.common import config as calico_config
+
+_log = logging.getLogger(__name__)
+
+# The CIDR that both test networks share, and its gateway IP, on which each
+# network's dnsmasq must listen.
+CIDR = "10.65.0.0/24"
+GATEWAY_IP = "10.65.0.1"
+
+
+class FakeDnsmasqFleet(object):
+    """Test double for the DHCP agent's call_driver method.
+
+    This models the two behaviours of the real dnsmasq driver stack that
+    matter for CIDR re-use:
+
+    1. A network's dnsmasq process listens on that network's gateway IP(s),
+       in the root namespace, so only one network with a given gateway IP can
+       have a running dnsmasq at any time.
+
+    2. When the listening address is already in use, an 'enable' or 'restart'
+       driver call does not fail promptly: the driver and process-monitor
+       machinery keeps retrying the spawn, blocking the calling thread, for
+       RETRY_SECS.  (Observed as ~5 minutes for the real driver.)
+    """
+
+    RETRY_SECS = 60
+
+    def __init__(self):
+        # Map from network ID to the set of gateway IPs that that network's
+        # running dnsmasq instance is listening on.
+        self.gateways_by_network = {}
+
+        # Networks for which an enable/restart call is currently blocked,
+        # retrying, because the address is in use.
+        self.blocked_networks = set()
+
+        # Record of (action, network_id) driver calls, for debuggability.
+        self.calls = []
+
+    def running(self, network_id):
+        return network_id in self.gateways_by_network
+
+    def call_driver(self, action, network, **kwargs):
+        _log.info("call_driver: %s %s", action, network.id)
+        self.calls.append((action, network.id))
+        if action == "disable":
+            self.gateways_by_network.pop(network.id, None)
+        elif action in ("enable", "restart"):
+            # A restart stops any existing instance for this network first.
+            self.gateways_by_network.pop(network.id, None)
+            wanted = set(subnet.gateway_ip for subnet in network.subnets)
+            deadline = time.monotonic() + self.RETRY_SECS
+
+            # Retry, blocking this thread, while another network's dnsmasq
+            # holds any of the addresses that we want to listen on.
+            while any(
+                wanted & held
+                for other_id, held in self.gateways_by_network.items()
+                if other_id != network.id
+            ):
+                if time.monotonic() > deadline:
+                    _log.warning("Giving up starting dnsmasq for %s", network.id)
+                    self.blocked_networks.discard(network.id)
+                    return False
+                self.blocked_networks.add(network.id)
+                eventlet.sleep(0.1)
+            self.blocked_networks.discard(network.id)
+            self.gateways_by_network[network.id] = wanted
+        return True
+
+
+@unittest.skipUnless(_FV_ENABLED, "set CALICO_RUN_FV_TESTS=1 to run FV tests")
+class TestFVDhcpAgent(unittest.TestCase):
+    def setUp(self):
+        super(TestFVDhcpAgent, self).setUp()
+        self.etcd_server_running = False
+        self.greenlets = []
+        self.agent = None
+
+        # Track every green thread spawned during the test - including those
+        # spawned internally by CalicoEtcdWatcher.start() - so that tearDown
+        # can kill them all.
+        self._real_spawn = eventlet.spawn
+
+        def tracking_spawn(*args, **kwargs):
+            greenlet = self._real_spawn(*args, **kwargs)
+            self.greenlets.append(greenlet)
+            return greenlet
+
+        self._spawn_patch = mock.patch("eventlet.spawn", new=tracking_spawn)
+        self._spawn_patch.start()
+
+        # The agent code path doesn't need to create real directories here.
+        self._makedirs_patch = mock.patch("os.makedirs")
+        self._makedirs_patch.start()
+
+    def tearDown(self):
+        if self.agent:
+            self.agent.etcd.stop()
+            self.agent.etcd.v1_subnet_watcher.stop()
+            self.agent.etcd.subnet_watcher.stop()
+        for greenlet in reversed(self.greenlets):
+            try:
+                greenlet.kill()
+            except Exception:
+                pass
+        self._makedirs_patch.stop()
+        self._spawn_patch.stop()
+        self.stop_etcd_server()
+        etcdv3._client = None
+        super(TestFVDhcpAgent, self).tearDown()
+
+    # Real etcd server management, as in test_fv_etcdutils.py.
+    def start_etcd_server(self):
+        shutil.rmtree(".default.etcd", ignore_errors=True)
+        shutil.rmtree("default.etcd", ignore_errors=True)
+        self.etcd = subprocess.Popen(
+            [
+                "/usr/local/bin/etcd",
+                "--advertise-client-urls",
+                "http://127.0.0.1:2379",
+                "--listen-client-urls",
+                "http://0.0.0.0:2379",
+                "--log-level",
+                "error",
+            ]
+        )
+        self.etcd_server_running = True
+
+    def wait_etcd_ready(self):
+        self.assertTrue(self.etcd_server_running)
+        ready = False
+        for ii in range(10):
+            try:
+                _log.warning("Try connecting to etcd server...")
+                etcdv3.get_status()
+                ready = True
+                break
+            except Exception:
+                _log.exception("etcd server not ready yet")
+                eventlet.sleep(2)
+        self.assertTrue(ready)
+
+    def stop_etcd_server(self):
+        if self.etcd_server_running:
+            self.etcd.kill()
+            self.etcd.wait()
+        self.etcd_server_running = False
+
+    def start_agent(self):
+        """Create a Calico DHCP agent, with a fake driver, and start it."""
+
+        # Import here so that neutron code is only pulled in when the FV
+        # tests are actually enabled and running.
+        from neutron.agent.dhcp_agent import register_options
+        from neutron_lib import rpc as n_rpc
+        from networking_calico.agent.dhcp_agent import CalicoDhcpAgent
+
+        register_options(cfg.CONF)
+        calico_config.register_options(cfg.CONF)
+
+        # The base neutron DhcpAgent class sets up an RPC client, which
+        # needs a messaging transport to exist, even though the Calico agent
+        # then immediately replaces that client with FakePlugin.
+        if not n_rpc.TRANSPORT:
+            from oslo_messaging import conffixture as messaging_conffixture
+
+            messaging_conf = messaging_conffixture.ConfFixture(cfg.CONF)
+            messaging_conf.setUp()
+            messaging_conf.transport_url = "fake://"
+            self.addCleanup(messaging_conf.cleanUp)
+            n_rpc.init(cfg.CONF)
+            self.addCleanup(n_rpc.cleanup)
+        self.hostname = socket.gethostname()
+        cfg.CONF.host = self.hostname
+        self.region_string = calico_config.get_region_string()
+        self.namespace = datamodel_v3.get_namespace(self.region_string)
+
+        self.agent = CalicoDhcpAgent()
+
+        # Divert all driver calls to the fake dnsmasq fleet.
+        self.fake_fleet = FakeDnsmasqFleet()
+        self.agent.call_driver = self.fake_fleet.call_driver
+
+        # Fake the MTU watcher; its real implementation runs 'ip monitor
+        # link', and an endpoint's dnsmasq update is deferred until the MTU
+        # for its TAP interface is known.
+        self.agent.etcd.mtu_watcher = mock.Mock()
+        self.agent.etcd.mtu_watcher.get_mtu.return_value = 1500
+
+        eventlet.spawn(self.agent.etcd.start)
+
+    def wait_for(self, description, predicate, timeout_secs=10):
+        deadline = time.monotonic() + timeout_secs
+        while time.monotonic() < deadline:
+            if predicate():
+                return
+            eventlet.sleep(0.1)
+        self.fail(
+            "Timed out (%ss) waiting for %s; driver calls were %r"
+            % (timeout_secs, description, self.fake_fleet.calls)
+        )
+
+    # Writing and deleting the etcd data that the mechanism driver would
+    # write for a network's subnet and for a VM port's WorkloadEndpoint.
+    def write_subnet(self, subnet_id, network_id):
+        etcdv3.put(
+            datamodel_v2.key_for_subnet(subnet_id, self.region_string),
+            json.dumps(
+                {
+                    "network_id": network_id,
+                    "cidr": CIDR,
+                    "gateway_ip": GATEWAY_IP,
+                    "host_routes": [],
+                }
+            ),
+        )
+        self.wait_for(
+            "subnet %s to be seen by the agent" % subnet_id,
+            lambda: subnet_id in self.agent.etcd.subnet_watcher.subnets_by_id,
+        )
+
+    def delete_subnet(self, subnet_id):
+        etcdv3.delete(datamodel_v2.key_for_subnet(subnet_id, self.region_string))
+
+    def endpoint_name(self, workload_id, endpoint_id):
+        parts = [self.hostname, "openstack", workload_id, endpoint_id]
+        return "-".join(p.replace("-", "--") for p in parts)
+
+    def write_endpoint(self, workload_id, endpoint_id, network_id, if_name, ip):
+        name = self.endpoint_name(workload_id, endpoint_id)
+        self.assertTrue(
+            datamodel_v3.put(
+                "WorkloadEndpoint",
+                self.namespace,
+                name,
+                {
+                    "orchestrator": "openstack",
+                    "workload": workload_id,
+                    "node": self.hostname,
+                    "endpoint": endpoint_id,
+                    "interfaceName": if_name,
+                    "mac": "fa:16:3e:00:00:01",
+                    "ipNetworks": ["%s/32" % ip],
+                    "allowedIps": [],
+                },
+                annotations={datamodel_v3.ANN_KEY_NETWORK_ID: network_id},
+            )
+        )
+        return name
+
+    def delete_endpoint(self, name):
+        self.assertTrue(datamodel_v3.delete("WorkloadEndpoint", self.namespace, name))
+
+    def test_cidr_reuse(self):
+        # Start a real local etcd server, and an agent against it.
+        self.start_etcd_server()
+        calico_config.register_options(cfg.CONF)
+        self.wait_etcd_ready()
+        self.start_agent()
+
+        # Create network A: one subnet and one VM port.  Its dnsmasq should
+        # start, listening on the gateway IP.
+        self.write_subnet("subnet-a", "net-a")
+        endpoint_a = self.write_endpoint(
+            "vm-a", "port-a", "net-a", "tapa", "10.65.0.10"
+        )
+        self.wait_for(
+            "dnsmasq for net-a to start",
+            lambda: self.fake_fleet.running("net-a"),
+        )
+
+        # Create network B, re-using the same CIDR, before the agent has any
+        # reason to stop network A's dnsmasq.  The driver call to start
+        # network B's dnsmasq cannot succeed yet - the gateway IP is still
+        # held - and blocks, retrying.
+        self.write_subnet("subnet-b", "net-b")
+        self.write_endpoint("vm-b", "port-b", "net-b", "tapb", "10.65.0.20")
+        self.wait_for(
+            "dnsmasq start for net-b to be attempted and blocked",
+            lambda: "net-b" in self.fake_fleet.blocked_networks,
+        )
+
+        # Now delete network A's port and subnet, as when the VM and then the
+        # network are deleted in Neutron.  The agent should promptly stop
+        # network A's dnsmasq, whereupon network B's dnsmasq can come up.
+        self.delete_endpoint(endpoint_a)
+        self.delete_subnet("subnet-a")
+        self.wait_for(
+            "dnsmasq for net-a to be stopped",
+            lambda: not self.fake_fleet.running("net-a"),
+            timeout_secs=15,
+        )
+        self.wait_for(
+            "dnsmasq for net-b to start",
+            lambda: self.fake_fleet.running("net-b"),
+            timeout_secs=15,
+        )

--- a/networking-calico/networking_calico/tests/test_fv_etcdutils.py
+++ b/networking-calico/networking_calico/tests/test_fv_etcdutils.py
@@ -273,7 +273,7 @@ class TestFVEtcdutils(unittest.TestCase):
         # the deadline.  (The delete must come from another process, since
         # this process is stalled.)
         eventlet.sleep(8)
-        subprocess.Popen(
+        curl = subprocess.Popen(
             [
                 "curl",
                 "-s",
@@ -287,6 +287,7 @@ class TestFVEtcdutils(unittest.TestCase):
             ]
         )
         eventlet.patcher.original("time").sleep(3.5)
+        curl.wait(timeout=10)
 
         # The delete event arrived during the stall, and the watch is now
         # being cancelled for inactivity; the cancellation must deliver the

--- a/networking-calico/networking_calico/tests/test_fv_etcdutils.py
+++ b/networking-calico/networking_calico/tests/test_fv_etcdutils.py
@@ -45,9 +45,11 @@ import eventlet
 if _FV_ENABLED:
     eventlet.monkey_patch()
 
-import logging  # noqa: I100
+import base64  # noqa: I100
+import logging
 import shutil
 import subprocess
+import time
 import unittest
 
 from oslo_config import cfg
@@ -226,4 +228,70 @@ class TestFVEtcdutils(unittest.TestCase):
         )
 
         # Kill the etcd server.
+        self.stop_etcd_server()
+
+    def wait_for(self, description, predicate, timeout_secs=5):
+        deadline = time.monotonic() + timeout_secs
+        while time.monotonic() < deadline:
+            if predicate():
+                return
+            eventlet.sleep(0.05)
+        self.fail("Timed out (%ss) waiting for %s" % (timeout_secs, description))
+
+    def test_event_during_stall_survives_watch_cancel(self):
+        # Regression test for watch event loss at cancellation, found when
+        # investigating why the DHCP agent missed WorkloadEndpoint deletions
+        # in CI.  An event that arrives while this process
+        # is stalled - such that EtcdWatcher's WATCH_TIMEOUT_SECS inactivity
+        # deadline expires during the same stall - used to be discarded:
+        # after the stall, eventlet runs the canceller's timer before the
+        # event's consumer, and etcd3gw's watch cancellation threw away
+        # everything already received but not yet consumed.  With
+        # drain-then-cancel semantics (Etcd3AuthClient.watch) the event must
+        # still be delivered.
+        self.start_etcd_server()
+        calico_config.register_options(cfg.CONF)
+        self.wait_etcd_ready()
+
+        events = []
+        ew = etcdutils.EtcdWatcher("/drain-test")
+        ew.register_path(
+            "/drain-test/<key>",
+            on_set=lambda response, key: events.append(("set", key)),
+            on_del=lambda response, key: events.append(("del", key)),
+        )
+        eventlet.spawn(ew.start)
+        eventlet.sleep(1)
+
+        # Write a key and wait for the event; this also resets the watch's
+        # inactivity deadline to WATCH_TIMEOUT_SECS from now.
+        etcdv3.put("/drain-test/k1", "v")
+        self.wait_for("set event", lambda: ("set", "k1") in events)
+
+        # Wait until just before that deadline, then delete the key from a
+        # separate process while stalling this process's eventlet hub across
+        # the deadline.  (The delete must come from another process, since
+        # this process is stalled.)
+        eventlet.sleep(8)
+        subprocess.Popen(
+            [
+                "curl",
+                "-s",
+                "-o",
+                "/dev/null",
+                "http://127.0.0.1:2379/v3/kv/deleterange",
+                "-X",
+                "POST",
+                "-d",
+                '{"key": "%s"}' % base64.b64encode(b"/drain-test/k1").decode(),
+            ]
+        )
+        eventlet.patcher.original("time").sleep(3.5)
+
+        # The delete event arrived during the stall, and the watch is now
+        # being cancelled for inactivity; the cancellation must deliver the
+        # event rather than throw it away.
+        self.wait_for("del event", lambda: ("del", "k1") in events)
+
+        ew.stop()
         self.stop_etcd_server()

--- a/networking-calico/tox.ini
+++ b/networking-calico/tox.ini
@@ -36,6 +36,7 @@ setenv =
    CALICO_RUN_FV_TESTS=1
 commands =
    python -m unittest -v networking_calico.tests.test_fv_etcdutils
+   python -m unittest -v networking_calico.tests.test_fv_dhcp_agent
 
 [testenv:cover]
 commands = python setup.py test --coverage --coverage-package-name=networking_calico --testr-args='{posargs}'


### PR DESCRIPTION
When an OpenStack network is deleted and another network is then created re-using the same subnet CIDR, the Calico DHCP agent could fail to provide DHCP service — in the worst case losing DHCP updates for **all** networks on the host for ~5 minutes.  Both networks' dnsmasq instances need to listen on the same gateway IP, so the new network's dnsmasq cannot start until the old network's dnsmasq has been stopped.  Tracked internally as CORE-11891; previously worked around in CI by commits a2815789 and 40ef33ec.

Two independent bugs combined to cause this, and this PR fixes both (one commit each), then reverts the CI workarounds so that the DevStack QoS tests exercise CIDR re-use again (third commit):

1. **etcd watch events were silently discarded at watch cancellation.**  `EtcdWatcher` cancels any watch that is quiet for 10s and re-snapshots; etcd3gw's cancellation throws away events already received but not yet consumed.  Whenever the agent stalled past the deadline with an event in flight (eventlet runs the canceller's timer before the event's consumer), that event was lost — observed in CI logs as lost WorkloadEndpoint deletions, i.e. stale dnsmasq instances, with recovery deferred to the next 10s snapshot and the delete/create ordering collapsed into one reconciliation batch.  Fixed with drain-then-cancel semantics in `Etcd3AuthClient.watch()`: cancellation now delivers everything already received before ending the event stream.

2. **A blocked dnsmasq start wedged all dnsmasq management.**  `DnsmasqUpdater` processed all networks serially on one thread, in arbitrary set order.  If the new network's dnsmasq start was attempted while the old network's dnsmasq still held the listen address, the driver call blocked (retrying the spawn) for ~5 minutes, with the old network's stop — the very thing that would unblock it — queued behind it.  Fixed by dispatching updates to per-network workers (serialized and coalesced per network, bounded overall concurrency).  Two adjacent bugs fixed with it: a failed driver call was recorded as success and so never retried; and a stale queue entry for a network already removed from the cache crashed `really_update_dnsmasq` with `AttributeError` instead of stopping that network's dnsmasq.

Testing:

- New FV test `test_fv_dhcp_agent.py` runs the real agent and watchers against a real etcd, with a fake dnsmasq driver modelling the address-conflict and blocking-retry behaviour, and reproduces the wedge deterministically: it fails (wedged) without commit 2 and passes in ~5s with it.
- New FV test in `test_fv_etcdutils.py` reproduces the watch event loss deterministically by stalling the eventlet hub across the inactivity deadline while a delete event arrives: it fails without commit 1 and passes with it.
- Full `tox -e fv` and unit suites pass; black and flake8 clean.
- With the third commit, the DevStack CI QoS responsiveness tests re-use one CIDR across sequentially created networks (and collide with the Tempest test's CIDR), so CI now directly exercises the fixed behaviour.

**Release note:**
```release-note
Fixed OpenStack DHCP agent handling of subnet CIDR re-use.  Previously, when a network was deleted and a new network was created re-using the same subnet CIDR, the new network's VMs could fail to get DHCP responses, and DHCP updates for other networks on the same host could be delayed by several minutes.  Also fixed the underlying etcd watch issue, which could delay the DHCP agent's response to any port or subnet change by around 10 seconds.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
