### PR TITLE
libcalico-go: cherry-pick the etcdv3 connection check from enterprise

### DIFF
--- a/libcalico-go/lib/backend/etcdv3/etcdv3.go
+++ b/libcalico-go/lib/backend/etcdv3/etcdv3.go
@@ -29,6 +29,7 @@ import (
 	"go.etcd.io/etcd/client/pkg/v3/srv"
 	"go.etcd.io/etcd/client/pkg/v3/transport"
 	clientv3 "go.etcd.io/etcd/client/v3"
+	"google.golang.org/grpc/connectivity"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 
@@ -147,7 +148,51 @@ func NewEtcdV3Client(config *apiconfig.EtcdConfig) (api.Client, error) {
 		return nil, err
 	}
 
+	// clientv3.New() does not connect, so an unreachable endpoint must be caught
+	// here: callers rely on it being reported as an error from this function
+	// rather than surfacing later on an unrelated read.
+	if err := waitForConnection(client, clientTimeout); err != nil {
+		_ = client.Close()
+		return nil, err
+	}
+
 	return &etcdV3Client{etcdClient: client}, nil
+}
+
+// waitForConnection blocks until the client's connection is ready, returning the
+// context error if it does not become ready within timeout.
+//
+// It waits on gRPC connectivity rather than issuing an RPC, so it must not be
+// replaced with a Status()/Sync() call: that would require the configured
+// credentials to be authorized for that operation, turning a locked-down etcd
+// into a start-up failure.
+func waitForConnection(client *clientv3.Client, timeout time.Duration) error {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	conn := client.ActiveConnection()
+	if conn == nil {
+		return errors.New("etcdv3 client has no active connection")
+	}
+
+	// The channel stays idle until it is used, so trigger the connection.
+	conn.Connect()
+
+	for {
+		switch state := conn.GetState(); state {
+		case connectivity.Ready:
+			return nil
+		case connectivity.Shutdown:
+			return errors.New("etcdv3 client connection is shut down")
+		default:
+			// Idle, Connecting or TransientFailure: keep waiting. An unreachable
+			// endpoint cycles between Connecting and TransientFailure until the
+			// timeout fires.
+			if !conn.WaitForStateChange(ctx, state) {
+				return ctx.Err()
+			}
+		}
+	}
 }
 
 // Create an entry in the datastore.  If the entry already exists, this will return


### PR DESCRIPTION
## What

A cherry-pick of the etcd half of tigera/calico-private#12946 (the Kubernetes
v1.37 bump, whose open-source counterpart is #13270). The single hunk here is
line-for-line the enterprise change, less the `grpc.WithBlock()` removal, which
does not apply — open source never passed that option.

## Why it was needed on the enterprise side

etcd's client v3.7.0 builds its gRPC channel with `grpc.NewClient()` rather than
`grpc.DialContext()`. CHANGELOG-3.7, under "Package `clientv3`":

> Make the etcd client creation non-blocking: etcd no longer honors the
> deprecated `grpc.WithBlock` dial option.

and grpc documents the consequence for `NewClient`: *"No I/O is performed."*

The enterprise build passed `grpc.WithBlock()` here, so `clientv3.New()` used to
dial before returning. Picking up etcd 3.7 turned that into a silent no-op and
cost it eager validation, which broke two remote-cluster FVs. `waitForConnection()`
restores the behaviour without depending on `WithBlock`: it blocks up to
`clientTimeout` (10s) for the channel to reach `Ready`, waiting on gRPC
connectivity rather than issuing an RPC, so it does not require the configured
credentials to be authorized for any particular etcd operation — a
`Status()`/`Sync()` probe would turn a locked-down etcd into a start-up failure.

## Why that argument does not carry over

Open source never passed `grpc.WithBlock()` — `git log -S WithBlock --
libcalico-go/lib/backend/etcdv3/etcdv3.go` returns nothing — so nothing regressed
here when etcd 3.7 landed, and `NewEtcdV3Client()` has never validated the
connection. Cherry-picking this **adds** eager validation rather than restoring
it, which is a behaviour change to every etcdv3 consumer and needs to be justified
on those terms rather than as a port. See the discussion below.

Worth noting explicitly, since it is not in the diff: as it stands this fails the
`libcalico-go` FV spec *"should not raise any error while creating client object
with inline Certificate-Key values as parameters"*. The fixtures in
`libcalico-go/test/etcd-ut-certs/` expired in **February 2020**, and that spec has
only ever passed because construction never completed a TLS handshake. With this
change it does, and it fails after 10s. Regenerating them is not included here —
it would only be needed *because* of this change.

## Callers, for reference

- **felix** (`daemon/daemon.go:217`, `:285`) and **typha** (`daemon/daemon.go:216`)
  retry client construction in their config loops — unaffected.
- **apiserver** (`storage/calico/resource.go:127`), **kube-controllers**
  (`kubecontrollers/run.go:312`) and **confd** (`run/run.go:128`) already
  `os.Exit`/`Fatal` on a construction error and detect unreachability one call
  later via `EnsureInitialized`. They would fail one step earlier.
- **calico-node** (`node/pkg/calicoclient.CreateClient()`) `os.Exit(1)`s on a
  construction error at `startup.go:116`, *before* the `WAIT_FOR_DATASTORE` check
  at line 121 — so an unreachable etcd would exit there and the wait loop would
  never run, silently breaking that variable.
- **cni-plugin** (`internal/pkg/utils/utils.go:730`) builds a client on every
  ADD/DEL, so with etcd down an ADD would block in the constructor rather than in
  the first read.

**Release note:**
```release-note
None
```
