### PR TITLE
OpenStack: reconcile DHCP agent subnet store against snapshots

### DIFF
--- a/networking-calico/networking_calico/agent/dhcp_agent.py
+++ b/networking-calico/networking_calico/agent/dhcp_agent.py
@@ -797,6 +797,13 @@ class SubnetWatcher(etcdutils.EtcdWatcher):
     def on_subnet_set(self, response, subnet_id):
         """Handler for subnet creations and updates."""
         LOG.debug("Subnet %s created or updated", subnet_id)
+
+        # This subnet's key is present, so snapshot reconciliation must not
+        # discard it - even if its data turns out to be invalid, in which
+        # case we hold on to any previously cached data for it, just as for
+        # an invalid update event on an established watch.
+        self._possibly_stale_subnet_ids.discard(subnet_id)
+
         subnet_data = etcdutils.safe_decode_json(response.value, "subnet")
 
         if subnet_data is None:
@@ -812,7 +819,6 @@ class SubnetWatcher(etcdutils.EtcdWatcher):
             return
 
         self.subnets_by_id[subnet_id] = subnet_data
-        self._possibly_stale_subnet_ids.discard(subnet_id)
         return
 
     def on_subnet_del(self, response, subnet_id):

--- a/networking-calico/networking_calico/agent/dhcp_agent.py
+++ b/networking-calico/networking_calico/agent/dhcp_agent.py
@@ -389,11 +389,12 @@ class CalicoEtcdWatcher(etcdutils.EtcdWatcher):
         # Create MTU watcher.
         self.mtu_watcher = MTUWatcher(agent, self)
 
-        # Also watch the etcd subnet trees: both the new region-aware
-        # one, and the old pre-region one, so as to support a VM
-        # renewing its DHCP lease while an upgrade is still in
-        # progress.  When something in that subtree changes, the
-        # subnet watcher will tell _this_ watcher to resync.
+        # Also watch the etcd subnet trees: both the new region-aware one,
+        # and the old pre-region one, so as to support a VM renewing its DHCP
+        # lease while an upgrade is still in progress.  The subnet watchers
+        # just maintain a store of subnet data (CIDR, gateway, DNS and so
+        # on), which the endpoint processing in _this_ watcher consults; a
+        # subnet change on its own does not trigger any dnsmasq update.
         self.v1_subnet_watcher = SubnetWatcher(self, datamodel_v1.SUBNET_DIR)
         self.subnet_watcher = SubnetWatcher(
             self, datamodel_v2.subnet_dir(self.region_string)
@@ -754,6 +755,28 @@ class SubnetWatcher(etcdutils.EtcdWatcher):
         )
         self.subnets_by_id = {}
 
+        # While a snapshot is being processed, the IDs of the subnets that we
+        # knew about before the snapshot began, minus those that the snapshot
+        # has (re)reported so far; see _pre_snapshot_hook.
+        self._possibly_stale_subnet_ids = set()
+
+    def _pre_snapshot_hook(self):
+        # Deletion events can be missed - for example when the deletion falls
+        # between one watch being cancelled and the next being created - so
+        # reconcile against each snapshot: note all the subnet IDs that we
+        # currently know about; on_subnet_set removes each ID that the
+        # snapshot reports, and _post_snapshot_hook then discards the
+        # leftovers, i.e. the subnets that no longer exist.  subnets_by_id
+        # itself continues to serve lookups throughout.
+        self._possibly_stale_subnet_ids = set(self.subnets_by_id.keys())
+        return None
+
+    def _post_snapshot_hook(self, _):
+        for subnet_id in self._possibly_stale_subnet_ids:
+            LOG.info("Subnet %s no longer exists; discarding", subnet_id)
+            self.subnets_by_id.pop(subnet_id, None)
+        self._possibly_stale_subnet_ids = set()
+
     def start(self):
         # Catch and report any exceptions that escape here.
         try:
@@ -789,13 +812,14 @@ class SubnetWatcher(etcdutils.EtcdWatcher):
             return
 
         self.subnets_by_id[subnet_id] = subnet_data
+        self._possibly_stale_subnet_ids.discard(subnet_id)
         return
 
     def on_subnet_del(self, response, subnet_id):
         """Handler for subnet deletions."""
         LOG.info("Subnet %s deleted", subnet_id)
-        if subnet_id in self.subnets_by_id:
-            del self.subnets_by_id[subnet_id]
+        self.subnets_by_id.pop(subnet_id, None)
+        self._possibly_stale_subnet_ids.discard(subnet_id)
         return
 
     def get_subnet_id_for_addr(self, ip_str, network_id):

--- a/networking-calico/networking_calico/tests/test_subnet_watcher.py
+++ b/networking-calico/networking_calico/tests/test_subnet_watcher.py
@@ -87,6 +87,16 @@ class TestSubnetWatcher(base.BaseTestCase):
         sw._post_snapshot_hook(snapshot_data)
         self.assertEqual({"subnet-b", "subnet-c"}, set(sw.subnets_by_id.keys()))
 
+        # A subnet whose key a snapshot reports with invalid data must not be
+        # discarded either: its previously cached data is retained, just as
+        # for an invalid update event on an established watch.
+        snapshot_data = sw._pre_snapshot_hook()
+        sw.on_subnet_set(EtcdResponse(value="not json"), "subnet-b")
+        set_subnet("subnet-c")
+        sw._post_snapshot_hook(snapshot_data)
+        self.assertEqual({"subnet-b", "subnet-c"}, set(sw.subnets_by_id.keys()))
+        self.assertEqual("10.65.0.1", sw.subnets_by_id["subnet-b"]["gateway_ip"])
+
         # An ordinary deletion event still works, whether or not the subnet
         # is known.
         sw.on_subnet_del(None, "subnet-b")

--- a/networking-calico/networking_calico/tests/test_subnet_watcher.py
+++ b/networking-calico/networking_calico/tests/test_subnet_watcher.py
@@ -12,7 +12,9 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+import json
 import logging
+from collections import namedtuple
 
 from etcd3gw.exceptions import Etcd3Exception
 
@@ -25,6 +27,8 @@ from networking_calico.etcdutils import EtcdWatcher
 
 
 LOG = logging.getLogger(__name__)
+
+EtcdResponse = namedtuple("EtcdResponse", ["value"])
 
 
 class TestSubnetWatcher(base.BaseTestCase):
@@ -49,3 +53,42 @@ class TestSubnetWatcher(base.BaseTestCase):
                 "Etcd3Exception in SubnetWatcher.start():\n%s",
                 "from test_exception_detail",
             )
+
+    def test_snapshot_reconciliation(self):
+        # Deletion events can be missed, so SubnetWatcher must discard any
+        # subnet that a snapshot no longer reports.
+        sw = SubnetWatcher(mock.Mock(), "/calico/dhcp/v2/no-region/subnet")
+
+        def set_subnet(subnet_id):
+            sw.on_subnet_set(
+                EtcdResponse(
+                    value=json.dumps(
+                        {
+                            "network_id": "net-1",
+                            "cidr": "10.65.0.0/24",
+                            "gateway_ip": "10.65.0.1",
+                        }
+                    )
+                ),
+                subnet_id,
+            )
+
+        # Learn two subnets from watch events.
+        set_subnet("subnet-a")
+        set_subnet("subnet-b")
+        self.assertEqual({"subnet-a", "subnet-b"}, set(sw.subnets_by_id.keys()))
+
+        # Process a snapshot that reports subnet-b again, plus a new
+        # subnet-c, but not subnet-a - as when subnet-a's deletion event was
+        # missed.  subnet-a must be discarded; the others must survive.
+        snapshot_data = sw._pre_snapshot_hook()
+        set_subnet("subnet-b")
+        set_subnet("subnet-c")
+        sw._post_snapshot_hook(snapshot_data)
+        self.assertEqual({"subnet-b", "subnet-c"}, set(sw.subnets_by_id.keys()))
+
+        # An ordinary deletion event still works, whether or not the subnet
+        # is known.
+        sw.on_subnet_del(None, "subnet-b")
+        sw.on_subnet_del(None, "subnet-never-seen")
+        self.assertEqual({"subnet-c"}, set(sw.subnets_by_id.keys()))


### PR DESCRIPTION
The DHCP agent's `SubnetWatcher` maintained its subnet data store purely from watch events: sets added entries and deletes removed them, with no reconciliation when the watch loop takes a fresh snapshot.  Subnet deletion events can be missed — for example when the deletion falls between one watch being cancelled and the next being created — and a missed deletion left a stale entry in the store forever.  Mostly harmless, because lookups are keyed by exact subnet ID or filtered by network ID, but with a real hazard: if a subnet is deleted and another subnet with an overlapping CIDR is created in the same network, `get_subnet_id_for_addr()` can match the stale entry and serve outdated gateway/DNS data indefinitely.

Found by code reading during the CORE-11891 investigation (see #13364, which fixes the related endpoint-side problems; the two PRs are independent and touch disjoint code).

The fix reconciles the store against each snapshot, as the endpoint watcher already does for its caches: note the known subnet IDs when a snapshot begins, tick each off as the snapshot reports it, and discard the leftovers when it ends.  The store continues to serve lookups throughout, and a subnet newly created mid-snapshot is unaffected.

Also corrects a comment in `CalicoEtcdWatcher.__init__` which claimed that subnet changes trigger an endpoint watcher resync; they do not, and never have in the etcdv3 implementation.

Testing: new unit test `test_snapshot_reconciliation` covering the missed-delete discard, mid-snapshot subnet creation, and ordinary deletions (including of an unknown subnet).

**Release note:**
```release-note
Fixed a case where the OpenStack DHCP agent could serve stale subnet data (e.g. outdated gateway or DNS options) indefinitely, if a subnet deletion coincided with an etcd watch restart and an overlapping subnet was later created in the same network.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
