### PR TITLE
Publish the DatastoreMigration CRD to manifests/

### DIFF
--- a/.semaphore/semaphore-scheduled-builds.yml
+++ b/.semaphore/semaphore-scheduled-builds.yml
@@ -347,7 +347,7 @@ blocks:
     run:
       when: >-
         true or
-        change_in(['/api', '/manifests', '/charts', '/libcalico-go/lib/apis', '/libcalico-go/config', '/libcalico-go/Makefile', '/felix/config', '/felix/docs', '/felix/Makefile', '/goldmane', '/Makefile', '/lib.Makefile', '/metadata.mk'], {pipeline_file: 'ignore'})
+        change_in(['/api', '/manifests', '/charts', '/libcalico-go/lib/apis', '/libcalico-go/config', '/libcalico-go/Makefile', '/felix/config', '/felix/docs', '/felix/Makefile', '/goldmane', '/kube-controllers/pkg/controllers/migration', '/Makefile', '/lib.Makefile', '/metadata.mk'], {pipeline_file: 'ignore'})
     dependencies: []
     task:
       jobs:
@@ -358,6 +358,7 @@ blocks:
             - make -C libcalico-go gen-files
             - make -C felix gen-files
             - make -C goldmane gen-files
+            - make -C kube-controllers gen-files
             - make gen-manifests
             - make fix-changed
             - make check-ocp-no-crds

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -347,7 +347,7 @@ blocks:
     run:
       when: >-
         false or
-        change_in(['/api', '/manifests', '/charts', '/libcalico-go/lib/apis', '/libcalico-go/config', '/libcalico-go/Makefile', '/felix/config', '/felix/docs', '/felix/Makefile', '/goldmane', '/Makefile', '/lib.Makefile', '/metadata.mk'], {pipeline_file: 'ignore'})
+        change_in(['/api', '/manifests', '/charts', '/libcalico-go/lib/apis', '/libcalico-go/config', '/libcalico-go/Makefile', '/felix/config', '/felix/docs', '/felix/Makefile', '/goldmane', '/kube-controllers/pkg/controllers/migration', '/Makefile', '/lib.Makefile', '/metadata.mk'], {pipeline_file: 'ignore'})
     dependencies: []
     task:
       jobs:
@@ -358,6 +358,7 @@ blocks:
             - make -C libcalico-go gen-files
             - make -C felix gen-files
             - make -C goldmane gen-files
+            - make -C kube-controllers gen-files
             - make gen-manifests
             - make fix-changed
             - make check-ocp-no-crds

--- a/.semaphore/semaphore.yml.d/blocks/10-prerequisites.yml
+++ b/.semaphore/semaphore.yml.d/blocks/10-prerequisites.yml
@@ -99,7 +99,7 @@
   run:
     when: >-
       ${FORCE_RUN} or
-      change_in(['/api', '/manifests', '/charts', '/libcalico-go/lib/apis', '/libcalico-go/config', '/libcalico-go/Makefile', '/felix/config', '/felix/docs', '/felix/Makefile', '/goldmane', '/Makefile', '/lib.Makefile', '/metadata.mk'], {pipeline_file: 'ignore'})
+      change_in(['/api', '/manifests', '/charts', '/libcalico-go/lib/apis', '/libcalico-go/config', '/libcalico-go/Makefile', '/felix/config', '/felix/docs', '/felix/Makefile', '/goldmane', '/kube-controllers/pkg/controllers/migration', '/Makefile', '/lib.Makefile', '/metadata.mk'], {pipeline_file: 'ignore'})
   dependencies: []
   task:
     jobs:
@@ -110,6 +110,7 @@
           - make -C libcalico-go gen-files
           - make -C felix gen-files
           - make -C goldmane gen-files
+          - make -C kube-controllers gen-files
           - make gen-manifests
           - make fix-changed
           - make check-ocp-no-crds

--- a/manifests/README.md
+++ b/manifests/README.md
@@ -20,7 +20,8 @@ One manifest is generated, but not from `charts/`:
 
 - `migration.projectcalico.org_datastoremigrations.yaml` is copied from
   `kube-controllers/pkg/controllers/migration/crd/`, which is controller-gen output. Edit the Go
-  types there and run `make -C kube-controllers gen-files`, then `make gen-manifests`.
+  types in `kube-controllers/pkg/controllers/migration/api.go` and run
+  `make -C kube-controllers gen-files`, then `make gen-manifests`.
 
   It's not in the charts because it isn't part of a Calico install. The DatastoreMigration API
   drives a one-time migration of stored resources from the v1 CRDs to the v3 CRDs, so a user only

--- a/manifests/README.md
+++ b/manifests/README.md
@@ -22,6 +22,10 @@ One manifest is generated, but not from `charts/`:
   `kube-controllers/pkg/controllers/migration/crd/`, which is controller-gen output. Edit the Go
   types there and run `make -C kube-controllers gen-files`, then `make gen-manifests`.
 
+  It's not in the charts because it isn't part of a Calico install. The DatastoreMigration API
+  drives a one-time migration of stored resources from the v1 CRDs to the v3 CRDs, so a user only
+  installs the CRD if and when they run that migration.
+
 Some of these manifests are not automatically generated. To edit these, modify the manifests directly and
 commit your changes. **The following manifests are not auto generated:**
 

--- a/manifests/README.md
+++ b/manifests/README.md
@@ -16,6 +16,12 @@ To make changes to the auto-generated manifests:
    make gen-manifests
    ```
 
+One manifest is generated, but not from `charts/`:
+
+- `migration.projectcalico.org_datastoremigrations.yaml` is copied from
+  `kube-controllers/pkg/controllers/migration/crd/`, which is controller-gen output. Edit the Go
+  types there and run `make -C kube-controllers gen-files`, then `make gen-manifests`.
+
 Some of these manifests are not automatically generated. To edit these, modify the manifests directly and
 commit your changes. **The following manifests are not auto generated:**
 

--- a/manifests/generate.sh
+++ b/manifests/generate.sh
@@ -109,6 +109,12 @@ done
 # Maintain legacy operator-crds.yaml for a while.
 cp v1_crd_projectcalico_org.yaml operator-crds.yaml
 
+# The DatastoreMigration CRD is installed as its own step in the CRD migration
+# procedure, separately from the v3 CRD bundle, so publish it as a standalone
+# manifest rather than folding it into a chart.
+cp ../kube-controllers/pkg/controllers/migration/crd/migration.projectcalico.org_datastoremigrations.yaml \
+	migration.projectcalico.org_datastoremigrations.yaml
+
 echo "# projectcalico.org/v3 and operator.tigera.io/v1 APIs" > v3_projectcalico_org.yaml
 for FILE in $(ls ../charts/projectcalico.org.v3/templates/*.yaml | xargs -n1 basename); do
 	${HELM} template \

--- a/manifests/generate.sh
+++ b/manifests/generate.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 export LC_ALL=C
 
 # Filter out Helm symlink warnings (walk.go).  The charts/calico directory

--- a/manifests/migration.projectcalico.org_datastoremigrations.yaml
+++ b/manifests/migration.projectcalico.org_datastoremigrations.yaml
@@ -1,0 +1,229 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: datastoremigrations.migration.projectcalico.org
+spec:
+  group: migration.projectcalico.org
+  names:
+    kind: DatastoreMigration
+    listKind: DatastoreMigrationList
+    plural: datastoremigrations
+    singular: datastoremigration
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .status.progress.typeProgress
+      name: Types
+      type: string
+    - jsonPath: .status.message
+      name: Message
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.progress.currentType
+      name: Current Type
+      priority: 1
+      type: string
+    - jsonPath: .status.progress.migrated
+      name: Migrated
+      priority: 1
+      type: integer
+    - jsonPath: .status.progress.skipped
+      name: Skipped
+      priority: 1
+      type: integer
+    - jsonPath: .status.progress.conflicts
+      name: Conflicts
+      priority: 1
+      type: integer
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          DatastoreMigration triggers and tracks the migration of Calico resources
+          from crd.projectcalico.org/v1 CRDs to projectcalico.org/v3 CRDs.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired migration behavior.
+            properties:
+              type:
+                description: Type specifies the migration to perform (e.g., APIServerToCRDs).
+                enum:
+                - APIServerToCRDs
+                type: string
+            required:
+            - type
+            type: object
+          status:
+            description: Status reports the observed state of the migration.
+            properties:
+              completedAt:
+                description: CompletedAt is the timestamp when the migration transitioned
+                  to Complete.
+                format: date-time
+                type: string
+              conditions:
+                description: Conditions report conflicts and errors encountered during
+                  migration.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              message:
+                description: |-
+                  Message is a human-readable status message describing what the controller
+                  is currently doing or waiting on.
+                type: string
+              phase:
+                description: Phase is the current phase of the migration state machine.
+                type: string
+              progress:
+                description: Progress tracks per-type and aggregate migration counters.
+                properties:
+                  completedTypes:
+                    description: CompletedTypes is the number of resource types that
+                      have been fully processed.
+                    type: integer
+                  conflicts:
+                    description: Conflicts is the number of resources that existed
+                      in v3 with different content.
+                    type: integer
+                  currentType:
+                    description: CurrentType is the resource kind currently being
+                      migrated, or empty if done.
+                    type: string
+                  migrated:
+                    description: Migrated is the number of resources successfully
+                      copied to v3.
+                    type: integer
+                  skipped:
+                    description: Skipped is the number of resources that already existed
+                      in v3 with matching content.
+                    type: integer
+                  total:
+                    description: Total is the total number of resources processed
+                      across all types.
+                    type: integer
+                  totalTypes:
+                    description: TotalTypes is the number of resource types to migrate.
+                    type: integer
+                  typeDetails:
+                    description: TypeDetails contains per-resource-type migration
+                      results.
+                    items:
+                      description: TypeMigrationProgress tracks the migration result
+                        for a single resource kind.
+                      properties:
+                        conflicts:
+                          description: Conflicts is the number of resources of this
+                            kind that existed in v3 with different content.
+                          type: integer
+                        kind:
+                          description: Kind is the Calico resource kind (e.g., "NetworkPolicy",
+                            "GlobalNetworkPolicy").
+                          type: string
+                        migrated:
+                          description: Migrated is the number of resources of this
+                            kind successfully copied to v3.
+                          type: integer
+                        skipped:
+                          description: Skipped is the number of resources of this
+                            kind that already existed in v3 with matching content.
+                          type: integer
+                      required:
+                      - kind
+                      type: object
+                    type: array
+                  typeProgress:
+                    description: TypeProgress is a human-readable summary like "5
+                      / 21" for printer columns.
+                    type: string
+                type: object
+              startedAt:
+                description: StartedAt is the timestamp when the migration transitioned
+                  to Migrating.
+                format: date-time
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}


### PR DESCRIPTION
The DatastoreMigration CRD only ever existed inside the kube-controllers source tree, so the migration docs pointed people at a raw path under `kube-controllers/pkg/`. Copies it into `manifests/` during generation so it can be installed the same way as everything else in there, and adds a CI check so the published copy can't drift from the Go types.

Split out from the v1 promotion (https://github.com/projectcalico/calico/pull/13383) so it can be backported to release-v3.32, where the CRD is still v1beta1 and the docs have the same problem.

Related: CORE-12573

```release-note
The DatastoreMigration CRD is now published to the release manifests directory, so it can be installed with `kubectl apply -f .../manifests/migration.projectcalico.org_datastoremigrations.yaml` instead of a path into the source tree.
```
