### PR TITLE
fix(confd): re-advertise service external IPs from route reflectors

### DIFF
--- a/confd/pkg/backends/calico/bgp_processor.go
+++ b/confd/pkg/backends/calico/bgp_processor.go
@@ -84,6 +84,7 @@ func (c *client) GetBirdBGPConfig(ipVersion int) (*types.BirdBGPConfig, error) {
 		Peers:           make([]types.BirdBGPPeer, 0),
 		Filters:         make(map[string]string),
 		Communities:     make([]types.CommunityRule, 0),
+		ExternalIPs:     getServiceExternalIPs(pc.globalBGPConfig),
 		LoadBalancerIPs: getServiceLoadBalancerIPs(pc.globalBGPConfig),
 	}
 

--- a/confd/pkg/backends/calico/bgp_processor_test.go
+++ b/confd/pkg/backends/calico/bgp_processor_test.go
@@ -122,6 +122,25 @@ func TestBuildExportFilter_EmptyFilters(t *testing.T) {
 	assert.Contains(t, result, "calico_export_to_bgp_peers")
 }
 
+func TestGetBirdBGPConfig_ServiceExternalIPs(t *testing.T) {
+	originalNodeName := NodeName
+	NodeName = "test-node"
+	defer func() { NodeName = originalNodeName }()
+
+	cache := map[string]string{
+		"/calico/bgp/v1/host/test-node/ip_addr_v4": "10.0.0.1",
+		"/calico/bgp/v1/global/as_num":             "64512",
+	}
+	c := newTestClient(cache, nil)
+	c.globalBGPConfig.Spec.ServiceExternalIPs = []v3.ServiceExternalIPBlock{
+		{CIDR: "203.0.113.10/32"},
+	}
+
+	config, err := c.GetBirdBGPConfig(4)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"203.0.113.10/32"}, config.ExternalIPs)
+}
+
 func TestRouterIDGeneration_Hash(t *testing.T) {
 	NodeName = "test-node-hash"
 	require.NoError(t, os.Setenv("CALICO_ROUTER_ID", "hash"))

--- a/confd/pkg/backends/types/bird_bgp_config.go
+++ b/confd/pkg/backends/types/bird_bgp_config.go
@@ -31,6 +31,7 @@ type BirdBGPConfig struct {
 	ListenPort       string
 	DirectInterfaces string // Complete interface pattern string for protocol direct
 
+	ExternalIPs                       []string
 	LoadBalancerIPs                   []string
 	BGPExportFilterForDisabledIPPools []string
 	BGPExportFilterForEnabledIPPools  []string

--- a/node/filesystem/etc/calico/confd/templates/bird6_ipam.cfg.template
+++ b/node/filesystem/etc/calico/confd/templates/bird6_ipam.cfg.template
@@ -55,6 +55,16 @@ function calico_export_to_bgp_peers(bool internal_peer) {
     {{- end}}
   {{- end}}
 {{- end}}
+{{- if and (not (eq $rr_cluster_id "")) $config.ExternalIPs}}
+
+  # Configured as a RR - accept any routes within configured external service IP ranges
+  {{- range $config.ExternalIPs}}
+    {{- $cidr := .}}
+    {{- if contains $cidr ":"}}
+  if ( net ~ {{$cidr}} ) then { accept; }
+    {{- end}}
+  {{- end}}
+{{- end}}
 {{- end}}
 
 {{- range $line := $config.BGPExportFilterForEnabledIPPools }}

--- a/node/filesystem/etc/calico/confd/templates/bird_ipam.cfg.template
+++ b/node/filesystem/etc/calico/confd/templates/bird_ipam.cfg.template
@@ -55,6 +55,16 @@ function calico_export_to_bgp_peers(bool internal_peer) {
     {{- end}}
   {{- end}}
 {{- end}}
+{{- if and (not (eq $rr_cluster_id "")) $config.ExternalIPs}}
+
+  # Configured as a RR - accept any routes within configured external service IP ranges
+  {{- range $config.ExternalIPs}}
+    {{- $cidr := .}}
+    {{- if not (contains $cidr ":")}}
+  if ( net ~ {{$cidr}} ) then { accept; }
+    {{- end}}
+  {{- end}}
+{{- end}}
 {{- end}}
 {{- range $line := $config.BGPExportFilterForEnabledIPPools }}
 {{ $line }}


### PR DESCRIPTION
## Description

Allow Calico route reflectors to re-advertise routes within configured `serviceExternalIPs` ranges.

Route reflectors already accept configured `serviceLoadBalancerIPs` ranges from their clients, but `serviceExternalIPs` was not included in the generated BIRD export filter. As a result, a `/32` external service IP learned from a node with a local endpoint was not re-advertised by an RR that had no local endpoint.

## Changes

- Carry `serviceExternalIPs` into the BIRD configuration model.
- Accept IPv4 external service ranges in the IPv4 RR export filter.
- Accept IPv6 external service ranges in the IPv6 RR export filter.
- Add a configuration regression test.

Fixes #13341.

## Validation

- `go test ./confd/pkg/backends/calico`
- `gofmt`
- `git diff --check`

**Release note:**
```release-note
Route reflectors now re-advertise service external IP routes that fall within configured serviceExternalIPs ranges.
```
