### PR TITLE
Evaluate policy rule criteria cheapest-first in Dikastes

### DIFF
--- a/app-policy/checker/adapter_checkrequest.go
+++ b/app-policy/checker/adapter_checkrequest.go
@@ -19,7 +19,6 @@ import (
 	"strings"
 
 	authz "github.com/envoyproxy/go-control-plane/envoy/service/auth/v3"
-	log "github.com/sirupsen/logrus"
 )
 
 // CheckRequestToFlowAdapter adapts CheckRequest to the l4 and l7 flow interfaces for use in the
@@ -69,7 +68,7 @@ func (a *CheckRequestToFlowAdapter) GetProtocol() int {
 	if p, ok := protocolMap[strings.ToLower(protocol)]; ok {
 		return p
 	}
-	log.Warnf("unsupported protocol: %s, defaulting to TCP", protocol)
+	rlogBadProtocolName.Warnf("unsupported protocol: %s, defaulting to TCP", protocol)
 	return 6
 }
 

--- a/app-policy/checker/bench_egress_test.go
+++ b/app-policy/checker/bench_egress_test.go
@@ -1,0 +1,308 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package checker
+
+// Benchmark for Evaluate() against a single-tier egress allow-list, the second rule-set shape
+// measured in production (the first is in bench_test.go). All data is synthetic; the scale
+// parameters and distributions below are anonymized measurements from a policy dump.
+//
+//	go test ./app-policy/checker/ -run '^$' -bench BenchmarkEvaluateEgressAllowList \
+//	    -benchmem -benchtime 100x -cpu 1
+//
+// Shape: one tier, ~301 policies with no selector (so all of them apply to every endpoint),
+// ~18,600 egress rules, almost all Pass. The tier is a destination allow-list: match a rule
+// and leave the tier, match nothing and the tier default denies. Every rule's source block is
+// empty; each matches a destination address plus a handful of destination ports.
+//
+// The three cases below must be read separately, because criterion ordering helps them by
+// different amounts. A flow whose port is shared by few rules is rejected on the port
+// comparison almost everywhere and never pays for the address criteria; a flow on a popular
+// port pays the address criteria on every rule that shares it; and a denied flow walks the
+// whole tier no matter what, so ordering can only reduce its per-rule cost, never its scan
+// depth. Averaging the three hides that.
+
+import (
+	"fmt"
+	"math/rand"
+	"net"
+	"testing"
+
+	v3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/projectcalico/calico/app-policy/policystore"
+	"github.com/projectcalico/calico/felix/proto"
+	"github.com/projectcalico/calico/felix/rules"
+	"github.com/projectcalico/calico/felix/types"
+)
+
+const (
+	egressNumPolicies    = 301
+	egressRulesPerPolicy = 62 // 18,662 rules.
+
+	// Fraction of rules whose destination is a selector, which reaches Dikastes as an IP set
+	// reference; the rest carry a CIDR. Measured: 4,644 of 18,675.
+	egressIPSetRuleFraction = 0.25
+
+	// Where in the walk the rule that matches sits, as a fraction of the whole tier. Real
+	// flows match at every depth; this picks one representative depth so the two matching
+	// cases are comparable with each other.
+	egressTargetDepth = 0.65
+
+	// The flow. The denied case keeps this destination, which no rule's CIDR contains; the
+	// matching cases replace it with an address inside the target rule's CIDR.
+	egressSourceIP   = "192.0.2.10"
+	egressDeniedIP   = "198.51.100.20"
+	egressSourcePort = 45000
+)
+
+// egressPortWeights reproduces the measured head of the port distribution: the fraction of
+// rules whose destination ports include each of these. 443 appears in 3,395 of 18,675 rules,
+// 11001 in 2,289, 27054 in 2,281 and 80 in 1,505. Rules not drawing a head port get ports from
+// a long tail of otherwise-unique values, so a tail port is shared by only a rule or two.
+var egressPortWeights = []struct {
+	port     int32
+	fraction float64
+}{
+	{443, 0.182},
+	{11001, 0.123},
+	{27054, 0.122},
+	{80, 0.081},
+}
+
+// egressPortsPerRule is the measured spread of destination ports per rule: median 2, mean ~5.
+var egressPortsPerRule = []struct {
+	count    int
+	fraction float64
+}{
+	{1, 0.25},
+	{2, 0.45},
+	{3, 0.15},
+	{8, 0.10},
+	{20, 0.05},
+}
+
+func BenchmarkEvaluateEgressAllowList(b *testing.B) {
+	// A flow on a port few rules share: rejected on the port comparison nearly everywhere.
+	b.Run("TailPort", func(b *testing.B) {
+		benchEvaluateEgressAllowList(b, egressTailPortFlow)
+	})
+	// A flow on the most popular port: ~18% of rules share it and go on to the address check.
+	b.Run("PopularPort", func(b *testing.B) {
+		benchEvaluateEgressAllowList(b, egressPopularPortFlow)
+	})
+	// No rule matches, so the walk covers the whole tier and ends in the tier default deny.
+	// Ordering cannot reduce the scan depth here, only the cost of each rejected rule.
+	b.Run("Denied", func(b *testing.B) {
+		benchEvaluateEgressAllowList(b, egressDeniedFlow)
+	})
+}
+
+// egressCase is what one benchmark case measures: the flow, how many rules the walk is
+// expected to visit, and whether a rule is expected to match it.
+type egressCase struct {
+	flow        *MockFlow
+	rulesWalked int
+	matches     bool
+}
+
+// egressCaseFunc builds one case from the fixture's target rule.
+type egressCaseFunc func(target egressTarget) egressCase
+
+func egressTailPortFlow(target egressTarget) egressCase {
+	return egressCase{
+		flow:        egressFlow(target.addrInCIDR, target.tailPort),
+		rulesWalked: target.rulesWalked,
+		matches:     true,
+	}
+}
+
+func egressPopularPortFlow(target egressTarget) egressCase {
+	return egressCase{
+		flow:        egressFlow(target.addrInCIDR, egressPortWeights[0].port),
+		rulesWalked: target.rulesWalked,
+		matches:     true,
+	}
+}
+
+func egressDeniedFlow(_ egressTarget) egressCase {
+	return egressCase{
+		flow:        egressFlow(egressDeniedIP, egressPortWeights[0].port),
+		rulesWalked: egressNumPolicies * egressRulesPerPolicy,
+	}
+}
+
+func egressFlow(destIP string, destPort int32) *MockFlow {
+	return &MockFlow{
+		SourceIP:   net.ParseIP(egressSourceIP),
+		DestIP:     net.ParseIP(destIP),
+		SourcePort: egressSourcePort,
+		DestPort:   int(destPort),
+		Protocol:   6, // TCP
+	}
+}
+
+func benchEvaluateEgressAllowList(b *testing.B, caseFor egressCaseFunc) {
+	_, restoreLogging := withBenchLogging(log.WarnLevel)
+	defer restoreLogging()
+
+	store, ep, target := buildEgressAllowListStore()
+	c := caseFor(target)
+
+	// Pre-flight outside the timed loop: prove the walk is the one the case intends, so that
+	// a fixture change cannot silently turn a full walk into an early exit.
+	trace, err := Evaluate(EnforcedOnly, rules.RuleDirEgress, store, ep, c.flow)
+	if err != nil {
+		b.Fatalf("evaluation failed: %v", err)
+	}
+	if c.matches {
+		if len(trace) != 1 || trace[0].Action != rules.RuleActionAllow || trace[0].Index != target.ruleIndex {
+			b.Fatalf("expected an allow from the target rule at index %d, got %v", target.ruleIndex, trace)
+		}
+	} else if len(trace) != 1 || trace[0].Action != rules.RuleActionDeny || trace[0].Index != tierDefaultActionIndex {
+		b.Fatalf("expected a full walk ending in the tier default deny, got %v", trace)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		benchTraceSink, _ = Evaluate(EnforcedOnly, rules.RuleDirEgress, store, ep, c.flow)
+	}
+	b.StopTimer()
+	b.ReportMetric(float64(c.rulesWalked), "rules/op")
+	b.ReportMetric(float64(b.Elapsed().Nanoseconds())/float64(b.N)/float64(c.rulesWalked), "ns/rule")
+}
+
+// egressTarget describes the one rule in the fixture that a matching flow is built to hit.
+type egressTarget struct {
+	ruleIndex   int    // Index of the rule within its policy, for the trace assertion.
+	addrInCIDR  string // An address inside the rule's destination CIDR.
+	tailPort    int32  // A port on the rule that few other rules share.
+	rulesWalked int    // Rules visited before and including it.
+}
+
+// buildEgressAllowListStore builds the policy store and the endpoint whose single tier applies
+// every policy, and returns the target rule a matching flow is aimed at.
+//
+// Destination CIDRs are handed out sequentially rather than at random so that no rule except
+// the target can contain the matching flow's address: a second rule matching earlier would
+// shorten the walk and make the case measure something other than what it claims to.
+func buildEgressAllowListStore() (*policystore.PolicyStore, *proto.WorkloadEndpoint, egressTarget) {
+	rng := rand.New(rand.NewSource(20200))
+	store := policystore.NewPolicyStore()
+	setIDs := makeEgressIPSets(store)
+
+	numRules := egressNumPolicies * egressRulesPerPolicy
+	targetRule := int(float64(numRules) * egressTargetDepth)
+
+	tier := &proto.TierInfo{Name: "perimeter", DefaultAction: "Deny"}
+	var target egressTarget
+	nextCIDR := 0
+	ruleIdx := 0
+	for i := 0; i < egressNumPolicies; i++ {
+		policyID := &proto.PolicyID{Name: fmt.Sprintf("egress-%03d", i), Kind: v3.KindGlobalNetworkPolicy}
+		policy := &proto.Policy{Tier: tier.Name}
+		for j := 0; j < egressRulesPerPolicy; j++ {
+			// All rules are Pass bar the target: a rule's action is only consulted once it
+			// matches, so the action mix does not affect the walk.
+			rule := &proto.Rule{Action: "pass", DstPorts: makeEgressRulePorts(rng)}
+			if rng.Float64() < egressIPSetRuleFraction {
+				rule.DstIpSetIds = []string{setIDs[rng.Intn(len(setIDs))]}
+			} else {
+				rule.DstNet = []string{fmt.Sprintf("10.%d.%d.0/24", nextCIDR>>8&0xff, nextCIDR&0xff)}
+				nextCIDR++
+			}
+			if ruleIdx == targetRule {
+				// Make the target reachable on address and on a port of its own, and give it
+				// a distinct action so the trace assertion is unambiguous.
+				rule.Action = "allow"
+				rule.DstNet = []string{fmt.Sprintf("10.%d.%d.0/24", nextCIDR>>8&0xff, nextCIDR&0xff)}
+				rule.DstIpSetIds = nil
+				// Carry both ports the matching cases use, so they differ only in how many
+				// rules along the way survive the port comparison.
+				rule.DstPorts = append(rule.DstPorts,
+					&proto.PortRange{First: egressTailPort, Last: egressTailPort},
+					&proto.PortRange{First: egressPortWeights[0].port, Last: egressPortWeights[0].port},
+				)
+				target = egressTarget{
+					ruleIndex:   j,
+					addrInCIDR:  fmt.Sprintf("10.%d.%d.7", nextCIDR>>8&0xff, nextCIDR&0xff),
+					tailPort:    egressTailPort,
+					rulesWalked: ruleIdx + 1,
+				}
+				nextCIDR++
+			}
+			policy.OutboundRules = append(policy.OutboundRules, rule)
+			ruleIdx++
+		}
+		store.PolicyByID[types.ProtoToPolicyID(policyID)] = policy
+		tier.EgressPolicies = append(tier.EgressPolicies, policyID)
+	}
+
+	ep := &proto.WorkloadEndpoint{Tiers: []*proto.TierInfo{tier}}
+	return store, ep, target
+}
+
+// egressTailPort is outside the range makeEgressRulePorts draws from, so only the target rule
+// carries it — the extreme of the measured tail, where 90% of ports are on 5 rules or fewer.
+const egressTailPort = 60999
+
+// makeEgressRulePorts picks a rule's destination ports: the measured head with its measured
+// frequency, topped up from a wide tail.
+func makeEgressRulePorts(rng *rand.Rand) []*proto.PortRange {
+	var ports []int32
+	for _, w := range egressPortWeights {
+		if rng.Float64() < w.fraction {
+			ports = append(ports, w.port)
+		}
+	}
+	for _, n := range egressPortsPerRule {
+		if rng.Float64() < n.fraction {
+			for len(ports) < n.count {
+				ports = append(ports, int32(1024+rng.Intn(55000)))
+			}
+			break
+		}
+	}
+	if len(ports) == 0 {
+		ports = append(ports, int32(1024+rng.Intn(55000)))
+	}
+
+	ranges := make([]*proto.PortRange, 0, len(ports))
+	for _, p := range ports {
+		ranges = append(ranges, &proto.PortRange{First: p, Last: p})
+	}
+	return ranges
+}
+
+// makeEgressIPSets populates the store with the NET sets the selector-matching rules reference:
+// 3,862 sets at a median of 3 members, none containing the flow's addresses. Members are /32s
+// from 10.128.0.0/9, kept clear of the rule CIDRs handed out from 10.0.0.0/9.
+func makeEgressIPSets(store *policystore.PolicyStore) []string {
+	const numSets = 3862
+	ids := make([]string, 0, numSets)
+	member := 0
+	for i := 0; i < numSets; i++ {
+		id := fmt.Sprintf("s:egress-%04d", i)
+		s := policystore.NewIPSet(proto.IPSetUpdate_NET)
+		for j := 0; j < 3; j++ {
+			s.AddString(fmt.Sprintf("10.%d.%d.%d/32", 128+(member>>16&0x7f), member>>8&0xff, member&0xff))
+			member++
+		}
+		store.IPSetByID[id] = s
+		ids = append(ids, id)
+	}
+	return ids
+}

--- a/app-policy/checker/bench_test.go
+++ b/app-policy/checker/bench_test.go
@@ -38,8 +38,10 @@ import (
 	"io"
 	"math/rand"
 	"net"
+	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	v3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
 	log "github.com/sirupsen/logrus"
@@ -49,6 +51,7 @@ import (
 	"github.com/projectcalico/calico/felix/proto"
 	"github.com/projectcalico/calico/felix/rules"
 	"github.com/projectcalico/calico/felix/types"
+	"github.com/projectcalico/calico/lib/logrusr"
 )
 
 // baselinePolicyScaleParams describes a policy store dominated by "baseline" policies:
@@ -87,6 +90,19 @@ var ipSetSizeHistogram = []struct{ numSets, minSize, maxSize int }{
 	{1, 54566, 54566},
 }
 
+// The benchmark flow. TEST-NET addresses; generated IP set members and rule CIDRs all
+// come from 10.0.0.0/8, so no rule ever matches on address and the walk covers the
+// whole policy set.
+const (
+	benchSourceIP   = "192.0.2.10"
+	benchDestIP     = "198.51.100.20"
+	benchSourcePort = 45000
+	benchDestPort   = 8080
+
+	// benchSentinelIPSetID is a set containing the flow's addresses; see makeScaleRule.
+	benchSentinelIPSetID = "s:bench-sentinel"
+)
+
 // benchTraceSink prevents the compiler from eliminating the Evaluate call.
 var benchTraceSink []*calc.RuleID
 
@@ -115,32 +131,18 @@ func BenchmarkEvaluateBaselinePolicyScale(b *testing.B) {
 
 func benchEvaluateBaselinePolicyScale(b *testing.B, p baselinePolicyScaleParams, level log.Level, matchEarly bool) {
 	logger := log.StandardLogger()
-	oldLevel, oldOut := logger.GetLevel(), logger.Out
-	counter := &ipsetMissCounter{}
-	hooks := make(log.LevelHooks)
-	hooks.Add(counter)
-	oldHooks := logger.ReplaceHooks(hooks)
-	defer func() {
-		logger.SetLevel(oldLevel)
-		logger.SetOutput(oldOut)
-		logger.ReplaceHooks(oldHooks)
-	}()
-	log.SetLevel(level)
-	// Discard output so we don't benchmark the terminal; the formatting cost stays, but
-	// a real deployment pays the log write too.
-	log.SetOutput(io.Discard)
+	counter, restoreLogging := withBenchLogging(level)
+	defer restoreLogging()
 
 	store, ep, expectedWarns := buildBaselinePolicyStore(p)
 	if matchEarly {
 		addMatchEarlyPolicy(store, ep)
 	}
 	flow := &MockFlow{
-		// TEST-NET addresses; generated IP set members all come from 10.0.0.0/8, so no
-		// rule ever matches and the walk covers the whole policy set.
-		SourceIP:   net.ParseIP("192.0.2.10"),
-		DestIP:     net.ParseIP("198.51.100.20"),
-		SourcePort: 45000,
-		DestPort:   8080,
+		SourceIP:   net.ParseIP(benchSourceIP),
+		DestIP:     net.ParseIP(benchDestIP),
+		SourcePort: benchSourcePort,
+		DestPort:   benchDestPort,
 		Protocol:   6, // TCP
 	}
 
@@ -243,6 +245,11 @@ func buildBaselinePolicyStore(p baselinePolicyScaleParams) (*policystore.PolicyS
 // measured deployment: selector and networkset derived sets) following the measured
 // size histogram. Members are unique /32s from 10.0.0.0/8.
 func makeScaleIPSets(rng *rand.Rand, store *policystore.PolicyStore) []string {
+	sentinel := policystore.NewIPSet(proto.IPSetUpdate_NET)
+	sentinel.AddString(benchSourceIP + "/32")
+	sentinel.AddString(benchDestIP + "/32")
+	store.IPSetByID[benchSentinelIPSetID] = sentinel
+
 	var ids []string
 	member := 0
 	for _, bucket := range ipSetSizeHistogram {
@@ -261,31 +268,29 @@ func makeScaleIPSets(rng *rand.Rand, store *policystore.PolicyStore) []string {
 	return ids
 }
 
-// makeScaleRule builds a rule that never matches the benchmark flow but still pays the
-// full match cost. Rules that reference an IP set are shaped so the set lookup always
-// executes:
-//   - src refs guard with a non-matching source port, which match() evaluates after the
-//     src IP set lookup; the guard is needed because a missing src set is skipped rather
-//     than treated as a non-match.
-//   - dst refs guard with a non-matching destination port for the same reason, and
-//     leave the source criteria empty so evaluation reaches the destination.
+// makeScaleRule builds a rule that never matches the benchmark flow. It returns the
+// referenced IP set ID, or "" for a rule with no reference.
 //
-// It returns the referenced IP set ID, or "" for a rule with no reference.
+// A rule that references an IP set must reach the set lookup whatever order match()
+// evaluates criteria in, and must still miss when the referenced set is absent from
+// the store (an absent set is skipped rather than treated as a non-match). Both hold
+// by pairing the reference with a negated reference to benchSentinelIPSetID, which
+// contains the flow's addresses: if the referenced set is present the lookup misses
+// and evaluation stops there; if it is absent the sentinel makes the rule miss.
 func makeScaleRule(rng *rand.Rand, setIDs []string, action string, refFraction float64) (*proto.Rule, string) {
 	rule := &proto.Rule{Action: action}
 	if rng.Float64() < refFraction {
 		id := setIDs[rng.Intn(len(setIDs))]
 		if rng.Intn(2) == 0 {
 			rule.SrcIpSetIds = []string{id}
-			rule.SrcPorts = []*proto.PortRange{{First: 65001, Last: 65001}}
+			rule.NotSrcIpSetIds = []string{benchSentinelIPSetID}
 		} else {
 			rule.DstIpSetIds = []string{id}
-			rule.DstPorts = []*proto.PortRange{{First: 65001, Last: 65001}}
+			rule.NotDstIpSetIds = []string{benchSentinelIPSetID}
 		}
 		return rule, id
 	}
-	// No IP set reference: guard with a non-matching destination port so the match walks
-	// the whole chain (including the per-rule dst-IP-port formatting) before failing.
+	// No IP set reference: guard with a non-matching destination port.
 	rule.DstPorts = []*proto.PortRange{{First: 65001, Last: 65001}}
 	return rule, ""
 }
@@ -309,8 +314,55 @@ type ipsetMissCounter struct {
 func (c *ipsetMissCounter) Levels() []log.Level { return []log.Level{log.WarnLevel} }
 
 func (c *ipsetMissCounter) Fire(e *log.Entry) error {
-	if e.Message == "IPSet not found" {
+	// The message carries the set ID, so match on the prefix.
+	if strings.HasPrefix(e.Message, "IPSet not found") {
 		c.count.Add(1)
 	}
 	return nil
+}
+
+// withBenchLogging sets the log level, discards output so the terminal is not part of the
+// measurement, installs the "IPSet not found" counter, and unthrottles the evaluation path's
+// rate-limited loggers. It returns the counter and a function restoring everything.
+func withBenchLogging(level log.Level) (*ipsetMissCounter, func()) {
+	logger := log.StandardLogger()
+	oldLevel, oldOut := logger.GetLevel(), logger.Out
+	counter := &ipsetMissCounter{}
+	hooks := make(log.LevelHooks)
+	hooks.Add(counter)
+	oldHooks := logger.ReplaceHooks(hooks)
+	restoreLoggers := withUnthrottledEvalPathLogs()
+
+	logger.SetLevel(level)
+	// The formatting cost stays in the measurement; a real deployment pays the write too.
+	logger.SetOutput(io.Discard)
+
+	return counter, func() {
+		logger.SetLevel(oldLevel)
+		logger.SetOutput(oldOut)
+		logger.ReplaceHooks(oldHooks)
+		restoreLoggers()
+	}
+}
+
+// withUnthrottledEvalPathLogs replaces the evaluation path's rate-limited loggers with ones
+// that never suppress, and returns a function restoring them. The warnings/op metric counts
+// every occurrence, which is the point of it — production gets the throttled loggers, and the
+// emitted line's "logsSkipped" field carries the count this benchmark reports directly.
+func withUnthrottledEvalPathLogs() func() {
+	saved := []**logrusr.RateLimitedLogger{
+		&rlogIPSetMissing, &rlogBadPrincipal, &rlogBadProtocol,
+		&rlogBadCIDR, &rlogBadSelector, &rlogBadRulePath,
+	}
+	originals := make([]*logrusr.RateLimitedLogger, len(saved))
+	for i, l := range saved {
+		originals[i] = *l
+		// A negative interval puts the next-log deadline in the past on every call.
+		*l = logrusr.NewRateLimitedLogger(logrusr.OptInterval(-time.Nanosecond))
+	}
+	return func() {
+		for i, l := range saved {
+			*l = originals[i]
+		}
+	}
 }

--- a/app-policy/checker/bench_test.go
+++ b/app-policy/checker/bench_test.go
@@ -351,14 +351,17 @@ func withBenchLogging(level log.Level) (*ipsetMissCounter, func()) {
 // emitted line's "logsSkipped" field carries the count this benchmark reports directly.
 func withUnthrottledEvalPathLogs() func() {
 	saved := []**logrusr.RateLimitedLogger{
-		&rlogIPSetMissing, &rlogBadPrincipal, &rlogBadProtocol,
+		&rlogIPSetMissing, &rlogBadPrincipal, &rlogBadProtocol, &rlogBadProtocolName,
 		&rlogBadCIDR, &rlogBadSelector, &rlogBadRulePath,
 	}
 	originals := make([]*logrusr.RateLimitedLogger, len(saved))
 	for i, l := range saved {
 		originals[i] = *l
-		// A negative interval puts the next-log deadline in the past on every call.
-		*l = logrusr.NewRateLimitedLogger(logrusr.OptInterval(-time.Nanosecond))
+		// A negative interval puts the next-log deadline in the past on every call. The
+		// burst keeps the limiter off the WithFields path it takes to report a skip count,
+		// which would otherwise allocate on every line the benchmark measures.
+		*l = logrusr.NewRateLimitedLogger(
+			logrusr.OptInterval(-time.Nanosecond), logrusr.OptBurst(1))
 	}
 	return func() {
 		for i, l := range saved {

--- a/app-policy/checker/check.go
+++ b/app-policy/checker/check.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2025 Tigera, Inc. All rights reserved.
+// Copyright (c) 2018-2026 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ package checker
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	v3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
 	log "github.com/sirupsen/logrus"
@@ -42,8 +43,8 @@ var (
 	INTERNAL          = int32(code.Code_INTERNAL)
 	UNKNOWN           = int32(code.Code_UNKNOWN)
 
-	rlog1 = logrusr.NewRateLimitedLogger()
-	rlog2 = logrusr.NewRateLimitedLogger()
+	rlogBadDstAddr = logrusr.NewRateLimitedLogger()
+	rlogBadSrcAddr = logrusr.NewRateLimitedLogger()
 	// A missing policy is one log line per evaluation, and Felix's collector re-evaluates every
 	// flow in both directions on every sweep, so a policy that stays missing would log per flow
 	// per sweep.
@@ -62,6 +63,37 @@ const (
 	// giving the "pending" verdict: what would happen if the staged policies went live now.
 	StagedAsEnforced
 )
+
+// Every log site on the per-request evaluation path needs its own rate limiter.
+//
+// A rule set that applies tens of thousands of rules to one endpoint turns any per-rule log
+// into a storm: the conditions below are all "shouldn't happen, but does" — a dangling IP set
+// reference while the store catches up, a malformed CIDR or selector that got past validation,
+// a flow that is not IP at all — and each one repeats for every rule in the set, on every
+// request. Rate limiting is per logger instance, so sharing one across sites would let the
+// noisiest message starve the rest; sites that report the same condition do share one.
+//
+// These sites must not use the WithField/WithError builders: those allocate a fields map, a
+// logrus.Entry and a wrapper *before* the rate limiter gets to drop the message, which is the
+// per-rule allocation this path has been optimised to avoid. Pass the value to Warnf instead.
+var (
+	rlogIPSetMissing = newEvalPathLogger()
+	rlogBadPrincipal = newEvalPathLogger()
+	rlogBadProtocol  = newEvalPathLogger()
+	rlogBadCIDR      = newEvalPathLogger()
+	rlogBadSelector  = newEvalPathLogger()
+	rlogBadRulePath  = newEvalPathLogger()
+)
+
+// newEvalPathLogger returns a logger that admits a short burst and then one line per interval,
+// so a storm leaves a few concrete examples plus a "logsSkipped" count rather than filling the
+// log. Tests that need every line replace these vars; see withUnthrottledEvalPathLogs.
+func newEvalPathLogger() *logrusr.RateLimitedLogger {
+	return logrusr.NewRateLimitedLogger(
+		logrusr.OptInterval(30*time.Second),
+		logrusr.OptBurst(10),
+	)
+}
 
 // Action is an enumeration of actions a policy rule can take if it is matched.
 type Action int
@@ -106,14 +138,14 @@ func LookupEndpointKeysFromSrcDst(store *policystore.PolicyStore, src, dst strin
 
 	// Map the destination
 	if destinationIp, err := ip.ParseCIDROrIP(dst); err != nil {
-		rlog1.WithError(err).Errorf("cannot process destination addr %s", dst)
+		rlogBadDstAddr.Errorf("cannot process destination addr %s: %v", dst, err)
 	} else {
 		log.Debugf("lookup endpoint for destination %s", destinationIp.String())
 		destination = ipToEndpointKeys(store, destinationIp.Addr())
 	}
 	// Map the source
 	if sourceIp, err := ip.ParseCIDROrIP(src); err != nil {
-		rlog2.WithError(err).Errorf("cannot process source addr %s", src)
+		rlogBadSrcAddr.Errorf("cannot process source addr %s: %v", src, err)
 	} else {
 		log.Debugf("lookup endpoint for source %s", sourceIp.String())
 		source = ipToEndpointKeys(store, sourceIp.Addr())

--- a/app-policy/checker/check.go
+++ b/app-policy/checker/check.go
@@ -80,9 +80,12 @@ var (
 	rlogIPSetMissing = newEvalPathLogger()
 	rlogBadPrincipal = newEvalPathLogger()
 	rlogBadProtocol  = newEvalPathLogger()
-	rlogBadCIDR      = newEvalPathLogger()
-	rlogBadSelector  = newEvalPathLogger()
-	rlogBadRulePath  = newEvalPathLogger()
+	// The adapter warns when Envoy names a protocol it cannot map. requestCache memoizes
+	// the resolved protocol, so this fires once per request rather than once per rule.
+	rlogBadProtocolName = newEvalPathLogger()
+	rlogBadCIDR         = newEvalPathLogger()
+	rlogBadSelector     = newEvalPathLogger()
+	rlogBadRulePath     = newEvalPathLogger()
 )
 
 // newEvalPathLogger returns a logger that admits a short burst and then one line per interval,

--- a/app-policy/checker/check_test.go
+++ b/app-policy/checker/check_test.go
@@ -1261,3 +1261,88 @@ func TestEvaluateRecordsStagedPolicyInPendingTraceOnly(t *testing.T) {
 			0, rules.RuleDirIngress, rules.RuleActionAllow),
 	}))
 }
+
+// A rule whose HTTP criteria would reject a malformed request path no longer decides the
+// request when the rule does not apply to it in the first place. Ordering the criteria
+// cheapest-first drops such a rule on its protocol, before matchRequest can panic on the
+// path, so the walk carries on to a rule that does apply.
+func TestMalformedHTTPPathOnlyFailsRulesThatReachIt(t *testing.T) {
+	RegisterTestingT(t)
+
+	udpWithPaths := &proto.PolicyID{Name: "udp-with-paths", Kind: v3.KindGlobalNetworkPolicy}
+	allowsTCP := &proto.PolicyID{Name: "allows-tcp", Kind: v3.KindGlobalNetworkPolicy}
+
+	httpRule := func(protocol string) *proto.Rule {
+		return &proto.Rule{
+			Action:   "allow",
+			Protocol: &proto.Protocol{NumberOrName: &proto.Protocol_Name{Name: protocol}},
+			HttpMatch: &proto.HTTPMatch{
+				Paths: []*proto.HTTPMatch_PathMatch{
+					{PathMatch: &proto.HTTPMatch_PathMatch_Exact{Exact: "/foo"}},
+				},
+			},
+		}
+	}
+
+	store := policystore.NewPolicyStore()
+	store.PolicyByID[types.ProtoToPolicyID(allowsTCP)] = &proto.Policy{
+		InboundRules: []*proto.Rule{{Action: "allow"}},
+	}
+	ep := &proto.WorkloadEndpoint{Tiers: tierInfos(policyIDs(udpWithPaths, allowsTCP))}
+
+	// A TCP request whose path is missing its leading "/". Envoy should not send one, so the
+	// evaluator treats it as bad data from the data plane rather than as a non-match.
+	badPath := "no-leading-slash"
+	flow := &MockFlow{Protocol: 6, DestPort: 80, HttpPath: &badPath}
+
+	// The UDP rule cannot apply to a TCP request, so its HTTP criteria are never reached and
+	// the next policy allows.
+	store.PolicyByID[types.ProtoToPolicyID(udpWithPaths)] = &proto.Policy{
+		InboundRules: []*proto.Rule{httpRule("UDP")},
+	}
+	Expect(checkStore(EnforcedOnly, store, ep, rules.RuleDirIngress, flow).Code).To(Equal(OK))
+
+	// The same rule on TCP does reach them, and the malformed path still fails the request.
+	store.PolicyByID[types.ProtoToPolicyID(udpWithPaths)] = &proto.Policy{
+		InboundRules: []*proto.Rule{httpRule("TCP")},
+	}
+	st := checkStore(EnforcedOnly, store, ep, rules.RuleDirIngress, flow)
+	Expect(st.Code).To(Equal(INVALID_ARGUMENT))
+	Expect(st.Message).To(ContainSubstring(badPath))
+}
+
+// countingFlow counts how often the evaluator asks the data plane for the flow's protocol.
+type countingFlow struct {
+	Flow
+	protocolCalls int
+}
+
+func (c *countingFlow) GetProtocol() int {
+	c.protocolCalls++
+	return c.Flow.GetProtocol()
+}
+
+// The protocol is the first criterion every rule is tested against, so the evaluator must not
+// ask the data plane for it per rule: the Envoy adapter derives it from an enum name via a
+// lowercased map lookup, which allocates.
+func TestProtocolResolvedOncePerRequest(t *testing.T) {
+	RegisterTestingT(t)
+
+	// Rules that no request matches, so that every one of them tests the protocol.
+	var noMatch []*proto.Rule
+	for range 50 {
+		noMatch = append(noMatch, &proto.Rule{
+			Action:   "allow",
+			Protocol: &proto.Protocol{NumberOrName: &proto.Protocol_Number{Number: 132}},
+		})
+	}
+
+	policy := &proto.PolicyID{Name: "policy1", Kind: v3.KindGlobalNetworkPolicy}
+	store := policystore.NewPolicyStore()
+	store.PolicyByID[types.ProtoToPolicyID(policy)] = &proto.Policy{InboundRules: noMatch}
+	ep := &proto.WorkloadEndpoint{Tiers: tierInfos(policyIDs(policy))}
+
+	flow := &countingFlow{Flow: &MockFlow{Protocol: 6, DestPort: 80}}
+	Expect(checkStore(EnforcedOnly, store, ep, rules.RuleDirIngress, flow).Code).To(Equal(PERMISSION_DENIED))
+	Expect(flow.protocolCalls).To(Equal(1))
+}

--- a/app-policy/checker/match.go
+++ b/app-policy/checker/match.go
@@ -21,6 +21,7 @@ import (
 	"path"
 	"regexp"
 	"slices"
+	"strconv"
 	"strings"
 
 	log "github.com/sirupsen/logrus"
@@ -92,15 +93,33 @@ func match(policyNamespace string, rule *proto.Rule, req *requestCache) bool {
 			"HttpPath":   req.GetHttpPath(),
 		}).Debug("Checking rule on request")
 	}
-	return matchSource(policyNamespace, rule, req) &&
-		matchDestination(policyNamespace, rule, req) &&
-		matchRequest(rule, req) &&
-		matchL4Protocol(rule, int32(req.GetProtocol()))
+	// A rule's criteria are ANDed, so they may be evaluated in any order. Evaluate them
+	// cheapest-first, because most rules in a large policy set are rejected by exactly
+	// one criterion and the walk stops at it:
+	//
+	//   - protocol and ports are integer comparisons against the flow;
+	//   - the address criteria parse a CIDR per entry, or hash and walk an IP set;
+	//   - the identity criteria parse and evaluate a label selector.
+	//
+	// The HTTP criteria go last because matchRequest normalises the request path,
+	// and because it panics on a malformed one: leaving it last confines that to
+	// requests that a rule otherwise matches.
+	return matchL4Protocol(rule, int32(req.GetProtocol())) &&
+		matchSrcPort(rule, req) &&
+		matchDstPort(rule, req) &&
+		matchSrcNet(rule, req) &&
+		matchDstNet(rule, req) &&
+		matchSrcIPSets(rule, req) &&
+		matchDstIPSets(rule, req) &&
+		matchDstIPPortSetIds(rule, req) &&
+		matchSrcIdentity(policyNamespace, rule, req) &&
+		matchDstIdentity(policyNamespace, rule, req) &&
+		matchRequest(rule, req)
 }
 
-// matchSource checks if the source part of the Rule matches the request. It returns true if the
-// Rule matches, false otherwise.
-func matchSource(policyNamespace string, r *proto.Rule, req *requestCache) bool {
+// matchSrcIdentity checks the source service account and namespace criteria of the Rule
+// against the request's identity. It returns true if the Rule matches, false otherwise.
+func matchSrcIdentity(policyNamespace string, r *proto.Rule, req *requestCache) bool {
 	nsMatch := computeNamespaceMatch(
 		policyNamespace,
 		r.GetOriginalSrcNamespaceSelector(),
@@ -109,15 +128,13 @@ func matchSource(policyNamespace string, r *proto.Rule, req *requestCache) bool 
 		r.GetSrcServiceAccountMatch())
 
 	return matchServiceAccounts(r.GetSrcServiceAccountMatch(), req.getSrcPeer()) &&
-		matchNamespace(nsMatch, req.getSrcNamespace()) &&
-		matchSrcIPSets(r, req) &&
-		matchSrcPort(r, req) &&
-		matchSrcNet(r, req)
+		matchNamespace(nsMatch, req.getSrcNamespace())
 }
 
-// matchDestination checks if the destination part of the Rule matches the request. It returns true if the
-// Rule matches, false otherwise.
-func matchDestination(policyNamespace string, r *proto.Rule, req *requestCache) bool {
+// matchDstIdentity checks the destination service account and namespace criteria of the
+// Rule against the request's identity. It returns true if the Rule matches, false
+// otherwise.
+func matchDstIdentity(policyNamespace string, r *proto.Rule, req *requestCache) bool {
 	nsMatch := computeNamespaceMatch(
 		policyNamespace,
 		r.GetOriginalDstNamespaceSelector(),
@@ -126,11 +143,7 @@ func matchDestination(policyNamespace string, r *proto.Rule, req *requestCache) 
 		r.GetDstServiceAccountMatch())
 
 	return matchServiceAccounts(r.GetDstServiceAccountMatch(), req.getDstPeer()) &&
-		matchNamespace(nsMatch, req.getDstNamespace()) &&
-		matchDstIPSets(r, req) &&
-		matchDstIPPortSetIds(r, req) &&
-		matchDstPort(r, req) &&
-		matchDstNet(r, req)
+		matchNamespace(nsMatch, req.getDstNamespace())
 }
 
 // computeNamespaceMatch computes the namespace match based on the policyNamespace, namespace
@@ -219,7 +232,7 @@ func matchLabels(selectorStr string, labels map[string]string) bool {
 	}
 	sel, err := selector.Parse(selectorStr)
 	if err != nil {
-		log.Warnf("Could not parse label selector %v, %v", selectorStr, err)
+		rlogBadSelector.Warnf("Could not parse label selector %v, %v", selectorStr, err)
 		return false
 	}
 	log.Debugf("Parsed selector.")
@@ -339,7 +352,7 @@ func matchHTTPPaths(paths []*proto.HTTPMatch_PathMatch, reqPath *string) bool {
 		case *proto.HTTPMatch_PathMatch_Exact:
 			rulePath, ok := normalizeHTTPPath(m.Exact)
 			if !ok {
-				log.WithField("rulePath", m.Exact).Warn("HTTP Path exact rule could not be normalized; skipping.")
+				rlogBadRulePath.Warnf("HTTP Path exact rule could not be normalized; skipping: %s", m.Exact)
 				continue
 			}
 			if normalizedReq == rulePath {
@@ -349,7 +362,7 @@ func matchHTTPPaths(paths []*proto.HTTPMatch_PathMatch, reqPath *string) bool {
 		case *proto.HTTPMatch_PathMatch_Prefix:
 			rulePrefix, ok := normalizeHTTPPath(m.Prefix)
 			if !ok {
-				log.WithField("rulePath", m.Prefix).Warn("HTTP Path prefix rule could not be normalized; skipping.")
+				rlogBadRulePath.Warnf("HTTP Path prefix rule could not be normalized; skipping: %s", m.Prefix)
 				continue
 			}
 			if segmentPrefixMatch(normalizedReq, rulePrefix) {
@@ -579,8 +592,11 @@ func matchPort(dir string, ranges []*proto.PortRange, namedPortSets []string, ip
 			return true
 		}
 	}
+	if len(namedPortSets) == 0 {
+		return false
+	}
+	portStr := strconv.Itoa(port)
 	for _, id := range namedPortSets {
-		portStr := fmt.Sprintf("%d", port)
 		if s := ipsSetFunc(id); s != nil && s.Contains(portStr) {
 			return true
 		}
@@ -608,8 +624,11 @@ func matchNotPort(dir string, ranges []*proto.PortRange, namedPortSets []string,
 			return false
 		}
 	}
+	if len(namedPortSets) == 0 {
+		return true
+	}
+	portStr := strconv.Itoa(port)
 	for _, id := range namedPortSets {
-		portStr := fmt.Sprintf("%d", port)
 		if s := ipsSetFunc(id); s != nil && s.Contains(portStr) {
 			return false
 		}
@@ -648,7 +667,7 @@ func matchNet(dir string, nets []string, ip net.IP) bool {
 		if err != nil {
 			// Don't match CIDRs if they are malformed. This case should generally be weeded out by
 			// validation earlier in processing before it gets to Dikastes.
-			log.WithField("cidr", n).Warn("unable to parse CIDR")
+			rlogBadCIDR.Warnf("unable to parse CIDR %s", n)
 			return false
 		}
 		if ipn.Contains(ip) {
@@ -677,7 +696,7 @@ func matchNotNet(dir string, nets []string, ip net.IP) bool {
 		if err != nil {
 			// Don't match CIDRs if they are malformed. This case should generally be weeded out by
 			// validation earlier in processing before it gets to Dikastes.
-			log.WithField("cidr", n).Warn("unable to parse CIDR")
+			rlogBadCIDR.Warnf("unable to parse CIDR %s", n)
 			return false
 		}
 		if ipn.Contains(ip) {
@@ -701,9 +720,7 @@ var stringToProto = map[string]int32{
 func matchL4Protocol(rule *proto.Rule, protocol int32) bool {
 	// Protocol is a 8-bit field.
 	if protocol > 255 || protocol < 1 {
-		log.WithFields(log.Fields{
-			"protocol": protocol,
-		}).Warn("Unsupported L4 protocol")
+		rlogBadProtocol.Warnf("Unsupported L4 protocol: %d", protocol)
 		return false
 	}
 	if log.IsLevelEnabled(log.DebugLevel) {

--- a/app-policy/checker/match.go
+++ b/app-policy/checker/match.go
@@ -31,7 +31,7 @@ import (
 	"github.com/projectcalico/calico/libcalico-go/lib/selector"
 )
 
-var protocolMapL4 = map[int32]string{
+var protocolMapL4 = map[int]string{
 	1:  "icmp",
 	6:  "tcp",
 	17: "udp",
@@ -104,7 +104,7 @@ func match(policyNamespace string, rule *proto.Rule, req *requestCache) bool {
 	// The HTTP criteria go last because matchRequest normalises the request path,
 	// and because it panics on a malformed one: leaving it last confines that to
 	// requests that a rule otherwise matches.
-	return matchL4Protocol(rule, int32(req.GetProtocol())) &&
+	return matchL4Protocol(rule, req.GetProtocol()) &&
 		matchSrcPort(rule, req) &&
 		matchDstPort(rule, req) &&
 		matchSrcNet(rule, req) &&
@@ -706,7 +706,7 @@ func matchNotNet(dir string, nets []string, ip net.IP) bool {
 	return true
 }
 
-var stringToProto = map[string]int32{
+var stringToProto = map[string]int{
 	"icmp":    1,
 	"icmpv6":  58,
 	"tcp":     6,
@@ -717,13 +717,13 @@ var stringToProto = map[string]int32{
 
 // validL4Protocol reports whether the flow's protocol is one the data plane could
 // have observed. Protocol is an 8-bit field, and 0 is unassigned.
-func validL4Protocol(protocol int32) bool {
+func validL4Protocol(protocol int) bool {
 	return protocol >= 1 && protocol <= 255
 }
 
 // matchL4Protocol checks if the L4 protocol matches the rule. It returns true if the protocol
 // matches, false otherwise. requestCache.GetProtocol warns about an out-of-range protocol.
-func matchL4Protocol(rule *proto.Rule, protocol int32) bool {
+func matchL4Protocol(rule *proto.Rule, protocol int) bool {
 	if !validL4Protocol(protocol) {
 		return false
 	}
@@ -735,13 +735,13 @@ func matchL4Protocol(rule *proto.Rule, protocol int32) bool {
 		}).Debug("Matching L4 protocol")
 	}
 
-	checkStringInRuleProtocol := func(p *proto.Protocol, pNumber int32, defaultResult bool) bool {
+	checkStringInRuleProtocol := func(p *proto.Protocol, pNumber int, defaultResult bool) bool {
 		if p == nil {
 			return defaultResult
 		}
 
 		// Check if given protocol matches what is specified in rule.
-		var protoNumber int32
+		var protoNumber int
 		if name := p.GetName(); name != "" {
 			var ok bool
 			protoNumber, ok = stringToProto[strings.ToLower(name)]
@@ -749,7 +749,8 @@ func matchL4Protocol(rule *proto.Rule, protocol int32) bool {
 				return false
 			}
 		} else {
-			protoNumber = p.GetNumber()
+			// Widening the rule's protobuf int32, so no value is lost.
+			protoNumber = int(p.GetNumber())
 		}
 		return protoNumber == pNumber
 	}

--- a/app-policy/checker/match.go
+++ b/app-policy/checker/match.go
@@ -84,7 +84,7 @@ func match(policyNamespace string, rule *proto.Rule, req *requestCache) bool {
 	if log.IsLevelEnabled(log.DebugLevel) {
 		log.WithFields(log.Fields{
 			"rule":       rule,
-			"Protocol":   req.GetProtocol(),
+			"Protocol":   req.getProtocol(),
 			"SourceIP":   req.GetSourceIP(),
 			"DestIP":     req.GetDestIP(),
 			"SourcePort": req.GetSourcePort(),
@@ -104,7 +104,7 @@ func match(policyNamespace string, rule *proto.Rule, req *requestCache) bool {
 	// The HTTP criteria go last because matchRequest normalises the request path,
 	// and because it panics on a malformed one: leaving it last confines that to
 	// requests that a rule otherwise matches.
-	return matchL4Protocol(rule, int32(req.GetProtocol())) &&
+	return matchL4Protocol(rule, req.getProtocol()) &&
 		matchSrcPort(rule, req) &&
 		matchDstPort(rule, req) &&
 		matchSrcNet(rule, req) &&
@@ -715,12 +715,16 @@ var stringToProto = map[string]int32{
 	"sctp":    132,
 }
 
+// validL4Protocol reports whether the flow's protocol is one the data plane could
+// have observed. Protocol is an 8-bit field, and 0 is unassigned.
+func validL4Protocol(protocol int32) bool {
+	return protocol >= 1 && protocol <= 255
+}
+
 // matchL4Protocol checks if the L4 protocol matches the rule. It returns true if the protocol
-// matches, false otherwise.
+// matches, false otherwise. requestCache.getProtocol warns about an out-of-range protocol.
 func matchL4Protocol(rule *proto.Rule, protocol int32) bool {
-	// Protocol is a 8-bit field.
-	if protocol > 255 || protocol < 1 {
-		rlogBadProtocol.Warnf("Unsupported L4 protocol: %d", protocol)
+	if !validL4Protocol(protocol) {
 		return false
 	}
 	if log.IsLevelEnabled(log.DebugLevel) {

--- a/app-policy/checker/match.go
+++ b/app-policy/checker/match.go
@@ -84,7 +84,7 @@ func match(policyNamespace string, rule *proto.Rule, req *requestCache) bool {
 	if log.IsLevelEnabled(log.DebugLevel) {
 		log.WithFields(log.Fields{
 			"rule":       rule,
-			"Protocol":   req.getProtocol(),
+			"Protocol":   req.GetProtocol(),
 			"SourceIP":   req.GetSourceIP(),
 			"DestIP":     req.GetDestIP(),
 			"SourcePort": req.GetSourcePort(),
@@ -104,7 +104,7 @@ func match(policyNamespace string, rule *proto.Rule, req *requestCache) bool {
 	// The HTTP criteria go last because matchRequest normalises the request path,
 	// and because it panics on a malformed one: leaving it last confines that to
 	// requests that a rule otherwise matches.
-	return matchL4Protocol(rule, req.getProtocol()) &&
+	return matchL4Protocol(rule, int32(req.GetProtocol())) &&
 		matchSrcPort(rule, req) &&
 		matchDstPort(rule, req) &&
 		matchSrcNet(rule, req) &&
@@ -722,7 +722,7 @@ func validL4Protocol(protocol int32) bool {
 }
 
 // matchL4Protocol checks if the L4 protocol matches the rule. It returns true if the protocol
-// matches, false otherwise. requestCache.getProtocol warns about an out-of-range protocol.
+// matches, false otherwise. requestCache.GetProtocol warns about an out-of-range protocol.
 func matchL4Protocol(rule *proto.Rule, protocol int32) bool {
 	if !validL4Protocol(protocol) {
 		return false

--- a/app-policy/checker/match_test.go
+++ b/app-policy/checker/match_test.go
@@ -15,6 +15,7 @@
 package checker
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -1223,6 +1224,130 @@ func TestMatchDstIPPortSetIds(t *testing.T) {
 
 			req := &requestCache{Flow: fl, store: store}
 			Expect(matchDstIPPortSetIds(tc.rule, req)).To(Equal(tc.expected), "Test case: %s", tc.title)
+		})
+	}
+}
+
+// Port matching covers both forms a rule can take: explicit ranges, and named port
+// sets resolved through the store.
+func TestMatchPort(t *testing.T) {
+	RegisterTestingT(t)
+
+	const namedPortSetID = "namedPortSet"
+
+	testCases := []struct {
+		title    string
+		rule     *proto.Rule
+		port     int
+		expected bool
+	}{
+		{"no port criteria", &proto.Rule{}, 8080, true},
+		{
+			"in range",
+			&proto.Rule{DstPorts: []*proto.PortRange{{First: 80, Last: 90}}},
+			85, true,
+		},
+		{
+			"below range",
+			&proto.Rule{DstPorts: []*proto.PortRange{{First: 80, Last: 90}}},
+			79, false,
+		},
+		{
+			"above range",
+			&proto.Rule{DstPorts: []*proto.PortRange{{First: 80, Last: 90}}},
+			91, false,
+		},
+		{
+			"in second of two ranges",
+			&proto.Rule{DstPorts: []*proto.PortRange{{First: 80, Last: 80}, {First: 443, Last: 443}}},
+			443, true,
+		},
+		{
+			"in negated range",
+			&proto.Rule{NotDstPorts: []*proto.PortRange{{First: 80, Last: 90}}},
+			85, false,
+		},
+		{
+			"outside negated range",
+			&proto.Rule{NotDstPorts: []*proto.PortRange{{First: 80, Last: 90}}},
+			91, true,
+		},
+		{
+			"in named port set",
+			&proto.Rule{DstNamedPortIpSetIds: []string{namedPortSetID}},
+			8080, true,
+		},
+		{
+			"not in named port set",
+			&proto.Rule{DstNamedPortIpSetIds: []string{namedPortSetID}},
+			8081, false,
+		},
+		{
+			"in negated named port set",
+			&proto.Rule{NotDstNamedPortIpSetIds: []string{namedPortSetID}},
+			8080, false,
+		},
+		{
+			"not in negated named port set",
+			&proto.Rule{NotDstNamedPortIpSetIds: []string{namedPortSetID}},
+			8081, true,
+		},
+		{
+			"range misses but named port set matches",
+			&proto.Rule{
+				DstPorts:             []*proto.PortRange{{First: 80, Last: 80}},
+				DstNamedPortIpSetIds: []string{namedPortSetID},
+			},
+			8080, true,
+		},
+		{
+			"unknown named port set is skipped",
+			&proto.Rule{DstNamedPortIpSetIds: []string{"nonexistent"}},
+			8080, false,
+		},
+	}
+
+	store := policystore.NewPolicyStore()
+	namedPortSet := policystore.NewIPSet(proto.IPSetUpdate_IP)
+	namedPortSet.AddString("8080")
+	store.IPSetByID[namedPortSetID] = namedPortSet
+
+	for _, tc := range testCases {
+		t.Run(tc.title, func(t *testing.T) {
+			fl := &mocks.Flow{}
+			fl.On("GetDestPort").Return(tc.port)
+			req := &requestCache{Flow: fl, store: store}
+			Expect(matchDstPort(tc.rule, req)).To(Equal(tc.expected), "Test case: %s", tc.title)
+
+			// The source criteria are the same code with the other set of fields, so
+			// mirror the case onto them.
+			srcRule := &proto.Rule{
+				SrcPorts:                tc.rule.DstPorts,
+				NotSrcPorts:             tc.rule.NotDstPorts,
+				SrcNamedPortIpSetIds:    tc.rule.DstNamedPortIpSetIds,
+				NotSrcNamedPortIpSetIds: tc.rule.NotDstNamedPortIpSetIds,
+			}
+			srcFl := &mocks.Flow{}
+			srcFl.On("GetSourcePort").Return(tc.port)
+			srcReq := &requestCache{Flow: srcFl, store: store}
+			Expect(matchSrcPort(srcRule, srcReq)).To(Equal(tc.expected), "Test case (source): %s", tc.title)
+		})
+	}
+}
+
+// Protocol is an 8-bit field, so a flow reporting a value outside 1-255 — a Unix pipe, say —
+// can match no rule, not even one with no protocol criterion of its own. match() tests this
+// first, so the warning it logs is rate limited: otherwise one such flow logs once per rule.
+func TestMatchUnsupportedL4Protocol(t *testing.T) {
+	RegisterTestingT(t)
+
+	for _, protocol := range []int{0, -1, 256, 1 << 20} {
+		t.Run(fmt.Sprintf("protocol %d", protocol), func(t *testing.T) {
+			fl := &mocks.Flow{}
+			fl.On("GetProtocol").Return(protocol)
+			req := &requestCache{Flow: fl, store: policystore.NewPolicyStore()}
+
+			Expect(match("testns", &proto.Rule{}, req)).To(BeFalse())
 		})
 	}
 }

--- a/app-policy/checker/match_test.go
+++ b/app-policy/checker/match_test.go
@@ -16,6 +16,7 @@ package checker
 
 import (
 	"fmt"
+	"math"
 	"strings"
 	"testing"
 
@@ -1341,7 +1342,7 @@ func TestMatchPort(t *testing.T) {
 func TestMatchUnsupportedL4Protocol(t *testing.T) {
 	RegisterTestingT(t)
 
-	for _, protocol := range []int{0, -1, 256, 1 << 20} {
+	for _, protocol := range []int{0, -1, 256, 1 << 20, math.MaxInt} {
 		t.Run(fmt.Sprintf("protocol %d", protocol), func(t *testing.T) {
 			fl := &mocks.Flow{}
 			fl.On("GetProtocol").Return(protocol)

--- a/app-policy/checker/requestcache.go
+++ b/app-policy/checker/requestcache.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2025 Tigera, Inc. All rights reserved.
+// Copyright (c) 2018-2026 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -50,6 +50,28 @@ type requestCache struct {
 	srcIPStr       string
 	dstIPStr       string
 	dstIPProtoPort string
+
+	// Memoized identity, indexed by flowSide. Resolving it parses a SPIFFE ID and copies
+	// two label maps, and the match functions ask for it once per rule.
+	identities [numFlowSides]identity
+}
+
+// flowSide identifies which end of the flow an identity belongs to.
+type flowSide int
+
+const (
+	sourceSide flowSide = iota
+	destSide
+	numFlowSides
+)
+
+// identity is the resolved peer and namespace for one side of the flow. A nil peer means
+// the side carries no principal, or one that could not be parsed; both cases match any
+// rule, because Dikastes falls back on IP addresses for plain-text requests.
+type identity struct {
+	peer      *peer
+	namespace *namespace
+	resolved  bool
 }
 
 type peer struct {
@@ -72,39 +94,45 @@ func NewRequestCache(store *policystore.PolicyStore, request Flow) *requestCache
 
 // getSrcPeer returns the source peer.
 func (r *requestCache) getSrcPeer() *peer {
-	if principal := r.GetSourcePrincipal(); principal != nil {
-		return r.initPeer(*principal, r.GetSourceLabels())
-	}
-
-	return nil
+	return r.getIdentity(sourceSide).peer
 }
 
 // getDstPeer returns the destination peer.
 func (r *requestCache) getDstPeer() *peer {
-	if principal := r.GetDestPrincipal(); principal != nil {
-		return r.initPeer(*principal, r.GetDestLabels())
-	}
-
-	return nil
+	return r.getIdentity(destSide).peer
 }
 
-// getSourceNamespace returns the namespace of the source peer.
+// getSrcNamespace returns the namespace of the source peer.
 func (r *requestCache) getSrcNamespace() *namespace {
-	if peer := r.getSrcPeer(); peer != nil {
-		return r.initNamespace(peer.Namespace)
-	}
-
-	return nil
+	return r.getIdentity(sourceSide).namespace
 }
 
 // getDstNamespace returns the namespace of the destination peer.
 func (r *requestCache) getDstNamespace() *namespace {
-	if peer := r.getDstPeer(); peer != nil {
-		return r.initNamespace(peer.Namespace)
+	return r.getIdentity(destSide).namespace
+}
 
+// getIdentity returns the peer and namespace for one side of the flow, resolving them from
+// the request and the store on first use and memoizing the result for the rest of the
+// request.
+func (r *requestCache) getIdentity(side flowSide) identity {
+	id := &r.identities[side]
+	if id.resolved {
+		return *id
 	}
+	id.resolved = true
 
-	return nil
+	principal, labels := r.GetSourcePrincipal(), r.GetSourceLabels()
+	if side == destSide {
+		principal, labels = r.GetDestPrincipal(), r.GetDestLabels()
+	}
+	if principal == nil {
+		return *id
+	}
+	if id.peer = r.initPeer(*principal, labels); id.peer != nil {
+		id.namespace = r.initNamespace(id.peer.Namespace)
+	}
+	return *id
 }
 
 // getSrcIPStr returns the source IP in string form, memoized across the request.
@@ -137,7 +165,7 @@ func (r *requestCache) getDstIPProtoPortStr() string {
 func (r *requestCache) getIPSet(id string) policystore.IPSet {
 	s, ok := r.store.IPSetByID[id]
 	if !ok {
-		log.WithField("ipset", id).Warn("IPSet not found")
+		rlogIPSetMissing.Warnf("IPSet not found: %s", id)
 		return nil
 	}
 	return s
@@ -160,7 +188,7 @@ func (r *requestCache) initNamespace(name string) *namespace {
 func (r *requestCache) initPeer(principal string, labels map[string]string) *peer {
 	peer, err := parseSpiffeID(principal)
 	if err != nil {
-		log.WithError(err).Error("failed to parse source principal")
+		rlogBadPrincipal.Errorf("failed to parse principal: %v", err)
 		return nil
 	}
 	peer.Labels = make(map[string]string)

--- a/app-policy/checker/requestcache.go
+++ b/app-policy/checker/requestcache.go
@@ -58,7 +58,7 @@ type requestCache struct {
 	// Memoized L4 protocol. The Envoy adapter derives it from an enum name via a
 	// lowercase and a map lookup, and match() asks for it once per rule. Protocol 0
 	// is a value the data plane can send, so resolution needs its own flag.
-	protocol         int32
+	protocol         int
 	protocolResolved bool
 }
 
@@ -157,12 +157,15 @@ func (r *requestCache) getDstIPStr() string {
 	return r.dstIPStr
 }
 
-// getProtocol returns the flow's L4 protocol, memoized across the request.
-func (r *requestCache) getProtocol() int32 {
+// GetProtocol shadows the embedded Flow's method to memoize the protocol across the
+// request. Callers need not know: it returns what the Flow would have returned.
+func (r *requestCache) GetProtocol() int {
 	if !r.protocolResolved {
-		r.protocol = int32(r.GetProtocol())
+		r.protocol = r.Flow.GetProtocol()
 		r.protocolResolved = true
-		if !validL4Protocol(r.protocol) {
+		// Checked as int32 because that is how matchL4Protocol sees it, so the
+		// warning and the rejection cannot disagree.
+		if !validL4Protocol(int32(r.protocol)) {
 			// Warn here rather than in matchL4Protocol: an out-of-range protocol
 			// rejects every rule, so the check runs once per rule and even a
 			// suppressed rate-limited log takes the logger's lock.
@@ -176,7 +179,7 @@ func (r *requestCache) getProtocol() int32 {
 // IP+port set matching, memoized across the request.
 func (r *requestCache) getDstIPProtoPortStr() string {
 	if r.dstIPProtoPort == "" {
-		protocolStr := protocolMapL4[r.getProtocol()]
+		protocolStr := protocolMapL4[int32(r.GetProtocol())]
 		r.dstIPProtoPort = fmt.Sprintf("%s,%s:%d", r.getDstIPStr(), protocolStr, r.GetDestPort())
 	}
 	return r.dstIPProtoPort

--- a/app-policy/checker/requestcache.go
+++ b/app-policy/checker/requestcache.go
@@ -54,6 +54,12 @@ type requestCache struct {
 	// Memoized identity, indexed by flowSide. Resolving it parses a SPIFFE ID and copies
 	// two label maps, and the match functions ask for it once per rule.
 	identities [numFlowSides]identity
+
+	// Memoized L4 protocol. The Envoy adapter derives it from an enum name via a
+	// lowercase and a map lookup, and match() asks for it once per rule. Protocol 0
+	// is a value the data plane can send, so resolution needs its own flag.
+	protocol         int32
+	protocolResolved bool
 }
 
 // flowSide identifies which end of the flow an identity belongs to.
@@ -151,11 +157,26 @@ func (r *requestCache) getDstIPStr() string {
 	return r.dstIPStr
 }
 
+// getProtocol returns the flow's L4 protocol, memoized across the request.
+func (r *requestCache) getProtocol() int32 {
+	if !r.protocolResolved {
+		r.protocol = int32(r.GetProtocol())
+		r.protocolResolved = true
+		if !validL4Protocol(r.protocol) {
+			// Warn here rather than in matchL4Protocol: an out-of-range protocol
+			// rejects every rule, so the check runs once per rule and even a
+			// suppressed rate-limited log takes the logger's lock.
+			rlogBadProtocol.Warnf("Unsupported L4 protocol: %d", r.protocol)
+		}
+	}
+	return r.protocol
+}
+
 // getDstIPProtoPortStr returns the destination "<IP>,<protocol>:<port>" key used for
 // IP+port set matching, memoized across the request.
 func (r *requestCache) getDstIPProtoPortStr() string {
 	if r.dstIPProtoPort == "" {
-		protocolStr := protocolMapL4[int32(r.GetProtocol())]
+		protocolStr := protocolMapL4[r.getProtocol()]
 		r.dstIPProtoPort = fmt.Sprintf("%s,%s:%d", r.getDstIPStr(), protocolStr, r.GetDestPort())
 	}
 	return r.dstIPProtoPort

--- a/app-policy/checker/requestcache.go
+++ b/app-policy/checker/requestcache.go
@@ -163,9 +163,7 @@ func (r *requestCache) GetProtocol() int {
 	if !r.protocolResolved {
 		r.protocol = r.Flow.GetProtocol()
 		r.protocolResolved = true
-		// Checked as int32 because that is how matchL4Protocol sees it, so the
-		// warning and the rejection cannot disagree.
-		if !validL4Protocol(int32(r.protocol)) {
+		if !validL4Protocol(r.protocol) {
 			// Warn here rather than in matchL4Protocol: an out-of-range protocol
 			// rejects every rule, so the check runs once per rule and even a
 			// suppressed rate-limited log takes the logger's lock.
@@ -179,7 +177,7 @@ func (r *requestCache) GetProtocol() int {
 // IP+port set matching, memoized across the request.
 func (r *requestCache) getDstIPProtoPortStr() string {
 	if r.dstIPProtoPort == "" {
-		protocolStr := protocolMapL4[int32(r.GetProtocol())]
+		protocolStr := protocolMapL4[r.GetProtocol()]
 		r.dstIPProtoPort = fmt.Sprintf("%s,%s:%d", r.getDstIPStr(), protocolStr, r.GetDestPort())
 	}
 	return r.dstIPProtoPort

--- a/app-policy/checker/requestcache_test.go
+++ b/app-policy/checker/requestcache_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2025 Tigera, Inc. All rights reserved.
+// Copyright (c) 2018-2026 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,14 +15,18 @@
 package checker
 
 import (
+	"io"
 	"testing"
+	"time"
 
 	authz "github.com/envoyproxy/go-control-plane/envoy/service/auth/v3"
 	. "github.com/onsi/gomega"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/projectcalico/calico/app-policy/policystore"
 	"github.com/projectcalico/calico/felix/proto"
 	"github.com/projectcalico/calico/felix/types"
+	"github.com/projectcalico/calico/lib/logrusr"
 )
 
 // Successful parse should return name and namespace.
@@ -215,4 +219,110 @@ func TestNamespaceLabels(t *testing.T) {
 	Expect(uut.getSrcNamespace().Labels).To(Equal(map[string]string{"k5": "v5", "k6": "v6"}))
 	Expect(uut.getDstNamespace().Name).To(Equal("sub"))
 	Expect(uut.getDstNamespace().Labels).To(Equal(map[string]string{"k7": "v7", "k8": "v8"}))
+}
+
+// Identity is resolved once per request, not once per rule: the match functions ask for the
+// peer and namespace of both sides for every rule, and resolving parses the SPIFFE ID and
+// copies two label maps.
+func TestIdentityResolvedOncePerRequest(t *testing.T) {
+	RegisterTestingT(t)
+
+	req := &authz.CheckRequest{Attributes: &authz.AttributeContext{
+		Source: &authz.AttributeContext_Peer{
+			Principal: "spiffe://cluster.local/ns/sandwich/sa/bacon",
+		},
+		Destination: &authz.AttributeContext_Peer{
+			Principal: "spiffe://cluster.local/ns/salad/sa/lettuce",
+		},
+	}}
+	uut := NewRequestCache(policystore.NewPolicyStore(), NewCheckRequestToFlowAdapter(req))
+
+	Expect(uut.getSrcPeer().Name).To(Equal("bacon"))
+	Expect(uut.getDstPeer().Name).To(Equal("lettuce"))
+	Expect(uut.getSrcNamespace().Name).To(Equal("sandwich"))
+	Expect(uut.getDstNamespace().Name).To(Equal("salad"))
+
+	// Repeated lookups return the memoized values rather than resolving again.
+	Expect(uut.getSrcPeer()).To(BeIdenticalTo(uut.getSrcPeer()))
+	Expect(uut.getDstPeer()).To(BeIdenticalTo(uut.getDstPeer()))
+	Expect(uut.getSrcNamespace()).To(BeIdenticalTo(uut.getSrcNamespace()))
+	Expect(uut.getDstNamespace()).To(BeIdenticalTo(uut.getDstNamespace()))
+	Expect(uut.getSrcPeer()).NotTo(BeIdenticalTo(uut.getDstPeer()))
+}
+
+// A principal that is not a SPIFFE ID leaves the side unidentified. Dikastes falls back on IP
+// addresses in that case, so rules without identity criteria still match.
+func TestUnparseablePrincipalIsMemoized(t *testing.T) {
+	RegisterTestingT(t)
+
+	req := &authz.CheckRequest{Attributes: &authz.AttributeContext{
+		Source: &authz.AttributeContext_Peer{
+			Principal: "http://foo.bar.com/ns/sandwich/sa/bacon",
+		},
+		Destination: &authz.AttributeContext_Peer{
+			Principal: "",
+		},
+	}}
+	uut := NewRequestCache(policystore.NewPolicyStore(), NewCheckRequestToFlowAdapter(req))
+
+	Expect(uut.getSrcPeer()).To(BeNil())
+	Expect(uut.getSrcNamespace()).To(BeNil())
+	// A nil peer must not be mistaken for "not resolved yet", or every rule retries the parse
+	// and re-logs the failure.
+	Expect(uut.identities[sourceSide].resolved).To(BeTrue())
+	Expect(matchServiceAccounts(nil, uut.getSrcPeer())).To(BeTrue())
+}
+
+// Repeated failures on the evaluation path are rate limited: one line, then a count of what
+// was suppressed. Without this a single dangling IP set reference logs once per rule, for
+// every request.
+func TestEvalPathWarningsAreRateLimited(t *testing.T) {
+	RegisterTestingT(t)
+
+	logger := log.StandardLogger()
+	oldLevel, oldOut := logger.GetLevel(), logger.Out
+	counter := &entryCounter{}
+	hooks := make(log.LevelHooks)
+	hooks.Add(counter)
+	oldHooks := logger.ReplaceHooks(hooks)
+	savedLogger := rlogIPSetMissing
+	defer func() {
+		logger.SetLevel(oldLevel)
+		logger.SetOutput(oldOut)
+		logger.ReplaceHooks(oldHooks)
+		rlogIPSetMissing = savedLogger
+	}()
+	logger.SetLevel(log.WarnLevel)
+	logger.SetOutput(io.Discard)
+	// A long interval with no burst allowance: the first message is written, the rest are
+	// counted.
+	rlogIPSetMissing = logrusr.NewRateLimitedLogger(logrusr.OptInterval(time.Hour))
+
+	uut := NewRequestCache(policystore.NewPolicyStore(), NewCheckRequestToFlowAdapter(
+		&authz.CheckRequest{Attributes: &authz.AttributeContext{}}))
+	for range 100 {
+		Expect(uut.getIPSet("missing-set")).To(BeNil())
+	}
+
+	Expect(counter.entries).To(HaveLen(1), "expected one emitted warning for 100 misses")
+	Expect(counter.entries[0].Message).To(ContainSubstring("missing-set"))
+	Expect(counter.entries[0].Data).NotTo(HaveKey("logsSkipped"))
+
+	// The suppressed count surfaces on the next line that is allowed through, so the storm is
+	// still visible in the log.
+	rlogIPSetMissing.Force().Warnf("IPSet not found: %s", "missing-set")
+	Expect(counter.entries).To(HaveLen(2))
+	Expect(counter.entries[1].Data).To(HaveKeyWithValue("logsSkipped", 99))
+}
+
+// entryCounter collects the log entries written during a test.
+type entryCounter struct {
+	entries []*log.Entry
+}
+
+func (c *entryCounter) Levels() []log.Level { return log.AllLevels }
+
+func (c *entryCounter) Fire(e *log.Entry) error {
+	c.entries = append(c.entries, e)
+	return nil
 }

--- a/app-policy/policystore/ipset.go
+++ b/app-policy/policystore/ipset.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2025 Tigera, Inc. All rights reserved.
+// Copyright (c) 2018-2026 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,10 +18,20 @@ import (
 	"net"
 	"strconv"
 	"strings"
+	"time"
 
 	log "github.com/sirupsen/logrus"
 
 	syncapi "github.com/projectcalico/calico/felix/proto"
+	"github.com/projectcalico/calico/lib/logrusr"
+)
+
+// rlogBadAddr rate limits the unparseable-address warning: membership is tested once per set
+// per rule, so a single non-IP request would otherwise log once for every set reference in the
+// endpoint's whole policy set.
+var rlogBadAddr = logrusr.NewRateLimitedLogger(
+	logrusr.OptInterval(30*time.Second),
+	logrusr.OptBurst(10),
 )
 
 // IPSet is a data structure that contains IP addresses, or IP address/port pairs. It allows fast
@@ -162,9 +172,10 @@ func (m ipNetSet) RemoveString(network string) {
 func (m ipNetSet) Contains(addr string) bool {
 	ip := net.ParseIP(addr)
 	if ip == nil {
-		// Envoy should not send us malformed IP addresses, but its possible we could get requests from non-IP
-		// connections, like Pipes.
-		log.WithField("addr", ip).Warn("could not parse IP")
+		// Envoy should not send us malformed IP addresses, but it's possible we could get requests from non-IP
+		// connections, like Pipes. Such a request is tested against every NET set every rule references, so
+		// the log is rate limited.
+		rlogBadAddr.Warnf("could not parse IP: %s", addr)
 		return false
 	}
 	ip4 := ip.To4()


### PR DESCRIPTION
Follow-up to #13265, which cut per-rule allocations in the user-mode policy evaluator. This attacks the remaining cost from a different angle: the **order** the criteria are evaluated in.

A rule's criteria are ANDed pure predicates, so they may be evaluated in any order, and most rules in a large policy set are rejected by exactly one of them. `match()` evaluated them most-expensive-first — label selectors and namespace matching, then IP set trie lookups, then ports, and the protocol (an 8-bit integer compare) dead last. Evaluating cheapest-first means a rule rejected on the L4 header costs nothing beyond the integer compares.

The motivating rule set is a single-tier destination allow-list: ~300 policies with no selector (so all apply to every endpoint), ~18,600 egress rules, almost all `Pass`, each matching a destination address (a CIDR for ~75%, a selector-derived IP set for ~25%) plus a handful of destination ports. Ports are the selective axis: 90% of ports appear on five rules or fewer.

### What changed

1. **`match()` is one flat, ordered list** — protocol, ports, addresses, IP sets, identity, HTTP. The ordering *is* the change, so it should be readable in one place. `matchSource`/`matchDestination` become `matchSrcIdentity`/`matchDstIdentity`, keeping each `computeNamespaceMatch` next to its only consumer. HTTP stays last because it `panic`s on a malformed request path; last position confines that to requests a rule otherwise fully matches, which narrows today's already order-dependent behaviour.

2. **Identity is resolved once per request.** The match functions ask for both sides' peer and namespace for every rule and nothing was memoized, so each rule re-ran the SPIFFE regex and re-copied two label maps — four times per rule, once `getSrcNamespace`'s own `getSrcPeer` call is counted.

3. **Every warning on the per-request path is rate limited.** Seven sites fire once per rule or once per IP set reference, so one dangling IP set reference, malformed CIDR or non-IP flow logs tens of thousands of lines per request — and hoisting the protocol check to first would have made its warning the worst of them. Each site gets its own limiter, because the limit is per instance. These sites avoid the `WithField`/`WithError` builders on purpose: those allocate a fields map, an `Entry` and a wrapper *before* the limiter can drop the message, which is exactly the per-rule allocation #13265 removed.

4. **The protocol is resolved once per request.** Hoisting the protocol check to first makes it the one criterion every rule reaches, and the Envoy adapter derives the protocol from an enum name via a `String()`, a `strings.ToLower` and a map lookup — an allocation per rule. Memoized on `requestCache` alongside the string forms. The out-of-range warning moves to the point of resolution for the same reason: an out-of-range protocol rejects every rule, and a *dropped* rate-limited log still takes the shared logger's lock, so per-rule the storm returned as lock contention rather than as log lines.

5. **A dead log line was costing an allocation per IP set lookup.** `ipNetSet.Contains` logged the *parsed* address on the unparseable branch, where it is nil by definition — so the line could only ever print `<nil>`. Passing it as a logrus field forced `net.ParseIP`'s result to escape to the heap on **every** membership test. Fixing the message makes the parse stack-allocated; `-gcflags=-m` confirms the escape is gone.

### Measurements

Two synthetic fixtures built from anonymized production scale, against `origin/master`. Each case runs in its own process, before and after interleaved over 7 rounds, reporting the **minimum** of each: a throttled round can only be slower, so comparing minima keeps CPU frequency scaling from skewing the ratio when one binary is throttled harder than the other.

| Case | Before | After | | Allocs/op |
|---|---|---|---|---|
| Egress allow-list, tail port | 2.10 ms | 0.57 ms | **3.7x** | 2,998 → 20 |
| Egress allow-list, popular port | 2.65 ms | 1.20 ms | **2.2x** | 9,802 → 6,825 |
| Egress allow-list, denied | 3.98 ms | 1.90 ms | **2.1x** | 14,962 → 10,361 |
| #13265 fixture, sets present | 3.21 ms | 1.95 ms | **1.7x** | 4,813 → 51 |
| #13265 fixture, missing sets | 3.17 ms | 1.94 ms | **1.6x** | 5,093 → 415 |

The allocation counts are `MockFlow` numbers. On the real Envoy adapter path the per-rule `GetProtocol` call added roughly one allocation per rule on top, which is why item 4 memoizes it — without that, the reorder traded allocations for wall time rather than winning both. Thanks to @electricjesus for measuring the adapter's call shape rather than taking the mock's figure at face value.

The three egress cases are reported separately rather than averaged. A denied flow walks every rule whatever the ordering, so there the change reduces per-rule cost (213 → 102 ns/rule) but not scan depth; averaging it in would hide that limitation.

Where the fixture is weakest, for anyone re-running it: the port distribution's head is measured, but its tail is synthesised (uniform over 1024-65535), so "a tail port is shared by ~2 rules" is a modelling choice. The tail-port figure is therefore the most fixture-sensitive of the three; the denied case depends only on rule composition, not on the port distribution.

### Testing

The existing `app-policy/checker` suite passes unchanged, which is the primary evidence that reordering changes no verdict. New tests cover:

- port matching — ranges, negated ranges, named port sets, negated named port sets, unknown set skipped, mirrored onto the source fields (named-port matching had **no** coverage, and this PR changes it);
- a flow protocol outside 1-255, previously uncovered;
- identity memoization, including that a nil peer is not mistaken for "not resolved yet";
- that a repeated warning emits one line plus a `logsSkipped` count;
- that the protocol is asked of the flow once per request rather than once per rule (50 rules, one call);
- that a rule whose HTTP criteria would reject a malformed request path no longer decides a request it does not apply to. A TCP request with a path missing its leading `/` used to reach `matchHTTPPaths` through a *UDP* rule and panic, failing the request with `INVALID_ARGUMENT`; the rule now drops on its protocol and the walk continues. The same rule on TCP still reaches the path and still fails the request.

Both new tests fail against the old ordering, so they pin the change rather than restate it.

The benchmark fixture from #13265 forced IP-set-referencing rules to reach their set lookup by pairing them with a *non-matching port*, which relied on ports being evaluated after IP sets. It now pairs each reference with a negated reference to a sentinel set holding the flow's own addresses, so it measures the same work under any ordering.

### Not in this PR

Found while measuring, in rough value order: `selector.Parse` runs per rule per side (including parsing `""`); `net.ParseCIDR` runs per rule per CIDR entry; `actionFromString` builds a map literal per call; `normalizeHTTPPath` re-normalises each rule's paths per request.

**Release note:**
```release-note
Felix/Dikastes performance: evaluate policy rule criteria cheapest-first in the user-mode policy engine, 1.6-3.7x faster evaluation for large policy sets. Rate limit the policy engine's per-rule warnings, which could previously emit tens of thousands of log lines per request.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


