### PR TITLE
Fix nameToIface leak on workload teardown in BPF endpoint manager

### DIFF
--- a/felix/dataplane/linux/bpf_ep_mgr.go
+++ b/felix/dataplane/linux/bpf_ep_mgr.go
@@ -1516,6 +1516,12 @@ func (m *bpfEndpointManager) onInterfaceUpdate(update *ifaceStateUpdate) {
 			iface.info.ifIndex = 0
 			iface.info.masterIfIndex = 0
 			iface.info.ifaceType = 0
+			// The interface is gone, so every scrap of state we derived from
+			// it is stale; drop it wholesale rather than field by field.
+			// withIface only forgets an interface once its bpfInterface is
+			// back to the zero value, so a field left set here would leak the
+			// entry for the lifetime of the process.
+			iface.dpState = zeroIface.dpState
 		}
 		// Capture the WEP binding + (possibly zero) ifIndex so we can
 		// refresh the connlimit pod info snapshot after the withIface
@@ -1576,7 +1582,11 @@ func (m *bpfEndpointManager) onWorkloadEndpointRemove(msg *proto.WorkloadEndpoin
 	}
 
 	m.withIface(oldWEP.Name, func(iface *bpfInterface) bool {
+		// Clear everything we learned from the endpoint, not just its ID:
+		// withIface only forgets an interface once its bpfInterface is back
+		// to the zero value.
 		iface.info.endpointID = nil
+		iface.info.hasIstioDSCP = false
 		return false
 	})
 	// Remove policy debug info if any

--- a/felix/dataplane/linux/bpf_ep_mgr_test.go
+++ b/felix/dataplane/linux/bpf_ep_mgr_test.go
@@ -1142,6 +1142,52 @@ var _ = Describe("BPF Endpoint Manager", func() {
 		})
 	})
 
+	// The manager only drops a nameToIface entry once every field of the
+	// bpfInterface has gone back to its zero value.  A field left set by a
+	// teardown leaks the entry for the lifetime of the process, so check the
+	// teardown of each kind of workload that sets an otherwise-sticky field.
+	//
+	// Both teardown orderings matter.  In practice the CNI deletes the veth
+	// before the datastore reports the endpoint gone, and that ordering is the
+	// weaker one: once the interface is down, applyPolicy short-circuits and
+	// stops refreshing the derived state.
+	describeTeardown := func(desc string, teardown func(name string)) {
+		DescribeTable("should not leak a nameToIface entry when the workload is torn down, "+desc,
+			func(ep *proto.WorkloadEndpoint) {
+				newBpfEpMgr(false)
+				ep.Name = "cali12345"
+				bpfEpMgr.OnUpdate(&proto.WorkloadEndpointUpdate{
+					Id: &proto.WorkloadEndpointID{
+						OrchestratorId: "k8s",
+						WorkloadId:     ep.Name,
+						EndpointId:     ep.Name,
+					},
+					Endpoint: ep,
+				})
+				genIfaceUpdate(ep.Name, ifacemonitor.StateUp, 15)()
+				Expect(bpfEpMgr.nameToIface).To(HaveKey(ep.Name))
+				// Pre-flight: the entry must actually be carrying the sticky
+				// state, otherwise the teardown check below is vacuous.
+				Expect(bpfEpMgr.nameToIface[ep.Name].info.hasIstioDSCP).
+					To(Equal(ep.IsIstioAmbient), "istio DSCP flag not recorded")
+
+				teardown(ep.Name)
+				Expect(bpfEpMgr.nameToIface).NotTo(HaveKey(ep.Name))
+			},
+			Entry("plain workload", &proto.WorkloadEndpoint{}),
+			Entry("istio ambient workload", &proto.WorkloadEndpoint{IsIstioAmbient: true}),
+		)
+	}
+
+	describeTeardown("interface first", func(name string) {
+		genIfaceUpdate(name, ifacemonitor.StateNotPresent, 15)()
+		genWLUpdateEpRemove(name)()
+	})
+	describeTeardown("endpoint first", func(name string) {
+		genWLUpdateEpRemove(name)()
+		genIfaceUpdate(name, ifacemonitor.StateNotPresent, 15)()
+	})
+
 	Context("with jit-harden", func() {
 		JustBeforeEach(func() {
 			dp.jitHarden = true


### PR DESCRIPTION
`withIface` only forgets an interface once its `bpfInterface` has gone back to the zero value. `info.hasIstioDSCP` is set from the workload endpoint but never cleared when the endpoint is removed, so the `nameToIface` entry leaks for the lifetime of the process — one entry per Istio ambient workload ever created on the node.

Leaked entries are not just memory: `bpfEndpointsGauge` reports `len(nameToIface)`, and `markEverythingDirty` walks the map, so every host IP change re-dirties every ghost interface.

The fix clears the endpoint-derived `info` when the endpoint goes away. It also resets the derived `dpState` when the interface goes away, rather than clearing the readiness fields one at a time — no field in `bpfInterfaceState` leaks today, but the one-at-a-time form is what let this class of bug in, and a field added later would reintroduce it silently.

Tests: a table covering plain and Istio ambient workloads, torn down in both orders (interface first — what the CNI actually does — and endpoint first). Each spec asserts the sticky state was really recorded before checking it is gone, so the check cannot pass vacuously. The Istio specs fail before this change and pass after. The 12 pre-existing `xdp_state_test.go` failures in this package are unaffected.

## Release Note
```release-note
Fixed a leak in the eBPF endpoint manager that retained per-interface state for every Istio ambient workload torn down on a node.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)