### PR TITLE
felix: suppress and elevate IPv6 workload routes during live migration (CORE-12806)

### DIFF
--- a/felix/dataplane/linux/export_test.go
+++ b/felix/dataplane/linux/export_test.go
@@ -51,3 +51,11 @@ func (d *InternalDataplane) WireguardEnabled() bool {
 func (d *InternalDataplane) WireguardEnabledV6() bool {
 	return d.wireguardManagerV6 != nil && d.wireguardManagerV6.wireguardRouteTable.Enabled()
 }
+
+// LiveMigrationListenerCount reports how many listeners - in production, endpoint
+// managers - are registered with the live migration monitor.  There must be one per
+// enabled IP version: with the IPv6 endpoint manager missing, IPv6 workload routes
+// are neither suppressed on a migration target nor elevated after cutover.
+func (d *InternalDataplane) LiveMigrationListenerCount() int {
+	return len(d.liveMigrationMonitor.listeners)
+}

--- a/felix/dataplane/linux/int_dataplane.go
+++ b/felix/dataplane/linux/int_dataplane.go
@@ -1276,7 +1276,7 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 	)
 	dp.RegisterManager(epManager)
 	dp.endpointsSourceV4 = epManager
-	dp.liveMigrationMonitor.listener = epManager
+	dp.liveMigrationMonitor.registerListener(epManager)
 	if mainTablePolV4 != nil {
 		mainTablePolV4.IsWorkloadBGPPeerIface = epManager.ifaceIsForLocalBGPPeer
 	}
@@ -1516,6 +1516,7 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 			nil, // arpMaps
 		)
 		dp.RegisterManager(epManagerV6)
+		dp.liveMigrationMonitor.registerListener(epManagerV6)
 		if mainTablePolV6 != nil {
 			mainTablePolV6.IsWorkloadBGPPeerIface = epManagerV6.ifaceIsForLocalBGPPeer
 		}

--- a/felix/dataplane/linux/int_dataplane_test.go
+++ b/felix/dataplane/linux/int_dataplane_test.go
@@ -138,6 +138,27 @@ var _ = Describe("Constructor test", func() {
 		Expect(dp).ToNot(BeNil())
 	})
 
+	// The live migration monitor drives per-workload route suppression and priority
+	// elevation through the endpoint managers, of which there is one per IP version.
+	// Each manager tracks its own live migration state, so all of them must be
+	// registered as listeners; registering only the IPv4 one leaves IPv6 workload
+	// routes unsuppressed on a migration target and unelevated after cutover
+	// (CORE-12806).
+	It("should register an endpoint manager per IP version with the live migration monitor", func() {
+		dpConfig.IPv6Enabled = true
+
+		dp := intdataplane.NewIntDataplaneDriver(dpConfig)
+		Expect(dp.LiveMigrationListenerCount()).To(Equal(2),
+			"both endpoint managers should listen for live migration state changes")
+	})
+
+	It("should register only the IPv4 endpoint manager when IPv6 is disabled", func() {
+		dpConfig.IPv6Enabled = false
+
+		dp := intdataplane.NewIntDataplaneDriver(dpConfig)
+		Expect(dp.LiveMigrationListenerCount()).To(Equal(1))
+	})
+
 	Context("when nft is not available", func() {
 		BeforeEach(func() {
 			nftablesDataplane = func(knftables.Family, string, ...knftables.Option) (knftables.Interface, error) {

--- a/felix/dataplane/linux/live_migration.go
+++ b/felix/dataplane/linux/live_migration.go
@@ -45,7 +45,7 @@ type garpHandle interface {
 }
 
 // liveMigrationStateUpdate records a per-workload FSM state change that the
-// liveMigrationMonitor needs to forward to its listener (the endpoint manager).
+// liveMigrationMonitor needs to forward to its listeners (the endpoint managers).
 type liveMigrationStateUpdate struct {
 	ID    types.WorkloadEndpointID
 	State liveMigrationState
@@ -53,13 +53,17 @@ type liveMigrationStateUpdate struct {
 
 // liveMigrationMonitor tracks per-workload live migration state that cannot be inferred
 // statelessly from the datastore.  It sees WorkloadEndpoint updates, extracts the live
-// migration role, and drives a per-workload FSM whose state changes are forwarded to
-// the endpoint manager via the liveMigrationListener interface during ResolveUpdateBatch.
+// migration role, and drives a per-workload FSM whose state changes are forwarded to the
+// endpoint managers via the liveMigrationListener interface during ResolveUpdateBatch.
+//
+// There is one endpoint manager per IP version, and each keeps its own live migration state,
+// so every state change must be forwarded to all of them: a monitor with only the IPv4
+// manager registered would leave IPv6 workload routes unsuppressed and unelevated.
 type liveMigrationMonitor struct {
 	roles           map[types.WorkloadEndpointID]proto.LiveMigrationRole
 	fsms            map[types.WorkloadEndpointID]*liveMigrationFSM
 	pendingUpdates  []liveMigrationStateUpdate
-	listener        liveMigrationListener
+	listeners       []liveMigrationListener
 	timerC          chan types.WorkloadEndpointID
 	garpC           chan types.WorkloadEndpointID
 	ifaceNames      map[types.WorkloadEndpointID]string
@@ -99,13 +103,21 @@ func newLiveMigrationMonitor(convergenceTime time.Duration, ipamClient ipam.Inte
 	}
 }
 
-// ResolveUpdateBatch drains accumulated FSM state changes and forwards them
-// to the endpoint manager via the liveMigrationListener interface.  This runs
-// before CompleteDeferredWork, so the endpoint manager sees the state changes
-// before it programs the dataplane.
+// registerListener adds a listener - in production, one endpoint manager per IP version -
+// that should be told about every FSM state change.
+func (m *liveMigrationMonitor) registerListener(l liveMigrationListener) {
+	m.listeners = append(m.listeners, l)
+}
+
+// ResolveUpdateBatch drains accumulated FSM state changes and forwards them to each
+// registered listener via the liveMigrationListener interface.  This runs before
+// CompleteDeferredWork, so the endpoint managers see the state changes before they
+// program the dataplane.
 func (m *liveMigrationMonitor) ResolveUpdateBatch() error {
 	for _, update := range m.pendingUpdates {
-		m.listener.OnLiveMigrationStateUpdate(update.ID, update.State)
+		for _, l := range m.listeners {
+			l.OnLiveMigrationStateUpdate(update.ID, update.State)
+		}
 	}
 	m.pendingUpdates = m.pendingUpdates[:0]
 	return nil

--- a/felix/dataplane/linux/live_migration_test.go
+++ b/felix/dataplane/linux/live_migration_test.go
@@ -60,13 +60,13 @@ func newTestMonitor(convergenceTime time.Duration) *liveMigrationMonitor {
 	m.newGARPHandle = func(ifaceName string) (garpHandle, error) {
 		return newFakeGARPHandle(), nil
 	}
-	m.listener = &fakeLiveMigrationListener{}
+	m.registerListener(&fakeLiveMigrationListener{})
 	return m
 }
 
 // testListener returns the fake listener from a test monitor.
 func testListener(m *liveMigrationMonitor) *fakeLiveMigrationListener {
-	return m.listener.(*fakeLiveMigrationListener)
+	return m.listeners[0].(*fakeLiveMigrationListener)
 }
 
 // drainUpdates resolves the current batch and returns the updates delivered to
@@ -286,6 +286,25 @@ func TestMonitorOnUpdate(t *testing.T) {
 		m := newTestMonitor(testConvergenceTime)
 		m.OnUpdate(wepUpdate(wepID1, proto.LiveMigrationRole_TARGET))
 		g.Expect(m.ifaceNames[wepID1]).To(Equal("cali" + wepID1.EndpointId))
+	})
+}
+
+func TestMonitorMultipleListeners(t *testing.T) {
+	t.Run("state changes are forwarded to every registered listener", func(t *testing.T) {
+		g := NewWithT(t)
+		m := newTestMonitor(testConvergenceTime)
+
+		// In production the monitor has one listener per IP version; a second
+		// listener here stands in for the IPv6 endpoint manager.
+		second := &fakeLiveMigrationListener{}
+		m.registerListener(second)
+
+		m.OnUpdate(wepUpdate(wepID1, proto.LiveMigrationRole_TARGET))
+		g.Expect(m.ResolveUpdateBatch()).NotTo(HaveOccurred())
+
+		expected := []liveMigrationStateUpdate{{ID: wepID1, State: liveMigrationStateTarget}}
+		g.Expect(testListener(m).drain()).To(Equal(expected))
+		g.Expect(second.drain()).To(Equal(expected))
 	})
 }
 

--- a/felix/design/dataplane.md
+++ b/felix/design/dataplane.md
@@ -597,11 +597,45 @@ Legitimate asymmetries are rare on the `*tables` path. Two notes:
   table, but was kept as two to track the iptables structure for
   porting ease.
 
+### Cross-cutting components that feed the per-family managers
+
+Not everything is duplicated per family. Some components are
+deliberately **single instances that feed the per-family managers**.
+The live migration monitor (`dataplane/linux/live_migration.go`) is
+the model: one FSM per workload, driven by GARP detection and timers
+that have nothing to do with IP family, whose state changes are then
+pushed into the endpoint managers — which own the per-family route
+programming.
+
+For those components the dual-stack trap is not "did you duplicate
+the code" but **"did you fan out to every family's manager"**. A
+singleton holding a *single* reference to its downstream manager
+silently serves IPv4 only, and nothing fails loudly: the IPv6
+manager simply never learns the state, so its routes keep their
+default behaviour. That was CORE-12806 — the live migration
+monitor's `listener` field was assigned the IPv4 endpoint manager
+only, so IPv6 workload routes were never suppressed on a migration
+target nor elevated after cutover, and IPv6 traffic to a migrating
+VM could black-hole for the duration of the migration. Prefer a list
+plus an explicit registration call (`registerListener`) over a
+single-valued field: a missing family then shows up as a missing
+call at the construction site in `int_dataplane.go`, alongside the
+`RegisterManager` call it belongs with.
+
 ### Review notes for this section
 
 - A dataplane change must be applied symmetrically to the IPv4 and
   IPv6 manager/driver instances unless there's a specific reason not
   to. "Works on v4, forgot v6" is a recurring bug.
+- A cross-cutting (non-per-family) component that pushes state into
+  the per-family managers must be wired to **all** of them. Check the
+  construction site in `int_dataplane.go`: every per-family manager
+  the component needs should have a matching registration call. A
+  single-valued reference field where a list belongs is the smell.
+- Dual-stack behaviour needs dual-stack tests. A per-family manager's
+  own unit tests may already run for both families and still pass
+  while the family is disconnected upstream; the registration itself
+  and at least one FV path need explicit IPv6 coverage.
 
 ## Windows (contrast)
 

--- a/felix/fv/live_migration_test.go
+++ b/felix/fv/live_migration_test.go
@@ -256,7 +256,7 @@ func lmCheckConnectivity(expected connectivity.Expected, felix *infrastructure.F
 
 // lmDumpDiagsOnFailure logs each Felix's routing table and interfaces if the current test failed.
 func lmDumpDiagsOnFailure(tc infrastructure.TopologyContainers) {
-	if !CurrentGinkgoTestDescription().Failed {
+	if !CurrentSpecReport().Failed() {
 		return
 	}
 	for _, felix := range tc.Felixes {

--- a/felix/fv/live_migration_test.go
+++ b/felix/fv/live_migration_test.go
@@ -21,6 +21,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	gomegatypes "github.com/onsi/gomega/types"
 	api "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
 	log "github.com/sirupsen/logrus"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -52,7 +53,7 @@ import (
 //     VirtualMachineInstanceMigration (VMIM) resources, which the Kubernetes backend converts to
 //     LiveMigrations.
 //
-// In both suites the migrating VM is modelled by two FV workloads with the same IP, one on each
+// In both suites the migrating VM is modelled by two FV workloads with the same IPs, one on each
 // of two Felix hosts.  The expected route programming on the target host, as the migration
 // progresses, is:
 //
@@ -64,20 +65,31 @@ import (
 //     LiveMigrationRouteConvergenceTime has elapsed (back to state Base).
 //
 // Throughout, the source host's route programming for its WEP is normal.
+//
+// The workloads are dual-stack and every route expectation is checked for both families.  Felix
+// programs IPv4 and IPv6 workload routes through separate per-family endpoint managers, each
+// with its own copy of the live migration state, so an IPv4-only expectation proves nothing
+// about IPv6 (see CORE-12806, where the IPv6 endpoint manager was never told about live
+// migration state at all).
 const (
-	// Both workloads model the same migrating VM, so they share this IP.
-	lmMigratingIP = "10.65.0.2"
+	// Both workloads model the same migrating VM, so they share these IPs.
+	lmMigratingIP   = "10.65.0.2"
+	lmMigratingIPv6 = "dead:beef::2"
 
-	// Route priorities for these tests, matching the IPv4ElevatedRoutePriority and
-	// IPv4NormalRoutePriority defaults; lmTopologyOptions pins them explicitly so that the
-	// metric assertions cannot be broken by a change to the defaults.  Note that lower
-	// metric = more preferred.
+	// Route priorities for these tests, matching the IPv4/IPv6ElevatedRoutePriority and
+	// IPv4/IPv6NormalRoutePriority defaults; lmTopologyOptions pins all four explicitly so
+	// that the metric assertions cannot be broken by a change to the defaults.  Note that
+	// lower metric = more preferred.
 	lmElevatedPriority = "512"
 	lmNormalPriority   = "1024"
 
 	// Corresponding metric strings expected in "ip route show" output.
 	lmElevatedMetric = "metric " + lmElevatedPriority
 	lmNormalMetric   = "metric " + lmNormalPriority
+
+	// lmNoRoute is the route expectation for a workload whose route is suppressed
+	// altogether, i.e. no route at all.
+	lmNoRoute = ""
 
 	// LiveMigrationRouteConvergenceTime for these tests, in seconds.  Long enough that a
 	// Consistently over a few seconds fits within it, short enough that waiting for reversion
@@ -86,15 +98,18 @@ const (
 )
 
 // lmTopologyOptions returns the topology options shared by both live migration suites: flat
-// (unencapsulated) IPv4 routing, as in the OpenStack use case.  With no encap and the default
-// RouteSource, Felix programs only local workload routes, which are the subject of these tests.
+// (unencapsulated) dual-stack routing, as in the OpenStack use case.  With no encap and the
+// default RouteSource, Felix programs only local workload routes, which are the subject of
+// these tests.
 func lmTopologyOptions() infrastructure.TopologyOptions {
 	opts := infrastructure.DefaultTopologyOptions()
 	opts.IPIPMode = api.IPIPModeNever
-	opts.EnableIPv6 = false
+	opts.EnableIPv6 = true
 	opts.ExtraEnvVars["FELIX_LIVEMIGRATIONROUTECONVERGENCETIME"] = lmConvergenceTimeSecs
 	opts.ExtraEnvVars["FELIX_IPV4ELEVATEDROUTEPRIORITY"] = lmElevatedPriority
 	opts.ExtraEnvVars["FELIX_IPV4NORMALROUTEPRIORITY"] = lmNormalPriority
+	opts.ExtraEnvVars["FELIX_IPV6ELEVATEDROUTEPRIORITY"] = lmElevatedPriority
+	opts.ExtraEnvVars["FELIX_IPV6NORMALROUTEPRIORITY"] = lmNormalPriority
 
 	// The tests' routing expectations assume IPAM-derived routing (the default RouteSource);
 	// make that explicit too.
@@ -103,22 +118,82 @@ func lmTopologyOptions() infrastructure.TopologyOptions {
 	return opts
 }
 
+// lmFamilyRoute is one family's route-fetching function, labelled for failure messages.
+type lmFamilyRoute struct {
+	family string
+	route  func() string
+}
+
+// lmRoutes holds the route-fetching functions for one workload's IPv4 and IPv6 routes on one
+// host.  The lm*Route helpers below assert over both, so that no expectation can accidentally
+// cover only one family.
+type lmRoutes []lmFamilyRoute
+
+// lmWorkloadRoutes returns the host's main-table routes, per family, for the given workload's
+// IPs on that workload's interface.  Each function returns "" if there is no such route.
+func lmWorkloadRoutes(felix *infrastructure.Felix, w *workload.Workload) lmRoutes {
+	return lmRoutes{
+		{family: "IPv4", route: lmWorkloadRoute(felix, w, "-4", w.IP)},
+		{family: "IPv6", route: lmWorkloadRoute(felix, w, "-6", w.IP6)},
+	}
+}
+
 // lmWorkloadRoute returns a function that fetches the host's main-table route for the given
-// workload's IP on that workload's interface, or "" if there is no such route.
-func lmWorkloadRoute(felix *infrastructure.Felix, w *workload.Workload) func() string {
+// workload IP on that workload's interface, or "" if there is no such route.
+func lmWorkloadRoute(felix *infrastructure.Felix, w *workload.Workload, familyArg, ip string) func() string {
 	return func() string {
-		out, err := felix.ExecOutput("ip", "route", "show", "dev", w.InterfaceName)
+		out, err := felix.ExecOutput("ip", familyArg, "route", "show", "dev", w.InterfaceName)
 		if err != nil {
 			// Interface not present (e.g. workload stopped); no route.
 			return ""
 		}
 		for _, line := range strings.Split(out, "\n") {
 			fields := strings.Fields(line)
-			if len(fields) > 0 && fields[0] == w.IP {
+			if len(fields) > 0 && fields[0] == ip {
 				return strings.TrimSpace(line)
 			}
 		}
 		return ""
+	}
+}
+
+// lmRouteMatcher builds the matcher for a route expectation: either no route at all
+// (lmNoRoute), or a route carrying the given metric.
+func lmRouteMatcher(metric string) gomegatypes.GomegaMatcher {
+	if metric == lmNoRoute {
+		return BeEmpty()
+	}
+	return ContainSubstring(metric)
+}
+
+// lmRouteDesc labels a route expectation failure with the family it applies to.
+func lmRouteDesc(family string, desc []string) string {
+	if len(desc) == 0 {
+		return family + " route"
+	}
+	return family + " route: " + desc[0]
+}
+
+// lmEventuallyRoute asserts that both families' routes eventually reach the given expectation.
+func lmEventuallyRoute(routes lmRoutes, metric, timeout, poll string, desc ...string) {
+	for _, r := range routes {
+		EventuallyWithOffset(1, r.route, timeout, poll).Should(
+			lmRouteMatcher(metric), lmRouteDesc(r.family, desc))
+	}
+}
+
+// lmConsistentlyRoute asserts that both families' routes hold the given expectation throughout.
+func lmConsistentlyRoute(routes lmRoutes, metric, duration, poll string, desc ...string) {
+	for _, r := range routes {
+		ConsistentlyWithOffset(1, r.route, duration, poll).Should(
+			lmRouteMatcher(metric), lmRouteDesc(r.family, desc))
+	}
+}
+
+// lmExpectRoute asserts that both families' routes meet the given expectation right now.
+func lmExpectRoute(routes lmRoutes, metric string, desc ...string) {
+	for _, r := range routes {
+		ExpectWithOffset(1, r.route()).To(lmRouteMatcher(metric), lmRouteDesc(r.family, desc))
 	}
 }
 
@@ -132,15 +207,20 @@ func lmSendGARP(w *workload.Workload) {
 	}
 }
 
-// lmGARPElicitsRoute sends GARPs from the workload until the expected route appears on the host.
-// Retrying the GARP makes the test robust against the GARP being sent just before Felix's
-// listener is ready.
-func lmGARPElicitsRoute(felix *infrastructure.Felix, w *workload.Workload, expectedMetric string) {
-	route := lmWorkloadRoute(felix, w)
+// lmGARPElicitsRoutes sends GARPs from the workload until the expected routes appear on the
+// host.  Retrying the GARP makes the test robust against the GARP being sent just before
+// Felix's listener is ready.  Only the IPv4 route needs the retry loop: once it has appeared
+// the GARP has been seen, and the IPv6 route follows from the same FSM transition.
+func lmGARPElicitsRoutes(felix *infrastructure.Felix, w *workload.Workload, expectedMetric string) {
+	routes := lmWorkloadRoutes(felix, w)
 	EventuallyWithOffset(1, func() string {
 		lmSendGARP(w)
-		return route()
-	}, "10s", "500ms").Should(ContainSubstring(expectedMetric))
+		return routes[0].route()
+	}, "10s", "500ms").Should(ContainSubstring(expectedMetric), lmRouteDesc(routes[0].family, nil))
+	for _, r := range routes[1:] {
+		EventuallyWithOffset(1, r.route, "10s", "500ms").Should(
+			ContainSubstring(expectedMetric), lmRouteDesc(r.family, nil))
+	}
 }
 
 // lmWatchForState returns a channel that is closed when the given Felix logs a live migration
@@ -150,15 +230,27 @@ func lmWatchForState(felix *infrastructure.Felix, toState string) chan struct{} 
 		"Live migration state transition.*to=" + toState))
 }
 
-func lmExpectReachableVia(felix *infrastructure.Felix, w *workload.Workload) {
-	cc := &connectivity.Checker{}
-	cc.ExpectSome(felix, w)
-	cc.CheckConnectivity()
+// lmExpectReachableVia checks that the given host can reach the workload.  Both IP families
+// are checked unless ipVersions restricts them, because the two families' routes are
+// programmed independently.
+func lmExpectReachableVia(felix *infrastructure.Felix, w *workload.Workload, ipVersions ...int) {
+	lmCheckConnectivity(connectivity.Some, felix, w, ipVersions)
 }
 
-func lmExpectNotReachableVia(felix *infrastructure.Felix, w *workload.Workload) {
+func lmExpectNotReachableVia(felix *infrastructure.Felix, w *workload.Workload, ipVersions ...int) {
+	lmCheckConnectivity(connectivity.None, felix, w, ipVersions)
+}
+
+func lmCheckConnectivity(expected connectivity.Expected, felix *infrastructure.Felix,
+	w *workload.Workload, ipVersions []int,
+) {
+	if len(ipVersions) == 0 {
+		ipVersions = []int{4, 6}
+	}
 	cc := &connectivity.Checker{}
-	cc.ExpectNone(felix, w)
+	for _, ipVersion := range ipVersions {
+		cc.Expect(expected, felix, w, connectivity.ExpectWithIPVersion(ipVersion))
+	}
 	cc.CheckConnectivity()
 }
 
@@ -169,6 +261,7 @@ func lmDumpDiagsOnFailure(tc infrastructure.TopologyContainers) {
 	}
 	for _, felix := range tc.Felixes {
 		felix.Exec("ip", "route", "show")
+		felix.Exec("ip", "-6", "route", "show")
 		felix.Exec("ip", "addr", "show")
 	}
 }
@@ -195,10 +288,12 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ live migration route progra
 			// would create it.  The WEPs carry the "openstack" orchestrator ID, as
 			// networking-calico's would, so that any OpenStack-specific handling in
 			// Felix is exercised.
-			source = workload.Run(tc.Felixes[0], "source", "default", lmMigratingIP, "8055", "tcp")
+			source = workload.Run(tc.Felixes[0], "source", "default", lmMigratingIP, "8055", "tcp",
+				workload.WithIPv6Address(lmMigratingIPv6))
 			source.WorkloadEndpoint.Spec.Orchestrator = api.OrchestratorOpenStack
 			source.ConfigureInInfra(infra)
-			target = workload.Run(tc.Felixes[1], "target", "default", lmMigratingIP, "8055", "tcp")
+			target = workload.Run(tc.Felixes[1], "target", "default", lmMigratingIP, "8055", "tcp",
+				workload.WithIPv6Address(lmMigratingIPv6))
 			target.WorkloadEndpoint.Spec.Orchestrator = api.OrchestratorOpenStack
 		})
 
@@ -245,11 +340,11 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ live migration route progra
 		}
 
 		It("should follow the mainline migration flow, with GARP detection", func() {
-			srcRouteFn := lmWorkloadRoute(tc.Felixes[0], source)
-			tgtRouteFn := lmWorkloadRoute(tc.Felixes[1], target)
+			srcRoutes := lmWorkloadRoutes(tc.Felixes[0], source)
+			tgtRoutes := lmWorkloadRoutes(tc.Felixes[1], target)
 
 			By("programming a normal-priority route for the source workload")
-			Eventually(srcRouteFn, "10s", "200ms").Should(ContainSubstring(lmNormalMetric))
+			lmEventuallyRoute(srcRoutes, lmNormalMetric, "10s", "200ms")
 			lmExpectReachableVia(tc.Felixes[0], source)
 
 			By("creating the LiveMigration and then the target WEP")
@@ -259,15 +354,15 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ live migration route progra
 
 			By("suppressing the target workload's route while awaiting the GARP")
 			Eventually(targetSeen, "10s").Should(BeClosed())
-			Consistently(tgtRouteFn, "3s", "500ms").Should(BeEmpty(),
+			lmConsistentlyRoute(tgtRoutes, lmNoRoute, "3s", "500ms",
 				"target route should be suppressed before the target VM is live")
-			Expect(srcRouteFn()).To(ContainSubstring(lmNormalMetric),
+			lmExpectRoute(srcRoutes, lmNormalMetric,
 				"source route should be untouched during migration")
 			lmExpectReachableVia(tc.Felixes[0], source)
 			lmExpectNotReachableVia(tc.Felixes[1], target)
 
 			By("programming an elevated-priority route when the target sends a GARP")
-			lmGARPElicitsRoute(tc.Felixes[1], target, lmElevatedMetric)
+			lmGARPElicitsRoutes(tc.Felixes[1], target, lmElevatedMetric)
 			lmExpectReachableVia(tc.Felixes[1], target)
 
 			By("completing the migration: removing the source WEP and the LiveMigration")
@@ -275,44 +370,44 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ live migration route progra
 			deleteLiveMigration("migration-1")
 
 			By("keeping the elevated route until the convergence time has elapsed")
-			Consistently(tgtRouteFn, "3s", "500ms").Should(ContainSubstring(lmElevatedMetric))
-			Eventually(srcRouteFn, "10s", "200ms").Should(BeEmpty(),
+			lmConsistentlyRoute(tgtRoutes, lmElevatedMetric, "3s", "500ms")
+			lmEventuallyRoute(srcRoutes, lmNoRoute, "10s", "200ms",
 				"source route should be removed with the source WEP")
-			Eventually(tgtRouteFn, "15s", "500ms").Should(ContainSubstring(lmNormalMetric))
+			lmEventuallyRoute(tgtRoutes, lmNormalMetric, "15s", "500ms")
 			lmExpectReachableVia(tc.Felixes[1], target)
 		})
 
 		It("should complete a migration even if the GARP is missed", func() {
-			tgtRouteFn := lmWorkloadRoute(tc.Felixes[1], target)
+			tgtRoutes := lmWorkloadRoutes(tc.Felixes[1], target)
 
 			By("creating the LiveMigration and then the target WEP")
 			targetSeen := lmWatchForState(tc.Felixes[1], "Target")
 			createLiveMigration("migration-1", source, target)
 			target.ConfigureInInfra(infra)
 			Eventually(targetSeen, "10s").Should(BeClosed())
-			Consistently(tgtRouteFn, "3s", "500ms").Should(BeEmpty())
+			lmConsistentlyRoute(tgtRoutes, lmNoRoute, "3s", "500ms")
 
 			By("completing the migration without any GARP having been sent")
 			source.RemoveFromInfra(infra)
 			deleteLiveMigration("migration-1")
 
 			By("programming an elevated route and then reverting to normal priority")
-			Eventually(tgtRouteFn, "10s", "200ms").Should(ContainSubstring(lmElevatedMetric))
+			lmEventuallyRoute(tgtRoutes, lmElevatedMetric, "10s", "200ms")
 			lmExpectReachableVia(tc.Felixes[1], target)
-			Eventually(tgtRouteFn, "15s", "500ms").Should(ContainSubstring(lmNormalMetric))
+			lmEventuallyRoute(tgtRoutes, lmNormalMetric, "15s", "500ms")
 			lmExpectReachableVia(tc.Felixes[1], target)
 		})
 
 		It("should handle migration failure", func() {
-			srcRouteFn := lmWorkloadRoute(tc.Felixes[0], source)
-			tgtRouteFn := lmWorkloadRoute(tc.Felixes[1], target)
+			srcRoutes := lmWorkloadRoutes(tc.Felixes[0], source)
+			tgtRoutes := lmWorkloadRoutes(tc.Felixes[1], target)
 
 			By("creating the LiveMigration and then the target WEP")
 			targetSeen := lmWatchForState(tc.Felixes[1], "Target")
 			createLiveMigration("migration-1", source, target)
 			target.ConfigureInInfra(infra)
 			Eventually(targetSeen, "10s").Should(BeClosed())
-			Consistently(tgtRouteFn, "3s", "500ms").Should(BeEmpty())
+			lmConsistentlyRoute(tgtRoutes, lmNoRoute, "3s", "500ms")
 
 			By("cleaning up the failed migration: removing the target WEP and LiveMigration")
 			baseSeen := lmWatchForState(tc.Felixes[1], "Base")
@@ -321,21 +416,21 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ live migration route progra
 			Eventually(baseSeen, "10s").Should(BeClosed())
 
 			By("never programming a route for the failed target")
-			Consistently(tgtRouteFn, "3s", "500ms").Should(BeEmpty())
+			lmConsistentlyRoute(tgtRoutes, lmNoRoute, "3s", "500ms")
 
 			By("leaving the source untouched throughout")
-			Expect(srcRouteFn()).To(ContainSubstring(lmNormalMetric))
+			lmExpectRoute(srcRoutes, lmNormalMetric)
 			lmExpectReachableVia(tc.Felixes[0], source)
 		})
 
 		It("should handle immediate re-migration back to the original host", func() {
-			srcRouteFn := lmWorkloadRoute(tc.Felixes[0], source)
-			tgtRouteFn := lmWorkloadRoute(tc.Felixes[1], target)
+			srcRoutes := lmWorkloadRoutes(tc.Felixes[0], source)
+			tgtRoutes := lmWorkloadRoutes(tc.Felixes[1], target)
 
 			By("migrating to the target host")
 			createLiveMigration("migration-1", source, target)
 			target.ConfigureInInfra(infra)
-			lmGARPElicitsRoute(tc.Felixes[1], target, lmElevatedMetric)
+			lmGARPElicitsRoutes(tc.Felixes[1], target, lmElevatedMetric)
 
 			By("starting a re-migration back to the original host")
 			// The workloads swap roles: the target of the first migration becomes the
@@ -344,41 +439,41 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ live migration route progra
 			// the original workload's route is suppressed but the first migration's
 			// target keeps its elevated route.
 			createLiveMigration("migration-2", target, source)
-			Eventually(srcRouteFn, "10s", "200ms").Should(BeEmpty(),
+			lmEventuallyRoute(srcRoutes, lmNoRoute, "10s", "200ms",
 				"original workload's route should be suppressed as re-migration target")
-			Expect(tgtRouteFn()).To(ContainSubstring(lmElevatedMetric))
+			lmExpectRoute(tgtRoutes, lmElevatedMetric)
 
 			By("reverting the re-migration's source to a normal route immediately")
 			// Once the first LiveMigration is deleted, the first migration's target
 			// becomes purely a migration source, which takes effect immediately, with
 			// no elevated-priority TimeWait period.
 			deleteLiveMigration("migration-1")
-			Eventually(tgtRouteFn, "10s", "200ms").Should(ContainSubstring(lmNormalMetric))
+			lmEventuallyRoute(tgtRoutes, lmNormalMetric, "10s", "200ms")
 
 			By("completing the reverse migration with a GARP from the original workload")
-			lmGARPElicitsRoute(tc.Felixes[0], source, lmElevatedMetric)
+			lmGARPElicitsRoutes(tc.Felixes[0], source, lmElevatedMetric)
 			lmExpectReachableVia(tc.Felixes[0], source)
 
 			By("finishing: removing the reverse migration's source WEP and LiveMigration")
 			target.RemoveFromInfra(infra)
 			deleteLiveMigration("migration-2")
-			Consistently(srcRouteFn, "3s", "500ms").Should(ContainSubstring(lmElevatedMetric))
-			Eventually(tgtRouteFn, "10s", "200ms").Should(BeEmpty())
-			Eventually(srcRouteFn, "15s", "500ms").Should(ContainSubstring(lmNormalMetric))
+			lmConsistentlyRoute(srcRoutes, lmElevatedMetric, "3s", "500ms")
+			lmEventuallyRoute(tgtRoutes, lmNoRoute, "10s", "200ms")
+			lmEventuallyRoute(srcRoutes, lmNormalMetric, "15s", "500ms")
 			lmExpectReachableVia(tc.Felixes[0], source)
 		})
 
 		It("should withdraw the target's route if the WEP is created before the LiveMigration", func() {
-			tgtRouteFn := lmWorkloadRoute(tc.Felixes[1], target)
+			tgtRoutes := lmWorkloadRoutes(tc.Felixes[1], target)
 
 			By("programming a normal route when the target WEP is created with no LiveMigration")
 			target.ConfigureInInfra(infra)
-			Eventually(tgtRouteFn, "10s", "200ms").Should(ContainSubstring(lmNormalMetric))
+			lmEventuallyRoute(tgtRoutes, lmNormalMetric, "10s", "200ms")
 
 			By("withdrawing the route when the LiveMigration arrives")
 			createLiveMigration("migration-1", source, target)
-			Eventually(tgtRouteFn, "10s", "200ms").Should(BeEmpty())
-			Consistently(tgtRouteFn, "3s", "500ms").Should(BeEmpty())
+			lmEventuallyRoute(tgtRoutes, lmNoRoute, "10s", "200ms")
+			lmConsistentlyRoute(tgtRoutes, lmNoRoute, "3s", "500ms")
 		})
 	})
 
@@ -431,9 +526,11 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ live migration route progra
 			// source starts out registered; the target pod is created by each test at
 			// the point in the migration flow where KubeVirt would create the target
 			// virt-launcher pod.
-			source = workload.Run(tc.Felixes[0], "source", "default", lmMigratingIP, "8055", "tcp")
+			source = workload.Run(tc.Felixes[0], "source", "default", lmMigratingIP, "8055", "tcp",
+				workload.WithIPv6Address(lmMigratingIPv6))
 			source.ConfigureInInfra(infra)
-			target = workload.Run(tc.Felixes[1], "target", "default", lmMigratingIP, "8055", "tcp")
+			target = workload.Run(tc.Felixes[1], "target", "default", lmMigratingIP, "8055", "tcp",
+				workload.WithIPv6Address(lmMigratingIPv6))
 		})
 
 		AfterEach(func() {
@@ -530,11 +627,11 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ live migration route progra
 		}
 
 		It("should follow the mainline migration flow, with GARP detection and IPAM owner swap", func() {
-			srcRouteFn := lmWorkloadRoute(tc.Felixes[0], source)
-			tgtRouteFn := lmWorkloadRoute(tc.Felixes[1], target)
+			srcRoutes := lmWorkloadRoutes(tc.Felixes[0], source)
+			tgtRoutes := lmWorkloadRoutes(tc.Felixes[1], target)
 
 			By("programming a normal-priority route for the source pod")
-			Eventually(srcRouteFn, "10s", "200ms").Should(ContainSubstring(lmNormalMetric))
+			lmEventuallyRoute(srcRoutes, lmNormalMetric, "10s", "200ms")
 			lmExpectReachableVia(tc.Felixes[0], source)
 
 			By("seeding the VM's IPAM allocation, as the CNI plugin would have")
@@ -547,20 +644,21 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ live migration route progra
 
 			By("suppressing the target pod's route while awaiting the GARP")
 			Eventually(targetSeen, "10s").Should(BeClosed())
-			Consistently(tgtRouteFn, "3s", "500ms").Should(BeEmpty(),
+			lmConsistentlyRoute(tgtRoutes, lmNoRoute, "3s", "500ms",
 				"target route should be suppressed before the target VM is live")
-			Expect(srcRouteFn()).To(ContainSubstring(lmNormalMetric),
+			lmExpectRoute(srcRoutes, lmNormalMetric,
 				"source route should be untouched during migration")
 
 			// Unlike in the OpenStack-style suite, the VM's IP is still reachable from
 			// the target host here: the seeded IPAM block is affine to the source node
 			// and the source pod is the active owner, so Felix routes the traffic to
 			// the source host, where the still-live source VM answers.  That is the
-			// intended during-migration behaviour.
-			lmExpectReachableVia(tc.Felixes[1], target)
+			// intended during-migration behaviour.  Only the IPv4 address has seeded
+			// IPAM state, so this is the one connectivity check that is IPv4-only.
+			lmExpectReachableVia(tc.Felixes[1], target, 4)
 
 			By("programming an elevated-priority route when the target sends a GARP")
-			lmGARPElicitsRoute(tc.Felixes[1], target, lmElevatedMetric)
+			lmGARPElicitsRoutes(tc.Felixes[1], target, lmElevatedMetric)
 			lmExpectReachableVia(tc.Felixes[1], target)
 
 			By("swapping the IPAM owner attributes to make the target pod the active owner")
@@ -571,39 +669,39 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ live migration route progra
 			source.RemoveFromInfra(infra)
 
 			By("keeping the elevated route until the convergence time has elapsed")
-			Consistently(tgtRouteFn, "3s", "500ms").Should(ContainSubstring(lmElevatedMetric))
-			Eventually(srcRouteFn, "10s", "200ms").Should(BeEmpty(),
+			lmConsistentlyRoute(tgtRoutes, lmElevatedMetric, "3s", "500ms")
+			lmEventuallyRoute(srcRoutes, lmNoRoute, "10s", "200ms",
 				"source route should be removed with the source pod")
-			Eventually(tgtRouteFn, "15s", "500ms").Should(ContainSubstring(lmNormalMetric))
+			lmEventuallyRoute(tgtRoutes, lmNormalMetric, "15s", "500ms")
 			lmExpectReachableVia(tc.Felixes[1], target)
 		})
 
 		It("should handle migration failure", func() {
-			srcRouteFn := lmWorkloadRoute(tc.Felixes[0], source)
-			tgtRouteFn := lmWorkloadRoute(tc.Felixes[1], target)
+			srcRoutes := lmWorkloadRoutes(tc.Felixes[0], source)
+			tgtRoutes := lmWorkloadRoutes(tc.Felixes[1], target)
 
 			By("creating the VMIM and then the target pod")
 			targetSeen := lmWatchForState(tc.Felixes[1], "Target")
 			vmim := createVMIM("migration-1", kubevirtv1.MigrationRunning, source.Name)
 			configureTargetPod(vmim)
 			Eventually(targetSeen, "10s").Should(BeClosed())
-			Consistently(tgtRouteFn, "3s", "500ms").Should(BeEmpty())
+			lmConsistentlyRoute(tgtRoutes, lmNoRoute, "3s", "500ms")
 
 			By("keeping the target's route suppressed when the migration fails")
 			// A Failed VMIM still identifies the target pod, and the target VM never
 			// became live, so the route must stay suppressed until KubeVirt tears the
 			// target pod down.
 			setVMIMPhase("migration-1", kubevirtv1.MigrationFailed)
-			Consistently(tgtRouteFn, "3s", "500ms").Should(BeEmpty())
+			lmConsistentlyRoute(tgtRoutes, lmNoRoute, "3s", "500ms")
 
 			By("never programming a route for the target once it is torn down")
 			baseSeen := lmWatchForState(tc.Felixes[1], "Base")
 			target.RemoveFromInfra(infra)
 			Eventually(baseSeen, "10s").Should(BeClosed())
-			Consistently(tgtRouteFn, "3s", "500ms").Should(BeEmpty())
+			lmConsistentlyRoute(tgtRoutes, lmNoRoute, "3s", "500ms")
 
 			By("leaving the source untouched throughout")
-			Expect(srcRouteFn()).To(ContainSubstring(lmNormalMetric))
+			lmExpectRoute(srcRoutes, lmNormalMetric)
 			lmExpectReachableVia(tc.Felixes[0], source)
 		})
 	})

--- a/felix/fv/live_migration_test.go
+++ b/felix/fv/live_migration_test.go
@@ -208,9 +208,12 @@ func lmSendGARP(w *workload.Workload) {
 }
 
 // lmGARPElicitsRoutes sends GARPs from the workload until the expected routes appear on the
-// host.  Retrying the GARP makes the test robust against the GARP being sent just before
-// Felix's listener is ready.  Only the IPv4 route needs the retry loop: once it has appeared
-// the GARP has been seen, and the IPv6 route follows from the same FSM transition.
+// host.  Re-sending the GARP on each poll makes the test robust against the GARP being sent
+// just before Felix's listener is ready, and only the first (IPv4) assertion needs to do that:
+// once its route appears the GARP has demonstrably been seen, and the remaining families follow
+// from the same FSM transition.  Those still get a bounded wait rather than a bare expectation,
+// because each family's routes are programmed independently, by its own endpoint manager, and
+// may land a moment later.
 func lmGARPElicitsRoutes(felix *infrastructure.Felix, w *workload.Workload, expectedMetric string) {
 	routes := lmWorkloadRoutes(felix, w)
 	EventuallyWithOffset(1, func() string {


### PR DESCRIPTION
## What this fixes

Live migration route handling was wired up for IPv4 only. `liveMigrationMonitor`
held a single `listener` field, assigned the **IPv4** endpoint manager
(`int_dataplane.go`), and the IPv6 endpoint manager was never registered. Each
endpoint manager keeps its own copy of the live migration state and programs its
own family's routes, so on a dual-stack cluster the IPv6 side did nothing at all:
`pendingLiveMigrationStates` on the v6 manager was always empty, and
`calculateRoutes` therefore never suppressed or elevated IPv6 workload routes.

The fix is to hold a list of listeners and register both endpoint managers.

### Correction to the ticket's stated cause

CORE-12806 hypothesises that the IPv6 FIB treats `RTM_NEWROUTE` more strictly
than IPv4, and that BIRD needs to use `REPLACE`. **That is not what is
happening.** Verified in network namespaces on kernel 6.8: both families behave
identically — a route add returns `EEXIST` iff a route exists with the same
prefix *and* the same metric (a differing nexthop does not help), and succeeds
whenever the metric differs. For IPv6 an unset metric defaults to 1024, which is
why a *non-elevated* route collides with Felix's normal-priority route. The BIRD
filters in `felix/etc/bird/calico-bird6.conf.template` are already correct and
family-symmetric; **no BIRD work is needed**.

The diags from the CI run the ticket cites show the real signature directly: on
the migration target node the VM's IPv4 route is at `metric 512` (elevated)
while its IPv6 route is at `metric 1024` (normal). The `Netlink: File exists`
from bird6 is a downstream symptom — with the target's v6 route left at 1024 the
advertised `bgp_local_pref` is the non-elevated value, so the source computes
`krt_metric` 1024 and collides with its own local route at 1024.

### The more serious half, which the ticket does not mention

Because Target-state *suppression* was also missing for IPv6, the migration
target holds and advertises a local /128 pointing at a tap the VM is not running
on yet, for the entire pre-copy phase. Remote nodes then choose between two
equal-metric paths, so **IPv6 traffic to a migrating VM can black-hole for the
whole migration** — considerably worse than log noise on the source node.

## Changes

- `felix/dataplane/linux/live_migration.go`: `listener` → `listeners []liveMigrationListener`
  plus `registerListener()`; `ResolveUpdateBatch` dispatches to each.
- `felix/dataplane/linux/int_dataplane.go`: register **both** `epManager` and
  `epManagerV6` with the monitor.
- `felix/design/dataplane.md` (Dual stack): new passage plus review notes on the
  invariant this bug is an instance of — a cross-cutting singleton that feeds the
  per-family managers must fan out to *all* of them, and a single-valued
  reference field where a list belongs is the smell.
- `felix/fv/live_migration_test.go`: dual-stack coverage (below), and one
  drive-by — `CurrentSpecReport().Failed()` in place of the Ginkgo-v2-deprecated
  `CurrentGinkgoTestDescription()`, which otherwise prints a warning on every
  run. Only this file, which the PR already rewrites; the remaining occurrences
  in `felix/fv` are left to be fixed opportunistically as those files are next
  touched.

## Testing

All of the following was run on this branch head.

- **Unit**: `42 of 1013` specs green across the constructor and live-migration
  focus. Two new constructor specs assert that one endpoint manager is registered
  per *enabled* IP version — 2 listeners dual-stack, 1 with IPv6 disabled — via a
  `LiveMigrationListenerCount()` test hook. The endpoint manager's own
  suppression/elevation logic was already correct and already covered for both
  families; only the wiring was missing, which is why no existing unit test
  caught this.
- **FV**: the dual-stack live-migration suite is green — `7 of 7 Passed` in 170s,
  covering both the OpenStack-style and KubeVirt-style topologies.
- **Negative controls**, with the `epManagerV6` registration removed to
  reintroduce the bug:
  - unit → `11 Passed | 1 Failed`, on *"both endpoint managers should listen for
    live migration state changes"*;
  - FV → both mainline specs fail on the IPv6 assertion specifically, with
    `IPv6 route: target route should be suppressed before the target VM is live` /
    `Expected <string>: dead:beef::2 metric 1024 pref medium` / `to be empty`,
    IPv4 still passing.

  The FV failure is worth noting for what it demonstrates: the new assertions
  catch the *black-hole condition itself* — an unsuppressed IPv6 route on the
  target while the VM is still on the source — not merely a metric mismatch.
- Reproducing the `Netlink: File exists` symptom is out of scope here: it needs
  BIRD and the OpenStack topology, and it is downstream of the missing elevation.

### Why the FV is dual-stack in place, not IPv6 variants

The migration flow assertions are identical per family, so duplicating the specs
would have doubled a slow suite for no extra coverage. Instead every route
expectation goes through a small `lmRoutes` vocabulary
(`lmEventuallyRoute` / `lmConsistentlyRoute` / `lmExpectRoute`) that asserts each
family and labels failures with it, so a family cannot be forgotten at a call
site. `EnableIPv6` is set in the suite's own `lmTopologyOptions()`, so only these
7 specs run dual-stack — the rest of `felix/fv` is unaffected.

**Release note:**
```release-note
Fix IPv6 route programming during VM live migration: IPv6 workload routes are now suppressed on the migration target until the VM goes live, and elevated in priority after cutover, as was already the case for IPv4.  Previously IPv6 traffic to a migrating VM could black-hole for the duration of the migration on dual-stack clusters.
```
