### PR TITLE
fix(felix): report NFLOG subscribe failures from NFLogReader.Start

### DIFF
--- a/felix/collector/iptables.go
+++ b/felix/collector/iptables.go
@@ -72,7 +72,7 @@ func NewNFLogReader(lookupsCache *calc.LookupsCache, inGrp, eGrp, bufSize int, s
 
 func (r *NFLogReader) Start() error {
 	if err := r.subscribe(); err != nil {
-		return nil
+		return err
 	}
 
 	r.wg.Go(func() {
@@ -93,7 +93,8 @@ func (r *NFLogReader) PacketInfoChan() <-chan types.PacketInfo {
 	return r.packetInfoC
 }
 
-func subscribeToNflog(gn int, nlBufSiz int, nflogChan chan map[nfnetlink.NflogPacketTuple]*nfnetlink.NflogPacketAggregate, nflogDoneChan chan struct{}, enableServices bool) error {
+// subscribeToNflog is a variable so that tests can stand in for the netlink subscription.
+var subscribeToNflog = func(gn int, nlBufSiz int, nflogChan chan map[nfnetlink.NflogPacketTuple]*nfnetlink.NflogPacketAggregate, nflogDoneChan chan struct{}, enableServices bool) error {
 	return nfnetlink.NflogSubscribe(gn, nlBufSiz, nflogChan, nflogDoneChan, enableServices)
 }
 

--- a/felix/collector/iptables_test.go
+++ b/felix/collector/iptables_test.go
@@ -1,0 +1,80 @@
+//go:build linux
+
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/projectcalico/calico/felix/nfnetlink"
+)
+
+// A reader that cannot subscribe produces no rule hits and no policy verdicts for the lifetime of
+// the process, so Start must report the failure rather than looking like it succeeded.
+func TestNFLogReaderStartReportsSubscribeFailure(t *testing.T) {
+	subscribeErr := errors.New("no NFLOG for you")
+
+	for _, tc := range []struct {
+		name string
+		// failOnGroup is the netlink group whose subscription fails.
+		failOnGroup int
+		wantInErr   string
+	}{
+		{"ingress subscription fails", 1, "ingress"},
+		{"egress subscription fails", 2, "egress"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			withStubbedNflogSubscribe(t, func(gn int, _ int, _ chan map[nfnetlink.NflogPacketTuple]*nfnetlink.NflogPacketAggregate, _ chan struct{}, _ bool) error {
+				if gn == tc.failOnGroup {
+					return subscribeErr
+				}
+				return nil
+			})
+
+			err := NewNFLogReader(nil, 1, 2, 0, false).Start()
+			if err == nil {
+				t.Fatal("Start() returned nil after the subscription failed")
+			}
+			if !errors.Is(err, subscribeErr) {
+				t.Errorf("Start() error does not wrap the subscribe error: %v", err)
+			}
+			if !strings.Contains(err.Error(), tc.wantInErr) {
+				t.Errorf("Start() error %q does not say which direction failed (want %q)", err, tc.wantInErr)
+			}
+		})
+	}
+}
+
+func TestNFLogReaderStartSucceeds(t *testing.T) {
+	withStubbedNflogSubscribe(t, func(int, int, chan map[nfnetlink.NflogPacketTuple]*nfnetlink.NflogPacketAggregate, chan struct{}, bool) error {
+		return nil
+	})
+
+	r := NewNFLogReader(nil, 1, 2, 0, false)
+	if err := r.Start(); err != nil {
+		t.Fatalf("Start() failed with a working subscription: %v", err)
+	}
+	r.Stop()
+}
+
+func withStubbedNflogSubscribe(t *testing.T, stub func(int, int, chan map[nfnetlink.NflogPacketTuple]*nfnetlink.NflogPacketAggregate, chan struct{}, bool) error) {
+	t.Helper()
+	orig := subscribeToNflog
+	subscribeToNflog = stub
+	t.Cleanup(func() { subscribeToNflog = orig })
+}


### PR DESCRIPTION
`NFLogReader.Start` discarded the error from `subscribe()`:

```go
func (r *NFLogReader) Start() error {
	if err := r.subscribe(); err != nil {
		return nil
	}
```

A failed NFLOG subscription therefore looked like a successful start. The collector went on to run with no packet info source: no rule hits and no policy verdicts for the lifetime of the process. Worse, `sendMetrics` clears a connection's dirty flags and deltas whether or not a verdict was found, so conntrack counters were discarded tick after tick — flow logs simply empty, with nothing in the logs explaining why.

Fixed to `return err`. `subscribeToNflog` also becomes a var so the tests can stand in for the netlink subscription; it was already a one-line pass-through wrapper around `nfnetlink.NflogSubscribe`.

### Behaviour change worth a reviewer's attention

`felix/daemon/daemon.go:513-516` panics when the collector fails to start:

```go
if err := dpStatsCollector.Start(); err != nil {
	// XXX we should panic once all dataplanes expect the collector to run.
	log.WithError(err).Panic("Stats collector did not start.")
}
```

So on a node where NFLOG cannot be subscribed — missing `nfnetlink_log`, insufficient privileges — Felix will now panic instead of running with flow logs silently broken. That is the point of the change, and it matches how a `ConntrackInfoReader` failure is already treated, but it does mean an observability failure takes down dataplane programming on that node. The reader is only constructed when a collector is configured and the BPF dataplane is disabled (`felix/dataplane/linux/int_dataplane.go:1595-1600`).

If reviewers would rather degrade than panic, the alternative is to log the failure at error level and continue — but the current behaviour of returning `nil` is wrong either way, since it reports success.

### Testing

New `felix/collector/iptables_test.go` (vanilla `go test`, `//go:build linux` to match `iptables.go`): `Start` surfaces the wrapped error and names the failing direction, for an ingress-side and an egress-side failure, and still succeeds when the subscription works. Verified both failure sub-tests fail with the fix reverted (`Start() returned nil after the subscription failed`). `go test ./felix/collector/...` and `go vet ./felix/collector/` pass.

**Release note:**
```release-note
Felix now reports a failure to subscribe to NFLOG instead of starting the flow log collector with no packet source, which silently produced empty flow logs.
```
