### PR TITLE
e2e: add a dedicated scheduled run for the Maglev tests

### DIFF
--- a/.argoci/cron/e2e-bpf.yaml
+++ b/.argoci/cron/e2e-bpf.yaml
@@ -125,6 +125,15 @@ steps:
         value: "3"
       - name: CLUSTER_ROUTING_MODE
         value: Felix
+      # This run picks its tests with a config rather than a focus/skip pair:
+      # e2e/config/bpf-aws-single-subnet.yaml holds the same selection the
+      # focus/skip used to give, Maglev tests included.
+      - name: E2E_TEST_CONFIG
+        value: e2e/config/bpf-aws-single-subnet.yaml
+      # Maglev needs DSR, and this is the one run whose cluster otherwise suits
+      # it: BPF, an external node, one subnet, no encapsulation.
+      - name: ENABLE_BPF_DSR
+        value: "true"
       - name: ENABLE_EXTERNAL_NODE
         value: "true"
       - name: ENCAPSULATION_TYPE
@@ -135,8 +144,6 @@ steps:
         value: dual
       - name: K8S_E2E_DOCKER_EXTRA_FLAGS
         value: --env EKS_CNI
-      - name: K8S_E2E_FLAGS
-        value: --ginkgo.focus=(\[sig-calico\]|Conformance|Dataplane:BPF|Feature:NetworkPolicy) --ginkgo.skip=(Slow|Disruptive|calient|allow.ingress.access.from.updated.pod|Dataplane:LB|Feature:SCTP)
       - name: KUBE_PROXY_MANAGEMENT
         value: Enabled
       - name: PROVISIONER

--- a/.semaphore/end-to-end/pipelines/bpf.yml
+++ b/.semaphore/end-to-end/pipelines/bpf.yml
@@ -118,10 +118,15 @@ blocks:
             - env_var: ENABLE_WIREGUARD
               values: ["true", "false"]
           env_vars:
-            # Skip/Focus are the same as the BPF-run block,
-            # but we *don't* skip Maglev for this environment.
-            - name: K8S_E2E_FLAGS
-              value: --ginkgo.focus=(\[sig-calico\]|Conformance|Dataplane:BPF|Feature:NetworkPolicy) --ginkgo.skip=(Slow|Disruptive|calient|allow.ingress.access.from.updated.pod|Dataplane:LB|Feature:SCTP)
+            # This run picks its tests with a config rather than a focus/skip
+            # pair: e2e/config/bpf-aws-single-subnet.yaml holds the same
+            # selection the focus/skip used to give, Maglev tests included.
+            - name: E2E_TEST_CONFIG
+              value: "e2e/config/bpf-aws-single-subnet.yaml"
+            # Maglev needs DSR, and this is the one run whose cluster otherwise
+            # suits it: BPF, an external node, one subnet, no encapsulation.
+            - name: ENABLE_BPF_DSR
+              value: "true"
             - name: IP_FAMILY
               value: dual
             - name: VPC_SUBNETS

--- a/e2e/config/bpf-aws-single-subnet.yaml
+++ b/e2e/config/bpf-aws-single-subnet.yaml
@@ -1,0 +1,33 @@
+# bpf-aws-single-subnet.yaml - test selection for the AWS single-subnet BPF run.
+#
+# This reproduces the set of tests the run selected back when it used a
+# --ginkgo.focus/--ginkgo.skip pair, expressed the way the config loader wants
+# it. Adding or removing entries here changes what that run covers.
+#
+# The pre-testconfig filter was:
+#   --ginkgo.focus=(\[sig-calico\]|Conformance|Dataplane:BPF|Feature:NetworkPolicy)
+#   --ginkgo.skip=(Slow|Disruptive|calient|allow.ingress.access.from.updated.pod|Dataplane:LB|Feature:SCTP)
+
+include:
+  - sig-calico
+  - Conformance
+  # Upstream node and storage tests carrying [NodeConformance]. The old filter
+  # matched these because its bare "Conformance" also matched the longer label;
+  # naming it keeps the run's coverage unchanged and makes it a visible choice.
+  - NodeConformance
+  - Dataplane:BPF
+  - Feature:NetworkPolicy
+
+exclude:
+  # These stay regex patterns rather than label exclusions so they match the
+  # same tests the old filter did -- as text, "Feature:SCTP" also catches
+  # [Feature:SCTPConnectivity], which the label of that name does not.
+  namePatterns:
+    - group: "carried over from the run's own skip list"
+      patterns:
+        - Slow
+        - Disruptive
+        - calient
+        - allow.ingress.access.from.updated.pod
+        - Dataplane:LB
+        - Feature:SCTP

--- a/e2e/config/bpf-aws-single-subnet.yaml
+++ b/e2e/config/bpf-aws-single-subnet.yaml
@@ -1,0 +1,52 @@
+# bpf-aws-single-subnet.yaml - test selection for the AWS single-subnet BPF run.
+#
+# Standalone, not extending base.yaml: extends only ever adds, and base excludes
+# ExternalNode, which would drop this run's Maglev tests for good.
+#
+# This reproduces the set of tests the run selected back when it used a
+# --ginkgo.focus/--ginkgo.skip pair, expressed the way the config loader wants
+# it. Adding or removing entries here changes what that run covers.
+#
+# The pre-testconfig filter was:
+#   --ginkgo.focus=(\[sig-calico\]|Conformance|Dataplane:BPF|Feature:NetworkPolicy)
+#   --ginkgo.skip=(Slow|Disruptive|calient|allow.ingress.access.from.updated.pod|Dataplane:LB|Feature:SCTP)
+#
+# One deliberate departure from that filter: it also picked up tests needing
+# things this cluster hasn't got, which could only ever fail here. Those are
+# excluded by label below. Requirements the cluster does meet are left in, so
+# tests labelled RequiresAWS, RequiresBGPMesh, NoEncap, ExternalNode,
+# RequiresGoldmane and RequiresCalicoAPIServer all still run.
+
+include:
+  - sig-calico
+  - Conformance
+  # Upstream node and storage tests carrying [NodeConformance]. The old filter
+  # matched these because its bare "Conformance" also matched the longer label;
+  # naming it keeps the run's coverage unchanged and makes it a visible choice.
+  - NodeConformance
+  - Dataplane:BPF
+  - Feature:NetworkPolicy
+
+exclude:
+  labels:
+    - label: Feature:KubeVirt
+      reason: "no KubeVirt on this cluster; these run on the dedicated KubeVirt job (e2e/config/gcp-kubevirt.yaml)"
+
+    - label: RequiresXtables
+      reason: "requires iptables or nftables dataplane, but this cluster uses BPF"
+
+    - label: Feature:Istio
+      reason: "Istio is not installed here, and Calico policy is not enforced with Istio ambient on BPF"
+
+  # These stay regex patterns rather than label exclusions so they match the
+  # same tests the old filter did -- as text, "Feature:SCTP" also catches
+  # [Feature:SCTPConnectivity], which the label of that name does not.
+  namePatterns:
+    - group: "carried over from the run's own skip list"
+      patterns:
+        - Slow
+        - Disruptive
+        - calient
+        - allow.ingress.access.from.updated.pod
+        - Dataplane:LB
+        - Feature:SCTP


### PR DESCRIPTION
Three changes to the configuration of one scheduled end-to-end run, the AWS single-subnet BPF run. No product code is touched.

**Puts it on a test-selection config.** The run's `E2E_TEST_CONFIG` was never set, so it has not been selecting the tests its `--ginkgo.focus`/`--ginkgo.skip` pair asked for. That selection now lives in `e2e/config/bpf-aws-single-subnet.yaml`, and the pair it no longer reads is gone, so the run has one source of truth instead of two.

**Restores the tests it used to select**, bar one deliberate departure: of the 576 the old pair selected, 19 need KubeVirt, an xtables dataplane, or Istio, none of which this cluster has, so they could only ever fail here. Those are excluded by label with a reason each, leaving **557**. Requirements the cluster does meet are left alone, so `RequiresAWS`, `RequiresBGPMesh`, `NoEncap`, `ExternalNode`, `RequiresGoldmane` and `RequiresCalicoAPIServer` tests all still run — Goldmane, Whisker and `calico-apiserver` are all confirmed up in the run's own log.

**Enables DSR so it covers Maglev.** The Maglev tests are part of that selection but only give a meaningful result with DSR. This run's cluster already supplies the rest of what they need — BPF, an external node, one subnet, no encapsulation — which is why they belong here. No new run is added.

This is not the full fix for the underlying selection problem; other runs are affected and are being handled separately. Nothing here changes them.

Verified per job by resolving each run's effective `E2E_TEST_CONFIG` and dry-running the real e2e binary: **4 of 281 job/variants change** (this run, in both CI systems, across its WireGuard matrix), each landing on the same 557. The other 277 are untouched, and no run is added or removed. The exclusions were checked to remove exactly those 19 and nothing else, with Maglev's 2 specs still selected.

Two selection details in the config are load-bearing, and commented as such: `NodeConformance` is named explicitly because the old bare `Conformance` regex also matched `[NodeConformance]`, and the skips stay regex patterns rather than label exclusions because, as text, `Feature:SCTP` also matches `[Feature:SCTPConnectivity]` where the label of that name does not.

Related:
- [v3.31 E2E Maglev skips](https://github.com/projectcalico/calico/pull/13429)
- [v3.32 E2E Maglev new job](https://github.com/projectcalico/calico/pull/13431)

## Release Note

```release-note
None
```
