### PR TITLE
[release-v3.32] felix: don't peer-redirect the initial TCP SYN

### DIFF
--- a/felix/bpf-gpl/conntrack.h
+++ b/felix/bpf-gpl/conntrack.h
@@ -20,6 +20,18 @@
 
 // Connection tracking.
 
+/* Is this packet the initial SYN of a TCP connection, as opposed to a SYN-ACK?
+ *
+ * CT_RES_SYN is set by calico_ct_lookup() from the packet's own flags, and only
+ * when the lookup hits, so this answers "SYN on a flow we already track" - which
+ * is what the paths that force policy or withhold the bypass mark care about.
+ */
+static CALI_BPF_INLINE bool is_tcp_syn(struct cali_tc_ctx *ctx)
+{
+	return ctx->state->ip_proto == IPPROTO_TCP &&
+		ct_result_is_syn(ctx->state->ct_result.rc);
+}
+
 #define PSNAT_RETRIES	3
 
 static CALI_BPF_INLINE int psnat_get_port(struct cali_tc_ctx *ctx)

--- a/felix/bpf-gpl/fib_co_re.h
+++ b/felix/bpf-gpl/fib_co_re.h
@@ -35,9 +35,12 @@ static CALI_BPF_INLINE int try_redirect_to_peer(struct cali_tc_ctx *ctx)
 	struct cali_tc_state *state = ctx->state;
 	int rc = 0;
 	bool redirect_peer = GLOBAL_FLAGS & CALI_GLOBALS_REDIRECT_PEER;
+	/* Redirecting a SYN skips the destination's program, and with it the
+	 * policy that tc.c deliberately forces on every SYN. */
 	if (redirect_peer && ct_result_rc(state->ct_result.rc) == CALI_CT_ESTABLISHED_BYPASS &&
 			state->ct_result.ifindex_fwd != CT_INVALID_IFINDEX  &&
-			!(ctx->state->ct_result.flags & CALI_CT_FLAG_SKIP_REDIR_PEER)) {
+			!(ctx->state->ct_result.flags & CALI_CT_FLAG_SKIP_REDIR_PEER) &&
+			!is_tcp_syn(ctx)) {
 		if (CALI_F_L3_DEV) {
 			rc = make_room_for_l2_header(ctx);
 			if (rc < 0) {

--- a/felix/bpf-gpl/tc.c
+++ b/felix/bpf-gpl/tc.c
@@ -457,7 +457,7 @@ static CALI_BPF_INLINE void calico_tc_process_ct_lookup(struct cali_tc_ctx *ctx)
 			goto deny;
 		}
 
-		if (ctx->state->ip_proto == IPPROTO_TCP && ct_result_is_syn(ctx->state->ct_result.rc)) {
+		if (is_tcp_syn(ctx)) {
 			CALI_DEBUG("Forcing policy on SYN");
 			if (ct_result_rc(ctx->state->ct_result.rc) == CALI_CT_ESTABLISHED_DNAT) {
 				/* Set DNAT info for policy */
@@ -1384,7 +1384,7 @@ int calico_tc_skb_accepted_entrypoint(struct __sk_buff *skb)
 	}
 
 	// Set Istio DSCP mark, if traffic originates from a workload that's part of the mesh.
-	if (CALI_F_TO_WEP && ISTIO_DSCP >= 0 && ctx->state->ip_proto == IPPROTO_TCP && ct_result_is_syn(ctx->state->ct_result.rc)) {
+	if (CALI_F_TO_WEP && ISTIO_DSCP >= 0 && is_tcp_syn(ctx)) {
 		ipv46_addr_t src_ip = ctx->state->ip_src;
 		struct ip_set_key sip = {0};
 #ifdef IPVER6
@@ -1795,7 +1795,7 @@ static CALI_BPF_INLINE void calico_tc_skb_accepted(struct cali_tc_ctx *ctx)
 		goto do_post_nat;
 
 	case CALI_CT_ESTABLISHED_BYPASS:
-		if (!ct_result_is_syn(state->ct_result.rc)) {
+		if (!is_tcp_syn(ctx)) {
 			seen_mark = CALI_SKB_MARK_BYPASS;
 			CALI_DEBUG("marking CALI_SKB_MARK_BYPASS");
 		}

--- a/felix/bpf/ut/bpf_prog_test.go
+++ b/felix/bpf/ut/bpf_prog_test.go
@@ -861,6 +861,10 @@ func objLoad(fname, bpfFsDir, ipFamily string, topts testOpts, polProg, hasHostC
 					globals.Flags |= libbpf.GlobalsWorkloadSrcSpoofingConfigured
 				}
 
+				if topts.redirectPeer {
+					globals.Flags |= libbpf.GlobalsRedirectPeer
+				}
+
 				globals.DSCP = -1
 				if topts.dscp >= 0 {
 					globals.DSCP = topts.dscp
@@ -1246,6 +1250,7 @@ type testOpts struct {
 	istioDSCP                     int8
 	workloadSrcSpoofingConfigured bool
 	wgPort                        uint16
+	redirectPeer                  bool
 }
 
 type testOption func(opts *testOpts)
@@ -1352,6 +1357,12 @@ func withIstioDSCP(value uint8) testOption {
 func withWgPort(port uint16) testOption {
 	return func(o *testOpts) {
 		o.wgPort = port
+	}
+}
+
+func withRedirectPeer() testOption {
+	return func(o *testOpts) {
+		o.redirectPeer = true
 	}
 }
 

--- a/felix/bpf/ut/redirect_peer_test.go
+++ b/felix/bpf/ut/redirect_peer_test.go
@@ -1,0 +1,237 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ut_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/projectcalico/calico/felix/bpf/conntrack"
+	"github.com/projectcalico/calico/felix/bpf/counters"
+	"github.com/projectcalico/calico/felix/bpf/hook"
+	"github.com/projectcalico/calico/felix/bpf/routes"
+	tcdefs "github.com/projectcalico/calico/felix/bpf/tc/defs"
+)
+
+const (
+	redirPeerProtoTCP = 6
+	redirPeerSrcPort  = 54321
+	redirPeerDstPort  = 7890
+	// The harness runs every program as if attached to ifindex 1, and keys the
+	// route and counter maps on it.
+	redirPeerIfindex = 1
+)
+
+// bpf_redirect_peer hands the packet straight into the destination's network
+// namespace, so the destination endpoint's program - and therefore its policy -
+// never runs. That is only sound while ESTABLISHED_BYPASS really means "both
+// endpoints approved their own leg".
+//
+// A host-endpoint program breaks that assumption. When it updates an entry for
+// a packet that is already marked as seen it approves the leg facing away from
+// the host, because it expects the endpoint on that side to be off-node. A
+// packet on its way to a local workload can still reach a host endpoint: the
+// destination's route is programmed asynchronously, so until it lands the FIB
+// forwards the packet out of the node. The host endpoint then approves the
+// local workload's leg on its behalf and the entry reads as fully approved
+// before the workload has ever seen a packet.
+//
+// Withholding the peer redirect from SYNs keeps the destination in the path for
+// every new connection, where its program forces policy.
+func TestNoPeerRedirectForTCPSYN(t *testing.T) {
+	RegisterTestingT(t)
+
+	bpfIfaceName = "RPsyn"
+	defer func() { bpfIfaceName = "" }()
+	defer cleanUpMaps()
+
+	hostIP = node1ip
+
+	resetCTMap(ctMap)
+	resetRTMap(rtMap)
+	defer resetRTMap(rtMap)
+
+	// srcIP:sport sorts below dstIP:dport, so src_lt_dest() puts the source on
+	// the A side: A2B is the source's own leg, B2A the destination's.
+	_, _, _, _, synPkt, err := testPacketTCPV4WithPayload(dstIP,
+		redirPeerSrcPort, redirPeerDstPort, true, nil)
+	Expect(err).NotTo(HaveOccurred())
+	_, _, _, _, ackPkt, err := testPacketTCPV4WithPayload(dstIP,
+		redirPeerSrcPort, redirPeerDstPort, false, nil)
+	Expect(err).NotTo(HaveOccurred())
+
+	ctKey := conntrack.NewKey(redirPeerProtoTCP, srcIP, redirPeerSrcPort, dstIP, redirPeerDstPort)
+
+	// The source workload is local. The destination's route is deliberately
+	// absent: this is the window in which its packets are still forwarded out
+	// of the node.
+	err = rtMap.Update(
+		routes.NewKey(srcV4CIDR).AsBytes(),
+		routes.NewValueWithIfIndex(routes.FlagsLocalWorkload|routes.FlagInIPAMPool, redirPeerIfindex).AsBytes())
+	Expect(err).NotTo(HaveOccurred())
+
+	t.Log("SYN from the source workload creates the entry")
+
+	skbMark = 0
+	runBpfTest(t, "calico_from_workload_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+		res, err := bpfrun(synPkt)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.Retval).To(Equal(resTC_ACT_REDIRECT))
+
+		ct, err := conntrack.LoadMapMem(ctMap)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ct).To(HaveKey(ctKey))
+		Expect(ct[ctKey].Data().A2B.Approved).To(BeTrue())
+		Expect(ct[ctKey].Data().B2A.Approved).To(BeFalse())
+	}, withRedirectPeer())
+
+	expectMark(tcdefs.MarkSeen)
+
+	t.Log("the misrouted SYN reaches the host endpoint, which approves the destination's leg")
+
+	runBpfTest(t, "calico_to_host_ep", nil, func(bpfrun bpfProgRunFn) {
+		_, err := bpfrun(synPkt)
+		Expect(err).NotTo(HaveOccurred())
+
+		ct, err := conntrack.LoadMapMem(ctMap)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ct).To(HaveKey(ctKey))
+		// Not being a workload interface, the host endpoint records the leg as
+		// non-workload. The entry now reads as fully approved.
+		Expect(ct[ctKey].Data().A2B.Approved).To(BeTrue())
+		Expect(ct[ctKey].Data().B2A.Approved).To(BeTrue())
+		Expect(ct[ctKey].Data().B2A.Workload).To(BeFalse())
+	}, withRedirectPeer())
+
+	// The destination's route lands. From here the source's program sees a
+	// local workload and would take the peer redirect if the conntrack verdict
+	// allowed it.
+	err = rtMap.Update(
+		routes.NewKey(dstV4CIDR).AsBytes(),
+		routes.NewValueWithIfIndex(routes.FlagsLocalWorkload|routes.FlagInIPAMPool, redirPeerIfindex).AsBytes())
+	Expect(err).NotTo(HaveOccurred())
+
+	t.Log("the retransmitted SYN must not be peer-redirected")
+
+	Expect(counters.Flush(countersMap, redirPeerIfindex, hook.Ingress)).NotTo(HaveOccurred())
+
+	skbMark = 0
+	runBpfTest(t, "calico_from_workload_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+		_, err := bpfrun(synPkt)
+		Expect(err).NotTo(HaveOccurred())
+	}, withRedirectPeer())
+
+	c, err := counters.Read(countersMap, redirPeerIfindex, hook.Ingress)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(c[counters.RedirectPeer]).To(BeZero(),
+		"a TCP SYN redirected to the peer would skip the destination's policy")
+
+	t.Log("a non-SYN packet on the same entry still takes the fast path")
+
+	Expect(counters.Flush(countersMap, redirPeerIfindex, hook.Ingress)).NotTo(HaveOccurred())
+
+	skbMark = 0
+	runBpfTest(t, "calico_from_workload_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+		res, err := bpfrun(ackPkt)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.Retval).To(Equal(resTC_ACT_REDIRECT))
+	}, withRedirectPeer())
+
+	c, err = counters.Read(countersMap, redirPeerIfindex, hook.Ingress)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(c[counters.RedirectPeer]).To(BeNumerically("==", 1),
+		"established traffic must still take the peer-redirect fast path")
+}
+
+// TestPoisonedLegDoesNotBypassDestinationPolicy covers the other half of the SYN
+// detour: what the destination's program does once the packet reaches it. The
+// conntrack entry says the flow is established and approved by both sides, but
+// the SYN flag makes the program run policy anyway, so a deny still drops the
+// packet.
+//
+// The entry itself is left as it was. The destination's program allows or drops
+// on the strength of policy without rewriting the leg the host endpoint
+// approved, so the entry keeps reading as fully approved either way.
+func TestPoisonedLegDoesNotBypassDestinationPolicy(t *testing.T) {
+	RegisterTestingT(t)
+
+	bpfIfaceName = "RPpol"
+	defer func() { bpfIfaceName = "" }()
+	defer cleanUpMaps()
+
+	hostIP = node1ip
+
+	resetCTMap(ctMap)
+	resetRTMap(rtMap)
+	defer resetRTMap(rtMap)
+
+	_, _, _, _, synPkt, err := testPacketTCPV4WithPayload(dstIP,
+		redirPeerSrcPort, redirPeerDstPort, true, nil)
+	Expect(err).NotTo(HaveOccurred())
+
+	ctKey := conntrack.NewKey(redirPeerProtoTCP, srcIP, redirPeerSrcPort, dstIP, redirPeerDstPort)
+
+	err = rtMap.Update(
+		routes.NewKey(srcV4CIDR).AsBytes(),
+		routes.NewValueWithIfIndex(routes.FlagsLocalWorkload|routes.FlagInIPAMPool, redirPeerIfindex).AsBytes())
+	Expect(err).NotTo(HaveOccurred())
+
+	skbMark = 0
+	runBpfTest(t, "calico_from_workload_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+		res, err := bpfrun(synPkt)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.Retval).To(Equal(resTC_ACT_REDIRECT))
+	}, withRedirectPeer())
+
+	expectMark(tcdefs.MarkSeen)
+
+	runBpfTest(t, "calico_to_host_ep", nil, func(bpfrun bpfProgRunFn) {
+		_, err := bpfrun(synPkt)
+		Expect(err).NotTo(HaveOccurred())
+	}, withRedirectPeer())
+
+	ct, err := conntrack.LoadMapMem(ctMap)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(ct[ctKey].Data().A2B.Approved).To(BeTrue())
+	Expect(ct[ctKey].Data().B2A.Approved).To(BeTrue())
+
+	err = rtMap.Update(
+		routes.NewKey(dstV4CIDR).AsBytes(),
+		routes.NewValueWithIfIndex(routes.FlagsLocalWorkload|routes.FlagInIPAMPool, redirPeerIfindex).AsBytes())
+	Expect(err).NotTo(HaveOccurred())
+
+	t.Log("the destination's policy denies the SYN despite the approved entry")
+
+	ctSaved := saveCTMap(ctMap)
+
+	skbMark = tcdefs.MarkSeen
+	runBpfTest(t, "calico_to_workload_ep", &denyAllRulesWorkloads, func(bpfrun bpfProgRunFn) {
+		res, err := bpfrun(synPkt)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.Retval).To(Equal(resTC_ACT_SHOT))
+	}, withRedirectPeer())
+
+	t.Log("and allows it when policy allows")
+
+	restoreCTMap(ctMap, ctSaved)
+
+	skbMark = tcdefs.MarkSeen
+	runBpfTest(t, "calico_to_workload_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+		res, err := bpfrun(synPkt)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.Retval).NotTo(Equal(resTC_ACT_SHOT))
+	}, withRedirectPeer())
+}

--- a/felix/fv/bpf_redirect_peer_test.go
+++ b/felix/fv/bpf_redirect_peer_test.go
@@ -1,0 +1,208 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fv_test
+
+import (
+	"encoding/base64"
+	"net"
+	"regexp"
+	"strconv"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	api "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
+
+	"github.com/projectcalico/calico/felix/bpf/conntrack"
+	. "github.com/projectcalico/calico/felix/fv/connectivity"
+	"github.com/projectcalico/calico/felix/fv/infrastructure"
+	"github.com/projectcalico/calico/felix/fv/utils"
+	"github.com/projectcalico/calico/felix/fv/workload"
+	"github.com/projectcalico/calico/felix/timeshim"
+	"github.com/projectcalico/calico/libcalico-go/lib/apiconfig"
+	client "github.com/projectcalico/calico/libcalico-go/lib/clientv3"
+)
+
+// For same-node workload-to-workload traffic the source's program can hand the
+// packet straight to the destination's network namespace with
+// bpf_redirect_peer, skipping the destination's own program. It does so on the
+// strength of the conntrack verdict alone, so an entry that wrongly reads as
+// approved by both endpoints turns the fast path into a policy bypass.
+//
+// Entries can reach that state: a host-endpoint program approves the leg facing
+// away from the host, which is the wrong leg when the destination is a local
+// workload whose route has not been programmed yet. Rather than try to hit that
+// window, these tests write the resulting entry into the conntrack map directly.
+//
+// The peer-redirect counter is what the check turns on. Connectivity alone does
+// not discriminate: a redirected SYN reaches the destination's namespace but the
+// rest of the handshake may still fail for its own reasons, which looks the same
+// from the client as a policy drop.
+var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ BPF peer redirect policy enforcement",
+	[]apiconfig.DatastoreType{apiconfig.Kubernetes},
+	func(getInfra infrastructure.InfraFactory) {
+		if !BPFMode() {
+			// Peer redirect only exists in the BPF dataplane.
+			return
+		}
+
+		const (
+			clientIP   = "10.65.0.2"
+			serverIP   = "10.65.0.3"
+			serverPort = 8055
+			// Pinned so the forged conntrack entry and the connection attempt
+			// agree on the 5-tuple.
+			srcPort = 12345
+		)
+
+		var (
+			infra        infrastructure.DatastoreInfra
+			tc           infrastructure.TopologyContainers
+			calicoClient client.Interface
+			w            [2]*workload.Workload
+			cc           *Checker
+		)
+
+		BeforeEach(func() {
+			infra = getInfra()
+			tc, calicoClient = infrastructure.StartSingleNodeTopology(
+				infrastructure.DefaultTopologyOptions(), infra)
+			infra.AddDefaultAllow()
+
+			for i, ip := range []string{clientIP, serverIP} {
+				name := "w" + strconv.Itoa(i)
+				w[i] = workload.Run(tc.Felixes[0], name, "default", ip,
+					strconv.Itoa(serverPort), "tcp")
+				w[i].WorkloadEndpoint.Labels = map[string]string{"name": name}
+				w[i].ConfigureInInfra(infra)
+			}
+
+			cc = &Checker{Protocol: "tcp"}
+		})
+
+		AfterEach(func() {
+			if CurrentGinkgoTestDescription().Failed {
+				tc.Felixes[0].Exec("calico-bpf", "conntrack", "dump", "--raw")
+				tc.Felixes[0].Exec("calico-bpf", "counters", "dump")
+				tc.Felixes[0].Exec("calico-bpf", "policy", "dump", w[1].InterfaceName, "all")
+			}
+
+			for i := range w {
+				w[i].Stop()
+			}
+			tc.Stop()
+			if CurrentGinkgoTestDescription().Failed {
+				infra.DumpErrorData()
+			}
+			infra.Stop()
+		})
+
+		denyClientToServer := func() {
+			pol := api.NewGlobalNetworkPolicy()
+			pol.Name = "deny-w0-to-w1"
+			pol.Spec.Selector = "name == 'w1'"
+			pol.Spec.Types = []api.PolicyType{api.PolicyTypeIngress}
+			pol.Spec.Ingress = []api.Rule{{
+				Action: api.Deny,
+				Source: api.EntityRule{Selector: "name == 'w0'"},
+			}}
+			_, err := calicoClient.GlobalNetworkPolicies().Create(utils.Ctx, pol, utils.NoOptions)
+			Expect(err).NotTo(HaveOccurred())
+		}
+
+		// poisonConntrack writes the entry a host-endpoint program leaves
+		// behind: a normal TCP entry for the client-to-server tuple with both
+		// legs approved, so the source's program reads the flow as established
+		// and fully approved.
+		//
+		// The key's A and B sides are ordered by (address, port), lowest first.
+		// clientIP:srcPort sorts below serverIP:serverPort, so the client is A.
+		poisonConntrack := func() {
+			leg := conntrack.Leg{Approved: true, SynSeen: true, AckSeen: true}
+			val := conntrack.NewValueNormal(
+				time.Duration(timeshim.RealTime().KTimeNanos()), 0, leg, leg)
+			const protoTCP = 6
+			key := conntrack.NewKey(protoTCP,
+				net.ParseIP(clientIP), srcPort, net.ParseIP(serverIP), serverPort)
+
+			tc.Felixes[0].Exec("calico-bpf", "conntrack", "write",
+				base64.StdEncoding.EncodeToString(key[:]),
+				base64.StdEncoding.EncodeToString(val[:]))
+		}
+
+		// expectConntrackConsulted fails if the forged entry was never looked
+		// up. Without it a mistake in the key would leave the entry inert and
+		// the deny would pass for the wrong reason. Every lookup bumps the
+		// packet count on the leg the packet travels, which is A2B here.
+		expectConntrackConsulted := func() {
+			out, err := tc.Felixes[0].ExecOutput("calico-bpf", "conntrack", "dump", "--raw")
+			Expect(err).NotTo(HaveOccurred())
+
+			re := regexp.MustCompile(
+				`ConntrackKey\{proto=6 ` + regexp.QuoteMeta(clientIP) + `:` + strconv.Itoa(srcPort) +
+					` <-> ` + regexp.QuoteMeta(serverIP) + `:` + strconv.Itoa(serverPort) +
+					`\}.*A2B:\{Bytes:\d+ Packets:(\d+)`)
+			m := re.FindStringSubmatch(out)
+			Expect(m).NotTo(BeNil(), "forged conntrack entry not found in:\n%s", out)
+			Expect(strconv.Atoi(m[1])).To(BeNumerically(">", 0),
+				"forged conntrack entry was never looked up, so the test proves nothing")
+		}
+
+		// redirectPeerCount reads the "Redirect / peer" ingress counter for an
+		// interface. The source workload's program runs on that interface's
+		// ingress hook, so this counts the packets it handed straight to a peer
+		// namespace.
+		redirectPeerCount := func(ifName string) int {
+			out, err := tc.Felixes[0].ExecOutput("calico-bpf", "counters", "dump", "--iface="+ifName)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Table columns are category | caption | ingress | egress | xdp,
+			// and the category cell is blank on all but the first row of a
+			// group, so match on the caption.
+			m := regexp.MustCompile(`\|\s*peer\s*\|\s*(\d+)\s*\|`).FindStringSubmatch(out)
+			Expect(m).NotTo(BeNil(), "no peer-redirect counter for %s in:\n%s", ifName, out)
+			n, err := strconv.Atoi(m[1])
+			Expect(err).NotTo(HaveOccurred())
+			return n
+		}
+
+		It("should enforce the destination's policy on a new connection that hits an entry approved by both legs", func() {
+			By("checking the workloads can talk before any policy is applied")
+			cc.ExpectSome(w[0], w[1].Port(serverPort))
+			cc.CheckConnectivity()
+
+			By("denying the client on the server's ingress")
+			denyClientToServer()
+			cc.ResetExpectations()
+			cc.ExpectNone(w[0], w[1].Port(serverPort))
+			cc.CheckConnectivity()
+
+			By("writing a conntrack entry that reads as approved by both endpoints")
+			poisonConntrack()
+
+			By("checking the deny still applies to a connection matching that entry")
+			before := redirectPeerCount(w[0].InterfaceName)
+			cc.ResetExpectations()
+			cc.Expect(None, w[0], w[1].Port(serverPort), ExpectWithSrcPort(srcPort))
+			cc.CheckConnectivity()
+
+			expectConntrackConsulted()
+
+			By("checking the SYN reached the destination rather than its namespace")
+			Expect(redirectPeerCount(w[0].InterfaceName)).To(Equal(before),
+				"the SYN was handed straight to the destination's namespace, "+
+					"which skips its program and so its policy")
+		})
+	})


### PR DESCRIPTION
Backport of #13356 to `release-v3.32`.

The vulnerable gate is present on this branch unchanged, so the bug applies here:
`try_redirect_to_peer` skips the destination endpoint's program on the strength
of `CALI_CT_ESTABLISHED_BYPASS` alone, and that verdict can have been reached
because a *different* endpoint approved the leg while routing was still
converging. See #13356 for the full reasoning.

## Differences from master

Two hunks do not apply and are dropped:

- the ingress connlimit `is_tcp_syn()` call site — that feature is not on this
  branch, leaving three call sites rather than four;
- `felix/design/bpf-tc-programs.md` — the design corpus does not exist here.

The fix itself and the remaining call sites are unchanged from master.

## Testing

Run locally against this branch:

- BPF UT — 113 tests pass, including `TestPrecompiledBinariesAreLoadable` over
  all objects.
- BPF FV — `BPF peer redirect policy enforcement` passes.

**Release note:**
```release-note
[eBPF] Fix a window in which a new connection to a local workload could skip that workload's ingress policy, when the connection was started while the workload's route was still being programmed.
```