### PR TITLE
fix(felix): apply the BPF flow-log age-out floor as intended

### DIFF
--- a/felix/collector/collector.go
+++ b/felix/collector/collector.go
@@ -597,7 +597,6 @@ func (c *collector) checkEpStats() {
 	minLastRuleUpdatedAt := monotime.Now() - c.config.InitialReportingDelay
 
 	now := monotime.Now()
-	minExpirationAt := now - c.config.AgeTimeout
 
 	// For each entry
 	// - report metrics.  Metrics reported through the ticker processing will wait for the initial reporting delay
@@ -605,33 +604,45 @@ func (c *collector) checkEpStats() {
 	//   the flow is terminated or has changed.
 	// - check age and expire the entry if needed.
 	for _, data := range c.epStats {
+		ageTimeout := c.config.AgeTimeout
 		if c.config.IsBPFDataplane {
-			switch data.Tuple.Proto {
-			case 6 /* TCP */ :
-				// We use reset because likely already cleaned it up as an expired
-				// connection if we haven't seen any update this long.
-				minExpirationAt = now - c.config.BPFConntrackTimeouts.TCPResetSeen
-			case 17 /* UDP */ :
-				minExpirationAt = now - c.config.BPFConntrackTimeouts.UDPTimeout
-			case 1 /* ICMP */, 58 /* ICMPv6 */ :
-				minExpirationAt = now - c.config.BPFConntrackTimeouts.ICMPTimeout
-			default:
-				minExpirationAt = now - c.config.BPFConntrackTimeouts.GenericTimeout
-			}
-			if minExpirationAt < 2*bpfconntrack.ScanPeriod {
-				minExpirationAt = now - 2*bpfconntrack.ScanPeriod
-			}
+			ageTimeout = bpfAgeTimeout(c.config.BPFConntrackTimeouts, data.Tuple.Proto)
 		}
 
 		if data.IsDirty() && (data.Reported || data.RuleUpdatedAt() < minLastRuleUpdatedAt) {
 			c.checkPreDNATTuple(data)
 			c.reportMetrics(data, true)
 		}
-		if data.UpdatedAt() < minExpirationAt {
+		if data.UpdatedAt() < now-ageTimeout {
 			c.expireMetrics(data)
 			c.deleteDataFromEpStats(data)
 		}
 	}
+}
+
+// bpfAgeTimeout returns how long the collector keeps an epStats entry after its last update when
+// running the BPF dataplane, based on the dataplane's conntrack timeout for the entry's protocol.
+//
+// The collector only touches an entry when the BPF conntrack scanner reports it, i.e. once per
+// ScanPeriod, so a timeout shorter than a couple of scan periods would expire flows that are still
+// alive.  Re-creating the entry afterwards re-credits the conntrack counters' absolute values as a
+// fresh delta, so premature expiry over-counts traffic as well as churning flow logs.  Hence the
+// floor.
+func bpfAgeTimeout(timeouts bpfconntrack.Timeouts, proto int) time.Duration {
+	var timeout time.Duration
+	switch proto {
+	case 6 /* TCP */ :
+		// We use reset because likely already cleaned it up as an expired
+		// connection if we haven't seen any update this long.
+		timeout = timeouts.TCPResetSeen
+	case 17 /* UDP */ :
+		timeout = timeouts.UDPTimeout
+	case 1 /* ICMP */, 58 /* ICMPv6 */ :
+		timeout = timeouts.ICMPTimeout
+	default:
+		timeout = timeouts.GenericTimeout
+	}
+	return max(timeout, 2*bpfconntrack.ScanPeriod)
 }
 
 func (c *collector) checkPreDNATTuple(data *Data) {

--- a/felix/collector/collector_test.go
+++ b/felix/collector/collector_test.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	"github.com/projectcalico/calico/app-policy/policystore"
+	bpfconntrack "github.com/projectcalico/calico/felix/bpf/conntrack/timeouts"
 	"github.com/projectcalico/calico/felix/calc"
 	clttypes "github.com/projectcalico/calico/felix/collector/types"
 	"github.com/projectcalico/calico/felix/collector/types/counter"
@@ -51,10 +52,11 @@ import (
 )
 
 const (
-	ipv4       = 0x800
-	proto_icmp = 1
-	proto_tcp  = 6
-	proto_udp  = 17
+	ipv4         = 0x800
+	proto_icmp   = 1
+	proto_tcp    = 6
+	proto_udp    = 17
+	proto_icmpv6 = 58
 )
 
 var (
@@ -4152,4 +4154,83 @@ func TestEqualFunction(t *testing.T) {
 			t.Errorf("Expected false, got true")
 		}
 	})
+}
+
+func TestBPFAgeTimeout(t *testing.T) {
+	timeouts := bpfconntrack.DefaultTimeouts()
+	floor := 2 * bpfconntrack.ScanPeriod
+
+	// The floor only bites for timeouts shorter than two scan periods, which is true of the default
+	// ICMP timeout. Guard the premise so this test fails loudly rather than silently passing if the
+	// defaults change.
+	if timeouts.ICMPTimeout >= floor {
+		t.Fatalf("default ICMPTimeout (%v) is no longer below the floor (%v); pick another protocol",
+			timeouts.ICMPTimeout, floor)
+	}
+
+	shortTimeouts := timeouts
+	shortTimeouts.TCPResetSeen = time.Second
+
+	for _, tc := range []struct {
+		name     string
+		timeouts bpfconntrack.Timeouts
+		proto    int
+		want     time.Duration
+	}{
+		{"TCP uses the reset timeout", timeouts, proto_tcp, timeouts.TCPResetSeen},
+		{"UDP uses the UDP timeout", timeouts, proto_udp, timeouts.UDPTimeout},
+		{"unknown protocols use the generic timeout", timeouts, 47 /* GRE */, timeouts.GenericTimeout},
+		{"ICMP is floored", timeouts, proto_icmp, floor},
+		{"ICMPv6 is floored", timeouts, proto_icmpv6, floor},
+		{"a configured sub-floor timeout is floored", shortTimeouts, proto_tcp, floor},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := bpfAgeTimeout(tc.timeouts, tc.proto); got != tc.want {
+				t.Errorf("bpfAgeTimeout(proto=%d) = %v, want %v", tc.proto, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestBPFAgeOutFloorKeepsLiveFlows checks the end of the floor's job: an entry whose dataplane
+// conntrack timeout is shorter than the scan period must survive the gap between scans. The
+// collector only touches an entry when the BPF conntrack scanner reports it, so expiring sooner
+// churns live flows and re-credits their absolute counters as a fresh delta on re-creation.
+func TestBPFAgeOutFloorKeepsLiveFlows(t *testing.T) {
+	floor := 2 * bpfconntrack.ScanPeriod
+
+	for _, tc := range []struct {
+		name            string
+		sinceLastUpdate time.Duration
+		wantPresent     bool
+	}{
+		{"past the ICMP timeout but inside the floor", floor - 5*time.Second, true},
+		{"past the floor", floor + 5*time.Second, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c := newCollector(newMockLookupsCache(map[[16]byte]calc.EndpointData{
+				localIp1:  localEd1,
+				remoteIp1: remoteEd1,
+			}, nil, nil, nil), &Config{
+				AgeTimeout:            10 * time.Second,
+				InitialReportingDelay: 5 * time.Second,
+				ExportingInterval:     time.Second,
+				FlowLogsFlushInterval: 100 * time.Second,
+				IsBPFDataplane:        true,
+				BPFConntrackTimeouts:  bpfconntrack.DefaultTimeouts(),
+			}).(*collector)
+
+			tpl := *tuple.New(remoteIp1, localIp1, proto_icmp, 0, 0)
+			data := NewData(tpl, remoteEd1, localEd1)
+			c.updateEpStatsCache(tpl, data)
+			data.updatedAt = monotime.Now() - tc.sinceLastUpdate
+
+			c.checkEpStats()
+
+			if _, present := c.epStats[tpl]; present != tc.wantPresent {
+				t.Errorf("entry last updated %v ago: present=%v, want %v",
+					tc.sinceLastUpdate, present, tc.wantPresent)
+			}
+		})
+	}
 }


### PR DESCRIPTION
Bug fix in the flow-log collector's entry ageing, found by review.

`checkEpStats` has a guard that was meant to say "never age an entry out in less than two conntrack scans", but it compares a monotime **timestamp** against a **duration**:

```go
minExpirationAt = now - c.config.BPFConntrackTimeouts.ICMPTimeout   // per protocol
if minExpirationAt < 2*bpfconntrack.ScanPeriod {                    // 20s
    minExpirationAt = now - 2*bpfconntrack.ScanPeriod
}
```

`minExpirationAt` is `now - timeout`, so the condition is only true in the first ~25 seconds after boot. The floor never applied.

That matters because the collector only touches an entry when the BPF conntrack scanner reports it, i.e. once per `ScanPeriod` (10s), while `ICMPTimeout` defaults to 5s. A live, continuously-pinging ICMP flow was expired by the 1s `checkEpStats` ticker a few seconds after each scan and re-created by the next one — every cycle. Re-creation is not free: `counter.Set` treats the absolute conntrack count as a fresh delta, so the flow's whole cumulative packet/byte count was re-credited. Long-lived ICMP flows were over-counted and emitted a spurious expire/start flow-log pair per cycle. The same trap applies to any conntrack timeout an operator configures below 20s.

**Change:** extract the per-protocol timeout lookup into `bpfAgeTimeout`, so the floor is applied to the *timeout* rather than to a timestamp. This also drops the wart where `minExpirationAt` was computed before the loop and then reassigned per entry.

**Testing:** two tests in `felix/collector/collector_test.go` — a table test over `bpfAgeTimeout` (per-protocol mapping plus flooring of sub-scan-period timeouts), and a behavioural test that back-dates an ICMP entry's `updatedAt` and drives `checkEpStats()` directly, asserting the entry survives inside the floor and is expired beyond it. Verified the behavioural test fails without the fix (`present=false, want true`). `go test ./felix/collector/...` and `go vet ./felix/collector/` pass.

Not addressed here, noted for follow-up: the floor uses the configured `ScanPeriod`, but a slow scan over a large conntrack map also stretches the touch gap; flooring on the *observed* scan interval would need scanner state plumbed into the collector. The equivalent margin problem in the non-BPF path (`AgeTimeout` 10s vs a 5s netlink poll, with no floor at all) is also left for a separate PR.

**Release note:**
```release-note
Fixed premature age-out of flow log entries in the eBPF dataplane, which duplicated packet and byte counts and emitted spurious expire/start flow logs for long-lived ICMP flows.
```