### PR TITLE
Bump Windows packaging CNI config template to cniVersion 1.0.0

### DIFF
--- a/node/windows-packaging/CalicoWindows/cni.conf.template
+++ b/node/windows-packaging/CalicoWindows/cni.conf.template
@@ -2,7 +2,7 @@
   "name": "Calico",
   "windows_use_single_network": true,
 
-  "cniVersion": "0.3.1",
+  "cniVersion": "1.0.0",
   "type": "calico",
   "mode": "__MODE__",
 


### PR DESCRIPTION
Follow-up to #13352, which bumped the default CNI configuration to `cniVersion: 1.0.0` but missed the Calico-for-Windows packaging template (`node/windows-packaging/CalicoWindows/cni.conf.template`, consumed by `calico.psm1` for manual Windows installs). Flagged by Copilot review on the release-branch cherry-picks (#13378, #13379).

Windows containerd ≥ 1.6 accepts 1.0.0 configs, and the operator's Windows render already declares 1.0.0 (tigera/operator#5090). A repo-wide sweep with no file-extension filter confirms this was the last shipped default still on 0.3.1 (remaining hits are third-party test fixtures and legacy contrib scripts).

**Release note:**
```release-note
The manual Calico for Windows install now generates its CNI configuration with cniVersion 1.0.0, matching the default on Linux.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)