### PR TITLE
fix(felix): count dataplane stats errors once, with a counter

### DIFF
--- a/felix/collector/collector.go
+++ b/felix/collector/collector.go
@@ -89,13 +89,10 @@ var (
 		Help: "Histogram for measuring latency for processing merging the proto.DataplaneStatistics to the current data cache.",
 	})
 
-	gaugeDataplaneStatsUpdateErrorsPerMinute = prometheus.NewGauge(prometheus.GaugeOpts{
-		Name: "felix_collector_dataplanestats_update_processing_errors_per_minute",
+	counterDataplaneStatsUpdateErrors = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "felix_collector_dataplanestats_update_processing_errors_total",
 		Help: "Number of errors encountered when processing merging the proto.DataplaneStatistics to the current data cache.",
 	})
-
-	dataplaneStatsUpdateLastErrorReportTime time.Time
-	dataplaneStatsUpdateErrorsInLastMinute  uint32
 
 	// epStats cache prometheus metrics
 	gaugeEpStatsCacheSizeLength = prometheus.NewGauge(prometheus.GaugeOpts{
@@ -126,7 +123,7 @@ func init() {
 	prometheus.MustRegister(histogramDumpStatsLatency)
 	prometheus.MustRegister(gaugeEpStatsCacheSizeLength)
 	prometheus.MustRegister(histogramDataplaneStatsUpdate)
-	prometheus.MustRegister(gaugeDataplaneStatsUpdateErrorsPerMinute)
+	prometheus.MustRegister(counterDataplaneStatsUpdateErrors)
 	prometheus.MustRegister(counterPolicyEvalBatches)
 	prometheus.MustRegister(counterPolicyEvalFlows)
 	prometheus.MustRegister(histogramPolicyEvalSweepDuration)
@@ -250,9 +247,6 @@ func (c *collector) Start() error {
 			log.Warning("missing DataplaneInfoReader")
 		}
 	}
-
-	// init prometheus metrics timings
-	dataplaneStatsUpdateLastErrorReportTime = time.Now()
 
 	// Start all metric reporters
 	for _, r := range c.metricReporters {
@@ -933,7 +927,7 @@ func (c *collector) convertDataplaneStatsAndApplyUpdate(d *proto.DataplaneStats)
 	t, err := extractTupleFromDataplaneStats(d)
 	if err != nil {
 		log.Errorf("unable to extract 5-tuple from DataplaneStats: %v", err)
-		reportDataplaneStatsUpdateErrorMetrics(1)
+		counterDataplaneStatsUpdateErrors.Inc()
 		return
 	}
 
@@ -1083,7 +1077,6 @@ func extractTupleFromDataplaneStats(d *proto.DataplaneStats) (tuple.Tuple, error
 		case "udp":
 			protocol = 17
 		default:
-			reportDataplaneStatsUpdateErrorMetrics(1)
 			return tuple.Tuple{}, fmt.Errorf("unhandled protocol: %s", n)
 		}
 	}
@@ -1091,29 +1084,16 @@ func extractTupleFromDataplaneStats(d *proto.DataplaneStats) (tuple.Tuple, error
 	// Use the standard go net library to parse the IP since this always returns IPs as 16 bytes.
 	srcIP, ok := ip.ParseIPAs16Byte(d.SrcIp)
 	if !ok {
-		reportDataplaneStatsUpdateErrorMetrics(1)
 		return tuple.Tuple{}, fmt.Errorf("bad source IP: %s", d.SrcIp)
 	}
 	dstIP, ok := ip.ParseIPAs16Byte(d.DstIp)
 	if !ok {
-		reportDataplaneStatsUpdateErrorMetrics(1)
 		return tuple.Tuple{}, fmt.Errorf("bad destination IP: %s", d.DstIp)
 	}
 
 	// Locate the data for this connection, creating if not yet available (it's possible to get an update
 	// before nflogs or conntrack).
 	return tuple.Make(srcIP, dstIP, int(protocol), int(d.SrcPort), int(d.DstPort)), nil
-}
-
-// reportDataplaneStatsUpdateErrorMetrics reports error statistics encoutered when updating Dataplane stats
-func reportDataplaneStatsUpdateErrorMetrics(dataplaneErrorDelta uint32) {
-	if dataplaneStatsUpdateLastErrorReportTime.Before(time.Now().Add(-1 * time.Minute)) {
-		dataplaneStatsUpdateErrorsInLastMinute = dataplaneErrorDelta
-	} else {
-		dataplaneStatsUpdateErrorsInLastMinute += dataplaneErrorDelta
-	}
-	dataplaneStatsUpdateErrorsInLastMinute += dataplaneErrorDelta
-	gaugeDataplaneStatsUpdateErrorsPerMinute.Set(float64(dataplaneStatsUpdateErrorsInLastMinute))
 }
 
 // Logrus Formatter that strips the log entry of formatting such as time, log

--- a/felix/collector/dataplane_stats_metrics_test.go
+++ b/felix/collector/dataplane_stats_metrics_test.go
@@ -1,0 +1,114 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+import (
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+
+	"github.com/projectcalico/calico/felix/calc"
+	"github.com/projectcalico/calico/felix/proto"
+)
+
+// A DataplaneStats update that the collector cannot turn into a 5-tuple is one error, so it must
+// move the counter by one. It used to move it by four: the extract helper reported at its own
+// error paths, the caller reported the error it returned, and the reporting function added each
+// delta twice.
+func TestConvertDataplaneStatsCountsEachBadUpdateOnce(t *testing.T) {
+	RegisterTestingT(t)
+
+	for _, tc := range []struct {
+		name      string
+		stats     *proto.DataplaneStats
+		wantDelta float64
+	}{
+		{
+			name: "unhandled protocol name",
+			stats: &proto.DataplaneStats{
+				SrcIp: localIp1Str, DstIp: localIp2Str, SrcPort: 1000, DstPort: 2000,
+				Protocol: &proto.Protocol{NumberOrName: &proto.Protocol_Name{Name: "sctp"}},
+			},
+			wantDelta: 1,
+		},
+		{
+			name: "bad source IP",
+			stats: &proto.DataplaneStats{
+				SrcIp: "not-an-ip", DstIp: localIp2Str, SrcPort: 1000, DstPort: 2000,
+				Protocol: &proto.Protocol{NumberOrName: &proto.Protocol_Number{Number: proto_tcp}},
+			},
+			wantDelta: 1,
+		},
+		{
+			name: "bad destination IP",
+			stats: &proto.DataplaneStats{
+				SrcIp: localIp1Str, DstIp: "not-an-ip", SrcPort: 1000, DstPort: 2000,
+				Protocol: &proto.Protocol{NumberOrName: &proto.Protocol_Number{Number: proto_tcp}},
+			},
+			wantDelta: 1,
+		},
+		{
+			name: "good update",
+			stats: &proto.DataplaneStats{
+				SrcIp: localIp1Str, DstIp: localIp2Str, SrcPort: 1000, DstPort: 2000,
+				Protocol: &proto.Protocol{NumberOrName: &proto.Protocol_Number{Number: proto_tcp}},
+			},
+			wantDelta: 0,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			RegisterTestingT(t)
+			c := newDataplaneStatsTestCollector()
+
+			// The counter is package level and other tests in this package move it, so compare a
+			// delta rather than an absolute value.
+			before := testutil.ToFloat64(counterDataplaneStatsUpdateErrors)
+			c.convertDataplaneStatsAndApplyUpdate(tc.stats)
+			after := testutil.ToFloat64(counterDataplaneStatsUpdateErrors)
+
+			Expect(after - before).To(Equal(tc.wantDelta))
+		})
+	}
+}
+
+// extractTupleFromDataplaneStats is a pure conversion: it reports the failure by returning an
+// error, and leaves counting it to the caller. Reporting in both places is what double counted.
+func TestExtractTupleFromDataplaneStatsReportsNoMetric(t *testing.T) {
+	RegisterTestingT(t)
+
+	before := testutil.ToFloat64(counterDataplaneStatsUpdateErrors)
+	_, err := extractTupleFromDataplaneStats(&proto.DataplaneStats{
+		SrcIp: "not-an-ip", DstIp: localIp2Str, SrcPort: 1000, DstPort: 2000,
+		Protocol: &proto.Protocol{NumberOrName: &proto.Protocol_Number{Number: proto_tcp}},
+	})
+
+	Expect(err).To(HaveOccurred())
+	Expect(testutil.ToFloat64(counterDataplaneStatsUpdateErrors)).To(Equal(before))
+}
+
+func newDataplaneStatsTestCollector() *collector {
+	epMap := map[[16]byte]calc.EndpointData{
+		localIp1: localEd1,
+		localIp2: localEd2,
+	}
+	return newCollector(newMockLookupsCache(epMap, nil, nil, nil), &Config{
+		AgeTimeout:            10 * time.Second,
+		InitialReportingDelay: 5 * time.Second,
+		ExportingInterval:     time.Second,
+		FlowLogsFlushInterval: time.Second,
+	}).(*collector)
+}


### PR DESCRIPTION
### Description

`felix_collector_dataplanestats_update_processing_errors_per_minute` could not report what its name claimed. Three defects stacked up in `reportDataplaneStatsUpdateErrorMetrics`:

```go
if dataplaneStatsUpdateLastErrorReportTime.Before(time.Now().Add(-1 * time.Minute)) {
    dataplaneStatsUpdateErrorsInLastMinute = dataplaneErrorDelta
} else {
    dataplaneStatsUpdateErrorsInLastMinute += dataplaneErrorDelta
}
dataplaneStatsUpdateErrorsInLastMinute += dataplaneErrorDelta   // counted a second time
```

1. **Each error counted twice** — the branch adds the delta, then the line after the branch adds it again.
2. **The window never rolled.** `dataplaneStatsUpdateLastErrorReportTime` was assigned once, in `Start()`, and never again, so after a minute of uptime the `Before(...)` test was permanently true and the count reset on every error.
3. **Every call site double-reported.** `extractTupleFromDataplaneStats` reported at each of its three error paths *and* returned an error that `convertDataplaneStatsAndApplyUpdate` reported again.

Net effect on a Felix up longer than a minute: the gauge sat at exactly 2 whenever an error arrived — whatever the real rate — and stayed there once errors stopped.

A per-minute gauge is the wrong shape regardless: Prometheus derives rates itself, and a gauge only written when an error arrives cannot decay to zero. So this replaces it with a counter and lets queries do the rest:

```
felix_collector_dataplanestats_update_processing_errors_total
```

The report now happens once, at `convertDataplaneStatsAndApplyUpdate`, which already fires on any error the extract helper returns. That makes `extractTupleFromDataplaneStats` a pure conversion with no metric side effects, and leaves the only reporting point on the collector's own goroutine — so no globals and no locking.

### Follow-ups this needs from others

- **Docs**: the old name is in the Enterprise Felix metrics table — `tigera/docs`, `calico-enterprise/reference/component-resources/node/felix/prometheus.mdx` (line 154), plus the `*_versioned_docs` copies for 3.20-2 … 3.24-1. Hence `docs-pr-required`.
- `tigera/calico-private` and `tigera/felix-private` carry the same code and need the fix porting separately.

Noticed but deliberately left out of scope: if `DataplaneStats.Protocol`'s oneof is unset, neither `case` in `extractTupleFromDataplaneStats` matches, so `protocol` stays `0` and the helper returns a tuple for protocol 0 with **no** error — the flow is silently misattributed and no error is counted. Worth its own PR.

### Todos

- [x] Unit tests in a new file (`felix/collector/dataplane_stats_metrics_test.go`, so it does not conflict with the other collector PRs in flight): each of the three bad-update kinds moves the counter by exactly 1, a good update moves it by 0, and the extract helper on its own moves nothing. Verified as real regression tests by re-adding each half of the double-report and watching the matching case fail.

### Release Note

```release-note
Replaced the felix_collector_dataplanestats_update_processing_errors_per_minute gauge, which reported a value unrelated to the real error rate and never decayed, with a felix_collector_dataplanestats_update_processing_errors_total counter.
```
