### PR TITLE
Register the cluster-info webhook in the calico helm chart

### DIFF
--- a/charts/calico/templates/calico-webhooks.yaml
+++ b/charts/calico/templates/calico-webhooks.yaml
@@ -160,4 +160,33 @@ webhooks:
           - stagednetworkpolicies
           - stagedglobalnetworkpolicies
           - stagedkubernetesnetworkpolicies
+  # Blocks user writes to ClusterInformation, which is managed by Calico system components.
+  # This mirrors the write protection provided by the aggregated API server.
+  - name: cluster-info.api.projectcalico.org
+    admissionReviewVersions:
+      - v1
+    clientConfig:
+      # Replace with the CA bundle for the webhook TLS certificate.
+      caBundle: ""
+      service:
+        name: calico-webhooks
+        namespace: kube-system
+        path: /cluster-info
+    # Ignore rather than Fail: calico-node and typha write ClusterInformation at startup,
+    # so a cluster restart must not depend on the webhook being up.
+    failurePolicy: Ignore
+    sideEffects: None
+    timeoutSeconds: 5
+    rules:
+      - apiGroups:
+          - projectcalico.org
+        apiVersions:
+          - v3
+        operations:
+          - CREATE
+          - UPDATE
+          - DELETE
+        resources:
+          - clusterinformations
+        scope: '*'
 {{- end }}

--- a/charts/calico/templates/calico-webhooks.yaml
+++ b/charts/calico/templates/calico-webhooks.yaml
@@ -154,12 +154,13 @@ webhooks:
           - CREATE
           - UPDATE
           - DELETE
+          - CONNECT
         resources:
           - networkpolicies
           - globalnetworkpolicies
           - stagednetworkpolicies
           - stagedglobalnetworkpolicies
-          - stagedkubernetesnetworkpolicies
+        scope: '*'
   # Blocks user writes to ClusterInformation, which is managed by Calico system components.
   # This mirrors the write protection provided by the aggregated API server.
   - name: cluster-info.api.projectcalico.org

--- a/manifests/calico-v3-crds.yaml
+++ b/manifests/calico-v3-crds.yaml
@@ -13524,3 +13524,32 @@ webhooks:
           - stagednetworkpolicies
           - stagedglobalnetworkpolicies
           - stagedkubernetesnetworkpolicies
+  # Blocks user writes to ClusterInformation, which is managed by Calico system components.
+  # This mirrors the write protection provided by the aggregated API server.
+  - name: cluster-info.api.projectcalico.org
+    admissionReviewVersions:
+      - v1
+    clientConfig:
+      # Replace with the CA bundle for the webhook TLS certificate.
+      caBundle: ""
+      service:
+        name: calico-webhooks
+        namespace: kube-system
+        path: /cluster-info
+    # Ignore rather than Fail: calico-node and typha write ClusterInformation at startup,
+    # so a cluster restart must not depend on the webhook being up.
+    failurePolicy: Ignore
+    sideEffects: None
+    timeoutSeconds: 5
+    rules:
+      - apiGroups:
+          - projectcalico.org
+        apiVersions:
+          - v3
+        operations:
+          - CREATE
+          - UPDATE
+          - DELETE
+        resources:
+          - clusterinformations
+        scope: '*'

--- a/manifests/calico-v3-crds.yaml
+++ b/manifests/calico-v3-crds.yaml
@@ -13518,12 +13518,13 @@ webhooks:
           - CREATE
           - UPDATE
           - DELETE
+          - CONNECT
         resources:
           - networkpolicies
           - globalnetworkpolicies
           - stagednetworkpolicies
           - stagedglobalnetworkpolicies
-          - stagedkubernetesnetworkpolicies
+        scope: '*'
   # Blocks user writes to ClusterInformation, which is managed by Calico system components.
   # This mirrors the write protection provided by the aggregated API server.
   - name: cluster-info.api.projectcalico.org


### PR DESCRIPTION
The `calico` chart only registered the tiered RBAC webhook, so helm and manifest installs got no write protection on ClusterInformation while operator-managed installs did. That matters because `datastoreReady=false` is the cluster-wide IPAM pause switch, and the aggregated API server rejects these writes outright. This registers the `/cluster-info` handler the webhooks component already serves, using `failurePolicy: Ignore` since calico-node and typha write ClusterInformation at startup, and aligns the existing tiered-rbac rule with what the operator renders. [CORE-13249](https://tigera.atlassian.net/browse/CORE-13249)

```release-note
Helm and manifest installs now block user writes to ClusterInformation, matching the protection already provided by the aggregated API server and operator-managed installs.
```

[CORE-13249]: https://tigera.atlassian.net/browse/CORE-13249?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ