### PR TITLE
[release-v3.32] Bump default CNI config cniVersion to 1.0.0

### DIFF
--- a/charts/calico/templates/calico-config.yaml
+++ b/charts/calico/templates/calico-config.yaml
@@ -69,7 +69,7 @@ data:
   cni_network_config: |-
     {
         "name": "canal",
-        "cniVersion": "0.3.1",
+        "cniVersion": "1.0.0",
         "plugins": [
             {
                 "type": "flannel",
@@ -103,7 +103,7 @@ data:
   cni_network_config: |-
     {
       "name": "k8s-pod-network",
-      "cniVersion": "0.3.1",
+      "cniVersion": "1.0.0",
       "plugins": [
         {
           "type": "calico",

--- a/cni-plugin/pkg/install/install_linux.go
+++ b/cni-plugin/pkg/install/install_linux.go
@@ -19,7 +19,7 @@ package install
 func defaultNetConf() string {
 	netconf := `{
   "name": "k8s-pod-network",
-  "cniVersion": "0.3.1",
+  "cniVersion": "1.0.0",
   "plugins": [
     {
       "type": "calico",

--- a/cni-plugin/pkg/install/install_test.go
+++ b/cni-plugin/pkg/install/install_test.go
@@ -24,7 +24,7 @@ import (
 
 var expectedDefaultConfig string = `{
   "name": "k8s-pod-network",
-  "cniVersion": "0.3.1",
+  "cniVersion": "1.0.0",
   "plugins": [
     {
       "type": "calico",

--- a/cni-plugin/pkg/install/install_windows.go
+++ b/cni-plugin/pkg/install/install_windows.go
@@ -31,7 +31,7 @@ import (
 func defaultNetConf() string {
 	netconf := `{
   "name": "Calico",
-  "cniVersion": "0.3.1",
+  "cniVersion": "1.0.0",
   "plugins": [
     {
       "type": "calico",

--- a/manifests/calico-bpf.yaml
+++ b/manifests/calico-bpf.yaml
@@ -64,7 +64,7 @@ data:
   cni_network_config: |-
     {
       "name": "k8s-pod-network",
-      "cniVersion": "0.3.1",
+      "cniVersion": "1.0.0",
       "plugins": [
         {
           "type": "calico",

--- a/manifests/calico-etcd.yaml
+++ b/manifests/calico-etcd.yaml
@@ -85,7 +85,7 @@ data:
   cni_network_config: |-
     {
       "name": "k8s-pod-network",
-      "cniVersion": "0.3.1",
+      "cniVersion": "1.0.0",
       "plugins": [
         {
           "type": "calico",

--- a/manifests/calico-policy-only.yaml
+++ b/manifests/calico-policy-only.yaml
@@ -73,7 +73,7 @@ data:
   cni_network_config: |-
     {
       "name": "k8s-pod-network",
-      "cniVersion": "0.3.1",
+      "cniVersion": "1.0.0",
       "plugins": [
         {
           "type": "calico",

--- a/manifests/calico-typha.yaml
+++ b/manifests/calico-typha.yaml
@@ -75,7 +75,7 @@ data:
   cni_network_config: |-
     {
       "name": "k8s-pod-network",
-      "cniVersion": "0.3.1",
+      "cniVersion": "1.0.0",
       "plugins": [
         {
           "type": "calico",

--- a/manifests/calico-v3-crds.yaml
+++ b/manifests/calico-v3-crds.yaml
@@ -66,7 +66,7 @@ data:
   cni_network_config: |-
     {
       "name": "k8s-pod-network",
-      "cniVersion": "0.3.1",
+      "cniVersion": "1.0.0",
       "plugins": [
         {
           "type": "calico",

--- a/manifests/calico-vxlan.yaml
+++ b/manifests/calico-vxlan.yaml
@@ -59,7 +59,7 @@ data:
   cni_network_config: |-
     {
       "name": "k8s-pod-network",
-      "cniVersion": "0.3.1",
+      "cniVersion": "1.0.0",
       "plugins": [
         {
           "type": "calico",

--- a/manifests/calico.yaml
+++ b/manifests/calico.yaml
@@ -59,7 +59,7 @@ data:
   cni_network_config: |-
     {
       "name": "k8s-pod-network",
-      "cniVersion": "0.3.1",
+      "cniVersion": "1.0.0",
       "plugins": [
         {
           "type": "calico",

--- a/manifests/canal-etcd.yaml
+++ b/manifests/canal-etcd.yaml
@@ -92,7 +92,7 @@ data:
   cni_network_config: |-
     {
         "name": "canal",
-        "cniVersion": "0.3.1",
+        "cniVersion": "1.0.0",
         "plugins": [
             {
                 "type": "flannel",

--- a/manifests/canal.yaml
+++ b/manifests/canal.yaml
@@ -66,7 +66,7 @@ data:
   cni_network_config: |-
     {
       "name": "k8s-pod-network",
-      "cniVersion": "0.3.1",
+      "cniVersion": "1.0.0",
       "plugins": [
         {
           "type": "calico",

--- a/manifests/flannel-migration/calico.yaml
+++ b/manifests/flannel-migration/calico.yaml
@@ -59,7 +59,7 @@ data:
   cni_network_config: |-
     {
       "name": "k8s-pod-network",
-      "cniVersion": "0.3.1",
+      "cniVersion": "1.0.0",
       "plugins": [
         {
           "type": "calico",

--- a/node/windows-packaging/CalicoWindows/cni.conf.template
+++ b/node/windows-packaging/CalicoWindows/cni.conf.template
@@ -2,7 +2,7 @@
   "name": "Calico",
   "windows_use_single_network": true,
 
-  "cniVersion": "0.3.1",
+  "cniVersion": "1.0.0",
   "type": "calico",
   "mode": "__MODE__",
 


### PR DESCRIPTION
Cherry-pick of #13352 to release-v3.32 (merge commit f874c4634a). Part of the fix for #12965: multus on OpenShift 4.23+ requires the primary-CNI delegate config at cniVersion >= 0.4.0.

Conflict notes: manifests regenerated from charts on this branch via `make gen-manifests` (clean — no drift).

Safety on a release branch: every supported runtime accepts 1.0.0 configs (containerd >= 1.6 / CRI-O >= 1.24); existing attachments are unaffected on upgrade (the runtime replays each attachment's original cniVersion at DEL); manifest users can pin the old value directly in the calico-config ConfigMap. Validated live on OpenShift 5.0.0-ec.3 (heals the multus crash), GA OpenShift 4.18, and GCP/kubeadm (no regression, portmap/hostPort verified).

Companion operator backports: in progress for the matching operator release branches.

**Release note:**
```release-note
The default CNI configuration now declares cniVersion 1.0.0 (previously 0.3.1), enabling Calico as a multus delegate on OpenShift 4.23+. Requires containerd v1.6+ or CRI-O v1.24+.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)