### PR TITLE
fix(felix): stop discarding flow-log stats that were never reported

### DIFF
--- a/felix/collector/collector.go
+++ b/felix/collector/collector.go
@@ -97,6 +97,11 @@ var (
 	dataplaneStatsUpdateLastErrorReportTime time.Time
 	dataplaneStatsUpdateErrorsInLastMinute  uint32
 
+	counterFlowsExpiredWithoutVerdict = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "felix_collector_flows_expired_without_verdict",
+		Help: "Number of flows that expired before a policy verdict was seen, so their packet and byte counts were discarded.",
+	})
+
 	// epStats cache prometheus metrics
 	gaugeEpStatsCacheSizeLength = prometheus.NewGauge(prometheus.GaugeOpts{
 		Name: "felix_collector_epstats",
@@ -127,6 +132,7 @@ func init() {
 	prometheus.MustRegister(gaugeEpStatsCacheSizeLength)
 	prometheus.MustRegister(histogramDataplaneStatsUpdate)
 	prometheus.MustRegister(gaugeDataplaneStatsUpdateErrorsPerMinute)
+	prometheus.MustRegister(counterFlowsExpiredWithoutVerdict)
 	prometheus.MustRegister(counterPolicyEvalBatches)
 	prometheus.MustRegister(counterPolicyEvalFlows)
 	prometheus.MustRegister(histogramPolicyEvalSweepDuration)
@@ -740,19 +746,30 @@ func (c *collector) sendMetrics(data *Data, expired bool) {
 			// reporting Original IP metric updates and want to send a corresponding expiration metric update.
 			// When they are correlated with regular metric updates and connection metrics, we don't need to
 			// send this.
+			reported := false
 			if data.EgressRuleTrace.FoundVerdict() {
 				c.LogMetrics(data.MetricUpdateEgressConn(ut))
+				reported = true
 			}
 			if data.IngressRuleTrace.FoundVerdict() {
 				c.LogMetrics(data.MetricUpdateIngressConn(ut))
+				reported = true
 			}
 
-			// Clear the connection dirty flag once the stats have been reported. Note that we also clear the
-			// rule trace stats here too since any data stored in them has been superceded by the connection
-			// stats.
-			data.ClearConnDirtyFlag()
-			data.EgressRuleTrace.ClearDirtyFlag()
-			data.IngressRuleTrace.ClearDirtyFlag()
+			if reported {
+				// Clear the connection dirty flag once the stats have been reported. Note that we also clear the
+				// rule trace stats here too since any data stored in them has been superceded by the connection
+				// stats.
+				data.ClearConnDirtyFlag()
+				data.EgressRuleTrace.ClearDirtyFlag()
+				data.IngressRuleTrace.ClearDirtyFlag()
+			} else if expired {
+				// Neither direction has a verdict and the entry is on its way out, so these counts are
+				// lost. NFLOG is lossy under load, so make that visible rather than silent.
+				counterFlowsExpiredWithoutVerdict.Inc()
+			}
+			// With no verdict and the flow still alive, keep the deltas and the dirty flag so that the
+			// counts are reported in full once a verdict arrives.
 		}
 	} else {
 		// Report rule trace stats.
@@ -763,6 +780,14 @@ func (c *collector) sendMetrics(data *Data, expired bool) {
 		if (expired || data.IngressRuleTrace.IsDirty()) && data.IngressRuleTrace.FoundVerdict() {
 			c.LogMetrics(data.MetricUpdateIngressNoConn(ut))
 			data.IngressRuleTrace.ClearDirtyFlag()
+		}
+
+		// Both rule traces have been reported, so there is nothing left to report. Only
+		// ClearConnDirtyFlag used to clear the top-level flag, and that belongs to the connection
+		// branch above, so NFLOG-only entries (all denied traffic) stayed dirty for their whole life
+		// and checkEpStats redid the whole report path for them on every tick.
+		if !data.EgressRuleTrace.IsDirty() && !data.IngressRuleTrace.IsDirty() {
+			data.ClearDirtyFlag()
 		}
 
 		// We do not need to clear the connection stats here. Connection stats are fully reset if the Data moves

--- a/felix/collector/send_metrics_test.go
+++ b/felix/collector/send_metrics_test.go
@@ -1,0 +1,168 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+import (
+	"testing"
+	"time"
+
+	v3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+
+	"github.com/projectcalico/calico/felix/calc"
+	"github.com/projectcalico/calico/felix/collector/types/metric"
+	"github.com/projectcalico/calico/felix/collector/types/tuple"
+	"github.com/projectcalico/calico/felix/rules"
+)
+
+// A connection whose NFLOG verdict has not arrived yet must keep its counters. NFLOG is lossy under
+// load, and checkEpStats force-reports after InitialReportingDelay, so clearing the deltas here used
+// to discard the connection's traffic one tick at a time with nothing reported in exchange.
+func TestSendMetricsKeepsCountersUntilVerdictArrives(t *testing.T) {
+	c, rep := newSendMetricsCollector(t)
+
+	tpl := *tuple.New(remoteIp1, localIp1, proto_tcp, srcPort, dstPort)
+	data := NewData(tpl, remoteEd1, localEd1)
+	c.updateEpStatsCache(tpl, data)
+
+	// Conntrack reports traffic before the verdict is known.
+	data.SetConntrackCounters(10, 1000)
+	data.SetConntrackCountersReverse(5, 500)
+
+	c.sendMetrics(data, false)
+
+	if len(rep.updates) != 0 {
+		t.Fatalf("reported %d update(s) for a flow with no verdict: %+v", len(rep.updates), rep.updates)
+	}
+	if !data.IsDirty() {
+		t.Error("data is no longer dirty, so the unreported counters will never be reported")
+	}
+
+	// More traffic arrives, then the verdict finally shows up.
+	data.SetConntrackCounters(30, 3000)
+	data.AddRuleID(ingressAllowRuleID, 0, 0, 0)
+
+	c.sendMetrics(data, false)
+
+	if len(rep.updates) != 1 {
+		t.Fatalf("expected one update once the verdict arrived, got %d: %+v", len(rep.updates), rep.updates)
+	}
+	// Everything the connection sent, including what accumulated before the verdict, must be in the
+	// delta that is finally reported.
+	if got, want := rep.updates[0].InMetric.DeltaPackets, 30; got != want {
+		t.Errorf("reported %d packets, want %d (counts from before the verdict were dropped)", got, want)
+	}
+	if got, want := rep.updates[0].InMetric.DeltaBytes, 3000; got != want {
+		t.Errorf("reported %d bytes, want %d (counts from before the verdict were dropped)", got, want)
+	}
+	if data.IsDirty() {
+		t.Error("data is still dirty after being reported")
+	}
+}
+
+// An expired flow that never got a verdict really does lose its counters; that is unavoidable by
+// then, but it must not be silent.
+func TestSendMetricsCountsFlowsExpiringWithoutVerdict(t *testing.T) {
+	c, _ := newSendMetricsCollector(t)
+
+	tpl := *tuple.New(remoteIp1, localIp1, proto_tcp, srcPort, dstPort)
+	data := NewData(tpl, remoteEd1, localEd1)
+	c.updateEpStatsCache(tpl, data)
+	data.SetConntrackCounters(10, 1000)
+
+	before := testutil.ToFloat64(counterFlowsExpiredWithoutVerdict)
+	c.sendMetrics(data, true)
+	after := testutil.ToFloat64(counterFlowsExpiredWithoutVerdict)
+
+	if delta := after - before; delta != 1 {
+		t.Errorf("felix_collector_flows_expired_without_verdict moved by %v, want 1", delta)
+	}
+}
+
+// A reported NFLOG-only entry must end up clean, or checkEpStats redoes the whole report path for it
+// on every tick for as long as it lives — O(entries) of wasted work per tick during a port scan.
+func TestSendMetricsClearsDirtyFlagForNonConnections(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		ruleID    *calc.RuleID
+		wantDirty bool
+	}{
+		{"with a verdict, the entry is reported and left clean", ingressAllowRuleID, false},
+		{"with no verdict, the entry stays dirty so it is retried", ingressPassRuleID, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c, _ := newSendMetricsCollector(t)
+
+			tpl := *tuple.New(remoteIp1, localIp1, proto_tcp, srcPort, dstPort)
+			data := NewData(tpl, remoteEd1, localEd1)
+			c.updateEpStatsCache(tpl, data)
+			data.AddRuleID(tc.ruleID, 0, 1, 100)
+
+			if data.IsConnection {
+				t.Fatal("test precondition: entry should not be a connection")
+			}
+			if !data.IsDirty() {
+				t.Fatal("test precondition: entry should be dirty after a rule hit")
+			}
+
+			c.sendMetrics(data, false)
+
+			if data.IsDirty() != tc.wantDirty {
+				t.Errorf("after reporting, IsDirty()=%v, want %v", data.IsDirty(), tc.wantDirty)
+			}
+		})
+	}
+}
+
+var (
+	ingressAllowRuleID = calc.NewRuleID(v3.KindGlobalNetworkPolicy, "default", "policy1", "",
+		0, rules.RuleDirIngress, rules.RuleActionAllow)
+	// A pass is not a verdict, so a trace holding only this has nothing to report yet.
+	ingressPassRuleID = calc.NewRuleID(v3.KindGlobalNetworkPolicy, "default", "policy1", "",
+		0, rules.RuleDirIngress, rules.RuleActionPass)
+)
+
+func newSendMetricsCollector(t *testing.T) (*collector, *capturingReporter) {
+	t.Helper()
+
+	lm := newMockLookupsCache(map[[16]byte]calc.EndpointData{
+		localIp1:  localEd1,
+		remoteIp1: remoteEd1,
+	}, nil, nil, nil)
+
+	c := newCollector(lm, &Config{
+		AgeTimeout:            10 * time.Second,
+		InitialReportingDelay: 5 * time.Second,
+		ExportingInterval:     time.Second,
+		FlowLogsFlushInterval: 100 * time.Second,
+	}).(*collector)
+
+	rep := &capturingReporter{}
+	c.RegisterMetricsReporter(rep)
+	return c, rep
+}
+
+// capturingReporter keeps the metric updates whole, counters included, unlike the mockReporter in
+// collector_test.go which strips them for easier comparison.
+type capturingReporter struct {
+	updates []metric.Update
+}
+
+func (r *capturingReporter) Start() error { return nil }
+
+func (r *capturingReporter) Report(u any) error {
+	r.updates = append(r.updates, u.(metric.Update))
+	return nil
+}

--- a/felix/collector/stats.go
+++ b/felix/collector/stats.go
@@ -418,6 +418,12 @@ func (d *Data) setDirtyFlag() {
 	d.dirty = true
 }
 
+// ClearDirtyFlag clears the top-level dirty flag, leaving the connection counters alone. Use it for
+// non-connection data, which has no connection stats to reset; use ClearConnDirtyFlag otherwise.
+func (d *Data) ClearDirtyFlag() {
+	d.dirty = false
+}
+
 func (d *Data) ClearConnDirtyFlag() {
 	d.dirty = false
 	d.conntrackPktsCtr.ResetDelta()


### PR DESCRIPTION
Two dirty-flag bugs in `sendMetrics` (`felix/collector/collector.go`), found by review. Both are about clearing state that was never reported; they are in the two halves of the same function, hence one PR.

### 1. A connection with no verdict had its counters thrown away

The connection branch enters on `expired || data.IsDirty()`, emits nothing when neither rule trace has a verdict, and then cleared the connection deltas and both rule traces regardless. `reportMetrics` marks the data `Reported` afterwards.

`checkEpStats` force-reports after `InitialReportingDelay` (5s), so a connection whose NFLOG verdict has not arrived yet lost its accumulated packet and byte counts, one tick at a time, with nothing reported in exchange and no counter or log to show for it. NFLOG is lossy under load — socket buffer overflows are routine — and this is also the path a conntrack-only short-lived flow takes.

Now the clearing is gated on whether anything was actually reported, so the deltas accumulate until a verdict arrives and are then reported in full. Behaviour is unchanged whenever at least one direction is reported.

When the entry expires having never seen a verdict, the counts genuinely are lost by then. That case now increments a new counter rather than disappearing silently:

```
felix_collector_flows_expired_without_verdict
```

**Please sanity-check the docs label** — this adds a Felix Prometheus metric. I've marked the PR `docs-not-required` on the basis that the collector's internal metrics aren't enumerated in the docs, but say the word and I'll raise a docs PR.

### 2. Non-connection entries never cleared the top-level dirty flag

`Data.dirty` is only cleared by `ClearConnDirtyFlag`, which lives in the connection branch. NFLOG-only entries — all denied traffic — therefore stayed dirty for their entire lifetime, so `checkEpStats` ran the full `checkPreDNATTuple` + `reportMetrics` + no-op `sendMetrics` path for every one of them on every tick. During a port scan that's O(entries) of wasted work per second. It also made `IsDirty()` meaningless for those entries.

The non-connection branch now clears the flag once both rule traces are clean. If a trace is dirty but has no verdict it stays dirty, so the entry is still retried on later ticks.

`Data.ClearDirtyFlag` is new (`felix/collector/stats.go`): it clears the flag without touching the connection counters, which is what this branch needs. The connection branch keeps using `ClearConnDirtyFlag`, which also resets the conntrack deltas.

Note the connection branch still clears *both* rule traces together when it reports, as before — `checkPreDNATTuple` keys off those flags, so narrowing that would change pre-DNAT cleanup behaviour. Out of scope here.

### Testing

New file `felix/collector/send_metrics_test.go` (vanilla `go test`, new file so it doesn't collide with #13409's additions to `collector_test.go`):

- a verdict-less connection keeps its dirty flag and its deltas, and when the verdict arrives the reported update carries all 30 packets / 3000 bytes, including the 10/1000 that accumulated first;
- expiring without a verdict bumps the new counter;
- a reported NFLOG-only entry ends up clean, while one whose trace has only a `pass` (no verdict) stays dirty.

Each fix was reverted on its own to confirm the tests catch it — the first revert reports `20 packets, want 30`, i.e. exactly the 10 packets that used to be wiped. `go test ./felix/collector/...` and `go vet ./felix/collector/...` pass.

Branched from master after #13410 merged.

**Release note:**
```release-note
Fixed Felix discarding flow log packet and byte counts for connections whose policy verdict had not yet been received, which under-reported traffic when NFLOG messages were delayed or dropped.
```