### PR TITLE
Add chanutil.ReadError helper for error channels

### DIFF
--- a/lib/std/chanutil/chan.go
+++ b/lib/std/chanutil/chan.go
@@ -42,6 +42,18 @@ func Read[E any](ctx context.Context, ch <-chan E) (E, error) {
 	}
 }
 
+// ReadError is Read specialised to error channels. It returns the error read off the channel, or the context error if
+// the context is done. Unlike Read, a closed channel is not an error: a nil error and a close both mean success, so
+// senders may signal success either way.
+func ReadError(ctx context.Context, errCh <-chan error) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case err := <-errCh:
+		return err
+	}
+}
+
 // ReadNonBlocking reads from the given channel in a non-blocking manner. It returns the value read off the channel and
 // true if the read was successful, and an empty value and false otherwise.
 func ReadNonBlocking[E any](ch <-chan E) (E, bool) {

--- a/lib/std/chanutil/chan_test.go
+++ b/lib/std/chanutil/chan_test.go
@@ -54,12 +54,12 @@ func TestChanUtil_ReadError_ContextCancelled(t *testing.T) {
 	ch := make(chan error)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	// Cancel the context immediately to force the context.Cancelled error.
+	// Cancel the context immediately to force the context.Canceled error.
 	cancel()
 
 	err := chanutil.ReadError(ctx, ch)
 	if err == nil {
-		t.Fatal("Expected and error to be returned.")
+		t.Fatal("Expected an error to be returned.")
 	} else if !errors.Is(err, context.Canceled) {
 		t.Fatalf("Expected context canceled error, got '%s'", err)
 	}

--- a/lib/std/chanutil/chan_test.go
+++ b/lib/std/chanutil/chan_test.go
@@ -50,6 +50,84 @@ func TestChanUtil_Read_SuccessfulInPrefilledChan(t *testing.T) {
 	}
 }
 
+func TestChanUtil_ReadError_ContextCancelled(t *testing.T) {
+	ch := make(chan error)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	// Cancel the context immediately to force the context.Cancelled error.
+	cancel()
+
+	err := chanutil.ReadError(ctx, ch)
+	if err == nil {
+		t.Fatal("Expected and error to be returned.")
+	} else if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Expected context canceled error, got '%s'", err)
+	}
+}
+
+// Closing the channel without sending is a valid way to signal success, so it must not be reported as an error.
+func TestChanUtil_ReadError_ChannelClosedIsSuccess(t *testing.T) {
+	ch := make(chan error)
+	close(ch)
+
+	err := chanutil.ReadError(context.Background(), ch)
+	if err != nil {
+		t.Fatalf("Expected error to be nil, got '%s'", err)
+	}
+}
+
+func TestChanUtil_ReadError_ReturnsErrorOffChannel(t *testing.T) {
+	expected := errors.New("foobar")
+
+	ch := make(chan error, 1)
+	ch <- expected
+
+	err := chanutil.ReadError(context.Background(), ch)
+	if !errors.Is(err, expected) {
+		t.Fatalf("Expected error to be '%s', got '%s'", expected, err)
+	}
+}
+
+// Sending an explicit nil is the other valid way to signal success.
+func TestChanUtil_ReadError_ReturnsNilOffChannel(t *testing.T) {
+	ch := make(chan error, 1)
+	ch <- nil
+
+	err := chanutil.ReadError(context.Background(), ch)
+	if err != nil {
+		t.Fatalf("Expected error to be nil, got '%s'", err)
+	}
+}
+
+// A buffered error is still delivered after the sender closes the channel.
+func TestChanUtil_ReadError_ChannelClosedWithBufferedError(t *testing.T) {
+	expected := errors.New("foobar")
+
+	ch := make(chan error, 1)
+	ch <- expected
+	close(ch)
+
+	err := chanutil.ReadError(context.Background(), ch)
+	if !errors.Is(err, expected) {
+		t.Fatalf("Expected error to be '%s', got '%s'", expected, err)
+	}
+}
+
+func TestChanUtil_ReadError_BlocksUntilWrite(t *testing.T) {
+	expected := errors.New("foobar")
+
+	ch := make(chan error)
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		ch <- expected
+	}()
+
+	err := chanutil.ReadError(context.Background(), ch)
+	if !errors.Is(err, expected) {
+		t.Fatalf("Expected error to be '%s', got '%s'", expected, err)
+	}
+}
+
 func TestChanUtil_ReadWithDeadline_ReturnsDeadlineExceeded(t *testing.T) {
 	ch := make(chan string, 1)
 


### PR DESCRIPTION
Adds `chanutil.ReadError`, a small helper for the common pattern of blocking on an error channel until either an error arrives or the context is done.

It is `Read` specialised to `chan error`, with one deliberate difference: a closed channel is **not** an error. Both a nil error and a close mean success, so a sender can signal completion whichever way is convenient — `errCh <- nil` or just `close(errCh)`. `Read` would return `ErrChannelClosed` for the latter, which would force every caller to special-case it back into success.

Note that `ReadError` has no production callers yet — it is being added ahead of the code that will use it.

**Testing:** unit tests in `lib/std/chanutil/chan_test.go` cover the error, nil-error, closed-channel, buffered-error-then-close, blocking, and cancelled-context paths. `go test ./chanutil/...` passes from `lib/std`.

**Release note:**
```release-note
None
```