### PR TITLE
fix(felix): stop staged policies becoming the flow-log verdict

### DIFF
--- a/felix/collector/stats.go
+++ b/felix/collector/stats.go
@@ -282,7 +282,7 @@ func (t *RuleTrace) replaceRuleID(rid *calc.RuleID, matchIdx, numPkts, numBytes 
 	// Reset the reporting path so that we recalculate it next report.
 	t.rulesToReport = nil
 
-	if !model.KindIsStaged(rid.Name) && rid.Action != rules.RuleActionPass {
+	if !model.KindIsStaged(rid.Kind) && rid.Action != rules.RuleActionPass {
 		// This is a verdict action, so reset and set counters and set our verdict index.
 		t.pktsCtr.ResetAndSet(numPkts)
 		t.bytesCtr.ResetAndSet(numBytes)
@@ -475,7 +475,11 @@ func (d *Data) ConntrackBytesCounterReverse() counter.Counter {
 // Set In Counters' values to packets and bytes. Use the SetConntrackCounters* methods
 // when the source if packets/bytes are absolute values.
 func (d *Data) SetConntrackCounters(packets int, bytes int) {
-	if d.conntrackPktsCtr.Set(packets) && d.conntrackBytesCtr.Set(bytes) {
+	// Evaluate both counters before testing them: && would skip the bytes update whenever the
+	// packet count happens to be unchanged.
+	pktsChanged := d.conntrackPktsCtr.Set(packets)
+	bytesChanged := d.conntrackBytesCtr.Set(bytes)
+	if pktsChanged || bytesChanged {
 		d.setDirtyFlag()
 	}
 	d.IsConnection = true
@@ -515,7 +519,11 @@ func (d *Data) VerdictFound() bool {
 // Set In Counters' values to packets and bytes. Use the SetConntrackCounters* methods
 // when the source if packets/bytes are absolute values.
 func (d *Data) SetConntrackCountersReverse(packets int, bytes int) {
-	if d.conntrackPktsCtrReverse.Set(packets) && d.conntrackBytesCtrReverse.Set(bytes) {
+	// Evaluate both counters before testing them: && would skip the bytes update whenever the
+	// packet count happens to be unchanged.
+	pktsChanged := d.conntrackPktsCtrReverse.Set(packets)
+	bytesChanged := d.conntrackBytesCtrReverse.Set(bytes)
+	if pktsChanged || bytesChanged {
 		d.setDirtyFlag()
 	}
 	d.IsConnection = true

--- a/felix/collector/stats.go
+++ b/felix/collector/stats.go
@@ -473,7 +473,7 @@ func (d *Data) ConntrackBytesCounterReverse() counter.Counter {
 }
 
 // Set In Counters' values to packets and bytes. Use the SetConntrackCounters* methods
-// when the source if packets/bytes are absolute values.
+// when the packet/byte counts are absolute values.
 func (d *Data) SetConntrackCounters(packets int, bytes int) {
 	// Evaluate both counters before testing them: && would skip the bytes update whenever the
 	// packet count happens to be unchanged.

--- a/felix/collector/stats_test.go
+++ b/felix/collector/stats_test.go
@@ -50,6 +50,17 @@ var (
 		Tier:      "T2",
 		Direction: rules.RuleDirIngress,
 	}
+	stagedDenyIngressRid0 = &calc.RuleID{
+		Action:   rules.RuleActionDeny,
+		Index:    2,
+		IndexStr: "2",
+		PolicyID: calc.PolicyID{
+			Name: "P2",
+			Kind: v3.KindStagedGlobalNetworkPolicy,
+		},
+		Tier:      "T2",
+		Direction: rules.RuleDirIngress,
+	}
 	allowIngressRid1 = &calc.RuleID{
 		Action:   rules.RuleActionAllow,
 		Index:    1,
@@ -245,6 +256,21 @@ var _ = Describe("Rule Trace", func() {
 			})
 		})
 	})
+
+	// A staged policy never enforces anything, so it must never be recorded as the verdict, whether
+	// the hit arrives through AddRuleID or through ReplaceRuleID after a mid-flow rule change.
+	Describe("Replacing with a staged policy hit", func() {
+		BeforeEach(func() {
+			data.ReplaceRuleID(stagedDenyIngressRid0, 0, 0, 0)
+		})
+		It("should not record a verdict", func() {
+			Expect(data.IngressRuleTrace.FoundVerdict()).To(BeFalse())
+			Expect(data.IngressRuleTrace.VerdictRuleID()).To(BeNil())
+		})
+		It("should not attribute the staged policy's action to the flow", func() {
+			Expect(data.IngressAction()).NotTo(Equal(rules.RuleActionDeny))
+		})
+	})
 	Describe("RuleTraces with next Tier", func() {
 		BeforeEach(func() {
 			rm := data.AddRuleID(nextTierIngressRid0, 0, 0, 0)
@@ -371,6 +397,50 @@ var _ = Describe("Rule Trace", func() {
 			It("should have action set to allow", func() {
 				Expect(data.IngressAction()).To(Equal(rules.RuleActionDeny))
 			})
+		})
+	})
+})
+
+var _ = Describe("Conntrack counters", func() {
+	var data *collector.Data
+
+	BeforeEach(func() {
+		var src, dst [16]byte
+		copy(src[:], net.ParseIP("127.0.0.1").To16())
+		copy(dst[:], net.ParseIP("127.1.1.1").To16())
+		data = collector.NewData(*tuple.New(src, dst, 6, 12345, 80), nil, nil)
+
+		data.SetConntrackCounters(10, 1000)
+		data.SetConntrackCountersReverse(20, 2000)
+
+		// Data starts out dirty and holding deltas from the sets above; clear both so the
+		// assertions below only see the effect of the update under test.
+		data.ClearConnDirtyFlag()
+	})
+
+	// The byte counter must be updated even when the packet count happens to be unchanged.
+	Describe("a bytes-only update", func() {
+		It("should be recorded in the forward direction", func() {
+			data.SetConntrackCounters(10, 1500)
+			bytesCtr := data.ConntrackBytesCounter()
+			Expect(bytesCtr.Absolute()).To(Equal(1500))
+			Expect(bytesCtr.Delta()).To(Equal(500))
+			Expect(data.IsDirty()).To(BeTrue())
+		})
+		It("should be recorded in the reverse direction", func() {
+			data.SetConntrackCountersReverse(20, 2500)
+			bytesCtr := data.ConntrackBytesCounterReverse()
+			Expect(bytesCtr.Absolute()).To(Equal(2500))
+			Expect(bytesCtr.Delta()).To(Equal(500))
+			Expect(data.IsDirty()).To(BeTrue())
+		})
+	})
+
+	Describe("an unchanged update", func() {
+		It("should leave the data clean", func() {
+			data.SetConntrackCounters(10, 1000)
+			data.SetConntrackCountersReverse(20, 2000)
+			Expect(data.IsDirty()).To(BeFalse())
 		})
 	})
 })


### PR DESCRIPTION
Two independent fixes in `felix/collector/stats.go`, both found by review. They are in different functions; grouped because they are small and share a file.

### 1. `replaceRuleID` tested staged-ness on the wrong field

`addRuleID` uses `rid.Kind`; `replaceRuleID` used `rid.Name`:

```go
if !model.KindIsStaged(rid.Name) && rid.Action != rules.RuleActionPass {
```

`model.KindIsStaged` is a switch over three exact kind strings, so `KindIsStaged(rid.Name)` is always false. Every hit reaching `replaceRuleID` — the path taken after a mid-flow rule change (`AddRuleID` returns `RuleMatchIsDifferent`, then `ReplaceRuleID`) — was treated as an enforced verdict.

For a staged policy hit that means:

- `pktsCtr.ResetAndSet` / `bytesCtr.ResetAndSet` discard the enforced rule's counts and replace them with the staged rule's,
- `verdictIdx` points at a policy that enforces nothing, so `FoundVerdict()` goes true,
- the flow is reported with a staged policy as its verdict — wrong action attribution, wrong counters.

Fixed to `rid.Kind`, matching `addRuleID` and the other 15 `KindIsStaged` call sites in Felix.

### 2. `SetConntrackCounters` short-circuited on `&&`

```go
if d.conntrackPktsCtr.Set(packets) && d.conntrackBytesCtr.Set(bytes) {
```

`counter.Set` returns false when the absolute value is unchanged, so `&&` skipped the byte counter's update entirely whenever the packet count was unchanged, and set the dirty flag only when *both* counters moved. Now both are evaluated and the results OR'd, at both call sites (forward and reverse).

This one is latent rather than actively harmful: `Set` derives its delta from the last recorded absolute, so the next update that does move packets brings the byte total along with it. The exposure is a flow that expires inside a packets-unchanged window, and the code reading as "and" where it means "or".

### Testing

Four specs added to `felix/collector/stats_test.go`, following the existing `Describe`/`Context` pattern:

- a staged policy hit through `ReplaceRuleID` records no verdict and does not attribute its action to the flow;
- a bytes-only update is recorded and marks the data dirty, forward and reverse;
- an update that changes nothing leaves the data clean.

Each was verified to fail with only its own fix reverted — 2 failures for the `rid.Name` revert, 2 for the `&&` revert. `go test ./felix/collector/...` and `go vet ./felix/collector/` pass.

### Noted, not fixed here

`app-policy/policystore/process.go:42,52` has the same `KindIsStaged(Id.Name)` mistake, where `proto.PolicyID` also carries `Kind`. That guard is meant to skip staged policies when `storeStaged` is false, so it may mean staged policies reach the Dikastes policy store. Different component and the blast radius needs checking first, so it is left for a separate PR.

**Release note:**
```release-note
Fixed flow logs reporting a staged policy as the enforced verdict, with incorrect packet and byte counts, when a flow's policy path changed mid-flow.
```