### PR TITLE
Do not early-exit GC cold IPs on stale cache of IPAM blocks

### DIFF
--- a/kube-controllers/pkg/controllers/node/fake_client.go
+++ b/kube-controllers/pkg/controllers/node/fake_client.go
@@ -98,6 +98,23 @@ func (f *FakeCalicoClient) SetReleaseHostAffinityError(host string, err error) {
 	}
 }
 
+// SetColdGCError configures the fake IPAM client to return the given error for the
+// specified CIDR block, simulating a stale-revision conflict during the cold IP GC sweep
+func (f *FakeCalicoClient) SetColdGCError(blockCIDR string, err error) {
+	if fic, ok := f.ipamClient.(*fakeIPAMClient); ok {
+		fic.Lock()
+		defer fic.Unlock()
+		if fic.coldGCErrors == nil {
+			fic.coldGCErrors = make(map[string]error)
+		}
+		if err == nil {
+			delete(fic.coldGCErrors, blockCIDR)
+		} else {
+			fic.coldGCErrors[blockCIDR] = err
+		}
+	}
+}
+
 // StagedGlobalNetworkPolicies returns an interface for managing staged global network policy resources.
 func (f *FakeCalicoClient) StagedGlobalNetworkPolicies() clientv3.StagedGlobalNetworkPolicyInterface {
 	panic("not implemented") // TODO: Implement
@@ -299,6 +316,12 @@ type fakeIPAMClient struct {
 	// releaseHostAffinityErrors maps host names to errors that ReleaseHostAffinities
 	// should return, simulating per-node "block not empty" failures during cleanup.
 	releaseHostAffinityErrors map[string]error
+
+	// coldGCErrors maps cold IPs to errors that GarbageCollectColdIPs should
+	// return, simulating stale-revision conflicts during the cold IP GC sweep.
+	coldGCErrors map[string]error
+	// coldGCSeen records the cold IPs passed to GarbageCollectColdIPs.
+	coldGCSeen map[string]bool
 }
 
 // gcBlocks returns the CIDRs of the blocks GarbageCollectColdIPs was called with.
@@ -306,6 +329,12 @@ func (f *fakeIPAMClient) gcBlocks() []string {
 	f.Lock()
 	defer f.Unlock()
 	return slices.Clone(f.garbageCollectedBlocks)
+}
+
+func (f *fakeIPAMClient) coldGCVisited(blockCIDR string) bool {
+	f.Lock()
+	defer f.Unlock()
+	return f.coldGCSeen[blockCIDR]
 }
 
 func (f *fakeIPAMClient) affinityReleased(aff string) bool {
@@ -467,7 +496,15 @@ func (f *fakeIPAMClient) GarbageCollectColdIPs(ctx context.Context, config *ipam
 	f.Lock()
 	defer f.Unlock()
 	f.garbageCollected = true
-	f.garbageCollectedBlocks = append(f.garbageCollectedBlocks, kvp.Key.(model.BlockKey).CIDR.String())
+	cidr := kvp.Key.(model.BlockKey).CIDR.String()
+	f.garbageCollectedBlocks = append(f.garbageCollectedBlocks, cidr)
+	if f.coldGCSeen == nil {
+		f.coldGCSeen = make(map[string]bool)
+	}
+	f.coldGCSeen[cidr] = true
+	if err, ok := f.coldGCErrors[cidr]; ok {
+		return err
+	}
 	return nil
 }
 

--- a/kube-controllers/pkg/controllers/node/ipam.go
+++ b/kube-controllers/pkg/controllers/node/ipam.go
@@ -1374,6 +1374,13 @@ func (c *IPAMController) garbageCollectColdIPs() error {
 			continue
 		}
 		if err := c.client.IPAM().GarbageCollectColdIPs(ctx, ipamConfig, &kvp); err != nil {
+			switch err.(type) {
+			case cerrors.ErrorResourceUpdateConflict, cerrors.ErrorResourceDoesNotExist:
+				// Our cached copy of the block is stale. Don't fail the whole sync;
+				// the syncer will deliver the fresh state and the block will be GC'd on a subsequent sync.
+				log.WithError(err).WithField("block", cidr).Debug("Skipping cold IP GC for stale block")
+				continue
+			}
 			return err
 		}
 	}

--- a/kube-controllers/pkg/controllers/node/ipam_test.go
+++ b/kube-controllers/pkg/controllers/node/ipam_test.go
@@ -38,6 +38,7 @@ import (
 	bapi "github.com/projectcalico/calico/libcalico-go/lib/backend/api"
 	"github.com/projectcalico/calico/libcalico-go/lib/backend/model"
 	client "github.com/projectcalico/calico/libcalico-go/lib/clientv3"
+	cerrors "github.com/projectcalico/calico/libcalico-go/lib/errors"
 	"github.com/projectcalico/calico/libcalico-go/lib/ipam"
 	"github.com/projectcalico/calico/libcalico-go/lib/kubevirt"
 	"github.com/projectcalico/calico/libcalico-go/lib/net"
@@ -2547,6 +2548,84 @@ var _ = Describe("IPAM controller UTs", func() {
 		Eventually(func() bool {
 			return fakeClient.affinityReleased("node-c")
 		}, assertionTimeout, 100*time.Millisecond).Should(BeTrue(), "node-c affinity should be released after error is cleared")
+	})
+
+	// Regression test: a stale-revision conflict during the cold IP GC sweep must not
+	// abort the whole IPAM sync. The controller GCs blocks using cached revisions from
+	// the syncer, so conflicts with concurrent writers are routine; before the fix, the
+	// first ErrorResourceUpdateConflict aborted syncIPAM before releaseUnusedBlocks and
+	// releaseNodes, so a single contended block starved deleted-node cleanup indefinitely.
+	It("should clean up deleted nodes even when cold IP GC hits update conflicts", func() {
+		c.Start(stopChan)
+
+		fakeClient := cli.IPAM().(*fakeIPAMClient)
+		fc := cli.(*FakeCalicoClient)
+
+		// node-gc-a's block persistently fails cold GC with a CAS conflict, as happens
+		// when the syncer cache is stale relative to the datastore.
+		fc.SetColdGCError("10.1.0.0/30", cerrors.ErrorResourceUpdateConflict{Identifier: "10.1.0.0/30"})
+
+		// Create blocks with tunnel address allocations for two nodes that don't exist
+		// in Kubernetes.
+		type testNode struct {
+			name   string
+			cidr   string
+			handle string
+		}
+		nodes := []testNode{
+			{"node-gc-a", "10.1.0.0/30", "vxlan-tunnel-addr-node-gc-a"},
+			{"node-gc-b", "10.1.1.0/30", "vxlan-tunnel-addr-node-gc-b"},
+		}
+		for _, n := range nodes {
+			cidr := net.MustParseCIDR(n.cidr)
+			aff := fmt.Sprintf("host:%s", n.name)
+			handle := n.handle
+			idx := 0
+			b := model.AllocationBlock{
+				CIDR:        cidr,
+				Affinity:    &aff,
+				Allocations: []*int{&idx, nil, nil, nil},
+				Unallocated: []int{1, 2, 3},
+				Attributes: []model.AllocationAttribute{
+					{
+						HandleID: &handle,
+						ActiveOwnerAttrs: map[string]string{
+							ipam.AttributeNode: n.name,
+							ipam.AttributeType: ipam.AttributeTypeVXLAN,
+						},
+					},
+				},
+			}
+			kvp := model.KVPair{Key: model.BlockKey{CIDR: model.PrefixFromIPNet(cidr)}, Value: &b}
+			c.onUpdate(bapi.Update{KVPair: kvp, UpdateType: bapi.UpdateTypeKVNew})
+		}
+
+		// Wait for all blocks to be cached.
+		for _, n := range nodes {
+			cidr := n.cidr
+			Eventually(func() bool {
+				done := c.pause()
+				defer done()
+				_, ok := c.allBlocks[cidr]
+				return ok
+			}, 1*time.Second, 100*time.Millisecond).Should(BeTrue(), "Block %s should be cached", cidr)
+		}
+
+		// Trigger a full sync.
+		c.fullScanNextSync("forced by test")
+		c.onStatusUpdate(bapi.InSync)
+
+		// Despite the persistent conflict on node-gc-a's block, both nodes should be
+		// cleaned up: the conflict only skips that block's GC, not the rest of the sync.
+		Eventually(func() bool {
+			return fakeClient.affinityReleased("node-gc-a")
+		}, assertionTimeout, 100*time.Millisecond).Should(BeTrue(), "node-gc-a affinity should be released despite cold GC conflict")
+		Eventually(func() bool {
+			return fakeClient.affinityReleased("node-gc-b")
+		}, assertionTimeout, 100*time.Millisecond).Should(BeTrue(), "node-gc-b affinity should be released")
+
+		// The sweep should also have carried on past the conflicting block.
+		Expect(fakeClient.coldGCVisited("10.1.1.0/30")).To(BeTrue(), "cold GC should visit the healthy block")
 	})
 
 	// Regression test: verifies the controller makes progress even when ALL nodes fail


### PR DESCRIPTION
Small resiliency improvement to the `garbageCollectColdIPs()` loop. Let the GC loop continue to run for other blocks on a conflict or not found.

I think #13075 largely addresses this for us, but having the entire loop abort on conflicts can cause our GC to not complete for days at a time due to the high rate of node creation/deletion.
