### PR TITLE
Fix cherry-pick-pull conflict detection to catch delete/update conflicts

### DIFF
--- a/hack/cherry-pick-pull
+++ b/hack/cherry-pick-pull
@@ -360,15 +360,18 @@ function create-branch-and-pr() {
         exit 1
       fi
 
-      # If there are conflicts, prompt user to resolve them in another window and continue
+      # If there are conflicts, prompt user to resolve them in another window and continue.
+      # Unmerged paths show up in `git status --porcelain` with one of the XY codes
+      # DD, AU, UD, UA, DU, AA, UU (see git-status(1)) -- not just entries starting with
+      # "U", which misses e.g. delete/modify conflicts (reported as "DU").
       conflicts=false
-      while unmerged=$(git status --porcelain | grep ^U) && [[ -n ${unmerged} ]] \
+      while unmerged=$(git status --porcelain | grep -E '^(DD|AU|UD|UA|DU|AA|UU) ') && [[ -n ${unmerged} ]] \
         || [[ -e "${REBASEMAGIC}" ]]; do
         conflicts=true # <-- We should have detected conflicts once
         echo
         echo "+++ Conflicts detected:"
         echo
-        (git status --porcelain | grep ^U) || echo "!!! None. Did you '${add_cmd_msg}'?"
+        (git status --porcelain | grep -E '^(DD|AU|UD|UA|DU|AA|UU) ') || echo "!!! None. Did you '${add_cmd_msg}'?"
         echo
         echo "+++ Please resolve the conflicts in another window (and remember to '${add_cmd_msg}')"
         read -p "+++ Proceed (anything but 'y' aborts the cherry-pick)? [y/n] " -r


### PR DESCRIPTION
## Summary

\`hack/cherry-pick-pull\`'s conflict-handling loop only detected unmerged
paths whose \`git status --porcelain\` code starts with \`U\` (\`UU\`,
\`UA\`, \`UD\`). Delete/update conflicts are reported as \`DU\` (or \`AU\`,
\`AA\`, \`DD\` for other conflict shapes), none of which match \`^U\`. So a
cherry-pick that hit a delete/modify conflict never got the "resolve it and
continue" prompt — the script fell through to a misleading "likely an
in-progress git am or rebase" error and exited.

Reproduced with a scratch repo: cherry-picking a commit that modifies a file
which the target branch has deleted produces \`DU <path>\` in
\`git status --porcelain\`, which the old \`grep ^U\` missed and the fixed
\`grep -E '^(DD|AU|UD|UA|DU|AA|UU) '\` catches.

This is an internal release-engineering script (not shipped to Calico users),
so no release note or docs are needed.

## Test plan

- [x] Reproduced the bug in a scratch repo (cherry-pick onto a branch that
      deleted a file the picked commit modifies) and confirmed the old
      pattern found no match while the new pattern catches `DU <path>`.
- [x] `bash -n hack/cherry-pick-pull` passes.

**Release note:**
```release-note
None
```