### PR TITLE
[v3.32] packaging: use git rev-list --count for postN version suffix

### DIFF
--- a/release/packaging/utils/lib.sh
+++ b/release/packaging/utils/lib.sh
@@ -27,8 +27,11 @@ function git_auto_version {
         return
     fi
     # Get the last tag, and the number of commits since that tag.
+    # Note that we use `git rev-list --count` here, and not `git
+    # cherry`, because `git cherry` skips merge commits and so
+    # understates the count that `git describe` would report.
     last_tag=$(git_last_tag)
-    commits_since=$(git cherry -v "${last_tag}" | wc -l)
+    commits_since=$(git rev-list --count "${last_tag}..HEAD")
 
     # Generate corresponding PEP 440 version number.
     # Note that PEP 440 only allows [N!]N(.N)*[{a|b|rc}N][.postN][.devN]


### PR DESCRIPTION
**Cherry-pick history**
- Pick onto **release-v3.32**: projectcalico/calico#13365

Bug fix for pre-release package versioning.

`git_auto_version` in `release/packaging/utils/lib.sh` computed the number of commits since the last tag with `git cherry -v <tag> | wc -l`.  `git cherry` compares patch IDs and so silently skips merge commits, meaning the `postN` suffix understates the true commit count and diverges from what `git describe` reports.

For example, a recent PPA build ([pr-11008](https://launchpad.net/~project-calico/+archive/ubuntu/pr-11008)) was versioned `3.32.1.post40`, while the Felix binary inside it reported `v3.32.1-65-g5ef8a15aa975` — the missing 25 commits were all merges (21 PR merges on release-v3.32, 3 on the packaging branch, plus GitHub's merge-ref commit).  This caused confusion about which fixes were actually included in the build.

This change switches to `git rev-list --count <tag>..HEAD`, which counts every commit since the tag and so matches `git describe`.

Testing done: sourced the library and ran `git_auto_version` on this branch; it now reports `v3.33.0rc0.post1275`, matching `git describe --tags` output `v3.33.0-0.dev-1275-g3e212ae07a`.

**Version monotonicity, and why this PR is effectively one-way:**

PPA uploads require strictly increasing versions, so it matters that the `postN` number can never decrease across this change.  It can't: for any commit, `git rev-list --count` ≥ the old `git cherry` count (it counts a superset — all commits vs non-merge commits only), and building at any strict descendant adds at least one commit to the count.  So the first post-change build on a branch jumps up (e.g. release-v3.32 would go from post40 to post61+) and every subsequent build increases.  The only way to produce an equal version is to rebuild the exact same commit, which failed identically under the old scheme.  In fact the new scheme is strictly *more* monotonic: under `git cherry`, adding only a merge commit didn't bump the count at all, so a rebuild after such a merge produced the same version and failed to upload.

The flip side is that **reverting this PR is not a realistic option**: a revert would drop the count back to the smaller merge-excluding number, producing versions below what's already published, and uploads would fail until enough commits accumulated to catch up.  If a revert were ever truly needed, the escape hatch is bumping the Debian epoch (the `3:` prefix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

