### PR TITLE
[BPF] never share one NAT service ID between two services

### DIFF
--- a/felix/bpf/proxy/syncer.go
+++ b/felix/bpf/proxy/syncer.go
@@ -344,7 +344,19 @@ func (s *Syncer) startupBuildPrev(state DPSyncerState) error {
 	// the state map as well as the ServicePort values.
 	svcRef := s.svcMapToIPPortProtoMap(state.SvcMap)
 
-	inconsistent := false
+	// A service's ID indexes its own block of the backend map, so two distinct
+	// services must never share one - their backends would overwrite each other
+	// on every sync. Felix is not the only writer of these maps: they are pinned
+	// and outlive calico-node, and the ebpf-bootstrap init container programs the
+	// API server service into them before Felix starts. Adopting IDs therefore
+	// takes two passes, so that a duplicate is known before any ID is taken over.
+	type dpFrontend struct {
+		skey svcKey
+		val  nat.FrontendValue
+	}
+	frontends := make([]dpFrontend, 0, len(svcRef))
+	idOwner := make(map[uint32]k8sp.ServicePortName, len(svcRef))
+	duplicateIDs := make(map[uint32]struct{})
 
 	// Walk the frontend bpf map that was read into memory and match it against the
 	// references build from the state
@@ -363,20 +375,53 @@ func (s *Syncer) startupBuildPrev(state DPSyncerState) error {
 		}
 
 		id := svcv.ID()
-		count := int(svcv.Count())
-		s.prevSvcMap[*svckey] = svcInfo{
-			id:         id,
-			count:      count,
-			localCount: int(svcv.LocalCount()),
-			svc:        state.SvcMap[svckey.sname].(Service),
-		}
 
 		if id >= s.nextSvcID {
 			s.nextSvcID = id + 1
 		}
 
+		// A service shares its ID with all of its own derived (NodePort,
+		// ExternalIP, LoadBalancer) frontends, so only a clash between two
+		// different services is a conflict.
+		if owner, ok := idOwner[id]; ok && owner != svckey.sname {
+			log.WithFields(log.Fields{
+				"id":       id,
+				"service":  svckey.sname,
+				"conflict": owner,
+			}).Warn("Two services share one NAT service ID in the BPF maps, " +
+				"reprogramming both with new IDs.")
+			duplicateIDs[id] = struct{}{}
+		} else {
+			idOwner[id] = svckey.sname
+		}
+
+		frontends = append(frontends, dpFrontend{skey: *svckey, val: svcv})
+	})
+
+	inconsistent := false
+
+	for _, fe := range frontends {
+		svckey := fe.skey
+		id := fe.val.ID()
+
+		if _, dup := duplicateIDs[id]; dup {
+			// Leaving the service out of prevSvcMap makes applySvc give it a
+			// fresh ID and rewrite its frontends and backends. Nothing read
+			// through a duplicated ID is carried over: the backends found there
+			// may well belong to the other service.
+			continue
+		}
+
+		count := int(fe.val.Count())
+		s.prevSvcMap[svckey] = svcInfo{
+			id:         id,
+			count:      count,
+			localCount: int(fe.val.LocalCount()),
+			svc:        state.SvcMap[svckey.sname].(Service),
+		}
+
 		if svckey.extra != "" {
-			return
+			continue
 		}
 
 		if count > 0 {
@@ -394,7 +439,7 @@ func (s *Syncer) startupBuildPrev(state DPSyncerState) error {
 				NewEndpointInfo(ep.Addr().String(), int(ep.Port())),
 			)
 		}
-	})
+	}
 
 	if inconsistent {
 		return fmt.Errorf("found inconsistencies in existing BPF maps, will rewrite maps from scratch")

--- a/felix/bpf/proxy/syncer_test.go
+++ b/felix/bpf/proxy/syncer_test.go
@@ -1471,6 +1471,145 @@ var _ = Describe("BPF Syncer API server NAT preservation", func() {
 	})
 })
 
+// A NAT service ID indexes the service's own block of the backend map, so two
+// services sharing one overwrite each other's backends on every sync. Felix is
+// not the only writer of these maps - they are pinned and outlive calico-node,
+// and in bootstrap mode the ebpf-bootstrap init container programs the API
+// server service into them before Felix starts (node/pkg/nodeinit) - so the
+// syncer must not adopt a duplicated ID from the dataplane. Adopting one makes
+// the conflict permanent: it is re-adopted on every restart.
+// See projectcalico/calico#13279.
+var _ = Describe("BPF Syncer NAT service ID conflicts", func() {
+	var (
+		svcs  *mockNATMap
+		eps   *mockNATBackendMap
+		mgEps *mockMaglevMap
+		aff   *mockAffinityMap
+		rt    *proxy.RTCache
+		s     *proxy.Syncer
+	)
+
+	nodeIPs := []net.IP{net.IPv4(192, 168, 0, 1)}
+
+	apiSvcKey := k8sp.ServicePortName{
+		NamespacedName: types.NamespacedName{Namespace: "default", Name: "kubernetes"},
+	}
+	otherSvcKey := k8sp.ServicePortName{
+		NamespacedName: types.NamespacedName{Namespace: "test", Name: "other"},
+	}
+
+	apiClusterIP := net.IPv4(10, 49, 0, 1)
+	otherClusterIP := net.IPv4(10, 49, 0, 2)
+	apiServerIP := net.IPv4(10, 0, 1, 20)
+	otherBackendIP := net.IPv4(172, 30, 26, 146)
+	const (
+		apiPort       = 443
+		apiTgtPort    = 6443
+		otherPort     = 6789
+		otherNodePort = 30789
+	)
+
+	tcp := proxy.ProtoV1ToIntPanic(v1.ProtocolTCP)
+	apiFrontKey := nat.NewNATKey(apiClusterIP, apiPort, tcp)
+	otherFrontKey := nat.NewNATKey(otherClusterIP, otherPort, tcp)
+	apiBackend := nat.NewNATBackendValue(apiServerIP, apiTgtPort)
+	otherBackend := nat.NewNATBackendValue(otherBackendIP, otherPort)
+
+	// state is the two services as the k8s informers see them, each with one
+	// ready endpoint. otherOpts customises the second service.
+	state := func(otherOpts ...proxy.K8sServicePortOption) proxy.DPSyncerState {
+		other := svc(otherClusterIP.String(), otherPort)
+		other.opts = append(other.opts, otherOpts...)
+
+		return proxy.DPSyncerState{
+			SvcMap: k8sp.ServicePortMap{
+				apiSvcKey:   svc(apiClusterIP.String(), apiPort).build(),
+				otherSvcKey: other.build(),
+			},
+			EpsMap: k8sp.EndpointsMap{
+				apiSvcKey:   {ep(apiServerIP.String(), apiTgtPort).build()},
+				otherSvcKey: {ep(otherBackendIP.String(), otherPort).build()},
+			},
+		}
+	}
+
+	// expectBackends asserts that each frontend resolves to its own service's
+	// backend, which requires the two to hold different service IDs.
+	expectBackends := func() {
+		apiFront, ok := svcs.m[apiFrontKey]
+		ExpectWithOffset(1, ok).To(BeTrue(), "API server NAT frontend missing")
+		otherFront, ok := svcs.m[otherFrontKey]
+		ExpectWithOffset(1, ok).To(BeTrue(), "other service NAT frontend missing")
+
+		ExpectWithOffset(1, apiFront.ID()).NotTo(Equal(otherFront.ID()),
+			"two services must not share a NAT service ID")
+
+		ExpectWithOffset(1, apiFront.Count()).To(Equal(uint32(1)))
+		ExpectWithOffset(1, eps.m[nat.NewNATBackendKey(apiFront.ID(), 0)]).To(Equal(apiBackend))
+		ExpectWithOffset(1, otherFront.Count()).To(Equal(uint32(1)))
+		ExpectWithOffset(1, eps.m[nat.NewNATBackendKey(otherFront.ID(), 0)]).To(Equal(otherBackend))
+	}
+
+	newSyncer := func() *proxy.Syncer {
+		syncer, err := proxy.NewSyncer(4, nodeIPs, svcs, eps, mgEps, aff, rt, nil, maglevLUTSize)
+		Expect(err).NotTo(HaveOccurred())
+		return syncer
+	}
+
+	BeforeEach(func() {
+		svcs = newMockNATMap()
+		eps = newMockNATBackendMap()
+		mgEps = newMockMaglevMap()
+		aff = newMockAffinityMap()
+		rt = proxy.NewRTCache()
+		s = newSyncer()
+	})
+
+	It("reprograms both services when the dataplane has them sharing an ID", func() {
+		By("seeding the maps as a bootstrap write over an ID another service owns")
+		// Both frontends point at the same ID, so only one backend can live at
+		// (id, 0) and one of the services already resolves to the other's.
+		const shared = uint32(0)
+		Expect(svcs.Update(apiFrontKey.AsBytes(),
+			nat.NewNATValue(shared, 1, 0, 0).AsBytes())).NotTo(HaveOccurred())
+		Expect(svcs.Update(otherFrontKey.AsBytes(),
+			nat.NewNATValue(shared, 1, 0, 0).AsBytes())).NotTo(HaveOccurred())
+		Expect(eps.Update(nat.NewNATBackendKey(shared, 0).AsBytes(),
+			apiBackend.AsBytes())).NotTo(HaveOccurred())
+
+		By("syncing: neither service may keep the shared ID")
+		Expect(s.Apply(state())).NotTo(HaveOccurred())
+		expectBackends()
+
+		By("syncing again: the IDs are now clean and must be stable")
+		ids := []uint32{svcs.m[apiFrontKey].ID(), svcs.m[otherFrontKey].ID()}
+		Expect(s.Apply(state())).NotTo(HaveOccurred())
+		expectBackends()
+		Expect([]uint32{svcs.m[apiFrontKey].ID(), svcs.m[otherFrontKey].ID()}).To(Equal(ids))
+	})
+
+	It("keeps the IDs of a service that shares one with its own NodePort", func() {
+		By("programming a service that also has a NodePort")
+		npState := state(proxy.K8sSvcWithNodePort(otherNodePort))
+		Expect(s.Apply(npState)).NotTo(HaveOccurred())
+		expectBackends()
+
+		npFrontKey := nat.NewNATKey(nodeIPs[0], otherNodePort, tcp)
+		Expect(svcs.m).To(HaveKey(npFrontKey))
+		Expect(svcs.m[npFrontKey].ID()).To(Equal(svcs.m[otherFrontKey].ID()),
+			"a NodePort frontend shares the ID of the service it is derived from")
+
+		By("restarting the syncer: a service and its own derived frontends are no conflict")
+		ids := []uint32{svcs.m[apiFrontKey].ID(), svcs.m[otherFrontKey].ID()}
+		s = newSyncer()
+		Expect(s.Apply(npState)).NotTo(HaveOccurred())
+		expectBackends()
+		Expect([]uint32{svcs.m[apiFrontKey].ID(), svcs.m[otherFrontKey].ID()}).To(Equal(ids),
+			"IDs must be adopted from the dataplane, not reassigned")
+	})
+
+})
+
 type mockNATMap struct {
 	mock.DummyMap
 	sync.Mutex

--- a/felix/bpf/proxy/syncer_test.go
+++ b/felix/bpf/proxy/syncer_test.go
@@ -1588,6 +1588,48 @@ var _ = Describe("BPF Syncer NAT service ID conflicts", func() {
 		Expect([]uint32{svcs.m[apiFrontKey].ID(), svcs.m[otherFrontKey].ID()}).To(Equal(ids))
 	})
 
+	It("reprograms both services when their shared ID holds uneven backend counts", func() {
+		// The blocks differ in length, so only ordinal 0 is contested and the
+		// API server keeps its own backends at 1 and 2 - the shape in #13279.
+		apiIPs := []net.IP{apiServerIP, net.IPv4(10, 0, 1, 21), net.IPv4(10, 0, 1, 22)}
+
+		unevenState := state()
+		unevenState.EpsMap[apiSvcKey] = []k8sp.Endpoint{
+			ep(apiIPs[0].String(), apiTgtPort).build(),
+			ep(apiIPs[1].String(), apiTgtPort).build(),
+			ep(apiIPs[2].String(), apiTgtPort).build(),
+		}
+
+		By("seeding a shared ID whose ordinal 0 holds the other service's backend")
+		const shared = uint32(0)
+		Expect(svcs.Update(apiFrontKey.AsBytes(),
+			nat.NewNATValue(shared, 3, 0, 0).AsBytes())).NotTo(HaveOccurred())
+		Expect(svcs.Update(otherFrontKey.AsBytes(),
+			nat.NewNATValue(shared, 1, 0, 0).AsBytes())).NotTo(HaveOccurred())
+		Expect(eps.Update(nat.NewNATBackendKey(shared, 0).AsBytes(),
+			otherBackend.AsBytes())).NotTo(HaveOccurred())
+		for i, ip := range apiIPs[1:] {
+			Expect(eps.Update(nat.NewNATBackendKey(shared, uint32(i+1)).AsBytes(),
+				nat.NewNATBackendValue(ip, apiTgtPort).AsBytes())).NotTo(HaveOccurred())
+		}
+
+		By("syncing: each service gets a block of its own, whole")
+		Expect(s.Apply(unevenState)).NotTo(HaveOccurred())
+
+		apiFront := svcs.m[apiFrontKey]
+		otherFront := svcs.m[otherFrontKey]
+		Expect(apiFront.ID()).NotTo(Equal(otherFront.ID()),
+			"two services must not share a NAT service ID")
+
+		Expect(apiFront.Count()).To(Equal(uint32(3)))
+		for i, ip := range apiIPs {
+			Expect(eps.m[nat.NewNATBackendKey(apiFront.ID(), uint32(i))]).
+				To(Equal(nat.NewNATBackendValue(ip, apiTgtPort)))
+		}
+		Expect(otherFront.Count()).To(Equal(uint32(1)))
+		Expect(eps.m[nat.NewNATBackendKey(otherFront.ID(), 0)]).To(Equal(otherBackend))
+	})
+
 	It("keeps the IDs of a service that shares one with its own NodePort", func() {
 		By("programming a service that also has a NodePort")
 		npState := state(proxy.K8sSvcWithNodePort(otherNodePort))

--- a/felix/design/bpf-services.md
+++ b/felix/design/bpf-services.md
@@ -505,6 +505,40 @@ the BPF program ever runs.
 - Reverse-SNAT map (`cali_v4_srmsg` / `cali_v6_srmsg`) — used by
   the CTLB's `recvmsg` hook to undo destination rewrites.
 
+### Service IDs, and the second writer of these maps
+
+A service ID indexes the service's own block of the backend map, so
+**no two services may hold the same ID** — their backends would sit at
+the same `(id, ordinal)` keys and overwrite each other on every sync,
+leaving one frontend NATing to the other's backends. A service does
+share its ID with all of its *own* derived (NodePort, ExternalIP,
+LoadBalancer) frontends; that is how `applyDerived` points them at one
+block of backends.
+
+IDs are handed out by `newSvcID` and, on restart, re-adopted from the
+maps by `startupBuildPrev`, which pairs each frontend entry with the
+service that must have written it. Re-adoption keeps a restart from
+disrupting traffic, but it means Felix trusts the maps — and Felix is
+not their only writer:
+
+- the maps are pinned, so they outlive both Felix and calico-node;
+- with `bpfNetworkBootstrap` enabled the `ebpf-bootstrap` init
+  container programs the API server service into them on every
+  calico-node start, before Felix runs (`node/pkg/nodeinit`).
+
+So `startupBuildPrev` must **not** adopt an ID it finds shared by two
+different services: adopting it makes the conflict permanent, since
+`applySvc` keeps an unchanged service's ID forever and every later
+restart re-adopts it. Both services are instead left out of
+`prevSvcMap`, which gives each a fresh ID and rewrites its frontends
+and backends; nothing read through a duplicated ID is carried over,
+because those backends may belong to the other service.
+
+The bootstrap writer holds up the other end of the invariant: it
+reuses the ID already recorded for the service it is programming, and
+otherwise picks one no frontend entry uses, rather than assuming an ID
+is free.
+
 ### Semantics it enforces
 
 - Backend selection honours `externalTrafficPolicy=Local`
@@ -565,6 +599,11 @@ correct; a later update with real ready endpoints overwrites it.
   be wrong: a normal service legitimately scaling to zero must clear
   its backends so clients get a connection refusal rather than NAT
   to a dead backend.
+- Anything that writes a service ID — in Felix or in the bootstrap
+  init container — must keep IDs unique across services (above). A
+  change to either writer needs to hold up its end: Felix does not
+  adopt duplicated IDs from the maps, and the bootstrap does not claim
+  an ID that is already in use.
 
 
 

--- a/node/pkg/nodeinit/calico-init_linux.go
+++ b/node/pkg/nodeinit/calico-init_linux.go
@@ -96,14 +96,34 @@ func initBPFNetwork(serviceAddr, endpointAddrs string) (*bpfmap.Maps, error) {
 		return nil, err
 	}
 
-	id := uint32(0)
+	// The NAT maps are pinned and outlive calico-node, so Felix may already have
+	// programmed these services with IDs of its own choosing. Each family gets
+	// the ID that its service already holds there, or one that no other service
+	// uses. Claiming an ID blindly makes two services share a block of the
+	// backend map and overwrite each other - see projectcalico/calico#13279.
+	idIPv4, idIPv6 := uint32(0), uint32(0)
+	if bpfMaps.V4 != nil {
+		idIPv4, err = natServiceID(bpfMaps.V4.FrontendMap, servicesIPPort, true, bpfnat.NewNATKeyIntf)
+		if err != nil {
+			logrus.WithError(err).Error("Failed to pick an IPv4 NAT service ID.")
+			return nil, err
+		}
+	}
+	if bpfMaps.V6 != nil {
+		idIPv6, err = natServiceID(bpfMaps.V6.FrontendMap, servicesIPPort, false, bpfnat.NewNATKeyV6Intf)
+		if err != nil {
+			logrus.WithError(err).Error("Failed to pick an IPv6 NAT service ID.")
+			return nil, err
+		}
+	}
+
 	countIPv4, countIPv6 := 0, 0
 	for _, endpoint := range endpointsIPPort {
 		if endpoint.IsIPv4 {
-			err = updateBackendMap(bpfMaps.V4.BackendMap, bpfnat.NewNATBackendKey, bpfnat.NewNATBackendValueIntf, endpoint, id, uint32(countIPv4))
+			err = updateBackendMap(bpfMaps.V4.BackendMap, bpfnat.NewNATBackendKey, bpfnat.NewNATBackendValueIntf, endpoint, idIPv4, uint32(countIPv4))
 			countIPv4++
 		} else {
-			err = updateBackendMap(bpfMaps.V6.BackendMap, bpfnat.NewNATBackendKeyV6, bpfnat.NewNATBackendValueV6Intf, endpoint, id, uint32(countIPv6))
+			err = updateBackendMap(bpfMaps.V6.BackendMap, bpfnat.NewNATBackendKeyV6, bpfnat.NewNATBackendValueV6Intf, endpoint, idIPv6, uint32(countIPv6))
 			countIPv6++
 		}
 		if err != nil {
@@ -114,9 +134,9 @@ func initBPFNetwork(serviceAddr, endpointAddrs string) (*bpfmap.Maps, error) {
 
 	for _, service := range servicesIPPort {
 		if service.IsIPv4 {
-			err = updateFrontendMap(bpfMaps.V4.FrontendMap, bpfnat.NewNATKeyIntf, bpfnat.NewNATValue, service, id, uint32(countIPv4))
+			err = updateFrontendMap(bpfMaps.V4.FrontendMap, bpfnat.NewNATKeyIntf, bpfnat.NewNATValue, service, idIPv4, uint32(countIPv4))
 		} else {
-			err = updateFrontendMap(bpfMaps.V6.FrontendMap, bpfnat.NewNATKeyV6Intf, bpfnat.NewNATValueV6, service, id, uint32(countIPv6))
+			err = updateFrontendMap(bpfMaps.V6.FrontendMap, bpfnat.NewNATKeyV6Intf, bpfnat.NewNATValueV6, service, idIPv6, uint32(countIPv6))
 		}
 		if err != nil {
 			logrus.WithError(err).Error("Failed to add IP set entry in the frontend map.")
@@ -148,6 +168,55 @@ func updateFrontendMap(frontendMap maps.Map, newNATKeyFn func(net.IP, uint16, ui
 		newNATKeyFn(service.IP, service.Port, uint8(layers.IPProtocolTCP)).AsBytes(),
 		newNATValueFn(id, count, 0, 0).AsBytes(),
 	)
+}
+
+// natServiceID picks the NAT service ID to program the given services of one IP
+// family with. An ID already recorded in the frontend map for one of them is
+// reused, so that repeated runs keep writing into the same block of the backend
+// map. Otherwise it is the lowest ID that no frontend entry uses, because a
+// service ID is what indexes that block: were it shared with another service,
+// the two would overwrite each other's backends on every Felix sync.
+func natServiceID(frontendMap maps.Map, services []IPPort, ipv4 bool,
+	newNATKeyFn func(net.IP, uint16, uint8) bpfnat.FrontendKeyInterface,
+) (uint32, error) {
+	keys := make(map[string]struct{}, len(services))
+	for _, service := range services {
+		if service.IsIPv4 != ipv4 {
+			continue
+		}
+		keys[string(newNATKeyFn(service.IP, service.Port, uint8(layers.IPProtocolTCP)).AsBytes())] = struct{}{}
+	}
+
+	var ours uint32
+	var foundOurs bool
+	inUse := make(map[uint32]struct{})
+
+	err := frontendMap.Iter(func(k, v []byte) maps.IteratorAction {
+		id := bpfnat.FrontendValueFromBytes(v).ID()
+		inUse[id] = struct{}{}
+
+		if _, ok := keys[string(k)]; ok && !foundOurs {
+			ours, foundOurs = id, true
+		}
+
+		return maps.IterNone
+	})
+	if err != nil {
+		return 0, fmt.Errorf("failed to read the NAT frontend map: %w", err)
+	}
+
+	if foundOurs {
+		logrus.Infof("Reusing NAT service ID %d already programmed for the Kubernetes service.", ours)
+		return ours, nil
+	}
+
+	id := uint32(0)
+	for {
+		if _, taken := inUse[id]; !taken {
+			return id, nil
+		}
+		id++
+	}
 }
 
 // parseIPPort parses a string in the format "IP:Port" (IPv4 or IPv6).

--- a/node/pkg/nodeinit/calico-init_test.go
+++ b/node/pkg/nodeinit/calico-init_test.go
@@ -19,6 +19,9 @@ import (
 	"testing"
 
 	. "github.com/onsi/gomega"
+
+	"github.com/projectcalico/calico/felix/bpf/mock"
+	bpfnat "github.com/projectcalico/calico/felix/bpf/nat"
 )
 
 func TestIPPortParsing(t *testing.T) {
@@ -60,5 +63,71 @@ func TestIPPortParsing(t *testing.T) {
 		ipPorts, err := parseCommaSeparatedIPPorts(testCase.addr)
 		Expect(err != nil).To(Equal(testCase.errorExpected))
 		Expect(ipPorts).To(Equal(testCase.expectedIPPorts))
+	}
+}
+
+// The NAT maps are pinned and outlive calico-node, so this container often runs
+// against maps Felix has already programmed. A service ID indexes the service's
+// own block of the backend map, so claiming one that another service holds makes
+// the two overwrite each other's backends. See projectcalico/calico#13279.
+func TestNATServiceID(t *testing.T) {
+	RegisterTestingT(t)
+
+	apiService := IPPort{net.ParseIP("10.96.0.1"), 443, true}
+	tcp := uint8(6)
+
+	type entry struct {
+		service IPPort
+		id      uint32
+	}
+
+	frontend := func(entries []entry) *mock.Map {
+		m := mock.NewMockMap(bpfnat.FrontendMapParameters)
+		for _, e := range entries {
+			key := bpfnat.NewNATKeyIntf(e.service.IP, e.service.Port, tcp)
+			Expect(m.Update(key.AsBytes(), bpfnat.NewNATValue(e.id, 1, 0, 0).AsBytes())).NotTo(HaveOccurred())
+		}
+		return m
+	}
+
+	otherService := IPPort{net.ParseIP("10.96.0.99"), 6789, true}
+	thirdService := IPPort{net.ParseIP("10.96.0.98"), 80, true}
+	v6Service := IPPort{net.ParseIP("2001:db8::1"), 443, false}
+
+	testCases := []struct {
+		name       string
+		entries    []entry
+		expectedID uint32
+	}{
+		{"empty map claims the first ID", nil, 0},
+		{
+			"the service's own ID is reused",
+			[]entry{{apiService, 3}, {otherService, 7}},
+			3,
+		},
+		{
+			"an ID another service holds is never claimed",
+			[]entry{{otherService, 0}},
+			1,
+		},
+		{
+			"the lowest free ID is claimed, not one past the highest",
+			[]entry{{otherService, 0}, {thirdService, 12}},
+			1,
+		},
+		{
+			"a gap in the IDs in use is filled",
+			[]entry{{otherService, 0}, {thirdService, 1}, {IPPort{net.ParseIP("10.96.0.97"), 80, true}, 3}},
+			2,
+		},
+	}
+
+	for _, testCase := range testCases {
+		// The IPv6 service is passed in every time to check it is filtered out
+		// of the IPv4 lookup: the two families have independent ID spaces.
+		id, err := natServiceID(frontend(testCase.entries), []IPPort{apiService, v6Service},
+			true, bpfnat.NewNATKeyIntf)
+		Expect(err).NotTo(HaveOccurred(), testCase.name)
+		Expect(id).To(Equal(testCase.expectedID), testCase.name)
 	}
 }


### PR DESCRIPTION
A service's NAT ID indexes its own block of the backend map, so two services holding the same ID overwrite each other's backends on every sync: one frontend ends up NATing to the other service's backends, and which one wins flips with each `Apply`. In #13279 that showed up as the `default/kubernetes` frontend alternating between the real API server endpoints and an unrelated service's pod on consecutive `nat dump`s, breaking kubelet-to-apiserver connections.

Felix is not the only writer of the NAT maps. They are pinned and outlive calico-node, and with `bpfNetworkBootstrap` enabled the `ebpf-bootstrap` init container programs the API server service into them on every calico-node start, claiming a hardcoded ID 0. On a node whose maps already had ID 0 taken by an unrelated service, that write created two owners of ID 0, and the syncer's startup sync adopted both. Since `applySvc` keeps an unchanged service's ID indefinitely, every later restart re-adopted the conflict, so the corruption survived restarts until the pinned maps were wiped.

Both writers now hold up the invariant:

- `startupBuildPrev` adopts IDs in a second pass, after the whole frontend map has been checked, and leaves both services of a duplicated ID out of `prevSvcMap` so each is reprogrammed with a fresh one. Nothing read through a duplicated ID is carried over, including `prevEpsMap`, because those backends may belong to the other service. A service still shares its ID with its own derived NodePort/ExternalIP/LoadBalancer frontends, which is not a conflict — the check keys on the service name.
- the bootstrap (`node/pkg/nodeinit`) reuses the ID already recorded for the service it is programming, and otherwise takes the lowest ID no frontend entry uses, instead of assuming ID 0 is free. IDs are now picked per address family; they were previously shared across v4 and v6.

`felix/design/bpf-services.md` gains a section on the ID-uniqueness invariant and the two writers, plus a review note that a change to either writer must hold up its end.

One deliberate non-change: seeding `nextSvcID` from *every* dataplane ID rather than only adopted ones was tried and reverted. It breaks the existing `"wrongly recycled svc ID?"` assertion, which encodes tight ID recycling on purpose — a stale frontend must not push `nextSvcID` up permanently. Recycling a stale ID is safe because stale frontends are deleted before backends are written in the same `Apply`. `natServiceID` picks the lowest free ID for the same reason.

Fixes #13279

**Release note:**
```release-note
[BPF] Fix eBPF NAT corruption where the Kubernetes API server service could share a NAT service ID with an unrelated service, causing its frontend to load-balance to the wrong backends and intermittently breaking connections to the API server.
```
