### PR TITLE
ci: poll for approvals hourly, and widen the staleness cutoff to match

### DIFF
--- a/.github/workflows/ci-notify.yml
+++ b/.github/workflows/ci-notify.yml
@@ -37,9 +37,13 @@ on:
   #
   # A schedule is repository-level: nothing to approve, and it still gets the
   # secrets and the working `contents: write` the dedup marker needs. Cost is
-  # latency — a cycle, plus whatever delay GitHub adds to scheduled runs.
+  # latency: a cycle, plus GitHub's own delay in starting scheduled runs, which
+  # on this repo measures 31-46 minutes (sampled from sync-operator-crds.yml,
+  # whose hourly cron starts at :31 to :46). A finer cron buys nothing against
+  # a delay that size — GitHub drops schedule slots it cannot start — so this
+  # is hourly, and an approval DM should be expected within roughly two hours.
   schedule:
-    - cron: "*/15 * * * *"
+    - cron: "0 * * * *"
   # Manual test path: simulate a finished-CI status (or an approval) for a
   # given PR, so the full chain (resolve -> opt-in lookup -> DM) can be
   # exercised on demand without waiting for real CI. Dispatchable only once
@@ -491,9 +495,13 @@ jobs:
 
           # Ignore approvals older than this. Without it, deploying this
           # workflow — or recovering from an outage — would DM about every
-          # already-approved open PR at once. A cycle is 15 minutes, so this
-          # tolerates several missed cycles without ever mass-notifying.
-          CUTOFF=$(date -u -d '2 hours ago' +%Y-%m-%dT%H:%M:%SZ)
+          # already-approved open PR at once.
+          # It has to comfortably exceed one cycle plus GitHub's start delay
+          # plus a dropped slot, or an approval ages out before any poll sees
+          # it and its DM is lost silently: hourly cron + up to ~46 minutes of
+          # delay puts two consecutive polls as much as ~2h45m apart, so 2
+          # hours (the value while the cron was */15) would now drop DMs.
+          CUTOFF=$(date -u -d '6 hours ago' +%Y-%m-%dT%H:%M:%SZ)
 
           for LOGIN in $LOGINS; do
             # review:approved is GitHub's own review-decision filter, so this


### PR DESCRIPTION
Follow-up to #13397. The approval poll landed with `cron: "*/15 * * * *"`, and the PR described the cost as "up to a cycle late". That was inferred from the cron value, not measured, and it is wrong for this repo.

GitHub delays scheduled runs here by **31 to 46 minutes**, consistently. Sampled from `sync-operator-crds.yml`, whose cron is `0 * * * *`:

| Requested | Started | Delay |
|---|---|---|
| 11:00 | 11:40:28 | 40 min |
| 12:00 | 12:34:58 | 35 min |
| 13:00 | 13:31:22 | 31 min |
| 14:00 | 14:46:25 | 46 min |
| 15:00 | 15:40:29 | 40 min |

A 15-minute cron cannot deliver 15-minute freshness against that, and GitHub drops schedule slots it cannot start, so the finer cron bought nothing except an implied promptness the workflow never had. This polls hourly instead and states the real expectation: an approval DM within roughly two hours.

**The staleness cutoff has to move with the cron.** It exists so that deploying this — or recovering from an outage — cannot announce every already-approved open PR at once. But it is also a *floor* on freshness: an approval older than the cutoff is skipped, so if the cutoff is shorter than the longest gap between two polls, an approval ages out before any poll sees it and its DM is lost silently. Hourly plus a 46-minute delay puts consecutive polls up to ~2h45m apart, so the 2 hours that suited `*/15` would now drop DMs. 6 hours leaves room for a dropped slot on top.

Verified with a dry run at the 6h cutoff, so the first hourly cycle holds no surprise: `tomastigera` has no open approved PR, and `coutinhop`'s #11754 carries an approval from 2026-02-03, correctly skipped as stale. Nothing will be dispatched until a genuinely new approval lands. `actionlint` and the repo's `yamllint` are clean.

Note the poll job still has no manual trigger — its `if` is `github.event_name == 'schedule'`, so a `workflow_dispatch` exercises only the notify job. That is why this had to be reasoned from another workflow's timings rather than tested directly, and it is worth fixing separately.

**Release note:**
```release-note
TBD
```