### PR TITLE
Make the staged-policy scope of ALP policy evaluation explicit

### DIFF
--- a/app-policy/checker/alp_check_provider.go
+++ b/app-policy/checker/alp_check_provider.go
@@ -45,6 +45,6 @@ func (a *ALPCheckProvider) EnabledForRequest(ps *policystore.PolicyStore, _ *aut
 // for the local workload endpoint and returns the authorization decision.
 func (a *ALPCheckProvider) Check(ps *policystore.PolicyStore, req *authz.CheckRequest) (*authz.CheckResponse, error) {
 	flow := NewCheckRequestToFlowAdapter(req)
-	st := checkStore(ps, ps.Endpoint, rules.RuleDirIngress, flow)
+	st := checkStore(EnforcedOnly, ps, ps.Endpoint, rules.RuleDirIngress, flow)
 	return &authz.CheckResponse{Status: &st}, nil
 }

--- a/app-policy/checker/bench_test.go
+++ b/app-policy/checker/bench_test.go
@@ -146,7 +146,7 @@ func benchEvaluateBaselinePolicyScale(b *testing.B, p baselinePolicyScaleParams,
 
 	// Pre-flight outside the timed loop: prove the walk is the intended one and that
 	// the warning count matches the analytic count, so that warnings/op is exact.
-	trace := Evaluate(rules.RuleDirIngress, store, ep, flow)
+	trace := Evaluate(EnforcedOnly, rules.RuleDirIngress, store, ep, flow)
 	if matchEarly {
 		if len(trace) != 1 || trace[0].Action != rules.RuleActionAllow || trace[0].Index != 0 {
 			b.Fatalf("expected an immediate allow from the match-early policy, got %v", trace)
@@ -165,7 +165,7 @@ func benchEvaluateBaselinePolicyScale(b *testing.B, p baselinePolicyScaleParams,
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		benchTraceSink = Evaluate(rules.RuleDirIngress, store, ep, flow)
+		benchTraceSink = Evaluate(EnforcedOnly, rules.RuleDirIngress, store, ep, flow)
 	}
 	b.StopTimer()
 	b.ReportMetric(float64(counter.count.Load())/float64(b.N), "warnings/op")

--- a/app-policy/checker/bench_test.go
+++ b/app-policy/checker/bench_test.go
@@ -146,7 +146,7 @@ func benchEvaluateBaselinePolicyScale(b *testing.B, p baselinePolicyScaleParams,
 
 	// Pre-flight outside the timed loop: prove the walk is the intended one and that
 	// the warning count matches the analytic count, so that warnings/op is exact.
-	trace := Evaluate(EnforcedOnly, rules.RuleDirIngress, store, ep, flow)
+	trace, _ := Evaluate(EnforcedOnly, rules.RuleDirIngress, store, ep, flow)
 	if matchEarly {
 		if len(trace) != 1 || trace[0].Action != rules.RuleActionAllow || trace[0].Index != 0 {
 			b.Fatalf("expected an immediate allow from the match-early policy, got %v", trace)
@@ -165,7 +165,7 @@ func benchEvaluateBaselinePolicyScale(b *testing.B, p baselinePolicyScaleParams,
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		benchTraceSink = Evaluate(EnforcedOnly, rules.RuleDirIngress, store, ep, flow)
+		benchTraceSink, _ = Evaluate(EnforcedOnly, rules.RuleDirIngress, store, ep, flow)
 	}
 	b.StopTimer()
 	b.ReportMetric(float64(counter.count.Load())/float64(b.N), "warnings/op")

--- a/app-policy/checker/check.go
+++ b/app-policy/checker/check.go
@@ -79,7 +79,13 @@ const (
 // decides whether staged policies take part: pass StagedAsEnforced for the pending trace, or
 // EnforcedOnly for the trace the dataplane enforces.
 func Evaluate(scope PolicyScope, dir rules.RuleDir, store *policystore.PolicyStore, ep *proto.WorkloadEndpoint, flow Flow) []*calc.RuleID {
-	_, trace := checkTiers(scope, store, ep, dir, flow)
+	s, trace := checkTiers(scope, store, ep, dir, flow)
+	if s.Code == INTERNAL || s.Code == INVALID_ARGUMENT {
+		// The evaluation failed part way through, so the trace stops short of a verdict. Report no
+		// trace at all rather than one that reads as if policy ran out of rules to apply.
+		log.Debugf("Policy evaluation failed with %v, discarding partial trace", s.Code)
+		return nil
+	}
 	return trace
 }
 
@@ -157,16 +163,18 @@ func checkTiers(scope PolicyScope, store *policystore.PolicyStore, ep *proto.Wor
 			}
 			policiesInScope++
 
-			if policy := store.PolicyByID[ftypes.ProtoToPolicyID(pID)]; policy != nil {
-				action, ruleIndex = checkPolicy(policy, dir, request)
-				log.Debugf("Policy checked (ordinal=%d, Id=%+v, action=%v)", i, pID, action)
-			} else {
-				// The tier does contain this policy, we have just not been told its rules yet, so
-				// treat it as a non-match. The tier is still there, so its end-of-tier action still
-				// applies; only this policy's own verdict is missing.
-				log.Warnf("Policy not in store, treating as no-match (ordinal=%d, Id=%+v)", i, pID)
-				action, ruleIndex = NO_MATCH, tierDefaultActionIndex
+			policy := store.PolicyByID[ftypes.ProtoToPolicyID(pID)]
+			if policy == nil {
+				// The endpoint's tier lists this policy but we have not been told its rules, so we
+				// cannot know its verdict, and skipping it would apply the rest of the tier's
+				// policies to a request they may not govern. Fail closed instead.
+				log.Errorf("Policy in tier but not in store, failing evaluation (ordinal=%d, Id=%+v)", i, pID)
+				s.Code = INTERNAL
+				return
 			}
+
+			action, ruleIndex = checkPolicy(policy, dir, request)
+			log.Debugf("Policy checked (ordinal=%d, Id=%+v, action=%v)", i, pID, action)
 			switch action {
 			case NO_MATCH:
 				if tierDefaultActionRuleID == nil {

--- a/app-policy/checker/check.go
+++ b/app-policy/checker/check.go
@@ -44,6 +44,10 @@ var (
 
 	rlog1 = logrusr.NewRateLimitedLogger()
 	rlog2 = logrusr.NewRateLimitedLogger()
+	// A missing policy is one log line per evaluation, and Felix's collector re-evaluates every
+	// flow in both directions on every sweep, so a policy that stays missing would log per flow
+	// per sweep.
+	rlogMissingPolicy = logrusr.NewRateLimitedLogger()
 )
 
 // PolicyScope selects which of an endpoint's policies take part in an evaluation.
@@ -79,15 +83,18 @@ const (
 // Evaluate evaluates the flow against the policy store and returns the trace of rules. The scope
 // decides whether staged policies take part: pass StagedAsEnforced for the pending trace, or
 // EnforcedOnly for the trace the dataplane enforces.
-func Evaluate(scope PolicyScope, dir rules.RuleDir, store *policystore.PolicyStore, ep *proto.WorkloadEndpoint, flow Flow) []*calc.RuleID {
+//
+// ok is false if the evaluation could not be completed, in which case the trace is nil and the
+// caller should hold on to whatever trace it already had: an empty trace would say the flow has no
+// policy, which is a stronger claim than "we could not work it out".
+func Evaluate(scope PolicyScope, dir rules.RuleDir, store *policystore.PolicyStore, ep *proto.WorkloadEndpoint, flow Flow) (trace []*calc.RuleID, ok bool) {
 	s, trace := checkTiers(scope, store, ep, dir, flow)
 	if s.Code == INTERNAL || s.Code == INVALID_ARGUMENT {
-		// The evaluation failed part way through, so the trace stops short of a verdict. Report no
-		// trace at all rather than one that reads as if policy ran out of rules to apply.
-		log.Debugf("Policy evaluation failed with %v, discarding partial trace", s.Code)
-		return nil
+		// The evaluation stopped part way through, so the trace stops short of a verdict. It has
+		// already been logged with the reason.
+		return nil, false
 	}
-	return trace
+	return trace, true
 }
 
 // LookupEndpointKeysFromSrcDst looks up the source and destination endpoint keys for the given
@@ -170,7 +177,7 @@ func checkTiers(scope PolicyScope, store *policystore.PolicyStore, ep *proto.Wor
 				// know its verdict. We should never get here: a policy is sent before the endpoints
 				// that reference it. Fail closed rather than apply the rest of the tier to a request
 				// this policy may govern.
-				log.Errorf("Policy named in tier is missing from the store, failing evaluation (ordinal=%d, Id=%+v)", i, pID)
+				rlogMissingPolicy.Errorf("Policy named in tier is missing from the store, failing evaluation (ordinal=%d, Id=%+v)", i, pID)
 				s.Code = INTERNAL
 				s.Message = fmt.Sprintf("policy %s of tier %s is missing from the policy store",
 					policyDisplayName(pID), tier.GetName())

--- a/app-policy/checker/check.go
+++ b/app-policy/checker/check.go
@@ -171,16 +171,18 @@ func checkTiers(scope PolicyScope, store *policystore.PolicyStore, ep *proto.Wor
 			}
 			policiesInScope++
 
-			policy := store.PolicyByID[ftypes.ProtoToPolicyID(pID)]
+			policyID := ftypes.ProtoToPolicyID(pID)
+			policy := store.PolicyByID[policyID]
 			if policy == nil {
 				// The endpoint's tier names this policy but the store does not have it, so we cannot
 				// know its verdict. We should never get here: a policy is sent before the endpoints
 				// that reference it. Fail closed rather than apply the rest of the tier to a request
 				// this policy may govern.
-				rlogMissingPolicy.Errorf("Policy named in tier is missing from the store, failing evaluation (ordinal=%d, Id=%+v)", i, pID)
+				rlogMissingPolicy.Errorf("Policy named in tier is missing from the store, failing evaluation (ordinal=%d, policy=%s, tier=%s)",
+					i, policyID.ID(), tier.GetName())
 				s.Code = INTERNAL
 				s.Message = fmt.Sprintf("policy %s of tier %s is missing from the policy store",
-					policyDisplayName(pID), tier.GetName())
+					policyID.ID(), tier.GetName())
 				return
 			}
 
@@ -208,7 +210,7 @@ func checkTiers(scope PolicyScope, store *policystore.PolicyStore, ep *proto.Wor
 			case LOG:
 				log.Debug("policy should never return LOG action")
 				s.Code = INVALID_ARGUMENT
-				s.Message = fmt.Sprintf("policy %s returned a LOG action", policyDisplayName(pID))
+				s.Message = fmt.Sprintf("policy %s returned a LOG action", policyID.ID())
 				return
 			}
 		}
@@ -353,13 +355,4 @@ func getPoliciesByDirection(dir rules.RuleDir, tier *proto.TierInfo) []*proto.Po
 		return tier.EgressPolicies
 	}
 	return tier.IngressPolicies
-}
-
-// policyDisplayName renders a policy ID for a human: how an operator would name it when looking for
-// it with calicoctl.
-func policyDisplayName(pID *proto.PolicyID) string {
-	if pID.Namespace == "" {
-		return fmt.Sprintf("%s(%s)", pID.Name, pID.Kind)
-	}
-	return fmt.Sprintf("%s/%s(%s)", pID.Namespace, pID.Name, pID.Kind)
 }

--- a/app-policy/checker/check.go
+++ b/app-policy/checker/check.go
@@ -15,6 +15,7 @@
 package checker
 
 import (
+	"fmt"
 	"strings"
 
 	v3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
@@ -170,6 +171,8 @@ func checkTiers(scope PolicyScope, store *policystore.PolicyStore, ep *proto.Wor
 				// policies to a request they may not govern. Fail closed instead.
 				log.Errorf("Policy in tier but not in store, failing evaluation (ordinal=%d, Id=%+v)", i, pID)
 				s.Code = INTERNAL
+				s.Message = fmt.Sprintf("policy %s of tier %s has not been synced yet",
+					policyDisplayName(pID), tier.GetName())
 				return
 			}
 
@@ -197,6 +200,7 @@ func checkTiers(scope PolicyScope, store *policystore.PolicyStore, ep *proto.Wor
 			case LOG:
 				log.Debug("policy should never return LOG action")
 				s.Code = INVALID_ARGUMENT
+				s.Message = fmt.Sprintf("policy %s returned a LOG action", policyDisplayName(pID))
 				return
 			}
 		}
@@ -328,7 +332,7 @@ func handlePanic(s *status.Status) {
 	if r := recover(); r != nil {
 		if v, ok := r.(*InvalidDataFromDataPlane); ok {
 			log.Debug("InvalidFromDataPlane: ", v.string)
-			*s = status.Status{Code: INVALID_ARGUMENT}
+			*s = status.Status{Code: INVALID_ARGUMENT, Message: v.string}
 		} else {
 			panic(r)
 		}
@@ -341,4 +345,13 @@ func getPoliciesByDirection(dir rules.RuleDir, tier *proto.TierInfo) []*proto.Po
 		return tier.EgressPolicies
 	}
 	return tier.IngressPolicies
+}
+
+// policyDisplayName renders a policy ID for a human: how an operator would name it when looking for
+// it with calicoctl.
+func policyDisplayName(pID *proto.PolicyID) string {
+	if pID.Namespace == "" {
+		return fmt.Sprintf("%s(%s)", pID.Name, pID.Kind)
+	}
+	return fmt.Sprintf("%s/%s(%s)", pID.Namespace, pID.Name, pID.Kind)
 }

--- a/app-policy/checker/check.go
+++ b/app-policy/checker/check.go
@@ -30,6 +30,7 @@ import (
 	"github.com/projectcalico/calico/felix/rules"
 	ftypes "github.com/projectcalico/calico/felix/types"
 	"github.com/projectcalico/calico/lib/logrusr"
+	"github.com/projectcalico/calico/libcalico-go/lib/backend/model"
 )
 
 var (
@@ -119,7 +120,16 @@ func checkTiers(store *policystore.PolicyStore, ep *proto.WorkloadEndpoint, dir 
 
 	for _, tier := range ep.Tiers {
 		log.Debugf("Checking tier %s", tier.GetName())
-		policies := getPoliciesByDirection(dir, tier)
+		// Staged policies enforce nothing, so they take no part in the action. A tier holding only
+		// staged policies is skipped entirely — as if it were not there, so not even its end-of-tier
+		// action applies. Felix programs the same rule into the dataplane: "If all of the policies in
+		// a tier are staged then the default end of tier behavior should be pass rather than drop"
+		// (felix/rules/endpoints.go).
+		//
+		// The store may hold staged policies quite legitimately: Felix reuses this checker to
+		// evaluate pending policy for flow logs, and keeps them for that (policystore.ProcessUpdate).
+		// So the filtering has to happen here, not in the store.
+		policies := enforcedPolicies(getPoliciesByDirection(dir, tier))
 		if len(policies) == 0 {
 			continue
 		}
@@ -293,6 +303,28 @@ func handlePanic(s *status.Status) {
 			panic(r)
 		}
 	}
+}
+
+// enforcedPolicies drops the staged policies, leaving those that can affect the flow's action. It
+// returns the slice it was given when there is nothing to drop, which is the common case.
+func enforcedPolicies(policies []*proto.PolicyID) []*proto.PolicyID {
+	staged := 0
+	for _, p := range policies {
+		if model.KindIsStaged(p.GetKind()) {
+			staged++
+		}
+	}
+	if staged == 0 {
+		return policies
+	}
+
+	enforced := make([]*proto.PolicyID, 0, len(policies)-staged)
+	for _, p := range policies {
+		if !model.KindIsStaged(p.GetKind()) {
+			enforced = append(enforced, p)
+		}
+	}
+	return enforced
 }
 
 // getPoliciesByDirection returns the list of policy names for the given direction.

--- a/app-policy/checker/check.go
+++ b/app-policy/checker/check.go
@@ -166,12 +166,13 @@ func checkTiers(scope PolicyScope, store *policystore.PolicyStore, ep *proto.Wor
 
 			policy := store.PolicyByID[ftypes.ProtoToPolicyID(pID)]
 			if policy == nil {
-				// The endpoint's tier lists this policy but we have not been told its rules, so we
-				// cannot know its verdict, and skipping it would apply the rest of the tier's
-				// policies to a request they may not govern. Fail closed instead.
-				log.Errorf("Policy in tier but not in store, failing evaluation (ordinal=%d, Id=%+v)", i, pID)
+				// The endpoint's tier names this policy but the store does not have it, so we cannot
+				// know its verdict. We should never get here: a policy is sent before the endpoints
+				// that reference it. Fail closed rather than apply the rest of the tier to a request
+				// this policy may govern.
+				log.Errorf("Policy named in tier is missing from the store, failing evaluation (ordinal=%d, Id=%+v)", i, pID)
 				s.Code = INTERNAL
-				s.Message = fmt.Sprintf("policy %s of tier %s has not been synced yet",
+				s.Message = fmt.Sprintf("policy %s of tier %s is missing from the policy store",
 					policyDisplayName(pID), tier.GetName())
 				return
 			}

--- a/app-policy/checker/check.go
+++ b/app-policy/checker/check.go
@@ -45,6 +45,19 @@ var (
 	rlog2 = logrusr.NewRateLimitedLogger()
 )
 
+// PolicyScope selects which of an endpoint's policies take part in an evaluation.
+type PolicyScope int
+
+const (
+	// EnforcedOnly ignores staged policies, giving the verdict that is actually enforced.
+	// A tier whose policies are all staged is skipped entirely, end-of-tier action included,
+	// exactly as if the tier were not attached to the endpoint at all.
+	EnforcedOnly PolicyScope = iota
+	// StagedAsEnforced evaluates staged policies as though they had been promoted to enforced,
+	// giving the "pending" verdict: what would happen if the staged policies went live now.
+	StagedAsEnforced
+)
+
 // Action is an enumeration of actions a policy rule can take if it is matched.
 type Action int
 
@@ -62,14 +75,11 @@ const (
 	unknownIndex = -2
 )
 
-// Evaluate evaluates the flow against the policy store and returns the trace of rules.
-//
-// This is the "pending" policy trace: the trace for the current state of policy with every staged
-// policy treated as if it were enforced. It can differ from the verdict the dataplane recorded
-// either because staged policies took part in it, or because the enforced policies have changed
-// since the dataplane reached its verdict.
-func Evaluate(dir rules.RuleDir, store *policystore.PolicyStore, ep *proto.WorkloadEndpoint, flow Flow) []*calc.RuleID {
-	_, trace := checkTiers(store, ep, dir, flow, stagedAsEnforced)
+// Evaluate evaluates the flow against the policy store and returns the trace of rules. The scope
+// decides whether staged policies take part: pass StagedAsEnforced for the pending trace, or
+// EnforcedOnly for the trace the dataplane enforces.
+func Evaluate(scope PolicyScope, dir rules.RuleDir, store *policystore.PolicyStore, ep *proto.WorkloadEndpoint, flow Flow) []*calc.RuleID {
+	_, trace := checkTiers(scope, store, ep, dir, flow)
 	return trace
 }
 
@@ -105,29 +115,16 @@ func ipToEndpointKeys(store *policystore.PolicyStore, addr ip.Addr) []proto.Work
 
 // checkStore applies the tiered policy plus any config based corrections and returns OK if the
 // check passes or PERMISSION_DENIED if the check fails.
-func checkStore(store *policystore.PolicyStore, ep *proto.WorkloadEndpoint, dir rules.RuleDir, req Flow) (s status.Status) {
-	// Check using the configured policy. This decides whether to admit the request, so only the
-	// enforcing policies get a say.
-	s, _ = checkTiers(store, ep, dir, req, enforcedOnly)
+func checkStore(scope PolicyScope, store *policystore.PolicyStore, ep *proto.WorkloadEndpoint, dir rules.RuleDir, req Flow) (s status.Status) {
+	// Check using the configured policy
+	s, _ = checkTiers(scope, store, ep, dir, req)
 	return
 }
-
-// policyScope selects which of an endpoint's policies take part in evaluation.
-type policyScope int
-
-const (
-	// enforcedOnly evaluates only the policies that enforce, i.e. it answers "what does policy do to
-	// this flow right now". Staged policies play no part.
-	enforcedOnly policyScope = iota
-	// stagedAsEnforced treats staged policies as though they were enforced, for the pending policy
-	// trace. See Evaluate.
-	stagedAsEnforced
-)
 
 // checkTiers applies the tiered policy in the given store and returns OK if the check passes, or PERMISSION_DENIED if
 // the check fails. Note, if no policy matches, the default is PERMISSION_DENIED. It returns the trace of rules that
 // were evaluated.
-func checkTiers(store *policystore.PolicyStore, ep *proto.WorkloadEndpoint, dir rules.RuleDir, flow Flow, scope policyScope) (s status.Status, trace []*calc.RuleID) {
+func checkTiers(scope PolicyScope, store *policystore.PolicyStore, ep *proto.WorkloadEndpoint, dir rules.RuleDir, flow Flow) (s status.Status, trace []*calc.RuleID) {
 	s = status.Status{Code: PERMISSION_DENIED}
 	if ep == nil {
 		return
@@ -139,18 +136,6 @@ func checkTiers(store *policystore.PolicyStore, ep *proto.WorkloadEndpoint, dir 
 	for _, tier := range ep.Tiers {
 		log.Debugf("Checking tier %s", tier.GetName())
 		policies := getPoliciesByDirection(dir, tier)
-		if scope == enforcedOnly {
-			// Staged policies enforce nothing, so they take no part in this verdict. Dropping them can
-			// empty the tier, and a tier with nothing left to enforce is skipped entirely — as if it
-			// were not there, so not even its end-of-tier action applies. Felix programs the same rule
-			// into the dataplane: "If all of the policies in a tier are staged then the default end of
-			// tier behavior should be pass rather than drop" (felix/rules/endpoints.go).
-			//
-			// The store may hold staged policies quite legitimately — Felix keeps them for the pending
-			// trace (policystore.ProcessUpdate) — so the filtering has to happen here, not in the
-			// store.
-			policies = enforcedPolicies(policies)
-		}
 		if len(policies) == 0 {
 			continue
 		}
@@ -158,14 +143,30 @@ func checkTiers(store *policystore.PolicyStore, ep *proto.WorkloadEndpoint, dir 
 		var (
 			ruleIndex               int
 			tierDefaultActionRuleID *calc.RuleID
+			// Policies of this tier that are in scope for this evaluation. A tier with none of
+			// them contributes nothing at all, end-of-tier action included.
+			policiesInScope int
 		)
 
 		action := NO_MATCH
 	Policy:
 		for i, pID := range policies {
-			policy := store.PolicyByID[ftypes.ProtoToPolicyID(pID)]
-			action, ruleIndex = checkPolicy(policy, dir, request)
-			log.Debugf("Policy checked (ordinal=%d, Id=%+v, action=%v)", i, pID, action)
+			if scope == EnforcedOnly && model.KindIsStaged(pID.Kind) {
+				log.Debugf("Staged policy, not enforced, skipping (ordinal=%d, Id=%+v)", i, pID)
+				continue Policy
+			}
+			policiesInScope++
+
+			if policy := store.PolicyByID[ftypes.ProtoToPolicyID(pID)]; policy != nil {
+				action, ruleIndex = checkPolicy(policy, dir, request)
+				log.Debugf("Policy checked (ordinal=%d, Id=%+v, action=%v)", i, pID, action)
+			} else {
+				// The tier does contain this policy, we have just not been told its rules yet, so
+				// treat it as a non-match. The tier is still there, so its end-of-tier action still
+				// applies; only this policy's own verdict is missing.
+				log.Warnf("Policy not in store, treating as no-match (ordinal=%d, Id=%+v)", i, pID)
+				action, ruleIndex = NO_MATCH, tierDefaultActionIndex
+			}
 			switch action {
 			case NO_MATCH:
 				if tierDefaultActionRuleID == nil {
@@ -192,7 +193,7 @@ func checkTiers(store *policystore.PolicyStore, ep *proto.WorkloadEndpoint, dir 
 			}
 		}
 		// Done evaluating policies in the tier. If no policy rules have matched, apply tier's default action.
-		if action == NO_MATCH {
+		if policiesInScope > 0 && action == NO_MATCH {
 			log.Debugf("No policy matched. Tier default action %v applies.", tier.DefaultAction)
 			trace = append(trace, tierDefaultActionRuleID)
 			// If the default action is anything beside Pass, then apply tier default deny action.
@@ -324,28 +325,6 @@ func handlePanic(s *status.Status) {
 			panic(r)
 		}
 	}
-}
-
-// enforcedPolicies drops the staged policies, leaving those that can affect the flow's action. It
-// returns the slice it was given when there is nothing to drop, which is the common case.
-func enforcedPolicies(policies []*proto.PolicyID) []*proto.PolicyID {
-	staged := 0
-	for _, p := range policies {
-		if model.KindIsStaged(p.GetKind()) {
-			staged++
-		}
-	}
-	if staged == 0 {
-		return policies
-	}
-
-	enforced := make([]*proto.PolicyID, 0, len(policies)-staged)
-	for _, p := range policies {
-		if !model.KindIsStaged(p.GetKind()) {
-			enforced = append(enforced, p)
-		}
-	}
-	return enforced
 }
 
 // getPoliciesByDirection returns the list of policy names for the given direction.

--- a/app-policy/checker/check.go
+++ b/app-policy/checker/check.go
@@ -63,8 +63,13 @@ const (
 )
 
 // Evaluate evaluates the flow against the policy store and returns the trace of rules.
+//
+// This is the "pending" policy trace: the trace for the current state of policy with every staged
+// policy treated as if it were enforced. It can differ from the verdict the dataplane recorded
+// either because staged policies took part in it, or because the enforced policies have changed
+// since the dataplane reached its verdict.
 func Evaluate(dir rules.RuleDir, store *policystore.PolicyStore, ep *proto.WorkloadEndpoint, flow Flow) []*calc.RuleID {
-	_, trace := checkTiers(store, ep, dir, flow)
+	_, trace := checkTiers(store, ep, dir, flow, stagedAsEnforced)
 	return trace
 }
 
@@ -101,15 +106,28 @@ func ipToEndpointKeys(store *policystore.PolicyStore, addr ip.Addr) []proto.Work
 // checkStore applies the tiered policy plus any config based corrections and returns OK if the
 // check passes or PERMISSION_DENIED if the check fails.
 func checkStore(store *policystore.PolicyStore, ep *proto.WorkloadEndpoint, dir rules.RuleDir, req Flow) (s status.Status) {
-	// Check using the configured policy
-	s, _ = checkTiers(store, ep, dir, req)
+	// Check using the configured policy. This decides whether to admit the request, so only the
+	// enforcing policies get a say.
+	s, _ = checkTiers(store, ep, dir, req, enforcedOnly)
 	return
 }
+
+// policyScope selects which of an endpoint's policies take part in evaluation.
+type policyScope int
+
+const (
+	// enforcedOnly evaluates only the policies that enforce, i.e. it answers "what does policy do to
+	// this flow right now". Staged policies play no part.
+	enforcedOnly policyScope = iota
+	// stagedAsEnforced treats staged policies as though they were enforced, for the pending policy
+	// trace. See Evaluate.
+	stagedAsEnforced
+)
 
 // checkTiers applies the tiered policy in the given store and returns OK if the check passes, or PERMISSION_DENIED if
 // the check fails. Note, if no policy matches, the default is PERMISSION_DENIED. It returns the trace of rules that
 // were evaluated.
-func checkTiers(store *policystore.PolicyStore, ep *proto.WorkloadEndpoint, dir rules.RuleDir, flow Flow) (s status.Status, trace []*calc.RuleID) {
+func checkTiers(store *policystore.PolicyStore, ep *proto.WorkloadEndpoint, dir rules.RuleDir, flow Flow, scope policyScope) (s status.Status, trace []*calc.RuleID) {
 	s = status.Status{Code: PERMISSION_DENIED}
 	if ep == nil {
 		return
@@ -120,16 +138,19 @@ func checkTiers(store *policystore.PolicyStore, ep *proto.WorkloadEndpoint, dir 
 
 	for _, tier := range ep.Tiers {
 		log.Debugf("Checking tier %s", tier.GetName())
-		// Staged policies enforce nothing, so they take no part in the action. A tier holding only
-		// staged policies is skipped entirely — as if it were not there, so not even its end-of-tier
-		// action applies. Felix programs the same rule into the dataplane: "If all of the policies in
-		// a tier are staged then the default end of tier behavior should be pass rather than drop"
-		// (felix/rules/endpoints.go).
-		//
-		// The store may hold staged policies quite legitimately: Felix reuses this checker to
-		// evaluate pending policy for flow logs, and keeps them for that (policystore.ProcessUpdate).
-		// So the filtering has to happen here, not in the store.
-		policies := enforcedPolicies(getPoliciesByDirection(dir, tier))
+		policies := getPoliciesByDirection(dir, tier)
+		if scope == enforcedOnly {
+			// Staged policies enforce nothing, so they take no part in this verdict. Dropping them can
+			// empty the tier, and a tier with nothing left to enforce is skipped entirely — as if it
+			// were not there, so not even its end-of-tier action applies. Felix programs the same rule
+			// into the dataplane: "If all of the policies in a tier are staged then the default end of
+			// tier behavior should be pass rather than drop" (felix/rules/endpoints.go).
+			//
+			// The store may hold staged policies quite legitimately — Felix keeps them for the pending
+			// trace (policystore.ProcessUpdate) — so the filtering has to happen here, not in the
+			// store.
+			policies = enforcedPolicies(policies)
+		}
 		if len(policies) == 0 {
 			continue
 		}

--- a/app-policy/checker/check.go
+++ b/app-policy/checker/check.go
@@ -84,17 +84,17 @@ const (
 // decides whether staged policies take part: pass StagedAsEnforced for the pending trace, or
 // EnforcedOnly for the trace the dataplane enforces.
 //
-// ok is false if the evaluation could not be completed, in which case the trace is nil and the
-// caller should hold on to whatever trace it already had: an empty trace would say the flow has no
-// policy, which is a stronger claim than "we could not work it out".
-func Evaluate(scope PolicyScope, dir rules.RuleDir, store *policystore.PolicyStore, ep *proto.WorkloadEndpoint, flow Flow) (trace []*calc.RuleID, ok bool) {
+// It returns an error if the evaluation could not be completed, in which case the trace is nil and
+// the caller should hold on to whatever trace it already had: an empty trace would say the flow has
+// no policy, which is a stronger claim than "we could not work it out".
+func Evaluate(scope PolicyScope, dir rules.RuleDir, store *policystore.PolicyStore, ep *proto.WorkloadEndpoint, flow Flow) ([]*calc.RuleID, error) {
 	s, trace := checkTiers(scope, store, ep, dir, flow)
 	if s.Code == INTERNAL || s.Code == INVALID_ARGUMENT {
-		// The evaluation stopped part way through, so the trace stops short of a verdict. It has
-		// already been logged with the reason.
-		return nil, false
+		// The evaluation stopped part way through, so the trace stops short of a verdict. Drop it
+		// and report why it stopped.
+		return nil, fmt.Errorf("%s: %s", code.Code(s.Code), s.Message)
 	}
-	return trace, true
+	return trace, nil
 }
 
 // LookupEndpointKeysFromSrcDst looks up the source and destination endpoint keys for the given

--- a/app-policy/checker/check_test.go
+++ b/app-policy/checker/check_test.go
@@ -38,7 +38,7 @@ func TestEvaluateNoEndpoint(t *testing.T) {
 	store := policystore.NewPolicyStore()
 
 	flow := &MockFlow{}
-	trace := Evaluate(rules.RuleDirIngress, store, nil, flow)
+	trace := Evaluate(EnforcedOnly, rules.RuleDirIngress, store, nil, flow)
 	Expect(trace).To(BeNil())
 }
 
@@ -49,7 +49,7 @@ func TestEvaluateEndpointNoTiersNoProfiles(t *testing.T) {
 
 	ep := &proto.WorkloadEndpoint{}
 	flow := &MockFlow{}
-	trace := Evaluate(rules.RuleDirIngress, store, ep, flow)
+	trace := Evaluate(EnforcedOnly, rules.RuleDirIngress, store, ep, flow)
 	Expect(trace).To(HaveLen(1))
 	Expect(trace[0].Action).To(Equal(rules.RuleActionDeny))
 	Expect(trace[0].Direction).To(Equal(rules.RuleDirIngress))
@@ -85,7 +85,7 @@ func TestEvaluateEndpointWithMatchingPolicy(t *testing.T) {
 		Protocol: 6,
 		DestPort: 80,
 	}
-	trace := Evaluate(rules.RuleDirIngress, store, ep, flow)
+	trace := Evaluate(EnforcedOnly, rules.RuleDirIngress, store, ep, flow)
 	Expect(trace).To(HaveLen(1))
 	Expect(trace[0].Action).To(Equal(rules.RuleActionAllow))
 	Expect(trace[0].Direction).To(Equal(rules.RuleDirIngress))
@@ -151,7 +151,7 @@ func TestEvaluateEndpointWithNonMatchingPolicyTierDefaultAction(t *testing.T) {
 			store.PolicyByID[types.PolicyID{Name: "policy2", Kind: v3.KindGlobalNetworkPolicy}] = &proto.Policy{Tier: "default"}
 
 			flow := &MockFlow{Protocol: 6, DestPort: 443}
-			trace := Evaluate(rules.RuleDirIngress, store, ep, flow)
+			trace := Evaluate(EnforcedOnly, rules.RuleDirIngress, store, ep, flow)
 
 			Expect(trace).To(HaveLen(tt.expLen))
 			for i, act := range tt.expActs {
@@ -181,7 +181,7 @@ func TestEvaluateEndpointWithMatchingProfile(t *testing.T) {
 		Protocol: 6,
 		DestPort: 80,
 	}
-	trace := Evaluate(rules.RuleDirIngress, store, ep, flow)
+	trace := Evaluate(EnforcedOnly, rules.RuleDirIngress, store, ep, flow)
 	Expect(trace).To(HaveLen(1))
 	Expect(trace[0].Action).To(Equal(rules.RuleActionAllow))
 	Expect(trace[0].Direction).To(Equal(rules.RuleDirIngress))
@@ -238,7 +238,7 @@ func TestEvaluateEndpointWithNonMatchingProfile(t *testing.T) {
 		SourceIP:   ip_10_0_0_1,
 		DestIP:     ip_192_168_1_1,
 	}
-	trace := Evaluate(rules.RuleDirEgress, store, ep, flow1)
+	trace := Evaluate(EnforcedOnly, rules.RuleDirEgress, store, ep, flow1)
 	Expect(trace).To(HaveLen(1))
 	Expect(trace[0].Action).To(Equal(rules.RuleActionDeny))
 	Expect(trace[0].Direction).To(Equal(rules.RuleDirEgress))
@@ -255,7 +255,7 @@ func TestEvaluateEndpointWithNonMatchingProfile(t *testing.T) {
 		SourceIP:   ip_10_0_0_1,
 		DestIP:     ip_192_168_1_1,
 	}
-	trace = Evaluate(rules.RuleDirEgress, store, ep, flow2)
+	trace = Evaluate(EnforcedOnly, rules.RuleDirEgress, store, ep, flow2)
 	Expect(trace).To(HaveLen(1))
 	Expect(trace[0].Action).To(Equal(rules.RuleActionAllow))
 	Expect(trace[0].Direction).To(Equal(rules.RuleDirEgress))
@@ -272,7 +272,7 @@ func TestEvaluateEndpointWithNonMatchingProfile(t *testing.T) {
 		SourceIP:   ip_192_168_1_2,
 		DestIP:     ip_10_0_0_2,
 	}
-	trace = Evaluate(rules.RuleDirEgress, store, ep, flow3)
+	trace = Evaluate(EnforcedOnly, rules.RuleDirEgress, store, ep, flow3)
 	Expect(trace).To(HaveLen(1))
 	Expect(trace[0].Action).To(Equal(rules.RuleActionDeny))
 	Expect(trace[0].Direction).To(Equal(rules.RuleDirEgress))
@@ -425,7 +425,7 @@ func TestCheckNoIngressPolicyRulesInTier(t *testing.T) {
 		},
 	}}
 	flow := NewCheckRequestToFlowAdapter(req)
-	status, _ := checkTiers(store, store.Endpoint, rules.RuleDirIngress, flow, enforcedOnly)
+	status, _ := checkTiers(EnforcedOnly, store, store.Endpoint, rules.RuleDirIngress, flow)
 	expectedStatus := rpc.Status{Code: OK}
 	Expect(status.Code).To(Equal(expectedStatus.Code))
 	Expect(status.Message).To(Equal(expectedStatus.Message))
@@ -449,7 +449,7 @@ func TestCheckStoreNoEndpoint(t *testing.T) {
 		},
 	}}
 	flow := NewCheckRequestToFlowAdapter(req)
-	status := checkStore(store, nil, rules.RuleDirIngress, flow)
+	status := checkStore(EnforcedOnly, store, nil, rules.RuleDirIngress, flow)
 	Expect(status.Code).To(Equal(PERMISSION_DENIED))
 }
 
@@ -473,7 +473,7 @@ func TestCheckStoreNoTiers(t *testing.T) {
 		},
 	}}
 	flow := NewCheckRequestToFlowAdapter(req)
-	status := checkStore(store, store.Endpoint, rules.RuleDirIngress, flow)
+	status := checkStore(EnforcedOnly, store, store.Endpoint, rules.RuleDirIngress, flow)
 	Expect(status.Code).To(Equal(PERMISSION_DENIED))
 }
 
@@ -523,13 +523,13 @@ func TestCheckStorePolicyMatch(t *testing.T) {
 	}}
 	flow := NewCheckRequestToFlowAdapter(req)
 
-	status := checkStore(store, store.Endpoint, rules.RuleDirIngress, flow)
+	status := checkStore(EnforcedOnly, store, store.Endpoint, rules.RuleDirIngress, flow)
 	Expect(status.Code).To(Equal(OK))
 
 	http := req.GetAttributes().GetRequest().GetHttp()
 	http.Method = "HEAD"
 
-	status = checkStore(store, store.Endpoint, rules.RuleDirIngress, flow)
+	status = checkStore(EnforcedOnly, store, store.Endpoint, rules.RuleDirIngress, flow)
 	Expect(status.Code).To(Equal(PERMISSION_DENIED))
 }
 
@@ -572,13 +572,13 @@ func TestCheckStoreProfileOnly(t *testing.T) {
 	}}
 	flow := NewCheckRequestToFlowAdapter(req)
 
-	status := checkStore(store, store.Endpoint, rules.RuleDirIngress, flow)
+	status := checkStore(EnforcedOnly, store, store.Endpoint, rules.RuleDirIngress, flow)
 	Expect(status.Code).To(Equal(OK))
 
 	http := req.GetAttributes().GetRequest().GetHttp()
 	http.Method = "HEAD"
 
-	status = checkStore(store, store.Endpoint, rules.RuleDirIngress, flow)
+	status = checkStore(EnforcedOnly, store, store.Endpoint, rules.RuleDirIngress, flow)
 	Expect(status.Code).To(Equal(PERMISSION_DENIED))
 }
 
@@ -628,7 +628,7 @@ func TestCheckStorePolicyDefaultDeny(t *testing.T) {
 	}}
 	flow := NewCheckRequestToFlowAdapter(req)
 
-	status := checkStore(store, store.Endpoint, rules.RuleDirIngress, flow)
+	status := checkStore(EnforcedOnly, store, store.Endpoint, rules.RuleDirIngress, flow)
 	Expect(status.Code).To(Equal(PERMISSION_DENIED))
 }
 
@@ -689,7 +689,7 @@ func TestCheckStorePass(t *testing.T) {
 	}}
 	flow := NewCheckRequestToFlowAdapter(req)
 
-	status := checkStore(store, store.Endpoint, rules.RuleDirIngress, flow)
+	status := checkStore(EnforcedOnly, store, store.Endpoint, rules.RuleDirIngress, flow)
 	Expect(status.Code).To(Equal(OK))
 }
 
@@ -716,7 +716,7 @@ func TestCheckStoreInitFails(t *testing.T) {
 	}}
 	flow := NewCheckRequestToFlowAdapter(req)
 
-	status := checkStore(store, store.Endpoint, rules.RuleDirIngress, flow)
+	status := checkStore(EnforcedOnly, store, store.Endpoint, rules.RuleDirIngress, flow)
 	Expect(status.Code).To(Equal(PERMISSION_DENIED))
 }
 
@@ -758,7 +758,7 @@ func TestCheckStoreWithInvalidData(t *testing.T) {
 		},
 	}}
 	flow := NewCheckRequestToFlowAdapter(req)
-	status := checkStore(store, store.Endpoint, rules.RuleDirIngress, flow)
+	status := checkStore(EnforcedOnly, store, store.Endpoint, rules.RuleDirIngress, flow)
 	Expect(status.Code).To(Equal(INVALID_ARGUMENT))
 }
 
@@ -843,20 +843,20 @@ func TestCheckStorePolicyMultiTierMatch(t *testing.T) {
 	}}
 	flow := NewCheckRequestToFlowAdapter(req)
 
-	status := checkStore(store, store.Endpoint, rules.RuleDirIngress, flow)
+	status := checkStore(EnforcedOnly, store, store.Endpoint, rules.RuleDirIngress, flow)
 	Expect(status.Code).To(Equal(OK))
 
 	// Change to a bad path, and check that we get PERMISSION_DENIED
 	http := req.GetAttributes().GetRequest().GetHttp()
 	http.Path = "/bad"
 
-	status = checkStore(store, store.Endpoint, rules.RuleDirIngress, flow)
+	status = checkStore(EnforcedOnly, store, store.Endpoint, rules.RuleDirIngress, flow)
 	Expect(status.Code).To(Equal(PERMISSION_DENIED))
 
 	// Change to a path that hits tier2 default Pass action, and then is allowed in tier3
 	http.Path = "/bar"
 
-	status = checkStore(store, store.Endpoint, rules.RuleDirIngress, flow)
+	status = checkStore(EnforcedOnly, store, store.Endpoint, rules.RuleDirIngress, flow)
 	Expect(status.Code).To(Equal(OK))
 }
 
@@ -922,13 +922,13 @@ func TestCheckStorePolicyMultiTierDiffTierMatch(t *testing.T) {
 		},
 	}}
 	flow := NewCheckRequestToFlowAdapter(req)
-	status := checkStore(store, store.Endpoint, rules.RuleDirIngress, flow)
+	status := checkStore(EnforcedOnly, store, store.Endpoint, rules.RuleDirIngress, flow)
 	Expect(status.Code).To(Equal(PERMISSION_DENIED))
 
 	http := req.GetAttributes().GetRequest().GetHttp()
 	http.Method = "GET"
 
-	status = checkStore(store, store.Endpoint, rules.RuleDirIngress, flow)
+	status = checkStore(EnforcedOnly, store, store.Endpoint, rules.RuleDirIngress, flow)
 	Expect(status.Code).To(Equal(OK))
 }
 
@@ -1063,33 +1063,131 @@ func (m *MockFlow) GetDestLabels() map[string]string {
 	return m.DestLabels
 }
 
-// Staged policies enforce nothing, so a tier holding only staged policies takes no part in the
-// enforced verdict at all: evaluation falls through to the next tier without applying the skipped
-// tier's end-of-tier action. This matches what Felix programs into the dataplane, where a tier of
-// only staged policies ends in a pass rather than a drop.
-func TestCheckStoreSkipsTierOfOnlyStagedPolicies(t *testing.T) {
+// Staged policies are stored like any other, so which verdict comes out depends entirely on the
+// PolicyScope the caller asks for. Under EnforcedOnly the answer must be the same as if the staged
+// policies were not attached to the endpoint at all: they match nothing, and a tier holding only
+// staged policies does not even get to apply its end-of-tier action. Under StagedAsEnforced they
+// behave like ordinary policies, end-of-tier action included.
+func TestCheckTiersPolicyScope(t *testing.T) {
 	RegisterTestingT(t)
 
-	stagedDeny := &proto.PolicyID{Name: "staged1", Kind: v3.KindStagedGlobalNetworkPolicy}
-	enforcedAllow := &proto.PolicyID{Name: "policy2", Kind: v3.KindGlobalNetworkPolicy}
+	stagedDeny := &proto.PolicyID{Name: "staged-deny", Kind: v3.KindStagedGlobalNetworkPolicy}
+	stagedNoMatch := &proto.PolicyID{Name: "staged-no-match", Kind: v3.KindStagedGlobalNetworkPolicy}
+	enforcedAllow := &proto.PolicyID{Name: "allow", Kind: v3.KindGlobalNetworkPolicy}
+	enforcedNoMatch := &proto.PolicyID{Name: "no-match", Kind: v3.KindGlobalNetworkPolicy}
+	notInStore := &proto.PolicyID{Name: "not-in-store", Kind: v3.KindGlobalNetworkPolicy}
+
+	for _, tc := range []struct {
+		name        string
+		tiers       []*proto.TierInfo
+		wantEnforce int32
+		wantPending int32
+	}{
+		{
+			name:        "tier of only staged policies is skipped when enforcing",
+			tiers:       tierInfos(policyIDs(stagedDeny)),
+			wantEnforce: OK, // Falls through the tier, so the endpoint's allowing profile decides.
+			wantPending: PERMISSION_DENIED,
+		},
+		{
+			name:  "end-of-tier action of a staged-only tier applies only when pending",
+			tiers: tierInfos(policyIDs(stagedNoMatch)),
+			// Nothing matches either way, but when enforcing there is no tier to apply a default.
+			wantEnforce: OK,
+			wantPending: PERMISSION_DENIED,
+		},
+		{
+			name:        "end-of-tier action survives a staged policy last in a mixed tier",
+			tiers:       tierInfos(policyIDs(enforcedNoMatch, stagedNoMatch)),
+			wantEnforce: PERMISSION_DENIED,
+			wantPending: PERMISSION_DENIED,
+		},
+		{
+			name:        "end-of-tier action survives a staged policy first in a mixed tier",
+			tiers:       tierInfos(policyIDs(stagedNoMatch, enforcedNoMatch)),
+			wantEnforce: PERMISSION_DENIED,
+			wantPending: PERMISSION_DENIED,
+		},
+		{
+			name:        "staged policy ahead of an enforced one only decides the pending verdict",
+			tiers:       tierInfos(policyIDs(stagedDeny, enforcedAllow)),
+			wantEnforce: OK,
+			wantPending: PERMISSION_DENIED,
+		},
+		{
+			name:        "a staged policy does not shadow a later tier when enforcing",
+			tiers:       tierInfos(policyIDs(stagedDeny), policyIDs(enforcedAllow)),
+			wantEnforce: OK,
+			wantPending: PERMISSION_DENIED,
+		},
+		{
+			name: "a policy missing from the store counts as a non-match",
+			// Its update has not arrived yet; we cannot match it, but the tier is still there so its
+			// end-of-tier action still applies.
+			tiers:       tierInfos(policyIDs(notInStore)),
+			wantEnforce: PERMISSION_DENIED,
+			wantPending: PERMISSION_DENIED,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, scope := range []struct {
+				PolicyScope
+				want int32
+			}{{EnforcedOnly, tc.wantEnforce}, {StagedAsEnforced, tc.wantPending}} {
+				store := policystore.NewPolicyStore()
+				store.Endpoint = &proto.WorkloadEndpoint{Tiers: tc.tiers, ProfileIds: []string{"profile1"}}
+				// An allowing profile, so that an end-of-tier deny which failed to apply shows up as
+				// OK instead of being masked by the overall default deny.
+				store.ProfileByID[types.ProtoToProfileID(&proto.ProfileID{Name: "profile1"})] = &proto.Profile{
+					InboundRules: []*proto.Rule{{Action: "allow"}},
+				}
+				for _, id := range []*proto.PolicyID{stagedNoMatch, enforcedNoMatch} {
+					store.PolicyByID[types.ProtoToPolicyID(id)] = &proto.Policy{Tier: "tier1"}
+				}
+				for _, id := range []*proto.PolicyID{stagedDeny} {
+					store.PolicyByID[types.ProtoToPolicyID(id)] = &proto.Policy{
+						Tier:         "tier1",
+						InboundRules: []*proto.Rule{{Action: "deny"}},
+					}
+				}
+				store.PolicyByID[types.ProtoToPolicyID(enforcedAllow)] = &proto.Policy{
+					Tier:         "tier2",
+					InboundRules: []*proto.Rule{{Action: "allow"}},
+				}
+
+				st := checkStore(scope.PolicyScope, store, store.Endpoint, rules.RuleDirIngress,
+					&MockFlow{Protocol: 6, DestPort: 80})
+				Expect(st.Code).To(Equal(scope.want), "scope %v", scope.PolicyScope)
+			}
+		})
+	}
+}
+
+// policyIDs and tierInfos build one tier per argument list, named tier1, tier2, ... , each denying
+// at the end so that skipping a tier is visible.
+func policyIDs(ids ...*proto.PolicyID) []*proto.PolicyID { return ids }
+
+func tierInfos(tiers ...[]*proto.PolicyID) []*proto.TierInfo {
+	var tierInfos []*proto.TierInfo
+	for i, policies := range tiers {
+		tierInfos = append(tierInfos, &proto.TierInfo{
+			Name:            fmt.Sprintf("tier%d", i+1),
+			IngressPolicies: policies,
+			DefaultAction:   "Deny",
+		})
+	}
+	return tierInfos
+}
+
+// The pending trace records the staged policy that decided it, so that flow logs can show which
+// staged policy would have taken effect.
+func TestEvaluateRecordsStagedPolicyInPendingTraceOnly(t *testing.T) {
+	RegisterTestingT(t)
+
+	stagedDeny := &proto.PolicyID{Name: "staged-deny", Kind: v3.KindStagedGlobalNetworkPolicy}
+	enforcedAllow := &proto.PolicyID{Name: "allow", Kind: v3.KindGlobalNetworkPolicy}
 
 	store := policystore.NewPolicyStore()
-	store.Endpoint = &proto.WorkloadEndpoint{
-		Tiers: []*proto.TierInfo{
-			{
-				// Nothing enforcing here, so this whole tier is as good as absent: neither its staged
-				// deny nor its Deny end-of-tier action may stop the request.
-				Name:            "tier1",
-				IngressPolicies: []*proto.PolicyID{stagedDeny},
-				DefaultAction:   "Deny",
-			},
-			{
-				Name:            "tier2",
-				IngressPolicies: []*proto.PolicyID{enforcedAllow},
-				DefaultAction:   "Deny",
-			},
-		},
-	}
 	store.PolicyByID[types.ProtoToPolicyID(stagedDeny)] = &proto.Policy{
 		Tier:         "tier1",
 		InboundRules: []*proto.Rule{{Action: "deny"}},
@@ -1098,125 +1196,15 @@ func TestCheckStoreSkipsTierOfOnlyStagedPolicies(t *testing.T) {
 		Tier:         "tier2",
 		InboundRules: []*proto.Rule{{Action: "allow"}},
 	}
+	ep := &proto.WorkloadEndpoint{Tiers: tierInfos(policyIDs(stagedDeny), policyIDs(enforcedAllow))}
+	flow := &MockFlow{Protocol: 6, DestPort: 80}
 
-	status := checkStore(store, store.Endpoint, rules.RuleDirIngress, &MockFlow{Protocol: 6, DestPort: 80})
-	Expect(status.Code).To(Equal(OK))
-}
-
-// In a tier that does have an enforcing policy, the staged ones are ignored for the enforced verdict
-// but the tier is evaluated as usual, end-of-tier action included.
-func TestCheckStoreIgnoresStagedPolicyInMixedTier(t *testing.T) {
-	RegisterTestingT(t)
-
-	stagedDeny := &proto.PolicyID{Name: "staged1", Kind: v3.KindStagedGlobalNetworkPolicy}
-	enforcedAllow := &proto.PolicyID{Name: "policy2", Kind: v3.KindGlobalNetworkPolicy}
-	enforcedNoMatch := &proto.PolicyID{Name: "policy3", Kind: v3.KindGlobalNetworkPolicy}
-
-	tests := []struct {
-		name     string
-		policies []*proto.PolicyID
-		wantCode int32
-	}{
-		{
-			// The staged deny comes first, so it would win if it were enforced.
-			name:     "staged deny ahead of an enforced allow",
-			policies: []*proto.PolicyID{stagedDeny, enforcedAllow},
-			wantCode: OK,
-		},
-		{
-			// No enforcing policy matches, so the tier's own default still applies.
-			name:     "staged deny ahead of an enforced policy that does not match",
-			policies: []*proto.PolicyID{stagedDeny, enforcedNoMatch},
-			wantCode: PERMISSION_DENIED,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			store := policystore.NewPolicyStore()
-			store.Endpoint = &proto.WorkloadEndpoint{
-				Tiers: []*proto.TierInfo{{
-					Name:            "tier1",
-					IngressPolicies: tt.policies,
-					DefaultAction:   "Deny",
-				}},
-			}
-			store.PolicyByID[types.ProtoToPolicyID(stagedDeny)] = &proto.Policy{
-				Tier:         "tier1",
-				InboundRules: []*proto.Rule{{Action: "deny"}},
-			}
-			store.PolicyByID[types.ProtoToPolicyID(enforcedAllow)] = &proto.Policy{
-				Tier:         "tier1",
-				InboundRules: []*proto.Rule{{Action: "allow"}},
-			}
-			store.PolicyByID[types.ProtoToPolicyID(enforcedNoMatch)] = &proto.Policy{Tier: "tier1"}
-
-			status := checkStore(store, store.Endpoint, rules.RuleDirIngress, &MockFlow{Protocol: 6, DestPort: 80})
-			Expect(status.Code).To(Equal(tt.wantCode))
-		})
-	}
-}
-
-// The pending trace is the trace for the current state of policy with every staged policy treated as
-// if it were enforced, so staged policies do take part in it: a staged deny decides the trace, and a
-// tier of only staged policies is evaluated like any other.
-func TestEvaluateTreatsStagedPoliciesAsEnforced(t *testing.T) {
-	RegisterTestingT(t)
-
-	stagedDeny := &proto.PolicyID{Name: "staged1", Kind: v3.KindStagedGlobalNetworkPolicy}
-	enforcedAllow := &proto.PolicyID{Name: "policy2", Kind: v3.KindGlobalNetworkPolicy}
-
-	tests := []struct {
-		name  string
-		tiers []*proto.TierInfo
-		// The trace the pending view should produce, as (tier, policy name, action) in order.
-		wantTrace []*calc.RuleID
-	}{
-		{
-			name: "a tier of only staged policies still applies",
-			tiers: []*proto.TierInfo{
-				{
-					Name:            "tier1",
-					IngressPolicies: []*proto.PolicyID{stagedDeny},
-					DefaultAction:   "Deny",
-				},
-				{
-					Name:            "tier2",
-					IngressPolicies: []*proto.PolicyID{enforcedAllow},
-					DefaultAction:   "Deny",
-				},
-			},
-			// tier1's staged deny decides it; tier2 is never reached.
-			wantTrace: []*calc.RuleID{calc.NewRuleID(v3.KindStagedGlobalNetworkPolicy, "tier1", "staged1", "",
-				0, rules.RuleDirIngress, rules.RuleActionDeny)},
-		},
-		{
-			name: "a staged policy ahead of an enforced one decides the trace",
-			tiers: []*proto.TierInfo{{
-				Name:            "tier1",
-				IngressPolicies: []*proto.PolicyID{stagedDeny, enforcedAllow},
-				DefaultAction:   "Deny",
-			}},
-			wantTrace: []*calc.RuleID{calc.NewRuleID(v3.KindStagedGlobalNetworkPolicy, "tier1", "staged1", "",
-				0, rules.RuleDirIngress, rules.RuleActionDeny)},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			store := policystore.NewPolicyStore()
-			ep := &proto.WorkloadEndpoint{Tiers: tt.tiers}
-			store.PolicyByID[types.ProtoToPolicyID(stagedDeny)] = &proto.Policy{
-				Tier:         "tier1",
-				InboundRules: []*proto.Rule{{Action: "deny"}},
-			}
-			store.PolicyByID[types.ProtoToPolicyID(enforcedAllow)] = &proto.Policy{
-				Tier:         "tier1",
-				InboundRules: []*proto.Rule{{Action: "allow"}},
-			}
-
-			trace := Evaluate(rules.RuleDirIngress, store, ep, &MockFlow{Protocol: 6, DestPort: 80})
-			Expect(trace).To(Equal(tt.wantTrace))
-		})
-	}
+	Expect(Evaluate(StagedAsEnforced, rules.RuleDirIngress, store, ep, flow)).To(Equal([]*calc.RuleID{
+		calc.NewRuleID(v3.KindStagedGlobalNetworkPolicy, "tier1", "staged-deny", "",
+			0, rules.RuleDirIngress, rules.RuleActionDeny),
+	}))
+	Expect(Evaluate(EnforcedOnly, rules.RuleDirIngress, store, ep, flow)).To(Equal([]*calc.RuleID{
+		calc.NewRuleID(v3.KindGlobalNetworkPolicy, "tier2", "allow", "",
+			0, rules.RuleDirIngress, rules.RuleActionAllow),
+	}))
 }

--- a/app-policy/checker/check_test.go
+++ b/app-policy/checker/check_test.go
@@ -1201,7 +1201,7 @@ func TestCheckStoreReportsWhichPolicyIsMissing(t *testing.T) {
 	st := checkStore(EnforcedOnly, store, store.Endpoint, rules.RuleDirIngress,
 		&MockFlow{Protocol: 6, DestPort: 80})
 	Expect(st.Code).To(Equal(INTERNAL))
-	Expect(st.Message).To(Equal("policy ns1/policy1(NetworkPolicy) of tier tier1 is missing from the policy store"))
+	Expect(st.Message).To(Equal("policy np/ns1/policy1 of tier tier1 is missing from the policy store"))
 }
 
 // A trace that stops short of a verdict is worse than no trace: a flow log would show the flow

--- a/app-policy/checker/check_test.go
+++ b/app-policy/checker/check_test.go
@@ -1221,8 +1221,8 @@ func TestEvaluateReportsFailureInsteadOfPartialTrace(t *testing.T) {
 	ep := &proto.WorkloadEndpoint{Tiers: tierInfos(policyIDs(passes), policyIDs(notInStore))}
 
 	for _, scope := range []PolicyScope{EnforcedOnly, StagedAsEnforced} {
-		trace, ok := Evaluate(scope, rules.RuleDirIngress, store, ep, &MockFlow{Protocol: 6, DestPort: 80})
-		Expect(ok).To(BeFalse(), "scope %v", scope)
+		trace, err := Evaluate(scope, rules.RuleDirIngress, store, ep, &MockFlow{Protocol: 6, DestPort: 80})
+		Expect(err).To(MatchError(ContainSubstring("not-in-store")), "scope %v", scope)
 		Expect(trace).To(BeNil(), "scope %v", scope)
 	}
 }
@@ -1247,15 +1247,15 @@ func TestEvaluateRecordsStagedPolicyInPendingTraceOnly(t *testing.T) {
 	ep := &proto.WorkloadEndpoint{Tiers: tierInfos(policyIDs(stagedDeny), policyIDs(enforcedAllow))}
 	flow := &MockFlow{Protocol: 6, DestPort: 80}
 
-	pending, ok := Evaluate(StagedAsEnforced, rules.RuleDirIngress, store, ep, flow)
-	Expect(ok).To(BeTrue())
+	pending, err := Evaluate(StagedAsEnforced, rules.RuleDirIngress, store, ep, flow)
+	Expect(err).ToNot(HaveOccurred())
 	Expect(pending).To(Equal([]*calc.RuleID{
 		calc.NewRuleID(v3.KindStagedGlobalNetworkPolicy, "tier1", "staged-deny", "",
 			0, rules.RuleDirIngress, rules.RuleActionDeny),
 	}))
 
-	enforced, ok := Evaluate(EnforcedOnly, rules.RuleDirIngress, store, ep, flow)
-	Expect(ok).To(BeTrue())
+	enforced, err := Evaluate(EnforcedOnly, rules.RuleDirIngress, store, ep, flow)
+	Expect(err).ToNot(HaveOccurred())
 	Expect(enforced).To(Equal([]*calc.RuleID{
 		calc.NewRuleID(v3.KindGlobalNetworkPolicy, "tier2", "allow", "",
 			0, rules.RuleDirIngress, rules.RuleActionAllow),

--- a/app-policy/checker/check_test.go
+++ b/app-policy/checker/check_test.go
@@ -38,7 +38,7 @@ func TestEvaluateNoEndpoint(t *testing.T) {
 	store := policystore.NewPolicyStore()
 
 	flow := &MockFlow{}
-	trace := Evaluate(EnforcedOnly, rules.RuleDirIngress, store, nil, flow)
+	trace, _ := Evaluate(EnforcedOnly, rules.RuleDirIngress, store, nil, flow)
 	Expect(trace).To(BeNil())
 }
 
@@ -49,7 +49,7 @@ func TestEvaluateEndpointNoTiersNoProfiles(t *testing.T) {
 
 	ep := &proto.WorkloadEndpoint{}
 	flow := &MockFlow{}
-	trace := Evaluate(EnforcedOnly, rules.RuleDirIngress, store, ep, flow)
+	trace, _ := Evaluate(EnforcedOnly, rules.RuleDirIngress, store, ep, flow)
 	Expect(trace).To(HaveLen(1))
 	Expect(trace[0].Action).To(Equal(rules.RuleActionDeny))
 	Expect(trace[0].Direction).To(Equal(rules.RuleDirIngress))
@@ -85,7 +85,7 @@ func TestEvaluateEndpointWithMatchingPolicy(t *testing.T) {
 		Protocol: 6,
 		DestPort: 80,
 	}
-	trace := Evaluate(EnforcedOnly, rules.RuleDirIngress, store, ep, flow)
+	trace, _ := Evaluate(EnforcedOnly, rules.RuleDirIngress, store, ep, flow)
 	Expect(trace).To(HaveLen(1))
 	Expect(trace[0].Action).To(Equal(rules.RuleActionAllow))
 	Expect(trace[0].Direction).To(Equal(rules.RuleDirIngress))
@@ -151,7 +151,7 @@ func TestEvaluateEndpointWithNonMatchingPolicyTierDefaultAction(t *testing.T) {
 			store.PolicyByID[types.PolicyID{Name: "policy2", Kind: v3.KindGlobalNetworkPolicy}] = &proto.Policy{Tier: "default"}
 
 			flow := &MockFlow{Protocol: 6, DestPort: 443}
-			trace := Evaluate(EnforcedOnly, rules.RuleDirIngress, store, ep, flow)
+			trace, _ := Evaluate(EnforcedOnly, rules.RuleDirIngress, store, ep, flow)
 
 			Expect(trace).To(HaveLen(tt.expLen))
 			for i, act := range tt.expActs {
@@ -181,7 +181,7 @@ func TestEvaluateEndpointWithMatchingProfile(t *testing.T) {
 		Protocol: 6,
 		DestPort: 80,
 	}
-	trace := Evaluate(EnforcedOnly, rules.RuleDirIngress, store, ep, flow)
+	trace, _ := Evaluate(EnforcedOnly, rules.RuleDirIngress, store, ep, flow)
 	Expect(trace).To(HaveLen(1))
 	Expect(trace[0].Action).To(Equal(rules.RuleActionAllow))
 	Expect(trace[0].Direction).To(Equal(rules.RuleDirIngress))
@@ -238,7 +238,7 @@ func TestEvaluateEndpointWithNonMatchingProfile(t *testing.T) {
 		SourceIP:   ip_10_0_0_1,
 		DestIP:     ip_192_168_1_1,
 	}
-	trace := Evaluate(EnforcedOnly, rules.RuleDirEgress, store, ep, flow1)
+	trace, _ := Evaluate(EnforcedOnly, rules.RuleDirEgress, store, ep, flow1)
 	Expect(trace).To(HaveLen(1))
 	Expect(trace[0].Action).To(Equal(rules.RuleActionDeny))
 	Expect(trace[0].Direction).To(Equal(rules.RuleDirEgress))
@@ -255,7 +255,7 @@ func TestEvaluateEndpointWithNonMatchingProfile(t *testing.T) {
 		SourceIP:   ip_10_0_0_1,
 		DestIP:     ip_192_168_1_1,
 	}
-	trace = Evaluate(EnforcedOnly, rules.RuleDirEgress, store, ep, flow2)
+	trace, _ = Evaluate(EnforcedOnly, rules.RuleDirEgress, store, ep, flow2)
 	Expect(trace).To(HaveLen(1))
 	Expect(trace[0].Action).To(Equal(rules.RuleActionAllow))
 	Expect(trace[0].Direction).To(Equal(rules.RuleDirEgress))
@@ -272,7 +272,7 @@ func TestEvaluateEndpointWithNonMatchingProfile(t *testing.T) {
 		SourceIP:   ip_192_168_1_2,
 		DestIP:     ip_10_0_0_2,
 	}
-	trace = Evaluate(EnforcedOnly, rules.RuleDirEgress, store, ep, flow3)
+	trace, _ = Evaluate(EnforcedOnly, rules.RuleDirEgress, store, ep, flow3)
 	Expect(trace).To(HaveLen(1))
 	Expect(trace[0].Action).To(Equal(rules.RuleActionDeny))
 	Expect(trace[0].Direction).To(Equal(rules.RuleDirEgress))
@@ -1205,8 +1205,9 @@ func TestCheckStoreReportsWhichPolicyIsMissing(t *testing.T) {
 }
 
 // A trace that stops short of a verdict is worse than no trace: a flow log would show the flow
-// running off the end of policy. Callers get nothing instead.
-func TestEvaluateDiscardsTraceWhenEvaluationFails(t *testing.T) {
+// running off the end of policy. Callers are told the evaluation failed, so they can keep whatever
+// trace they had rather than record the flow as having no policy at all.
+func TestEvaluateReportsFailureInsteadOfPartialTrace(t *testing.T) {
 	RegisterTestingT(t)
 
 	notInStore := &proto.PolicyID{Name: "not-in-store", Kind: v3.KindGlobalNetworkPolicy}
@@ -1220,7 +1221,8 @@ func TestEvaluateDiscardsTraceWhenEvaluationFails(t *testing.T) {
 	ep := &proto.WorkloadEndpoint{Tiers: tierInfos(policyIDs(passes), policyIDs(notInStore))}
 
 	for _, scope := range []PolicyScope{EnforcedOnly, StagedAsEnforced} {
-		trace := Evaluate(scope, rules.RuleDirIngress, store, ep, &MockFlow{Protocol: 6, DestPort: 80})
+		trace, ok := Evaluate(scope, rules.RuleDirIngress, store, ep, &MockFlow{Protocol: 6, DestPort: 80})
+		Expect(ok).To(BeFalse(), "scope %v", scope)
 		Expect(trace).To(BeNil(), "scope %v", scope)
 	}
 }
@@ -1245,11 +1247,16 @@ func TestEvaluateRecordsStagedPolicyInPendingTraceOnly(t *testing.T) {
 	ep := &proto.WorkloadEndpoint{Tiers: tierInfos(policyIDs(stagedDeny), policyIDs(enforcedAllow))}
 	flow := &MockFlow{Protocol: 6, DestPort: 80}
 
-	Expect(Evaluate(StagedAsEnforced, rules.RuleDirIngress, store, ep, flow)).To(Equal([]*calc.RuleID{
+	pending, ok := Evaluate(StagedAsEnforced, rules.RuleDirIngress, store, ep, flow)
+	Expect(ok).To(BeTrue())
+	Expect(pending).To(Equal([]*calc.RuleID{
 		calc.NewRuleID(v3.KindStagedGlobalNetworkPolicy, "tier1", "staged-deny", "",
 			0, rules.RuleDirIngress, rules.RuleActionDeny),
 	}))
-	Expect(Evaluate(EnforcedOnly, rules.RuleDirIngress, store, ep, flow)).To(Equal([]*calc.RuleID{
+
+	enforced, ok := Evaluate(EnforcedOnly, rules.RuleDirIngress, store, ep, flow)
+	Expect(ok).To(BeTrue())
+	Expect(enforced).To(Equal([]*calc.RuleID{
 		calc.NewRuleID(v3.KindGlobalNetworkPolicy, "tier2", "allow", "",
 			0, rules.RuleDirIngress, rules.RuleActionAllow),
 	}))

--- a/app-policy/checker/check_test.go
+++ b/app-policy/checker/check_test.go
@@ -716,8 +716,8 @@ func TestCheckStoreInitFails(t *testing.T) {
 	}}
 	flow := NewCheckRequestToFlowAdapter(req)
 
-	// The tier lists policies whose rules have not been synced yet, so their verdict is unknowable
-	// and evaluation fails closed rather than guessing.
+	// The tier names policies the store does not have, so their verdict is unknowable and
+	// evaluation fails closed rather than guessing.
 	status := checkStore(EnforcedOnly, store, store.Endpoint, rules.RuleDirIngress, flow)
 	Expect(status.Code).To(Equal(INTERNAL))
 }
@@ -1124,16 +1124,16 @@ func TestCheckTiersPolicyScope(t *testing.T) {
 		},
 		{
 			name: "a policy missing from the store fails the evaluation",
-			// Its update has not arrived yet, so its verdict is unknowable: fail closed rather than
-			// hand the request on to the rest of the tier.
+			// Its verdict is unknowable, so fail closed rather than hand the request on to the rest
+			// of the tier.
 			tiers:       tierInfos(policyIDs(notInStore, enforcedAllow)),
 			wantEnforce: INTERNAL,
 			wantPending: INTERNAL,
 		},
 		{
 			name: "a policy missing from the store behind a match is never reached",
-			// Evaluation stops at the first match, in the store as in the dataplane, so a policy we
-			// know nothing about does not invalidate a verdict reached before it.
+			// Evaluation stops at the first match, in the store as in the dataplane, so a missing
+			// policy does not invalidate a verdict reached before it.
 			tiers:       tierInfos(policyIDs(enforcedAllow, notInStore)),
 			wantEnforce: OK,
 			wantPending: OK,
@@ -1201,7 +1201,7 @@ func TestCheckStoreReportsWhichPolicyIsMissing(t *testing.T) {
 	st := checkStore(EnforcedOnly, store, store.Endpoint, rules.RuleDirIngress,
 		&MockFlow{Protocol: 6, DestPort: 80})
 	Expect(st.Code).To(Equal(INTERNAL))
-	Expect(st.Message).To(Equal("policy ns1/policy1(NetworkPolicy) of tier tier1 has not been synced yet"))
+	Expect(st.Message).To(Equal("policy ns1/policy1(NetworkPolicy) of tier tier1 is missing from the policy store"))
 }
 
 // A trace that stops short of a verdict is worse than no trace: a flow log would show the flow

--- a/app-policy/checker/check_test.go
+++ b/app-policy/checker/check_test.go
@@ -1188,6 +1188,22 @@ func tierInfos(tiers ...[]*proto.PolicyID) []*proto.TierInfo {
 	return tierInfos
 }
 
+// The status message says which policy was missing, so an operator seeing a denied request in the
+// Dikastes log does not have to guess.
+func TestCheckStoreReportsWhichPolicyIsMissing(t *testing.T) {
+	RegisterTestingT(t)
+
+	missing := &proto.PolicyID{Name: "policy1", Namespace: "ns1", Kind: v3.KindNetworkPolicy}
+
+	store := policystore.NewPolicyStore()
+	store.Endpoint = &proto.WorkloadEndpoint{Tiers: tierInfos(policyIDs(missing))}
+
+	st := checkStore(EnforcedOnly, store, store.Endpoint, rules.RuleDirIngress,
+		&MockFlow{Protocol: 6, DestPort: 80})
+	Expect(st.Code).To(Equal(INTERNAL))
+	Expect(st.Message).To(Equal("policy ns1/policy1(NetworkPolicy) of tier tier1 has not been synced yet"))
+}
+
 // A trace that stops short of a verdict is worse than no trace: a flow log would show the flow
 // running off the end of policy. Callers get nothing instead.
 func TestEvaluateDiscardsTraceWhenEvaluationFails(t *testing.T) {

--- a/app-policy/checker/check_test.go
+++ b/app-policy/checker/check_test.go
@@ -25,6 +25,7 @@ import (
 	v3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
 
 	"github.com/projectcalico/calico/app-policy/policystore"
+	"github.com/projectcalico/calico/felix/calc"
 	"github.com/projectcalico/calico/felix/ip"
 	"github.com/projectcalico/calico/felix/proto"
 	"github.com/projectcalico/calico/felix/rules"
@@ -424,7 +425,7 @@ func TestCheckNoIngressPolicyRulesInTier(t *testing.T) {
 		},
 	}}
 	flow := NewCheckRequestToFlowAdapter(req)
-	status, _ := checkTiers(store, store.Endpoint, rules.RuleDirIngress, flow)
+	status, _ := checkTiers(store, store.Endpoint, rules.RuleDirIngress, flow, enforcedOnly)
 	expectedStatus := rpc.Status{Code: OK}
 	Expect(status.Code).To(Equal(expectedStatus.Code))
 	Expect(status.Message).To(Equal(expectedStatus.Message))
@@ -1062,54 +1063,49 @@ func (m *MockFlow) GetDestLabels() map[string]string {
 	return m.DestLabels
 }
 
-// A staged policy enforces nothing, so a tier holding only staged policies takes no part in the
-// action at all: evaluation falls through to the next tier without applying the skipped tier's
-// end-of-tier action. This matches what Felix programs into the dataplane, where a tier of only
-// staged policies ends in a pass rather than a drop.
-func TestEvaluateTierOfOnlyStagedPoliciesIsSkipped(t *testing.T) {
+// Staged policies enforce nothing, so a tier holding only staged policies takes no part in the
+// enforced verdict at all: evaluation falls through to the next tier without applying the skipped
+// tier's end-of-tier action. This matches what Felix programs into the dataplane, where a tier of
+// only staged policies ends in a pass rather than a drop.
+func TestCheckStoreSkipsTierOfOnlyStagedPolicies(t *testing.T) {
 	RegisterTestingT(t)
 
-	store := policystore.NewPolicyStore()
-	// Both policies deny, so if either tier were applied the flow would be denied.
-	for _, id := range []*proto.PolicyID{
-		{Name: "staged1", Kind: v3.KindStagedGlobalNetworkPolicy},
-		{Name: "policy2", Kind: v3.KindGlobalNetworkPolicy},
-	} {
-		store.PolicyByID[types.ProtoToPolicyID(id)] = &proto.Policy{
-			Tier:         "tier1",
-			InboundRules: []*proto.Rule{{Action: "deny"}},
-		}
-	}
+	stagedDeny := &proto.PolicyID{Name: "staged1", Kind: v3.KindStagedGlobalNetworkPolicy}
+	enforcedAllow := &proto.PolicyID{Name: "policy2", Kind: v3.KindGlobalNetworkPolicy}
 
-	ep := &proto.WorkloadEndpoint{
+	store := policystore.NewPolicyStore()
+	store.Endpoint = &proto.WorkloadEndpoint{
 		Tiers: []*proto.TierInfo{
 			{
-				// Nothing enforcing here, so this whole tier is as good as absent — its Deny
-				// end-of-tier action must not apply either.
+				// Nothing enforcing here, so this whole tier is as good as absent: neither its staged
+				// deny nor its Deny end-of-tier action may stop the request.
 				Name:            "tier1",
-				IngressPolicies: []*proto.PolicyID{{Name: "staged1", Kind: v3.KindStagedGlobalNetworkPolicy}},
+				IngressPolicies: []*proto.PolicyID{stagedDeny},
 				DefaultAction:   "Deny",
 			},
 			{
 				Name:            "tier2",
-				IngressPolicies: []*proto.PolicyID{{Name: "policy2", Kind: v3.KindGlobalNetworkPolicy}},
+				IngressPolicies: []*proto.PolicyID{enforcedAllow},
 				DefaultAction:   "Deny",
 			},
 		},
 	}
+	store.PolicyByID[types.ProtoToPolicyID(stagedDeny)] = &proto.Policy{
+		Tier:         "tier1",
+		InboundRules: []*proto.Rule{{Action: "deny"}},
+	}
+	store.PolicyByID[types.ProtoToPolicyID(enforcedAllow)] = &proto.Policy{
+		Tier:         "tier2",
+		InboundRules: []*proto.Rule{{Action: "allow"}},
+	}
 
-	trace := Evaluate(rules.RuleDirIngress, store, ep, &MockFlow{Protocol: 6, DestPort: 80})
-
-	// Only tier2's deny should show up: the staged tier contributed nothing, not even a tier default.
-	Expect(trace).To(HaveLen(1))
-	Expect(trace[0].Tier).To(Equal("tier2"))
-	Expect(trace[0].Name).To(Equal("policy2"))
-	Expect(trace[0].Action).To(Equal(rules.RuleActionDeny))
+	status := checkStore(store, store.Endpoint, rules.RuleDirIngress, &MockFlow{Protocol: 6, DestPort: 80})
+	Expect(status.Code).To(Equal(OK))
 }
 
-// In a tier that does have an enforcing policy, the staged ones are ignored but the tier is
-// evaluated as usual, end-of-tier action included.
-func TestEvaluateStagedPolicyDoesNotDecideMixedTier(t *testing.T) {
+// In a tier that does have an enforcing policy, the staged ones are ignored for the enforced verdict
+// but the tier is evaluated as usual, end-of-tier action included.
+func TestCheckStoreIgnoresStagedPolicyInMixedTier(t *testing.T) {
 	RegisterTestingT(t)
 
 	stagedDeny := &proto.PolicyID{Name: "staged1", Kind: v3.KindStagedGlobalNetworkPolicy}
@@ -1117,34 +1113,34 @@ func TestEvaluateStagedPolicyDoesNotDecideMixedTier(t *testing.T) {
 	enforcedNoMatch := &proto.PolicyID{Name: "policy3", Kind: v3.KindGlobalNetworkPolicy}
 
 	tests := []struct {
-		name       string
-		policies   []*proto.PolicyID
-		wantLen    int
-		wantAction rules.RuleAction
-		wantIndex  int
+		name     string
+		policies []*proto.PolicyID
+		wantCode int32
 	}{
 		{
-			// The staged deny is first, so it would win if it were enforced.
-			name:       "staged deny ahead of an enforced allow",
-			policies:   []*proto.PolicyID{stagedDeny, enforcedAllow},
-			wantLen:    1,
-			wantAction: rules.RuleActionAllow,
-			wantIndex:  0,
+			// The staged deny comes first, so it would win if it were enforced.
+			name:     "staged deny ahead of an enforced allow",
+			policies: []*proto.PolicyID{stagedDeny, enforcedAllow},
+			wantCode: OK,
 		},
 		{
-			// No enforced policy matches, so the tier's own default applies, and it must be
-			// attributed to an enforced policy rather than to the staged one.
-			name:       "staged deny ahead of an enforced policy that does not match",
-			policies:   []*proto.PolicyID{stagedDeny, enforcedNoMatch},
-			wantLen:    1,
-			wantAction: rules.RuleActionDeny,
-			wantIndex:  tierDefaultActionIndex,
+			// No enforcing policy matches, so the tier's own default still applies.
+			name:     "staged deny ahead of an enforced policy that does not match",
+			policies: []*proto.PolicyID{stagedDeny, enforcedNoMatch},
+			wantCode: PERMISSION_DENIED,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			store := policystore.NewPolicyStore()
+			store.Endpoint = &proto.WorkloadEndpoint{
+				Tiers: []*proto.TierInfo{{
+					Name:            "tier1",
+					IngressPolicies: tt.policies,
+					DefaultAction:   "Deny",
+				}},
+			}
 			store.PolicyByID[types.ProtoToPolicyID(stagedDeny)] = &proto.Policy{
 				Tier:         "tier1",
 				InboundRules: []*proto.Rule{{Action: "deny"}},
@@ -1155,20 +1151,72 @@ func TestEvaluateStagedPolicyDoesNotDecideMixedTier(t *testing.T) {
 			}
 			store.PolicyByID[types.ProtoToPolicyID(enforcedNoMatch)] = &proto.Policy{Tier: "tier1"}
 
-			ep := &proto.WorkloadEndpoint{
-				Tiers: []*proto.TierInfo{{
+			status := checkStore(store, store.Endpoint, rules.RuleDirIngress, &MockFlow{Protocol: 6, DestPort: 80})
+			Expect(status.Code).To(Equal(tt.wantCode))
+		})
+	}
+}
+
+// The pending trace is the trace for the current state of policy with every staged policy treated as
+// if it were enforced, so staged policies do take part in it: a staged deny decides the trace, and a
+// tier of only staged policies is evaluated like any other.
+func TestEvaluateTreatsStagedPoliciesAsEnforced(t *testing.T) {
+	RegisterTestingT(t)
+
+	stagedDeny := &proto.PolicyID{Name: "staged1", Kind: v3.KindStagedGlobalNetworkPolicy}
+	enforcedAllow := &proto.PolicyID{Name: "policy2", Kind: v3.KindGlobalNetworkPolicy}
+
+	tests := []struct {
+		name  string
+		tiers []*proto.TierInfo
+		// The trace the pending view should produce, as (tier, policy name, action) in order.
+		wantTrace []*calc.RuleID
+	}{
+		{
+			name: "a tier of only staged policies still applies",
+			tiers: []*proto.TierInfo{
+				{
 					Name:            "tier1",
-					IngressPolicies: tt.policies,
+					IngressPolicies: []*proto.PolicyID{stagedDeny},
 					DefaultAction:   "Deny",
-				}},
+				},
+				{
+					Name:            "tier2",
+					IngressPolicies: []*proto.PolicyID{enforcedAllow},
+					DefaultAction:   "Deny",
+				},
+			},
+			// tier1's staged deny decides it; tier2 is never reached.
+			wantTrace: []*calc.RuleID{calc.NewRuleID(v3.KindStagedGlobalNetworkPolicy, "tier1", "staged1", "",
+				0, rules.RuleDirIngress, rules.RuleActionDeny)},
+		},
+		{
+			name: "a staged policy ahead of an enforced one decides the trace",
+			tiers: []*proto.TierInfo{{
+				Name:            "tier1",
+				IngressPolicies: []*proto.PolicyID{stagedDeny, enforcedAllow},
+				DefaultAction:   "Deny",
+			}},
+			wantTrace: []*calc.RuleID{calc.NewRuleID(v3.KindStagedGlobalNetworkPolicy, "tier1", "staged1", "",
+				0, rules.RuleDirIngress, rules.RuleActionDeny)},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := policystore.NewPolicyStore()
+			ep := &proto.WorkloadEndpoint{Tiers: tt.tiers}
+			store.PolicyByID[types.ProtoToPolicyID(stagedDeny)] = &proto.Policy{
+				Tier:         "tier1",
+				InboundRules: []*proto.Rule{{Action: "deny"}},
+			}
+			store.PolicyByID[types.ProtoToPolicyID(enforcedAllow)] = &proto.Policy{
+				Tier:         "tier1",
+				InboundRules: []*proto.Rule{{Action: "allow"}},
 			}
 
 			trace := Evaluate(rules.RuleDirIngress, store, ep, &MockFlow{Protocol: 6, DestPort: 80})
-
-			Expect(trace).To(HaveLen(tt.wantLen))
-			Expect(trace[0].Action).To(Equal(tt.wantAction))
-			Expect(trace[0].Index).To(Equal(tt.wantIndex))
-			Expect(trace[0].Kind).NotTo(Equal(v3.KindStagedGlobalNetworkPolicy))
+			Expect(trace).To(Equal(tt.wantTrace))
 		})
 	}
 }

--- a/app-policy/checker/check_test.go
+++ b/app-policy/checker/check_test.go
@@ -1061,3 +1061,114 @@ func (m *MockFlow) GetSourceLabels() map[string]string {
 func (m *MockFlow) GetDestLabels() map[string]string {
 	return m.DestLabels
 }
+
+// A staged policy enforces nothing, so a tier holding only staged policies takes no part in the
+// action at all: evaluation falls through to the next tier without applying the skipped tier's
+// end-of-tier action. This matches what Felix programs into the dataplane, where a tier of only
+// staged policies ends in a pass rather than a drop.
+func TestEvaluateTierOfOnlyStagedPoliciesIsSkipped(t *testing.T) {
+	RegisterTestingT(t)
+
+	store := policystore.NewPolicyStore()
+	// Both policies deny, so if either tier were applied the flow would be denied.
+	for _, id := range []*proto.PolicyID{
+		{Name: "staged1", Kind: v3.KindStagedGlobalNetworkPolicy},
+		{Name: "policy2", Kind: v3.KindGlobalNetworkPolicy},
+	} {
+		store.PolicyByID[types.ProtoToPolicyID(id)] = &proto.Policy{
+			Tier:         "tier1",
+			InboundRules: []*proto.Rule{{Action: "deny"}},
+		}
+	}
+
+	ep := &proto.WorkloadEndpoint{
+		Tiers: []*proto.TierInfo{
+			{
+				// Nothing enforcing here, so this whole tier is as good as absent — its Deny
+				// end-of-tier action must not apply either.
+				Name:            "tier1",
+				IngressPolicies: []*proto.PolicyID{{Name: "staged1", Kind: v3.KindStagedGlobalNetworkPolicy}},
+				DefaultAction:   "Deny",
+			},
+			{
+				Name:            "tier2",
+				IngressPolicies: []*proto.PolicyID{{Name: "policy2", Kind: v3.KindGlobalNetworkPolicy}},
+				DefaultAction:   "Deny",
+			},
+		},
+	}
+
+	trace := Evaluate(rules.RuleDirIngress, store, ep, &MockFlow{Protocol: 6, DestPort: 80})
+
+	// Only tier2's deny should show up: the staged tier contributed nothing, not even a tier default.
+	Expect(trace).To(HaveLen(1))
+	Expect(trace[0].Tier).To(Equal("tier2"))
+	Expect(trace[0].Name).To(Equal("policy2"))
+	Expect(trace[0].Action).To(Equal(rules.RuleActionDeny))
+}
+
+// In a tier that does have an enforcing policy, the staged ones are ignored but the tier is
+// evaluated as usual, end-of-tier action included.
+func TestEvaluateStagedPolicyDoesNotDecideMixedTier(t *testing.T) {
+	RegisterTestingT(t)
+
+	stagedDeny := &proto.PolicyID{Name: "staged1", Kind: v3.KindStagedGlobalNetworkPolicy}
+	enforcedAllow := &proto.PolicyID{Name: "policy2", Kind: v3.KindGlobalNetworkPolicy}
+	enforcedNoMatch := &proto.PolicyID{Name: "policy3", Kind: v3.KindGlobalNetworkPolicy}
+
+	tests := []struct {
+		name       string
+		policies   []*proto.PolicyID
+		wantLen    int
+		wantAction rules.RuleAction
+		wantIndex  int
+	}{
+		{
+			// The staged deny is first, so it would win if it were enforced.
+			name:       "staged deny ahead of an enforced allow",
+			policies:   []*proto.PolicyID{stagedDeny, enforcedAllow},
+			wantLen:    1,
+			wantAction: rules.RuleActionAllow,
+			wantIndex:  0,
+		},
+		{
+			// No enforced policy matches, so the tier's own default applies, and it must be
+			// attributed to an enforced policy rather than to the staged one.
+			name:       "staged deny ahead of an enforced policy that does not match",
+			policies:   []*proto.PolicyID{stagedDeny, enforcedNoMatch},
+			wantLen:    1,
+			wantAction: rules.RuleActionDeny,
+			wantIndex:  tierDefaultActionIndex,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := policystore.NewPolicyStore()
+			store.PolicyByID[types.ProtoToPolicyID(stagedDeny)] = &proto.Policy{
+				Tier:         "tier1",
+				InboundRules: []*proto.Rule{{Action: "deny"}},
+			}
+			store.PolicyByID[types.ProtoToPolicyID(enforcedAllow)] = &proto.Policy{
+				Tier:         "tier1",
+				InboundRules: []*proto.Rule{{Action: "allow"}},
+			}
+			store.PolicyByID[types.ProtoToPolicyID(enforcedNoMatch)] = &proto.Policy{Tier: "tier1"}
+
+			ep := &proto.WorkloadEndpoint{
+				Tiers: []*proto.TierInfo{{
+					Name:            "tier1",
+					IngressPolicies: tt.policies,
+					DefaultAction:   "Deny",
+				}},
+			}
+
+			trace := Evaluate(rules.RuleDirIngress, store, ep, &MockFlow{Protocol: 6, DestPort: 80})
+
+			Expect(trace).To(HaveLen(tt.wantLen))
+			Expect(trace[0].Action).To(Equal(tt.wantAction))
+			Expect(trace[0].Index).To(Equal(tt.wantIndex))
+			Expect(trace[0].Kind).NotTo(Equal(v3.KindStagedGlobalNetworkPolicy))
+		})
+	}
+}

--- a/app-policy/checker/check_test.go
+++ b/app-policy/checker/check_test.go
@@ -716,8 +716,10 @@ func TestCheckStoreInitFails(t *testing.T) {
 	}}
 	flow := NewCheckRequestToFlowAdapter(req)
 
+	// The tier lists policies whose rules have not been synced yet, so their verdict is unknowable
+	// and evaluation fails closed rather than guessing.
 	status := checkStore(EnforcedOnly, store, store.Endpoint, rules.RuleDirIngress, flow)
-	Expect(status.Code).To(Equal(PERMISSION_DENIED))
+	Expect(status.Code).To(Equal(INTERNAL))
 }
 
 // Ensure checkStore returns INVALID_ARGUMENT on invalid input
@@ -1121,12 +1123,20 @@ func TestCheckTiersPolicyScope(t *testing.T) {
 			wantPending: PERMISSION_DENIED,
 		},
 		{
-			name: "a policy missing from the store counts as a non-match",
-			// Its update has not arrived yet; we cannot match it, but the tier is still there so its
-			// end-of-tier action still applies.
-			tiers:       tierInfos(policyIDs(notInStore)),
-			wantEnforce: PERMISSION_DENIED,
-			wantPending: PERMISSION_DENIED,
+			name: "a policy missing from the store fails the evaluation",
+			// Its update has not arrived yet, so its verdict is unknowable: fail closed rather than
+			// hand the request on to the rest of the tier.
+			tiers:       tierInfos(policyIDs(notInStore, enforcedAllow)),
+			wantEnforce: INTERNAL,
+			wantPending: INTERNAL,
+		},
+		{
+			name: "a policy missing from the store behind a match is never reached",
+			// Evaluation stops at the first match, in the store as in the dataplane, so a policy we
+			// know nothing about does not invalidate a verdict reached before it.
+			tiers:       tierInfos(policyIDs(enforcedAllow, notInStore)),
+			wantEnforce: OK,
+			wantPending: OK,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -1151,7 +1161,6 @@ func TestCheckTiersPolicyScope(t *testing.T) {
 					}
 				}
 				store.PolicyByID[types.ProtoToPolicyID(enforcedAllow)] = &proto.Policy{
-					Tier:         "tier2",
 					InboundRules: []*proto.Rule{{Action: "allow"}},
 				}
 
@@ -1177,6 +1186,27 @@ func tierInfos(tiers ...[]*proto.PolicyID) []*proto.TierInfo {
 		})
 	}
 	return tierInfos
+}
+
+// A trace that stops short of a verdict is worse than no trace: a flow log would show the flow
+// running off the end of policy. Callers get nothing instead.
+func TestEvaluateDiscardsTraceWhenEvaluationFails(t *testing.T) {
+	RegisterTestingT(t)
+
+	notInStore := &proto.PolicyID{Name: "not-in-store", Kind: v3.KindGlobalNetworkPolicy}
+	passes := &proto.PolicyID{Name: "passes", Kind: v3.KindGlobalNetworkPolicy}
+
+	store := policystore.NewPolicyStore()
+	store.PolicyByID[types.ProtoToPolicyID(passes)] = &proto.Policy{
+		InboundRules: []*proto.Rule{{Action: "pass"}},
+	}
+	// tier1 passes, then tier2 holds a policy we have not been told the rules for.
+	ep := &proto.WorkloadEndpoint{Tiers: tierInfos(policyIDs(passes), policyIDs(notInStore))}
+
+	for _, scope := range []PolicyScope{EnforcedOnly, StagedAsEnforced} {
+		trace := Evaluate(scope, rules.RuleDirIngress, store, ep, &MockFlow{Protocol: 6, DestPort: 80})
+		Expect(trace).To(BeNil(), "scope %v", scope)
+	}
 }
 
 // The pending trace records the staged policy that decided it, so that flow logs can show which

--- a/app-policy/policystore/process.go
+++ b/app-policy/policystore/process.go
@@ -39,7 +39,7 @@ func (store *PolicyStore) ProcessUpdate(subscriptionType string, update *proto.T
 	case *proto.ToDataplane_ActiveProfileRemove:
 		store.processActiveProfileRemove(payload.ActiveProfileRemove)
 	case *proto.ToDataplane_ActivePolicyUpdate:
-		if !storeStaged && model.KindIsStaged(payload.ActivePolicyUpdate.Id.Name) {
+		if !storeStaged && model.KindIsStaged(payload.ActivePolicyUpdate.Id.Kind) {
 			log.WithFields(log.Fields{
 				"id": payload.ActivePolicyUpdate.Id,
 			}).Debug("Skipping StagedPolicy ActivePolicyUpdate")
@@ -49,7 +49,7 @@ func (store *PolicyStore) ProcessUpdate(subscriptionType string, update *proto.T
 
 		store.processActivePolicyUpdate(payload.ActivePolicyUpdate)
 	case *proto.ToDataplane_ActivePolicyRemove:
-		if !storeStaged && model.KindIsStaged(payload.ActivePolicyRemove.Id.Name) {
+		if !storeStaged && model.KindIsStaged(payload.ActivePolicyRemove.Id.Kind) {
 			log.WithFields(log.Fields{
 				"id": payload.ActivePolicyRemove.Id,
 			}).Debug("Skipping StagedPolicy ActivePolicyRemove")

--- a/app-policy/policystore/process.go
+++ b/app-policy/policystore/process.go
@@ -19,11 +19,13 @@ import (
 
 	"github.com/projectcalico/calico/felix/proto"
 	"github.com/projectcalico/calico/felix/types"
-	"github.com/projectcalico/calico/libcalico-go/lib/backend/model"
 )
 
 // ProcessUpdate -  Update the PolicyStore with the information passed over the Sync API.
-func (store *PolicyStore) ProcessUpdate(subscriptionType string, update *proto.ToDataplane, storeStaged bool) {
+//
+// Staged policies are stored like any other. Whether they count towards a verdict is up to the
+// evaluation, which takes a checker.PolicyScope; see checker.Evaluate.
+func (store *PolicyStore) ProcessUpdate(subscriptionType string, update *proto.ToDataplane) {
 	// TODO: maybe coalesce-ing updater fits here
 	switch payload := update.Payload.(type) {
 	case *proto.ToDataplane_InSync:
@@ -39,24 +41,8 @@ func (store *PolicyStore) ProcessUpdate(subscriptionType string, update *proto.T
 	case *proto.ToDataplane_ActiveProfileRemove:
 		store.processActiveProfileRemove(payload.ActiveProfileRemove)
 	case *proto.ToDataplane_ActivePolicyUpdate:
-		if !storeStaged && model.KindIsStaged(payload.ActivePolicyUpdate.Id.Kind) {
-			log.WithFields(log.Fields{
-				"id": payload.ActivePolicyUpdate.Id,
-			}).Debug("Skipping StagedPolicy ActivePolicyUpdate")
-
-			return
-		}
-
 		store.processActivePolicyUpdate(payload.ActivePolicyUpdate)
 	case *proto.ToDataplane_ActivePolicyRemove:
-		if !storeStaged && model.KindIsStaged(payload.ActivePolicyRemove.Id.Kind) {
-			log.WithFields(log.Fields{
-				"id": payload.ActivePolicyRemove.Id,
-			}).Debug("Skipping StagedPolicy ActivePolicyRemove")
-
-			return
-		}
-
 		store.processActivePolicyRemove(payload.ActivePolicyRemove)
 	case *proto.ToDataplane_WorkloadEndpointUpdate:
 		store.processWorkloadEndpointUpdate(subscriptionType, payload.WorkloadEndpointUpdate)

--- a/app-policy/policystore/process_test.go
+++ b/app-policy/policystore/process_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	. "github.com/onsi/gomega"
+	v3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
 
 	"github.com/projectcalico/calico/felix/proto"
 	"github.com/projectcalico/calico/felix/types"
@@ -470,4 +471,37 @@ func TestInSyncDispatch(t *testing.T) {
 	store := NewPolicyStore()
 	update := &proto.ToDataplane{Payload: &proto.ToDataplane_InSync{}}
 	Expect(func() { store.ProcessUpdate("", update, false) }).ToNot(Panic())
+}
+
+// Dikastes has no use for staged policies — they enforce nothing — so it syncs with storeStaged
+// false and they must not be stored. Felix passes storeStaged true because it reuses this store to
+// evaluate pending policy for flow logs.
+func TestActivePolicyUpdateStagedHandling(t *testing.T) {
+	RegisterTestingT(t)
+
+	stagedID := &proto.PolicyID{Name: "test_id", Kind: v3.KindStagedGlobalNetworkPolicy}
+	enforcedID := &proto.PolicyID{Name: "test_id", Kind: v3.KindGlobalNetworkPolicy}
+
+	tests := []struct {
+		name        string
+		id          *proto.PolicyID
+		storeStaged bool
+		wantStored  bool
+	}{
+		{"staged policy is skipped when staged policies are not wanted", stagedID, false, false},
+		{"staged policy is stored when staged policies are wanted", stagedID, true, true},
+		{"enforced policy is always stored", enforcedID, false, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := NewPolicyStore()
+			store.ProcessUpdate("", &proto.ToDataplane{Payload: &proto.ToDataplane_ActivePolicyUpdate{
+				ActivePolicyUpdate: &proto.ActivePolicyUpdate{Id: tt.id, Policy: policy1},
+			}}, tt.storeStaged)
+
+			_, stored := store.PolicyByID[types.ProtoToPolicyID(tt.id)]
+			Expect(stored).To(Equal(tt.wantStored))
+		})
+	}
 }

--- a/app-policy/policystore/process_test.go
+++ b/app-policy/policystore/process_test.go
@@ -144,7 +144,7 @@ func TestIPSetUpdateDispatch(t *testing.T) {
 			},
 		}},
 	}
-	Expect(func() { store.ProcessUpdate("", update, false) }).ToNot(Panic())
+	Expect(func() { store.ProcessUpdate("", update) }).ToNot(Panic())
 }
 
 // IPSetDeltaUpdate with existing ID.
@@ -187,7 +187,7 @@ func TestIPSetDeltaUpdateDispatch(t *testing.T) {
 			RemovedMembers: []string{addr3Ip},
 		},
 	}}
-	Expect(func() { store.ProcessUpdate("", update, false) }).ToNot(Panic())
+	Expect(func() { store.ProcessUpdate("", update) }).ToNot(Panic())
 }
 
 // IPSetRemove with an existing ID.
@@ -222,7 +222,7 @@ func TestIPSetRemoveDispatch(t *testing.T) {
 	update := &proto.ToDataplane{Payload: &proto.ToDataplane_IpsetRemove{
 		IpsetRemove: &proto.IPSetRemove{Id: id},
 	}}
-	Expect(func() { store.ProcessUpdate("", update, false) }).ToNot(Panic())
+	Expect(func() { store.ProcessUpdate("", update) }).ToNot(Panic())
 }
 
 // ActiveProfileUpdate with a new id
@@ -265,7 +265,7 @@ func TestActiveProfileUpdateDispatch(t *testing.T) {
 			Profile: profile1,
 		},
 	}}
-	Expect(func() { store.ProcessUpdate("", update, false) }).ToNot(Panic())
+	Expect(func() { store.ProcessUpdate("", update) }).ToNot(Panic())
 }
 
 // ActiveProfileRemove with an unknown id is handled without panic.
@@ -299,7 +299,7 @@ func TestActiveProfileRemoveDispatch(t *testing.T) {
 	update := &proto.ToDataplane{Payload: &proto.ToDataplane_ActiveProfileRemove{
 		ActiveProfileRemove: &proto.ActiveProfileRemove{Id: &id},
 	}}
-	Expect(func() { store.ProcessUpdate("", update, false) }).ToNot(Panic())
+	Expect(func() { store.ProcessUpdate("", update) }).ToNot(Panic())
 }
 
 // ActivePolicyUpdate for a new id
@@ -342,7 +342,7 @@ func TestActivePolicyUpdateDispatch(t *testing.T) {
 			Policy: policy1,
 		},
 	}}
-	Expect(func() { store.ProcessUpdate("", update, false) }).ToNot(Panic())
+	Expect(func() { store.ProcessUpdate("", update) }).ToNot(Panic())
 }
 
 // ActivePolicyRemove with unknown id is handled
@@ -378,7 +378,7 @@ func TestActivePolicyRemoveDispatch(t *testing.T) {
 	update := &proto.ToDataplane{Payload: &proto.ToDataplane_ActivePolicyRemove{
 		ActivePolicyRemove: &proto.ActivePolicyRemove{Id: &id},
 	}}
-	Expect(func() { store.ProcessUpdate("", update, false) }).ToNot(Panic())
+	Expect(func() { store.ProcessUpdate("", update) }).ToNot(Panic())
 }
 
 // WorkloadEndpointUpdate sets the endpoint
@@ -397,7 +397,7 @@ func TestWorkloadEndpointUpdateDispatch(t *testing.T) {
 	update := &proto.ToDataplane{Payload: &proto.ToDataplane_WorkloadEndpointUpdate{
 		WorkloadEndpointUpdate: &proto.WorkloadEndpointUpdate{Endpoint: endpoint1},
 	}}
-	Expect(func() { store.ProcessUpdate("", update, false) }).ToNot(Panic())
+	Expect(func() { store.ProcessUpdate("", update) }).ToNot(Panic())
 }
 
 // WorkloadEndpointRemove removes the endpoint
@@ -418,14 +418,14 @@ func TestWorkloadEndpointRemoveDispatch(t *testing.T) {
 	update := &proto.ToDataplane{Payload: &proto.ToDataplane_WorkloadEndpointRemove{
 		WorkloadEndpointRemove: &proto.WorkloadEndpointRemove{},
 	}}
-	Expect(func() { store.ProcessUpdate("", update, false) }).ToNot(Panic())
+	Expect(func() { store.ProcessUpdate("", update) }).ToNot(Panic())
 }
 
 func TestServiceAccountUpdateDispatch(t *testing.T) {
 	RegisterTestingT(t)
 	store := NewPolicyStore()
 	update := &proto.ToDataplane{Payload: &proto.ToDataplane_ServiceAccountUpdate{ServiceAccountUpdate: serviceAccount1}}
-	Expect(func() { store.ProcessUpdate("", update, false) }).ToNot(Panic())
+	Expect(func() { store.ProcessUpdate("", update) }).ToNot(Panic())
 	Expect(store.ServiceAccountByID).To(Equal(map[types.ServiceAccountID]*proto.ServiceAccountUpdate{
 		types.ProtoToServiceAccountID(serviceAccount1.GetId()): serviceAccount1,
 	}))
@@ -439,7 +439,7 @@ func TestServiceAccountRemoveDispatch(t *testing.T) {
 	remove := &proto.ToDataplane{Payload: &proto.ToDataplane_ServiceAccountRemove{
 		ServiceAccountRemove: &proto.ServiceAccountRemove{Id: serviceAccount1.Id},
 	}}
-	Expect(func() { store.ProcessUpdate("", remove, false) }).ToNot(Panic())
+	Expect(func() { store.ProcessUpdate("", remove) }).ToNot(Panic())
 	Expect(store.ServiceAccountByID).To(Equal(map[types.ServiceAccountID]*proto.ServiceAccountUpdate{}))
 }
 
@@ -447,7 +447,7 @@ func TestNamespaceUpdateDispatch(t *testing.T) {
 	RegisterTestingT(t)
 	store := NewPolicyStore()
 	update := &proto.ToDataplane{Payload: &proto.ToDataplane_NamespaceUpdate{NamespaceUpdate: namespace1}}
-	Expect(func() { store.ProcessUpdate("", update, false) }).ToNot(Panic())
+	Expect(func() { store.ProcessUpdate("", update) }).ToNot(Panic())
 	Expect(store.NamespaceByID).To(Equal(map[types.NamespaceID]*proto.NamespaceUpdate{
 		types.ProtoToNamespaceID(namespace1.GetId()): namespace1,
 	}))
@@ -461,7 +461,7 @@ func TestNamespaceRemoveDispatch(t *testing.T) {
 	remove := &proto.ToDataplane{Payload: &proto.ToDataplane_NamespaceRemove{
 		NamespaceRemove: &proto.NamespaceRemove{Id: namespace1.Id},
 	}}
-	Expect(func() { store.ProcessUpdate("", remove, false) }).ToNot(Panic())
+	Expect(func() { store.ProcessUpdate("", remove) }).ToNot(Panic())
 	Expect(store.NamespaceByID).To(Equal(map[types.NamespaceID]*proto.NamespaceUpdate{}))
 }
 
@@ -470,38 +470,27 @@ func TestInSyncDispatch(t *testing.T) {
 	RegisterTestingT(t)
 	store := NewPolicyStore()
 	update := &proto.ToDataplane{Payload: &proto.ToDataplane_InSync{}}
-	Expect(func() { store.ProcessUpdate("", update, false) }).ToNot(Panic())
+	Expect(func() { store.ProcessUpdate("", update) }).ToNot(Panic())
 }
 
-// Dikastes has no use for staged policies — they enforce nothing — so it syncs with storeStaged
-// false and they must not be stored. Felix passes storeStaged true because it reuses this store to
-// evaluate pending policy for flow logs.
-func TestActivePolicyUpdateStagedHandling(t *testing.T) {
+// Staged policies are stored like enforced ones; it is the evaluation that decides whether they
+// count (see checker.PolicyScope).
+func TestActivePolicyUpdateStoresStagedPolicies(t *testing.T) {
 	RegisterTestingT(t)
 
-	stagedID := &proto.PolicyID{Name: "test_id", Kind: v3.KindStagedGlobalNetworkPolicy}
-	enforcedID := &proto.PolicyID{Name: "test_id", Kind: v3.KindGlobalNetworkPolicy}
-
-	tests := []struct {
-		name        string
-		id          *proto.PolicyID
-		storeStaged bool
-		wantStored  bool
-	}{
-		{"staged policy is skipped when staged policies are not wanted", stagedID, false, false},
-		{"staged policy is stored when staged policies are wanted", stagedID, true, true},
-		{"enforced policy is always stored", enforcedID, false, true},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+	for _, kind := range []string{v3.KindStagedGlobalNetworkPolicy, v3.KindStagedNetworkPolicy, v3.KindGlobalNetworkPolicy} {
+		t.Run(kind, func(t *testing.T) {
+			id := &proto.PolicyID{Name: "test_id", Kind: kind}
 			store := NewPolicyStore()
 			store.ProcessUpdate("", &proto.ToDataplane{Payload: &proto.ToDataplane_ActivePolicyUpdate{
-				ActivePolicyUpdate: &proto.ActivePolicyUpdate{Id: tt.id, Policy: policy1},
-			}}, tt.storeStaged)
+				ActivePolicyUpdate: &proto.ActivePolicyUpdate{Id: id, Policy: policy1},
+			}})
+			Expect(store.PolicyByID).To(HaveKey(types.ProtoToPolicyID(id)))
 
-			_, stored := store.PolicyByID[types.ProtoToPolicyID(tt.id)]
-			Expect(stored).To(Equal(tt.wantStored))
+			store.ProcessUpdate("", &proto.ToDataplane{Payload: &proto.ToDataplane_ActivePolicyRemove{
+				ActivePolicyRemove: &proto.ActivePolicyRemove{Id: id},
+			}})
+			Expect(store.PolicyByID).ToNot(HaveKey(types.ProtoToPolicyID(id)))
 		})
 	}
 }

--- a/app-policy/syncher/syncserver.go
+++ b/app-policy/syncher/syncserver.go
@@ -147,7 +147,7 @@ func (s *SyncClient) syncStore(cxt context.Context, inSync chan<- struct{}, done
 			s.storeManager.OnInSync()
 		default:
 			s.storeManager.DoWithLock(func(ps *policystore.PolicyStore) {
-				ps.ProcessUpdate(s.subscriptionType, update, false)
+				ps.ProcessUpdate(s.subscriptionType, update)
 			})
 		}
 	}

--- a/felix/collector/collector.go
+++ b/felix/collector/collector.go
@@ -1047,11 +1047,12 @@ func (c *collector) evaluatePendingRuleTraceForLocalEp(data *Data, reason policy
 func (c *collector) evaluatePendingRuleTrace(direction rules.RuleDir, store *policystore.PolicyStore, ep calc.EndpointData, flow TupleAsFlow, ruleIDs *[]*calc.RuleID) {
 	// Get the proto.WorkloadEndpoint, needed for the evaluation, from the policy store.
 	if protoEp := c.lookupProtoWorkloadEndpoint(store, ep.Key()); protoEp != nil {
-		trace, ok := checker.Evaluate(checker.StagedAsEnforced, direction, store, protoEp, &flow)
-		if !ok {
-			// The evaluation could not be completed, and has logged why. Keep the trace we worked
-			// out last time: reporting no pending policy at all would be a stronger claim than we
-			// are in a position to make.
+		trace, err := checker.Evaluate(checker.StagedAsEnforced, direction, store, protoEp, &flow)
+		if err != nil {
+			// Keep the trace we worked out last time: reporting no pending policy at all would be a
+			// stronger claim than we are in a position to make. The checker logs the reason, rate
+			// limited, so this one stays at trace level.
+			log.WithError(err).Tracef("Pending %s evaluation failed, tuple: %v", direction, flow)
 			return
 		}
 		if !equal(*ruleIDs, trace) {

--- a/felix/collector/collector.go
+++ b/felix/collector/collector.go
@@ -363,7 +363,7 @@ func (c *collector) loopProcessingDataplaneInfoUpdates(dpInfoC <-chan *proto.ToD
 		c.policyStoreManager.DoWithLock(func(ps *policystore.PolicyStore) {
 			log.Debugf("Dataplane payload: %+v and sequenceNumber: %d, ", dpInfo.Payload, dpInfo.SequenceNumber)
 			// Get the data and update the endpoints.
-			ps.ProcessUpdate(perHostPolicySubscription, dpInfo, true)
+			ps.ProcessUpdate(perHostPolicySubscription, dpInfo)
 		})
 		if _, ok := dpInfo.Payload.(*proto.ToDataplane_InSync); ok {
 			// Sync the policy store. This will swap the pending store to the active store. Setting the
@@ -1047,7 +1047,7 @@ func (c *collector) evaluatePendingRuleTraceForLocalEp(data *Data, reason policy
 func (c *collector) evaluatePendingRuleTrace(direction rules.RuleDir, store *policystore.PolicyStore, ep calc.EndpointData, flow TupleAsFlow, ruleIDs *[]*calc.RuleID) {
 	// Get the proto.WorkloadEndpoint, needed for the evaluation, from the policy store.
 	if protoEp := c.lookupProtoWorkloadEndpoint(store, ep.Key()); protoEp != nil {
-		trace := checker.Evaluate(direction, store, protoEp, &flow)
+		trace := checker.Evaluate(checker.StagedAsEnforced, direction, store, protoEp, &flow)
 		if !equal(*ruleIDs, trace) {
 			*ruleIDs = append([]*calc.RuleID(nil), trace...)
 			log.Tracef("Updated pending %s, tuple: %v, rule trace: %v", direction, flow, ruleIDs)

--- a/felix/collector/collector.go
+++ b/felix/collector/collector.go
@@ -1047,7 +1047,13 @@ func (c *collector) evaluatePendingRuleTraceForLocalEp(data *Data, reason policy
 func (c *collector) evaluatePendingRuleTrace(direction rules.RuleDir, store *policystore.PolicyStore, ep calc.EndpointData, flow TupleAsFlow, ruleIDs *[]*calc.RuleID) {
 	// Get the proto.WorkloadEndpoint, needed for the evaluation, from the policy store.
 	if protoEp := c.lookupProtoWorkloadEndpoint(store, ep.Key()); protoEp != nil {
-		trace := checker.Evaluate(checker.StagedAsEnforced, direction, store, protoEp, &flow)
+		trace, ok := checker.Evaluate(checker.StagedAsEnforced, direction, store, protoEp, &flow)
+		if !ok {
+			// The evaluation could not be completed, and has logged why. Keep the trace we worked
+			// out last time: reporting no pending policy at all would be a stronger claim than we
+			// are in a position to make.
+			return
+		}
 		if !equal(*ruleIDs, trace) {
 			*ruleIDs = append([]*calc.RuleID(nil), trace...)
 			log.Tracef("Updated pending %s, tuple: %v, rule trace: %v", direction, flow, ruleIDs)

--- a/felix/collector/pending_rule_trace_test.go
+++ b/felix/collector/pending_rule_trace_test.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	v3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
+
+	"github.com/projectcalico/calico/app-policy/policystore"
+	"github.com/projectcalico/calico/felix/calc"
+	"github.com/projectcalico/calico/felix/rules"
+	"github.com/projectcalico/calico/felix/types"
+)
+
+// An evaluation that cannot be completed says so, rather than returning an empty trace. Overwriting
+// the flow's pending trace with that would report the flow as having no pending policy at all,
+// which is a stronger claim than "we could not work it out" — so the last trace stands.
+func TestPendingRuleTraceKeptWhenEvaluationFails(t *testing.T) {
+	RegisterTestingT(t)
+
+	c, flowTuple1, _ := setupPolicyEvalCollector(t)
+	evaluated := []*calc.RuleID{calc.NewRuleID(
+		v3.KindGlobalNetworkPolicy, "default", "policy1", "", 0, rules.RuleDirIngress, rules.RuleActionAllow)}
+
+	// Control: with the endpoint's policy in the store, the trace is worked out and recorded.
+	var ruleIDs []*calc.RuleID
+	c.policyStoreManager.DoWithLock(func(ps *policystore.PolicyStore) {
+		c.evaluatePendingRuleTrace(rules.RuleDirIngress, ps, localEd1, TupleAsFlow(flowTuple1), &ruleIDs)
+	})
+	Expect(ruleIDs).To(Equal(evaluated))
+
+	c.policyStoreManager.DoWithLock(func(ps *policystore.PolicyStore) {
+		// The endpoint's tier still names policy1, but its rules are no longer in the store, so the
+		// evaluation fails part way through.
+		delete(ps.PolicyByID, types.PolicyID{Name: "policy1", Kind: v3.KindGlobalNetworkPolicy})
+		c.evaluatePendingRuleTrace(rules.RuleDirIngress, ps, localEd1, TupleAsFlow(flowTuple1), &ruleIDs)
+	})
+	Expect(ruleIDs).To(Equal(evaluated), "the trace from the last successful evaluation should stand")
+}


### PR DESCRIPTION
### Description

`policystore.ProcessUpdate` took a `storeStaged` flag that decided whether staged policies were stored at all, and `checker.checkTiers` then inferred what it was being asked for from whether it could find a policy in the store. Three problems:

1. The flag compared `Id.Name` against the staged *kinds*, so it never matched. No staged policy was ever skipped — the original bug this PR started from.
2. Even with the field fixed, the checker could not tell "staged, deliberately not stored" from "the update has not arrived yet". Both landed in `checkPolicy(nil)`, which returns `Action(INTERNAL)`; the `switch` has no `default`, so `action` was left as something other than `NO_MATCH` and the tier's **end-of-tier action was silently suppressed**. For a tier of only staged policies that happens to be the behaviour we want, but for a tier mixing staged and enforced policies it wrongly dropped the end-of-tier action — and policies are ordered by `order` then name (`calc.PolKVLess`), so a staged policy can be last in a tier.
3. Nothing tested any of it.

So make the caller say what it wants, and store staged policies unconditionally:

```go
Evaluate(checker.EnforcedOnly, ...)     // the verdict the dataplane enforces
Evaluate(checker.StagedAsEnforced, ...) // the pending verdict
```

* `EnforcedOnly` — staged policies match nothing, and a tier holding only staged policies is skipped entirely, end-of-tier action included, as if it were not attached to the endpoint. That matches what Felix programs into the dataplane (`felix/rules/endpoints.go`: if every policy in a tier is staged, the end of tier behaviour is pass, not drop). Dikastes uses this.
* `StagedAsEnforced` — every staged policy is treated as though it had been promoted to enforced. That is what "pending policy" means for a flow log: the trace for the current state of policy with all staged policies enforced. Felix's flow-log collector uses this.

A policy genuinely missing from the store — named in the endpoint's tier but absent from the store, which should never happen since a policy is sent before the endpoints referencing it — now fails the evaluation closed: logged at error level, returning `INTERNAL`, which the check server logs and denies on, distinctly from a policy-driven `PERMISSION_DENIED`. Skipping it would apply the rest of the tier to a request those policies may not govern, and applying the end-of-tier action would assume the missing policy did not match. `Evaluate` returns `(trace, ok)` so a failed evaluation is distinguishable from a flow that matched nothing, and the flow-log collector keeps the last trace it worked out rather than recording the flow as having no pending policy.

The `INTERNAL` status also carries a `Message` naming the policy and tier, as do the two `INVALID_ARGUMENT` paths. That stays server-side: Envoy's ext_authz filter maps `CheckResponse` into an internal struct with no field for `status.message`, and takes the denied response's status code and body only from `denied_response`, which Dikastes does not set — so a blocked client still gets a bare 403 with no body.

This changes what `TestCheckStoreInitFails` asserts: a tier naming policies the store does not have denied before too, but as a plain end-of-tier deny rather than an error.

### Related issues/PRs

Found while reviewing the flow-log collector for latent bugs; sibling PRs #13409, #13410, #13414, #13415.

### Todos

- [x] Unit tests covering both scopes, including end-of-tier action correctness for staged-only tiers, mixed tiers with the staged policy first and last, and a policy missing from the store.

### Release Note

```release-note
Fixed the pending policy trace in flow logs, and the enforced verdict computed by application layer policy, to handle staged policies correctly: staged policies now contribute to the pending trace only, and a tier containing nothing but staged policies no longer applies its end-of-tier action to the enforced verdict.
```

