### PR TITLE
Recreate the nftables table atomically with the rewrite

### DIFF
--- a/felix/dataplane/linux/endpoint_mgr_test.go
+++ b/felix/dataplane/linux/endpoint_mgr_test.go
@@ -4076,6 +4076,7 @@ func (f *fakeMapsDataplane) FinishMapUpdates(updates *nftables.MapUpdates)      
 func (f *fakeMapsDataplane) LoadDataplaneState(ctx context.Context, mapNames []string) error {
 	return nil
 }
+func (f *fakeMapsDataplane) InvalidateMapsCache() {}
 
 // fakeFlowtableHandler records the workload interface lists handed to the flowtable.
 type fakeFlowtableHandler struct {

--- a/felix/design/dataplane.md
+++ b/felix/design/dataplane.md
@@ -413,6 +413,17 @@ reconciliation of `*tables` chains and rules. The model:
   free: Felix still computes the hash delta and reprograms only
   changed rules, partly to avoid resetting iptables packet/byte
   counters on rules that didn't change.
+- **nftables rebuilds the table atomically after repeated
+  failures.** When `Apply()` has failed several times in a row, the
+  nftables backend recreates the table in case the change it is
+  trying to make is incompatible with the current state. The
+  `delete table` and `add table` go in the *same* transaction as
+  the rewrite of every chain and rule, and the sets and maps in the
+  table are marked for reprogramming at the same time. A failed
+  attempt therefore leaves the existing ruleset alone rather than
+  stripping the base chains and their hooks, which would leave
+  traffic unfiltered. iptables has no equivalent; its retry loop
+  only backs off.
 
 ### iptables vs nftables: parity and divergence
 

--- a/felix/nftables/fake_test.go
+++ b/felix/nftables/fake_test.go
@@ -16,6 +16,7 @@ package nftables_test
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"time"
 
@@ -60,6 +61,9 @@ type fakeNFT struct {
 
 	// Allow overriding the next ListAll response to be an error.
 	ListAllError error
+
+	// Number of subsequent Run calls to fail without touching the underlying fake.
+	RunErrors int
 
 	// Track the number of List calls (simulates nft process spawns).
 	ListCallCount int
@@ -108,7 +112,22 @@ func (f *fakeNFT) NewTransaction() *knftables.Transaction {
 // IsAlreadyExists methods can be used to test the result.
 func (f *fakeNFT) Run(ctx context.Context, tx *knftables.Transaction) error {
 	f.preRun(tx)
+	if err := f.takeRunError(); err != nil {
+		logrus.WithError(err).Info("Returning test error from Run")
+		return err
+	}
 	return f.fake.Run(ctx, tx)
+}
+
+func (f *fakeNFT) takeRunError() error {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+
+	if f.RunErrors == 0 {
+		return nil
+	}
+	f.RunErrors--
+	return errors.New("injected nft failure")
 }
 
 // Transactions returns a copy of the transactions Run has seen, for test assertions.

--- a/felix/nftables/maps.go
+++ b/felix/nftables/maps.go
@@ -47,6 +47,10 @@ type MapsDataplane interface {
 	MapUpdates() *MapUpdates
 	FinishMapUpdates(updates *MapUpdates)
 	LoadDataplaneState(ctx context.Context, mapNames []string) error
+
+	// InvalidateMapsCache discards our view of what is programmed, so that everything is
+	// reprogrammed. Used when the whole table is about to be recreated underneath us.
+	InvalidateMapsCache()
 }
 
 var _ MapsDataplane = &Maps{}
@@ -407,6 +411,15 @@ func (s *Maps) LoadDataplaneState(ctx context.Context, maps []string) error {
 	}
 
 	return nil
+}
+
+func (s *Maps) InvalidateMapsCache() {
+	s.logCxt.Debug("Discarding cached view of programmed maps.")
+	s.mapNameToProgrammedMetadata.Dataplane().DeleteAll()
+	for name, members := range s.mapNameToMembers {
+		members.Dataplane().DeleteAll()
+		s.updateDirtiness(name)
+	}
 }
 
 func (s *Maps) NFTablesMap(name string) *knftables.Map {

--- a/felix/nftables/table.go
+++ b/felix/nftables/table.go
@@ -1195,6 +1195,10 @@ func (t *NftablesTable) Apply() (rescheduleAfter time.Duration) {
 // queueTableRecreate arranges for the next applyUpdates to delete and re-add the table in the same
 // transaction that rewrites the whole ruleset, so the table is never left without its base chains.
 func (t *NftablesTable) queueTableRecreate() {
+	if t.recreatePending {
+		// Already queued, and the desired state cannot change mid-retry, so nothing to redo.
+		return
+	}
 	t.recreatePending = true
 
 	// Nothing in the table survives the recreate, so drop our view of it and mark everything we

--- a/felix/nftables/table.go
+++ b/felix/nftables/table.go
@@ -1213,8 +1213,8 @@ func (t *NftablesTable) queueTableRecreate() {
 
 	// Sets and maps live in the table too, and each layer programs them in its own transaction, so
 	// tell both that what they think they programmed is gone.
-	t.IPSetsDataplane.QueueResync()
-	t.MapsDataplane.InvalidateMapsCache()
+	t.QueueResync()
+	t.InvalidateMapsCache()
 
 	// We already know what the table will contain, so there is nothing to be gained from reading
 	// it back before the retry.

--- a/felix/nftables/table.go
+++ b/felix/nftables/table.go
@@ -1211,11 +1211,6 @@ func (t *NftablesTable) queueTableRecreate() {
 	}
 	t.flowtableDirty = t.flowtableEnabled
 
-	// Sets and maps live in the table too, and each layer programs them in its own transaction, so
-	// tell both that what they think they programmed is gone.
-	t.QueueResync()
-	t.InvalidateMapsCache()
-
 	// We already know what the table will contain, so there is nothing to be gained from reading
 	// it back before the retry.
 	t.inSyncWithDataPlane = true
@@ -1237,6 +1232,14 @@ func (t *NftablesTable) applyUpdates() error {
 	// - Create any new maps.
 	// - Create any new chains / rules.
 	// - Add elements to maps.
+	// The recreate below takes the sets and maps with it, and each layer tracks its own view of
+	// what it programmed. Drop those views here, next to the recreate they depend on, so the two
+	// cannot get out of step.
+	if t.recreatePending && !t.disabled {
+		t.QueueResync()
+		t.InvalidateMapsCache()
+	}
+
 	mapUpdates := t.MapUpdates()
 
 	if !t.disabled {

--- a/felix/nftables/table.go
+++ b/felix/nftables/table.go
@@ -292,6 +292,9 @@ type NftablesTable struct {
 	// to what we calculate from chainToContents.
 	chainToDataplaneHashes map[string][]string
 
+	// recreatePending is set by queueTableRecreate after repeated programming failures.
+	recreatePending bool
+
 	// hashCommentPrefix holds the prefix that we prepend to our rule-tracking hashes.
 	hashCommentPrefix string
 
@@ -1137,21 +1140,16 @@ func (t *NftablesTable) Apply() (rescheduleAfter time.Duration) {
 
 		if err := t.applyUpdates(); err != nil {
 			if retries > 0 {
-				if retries < 6 {
-					// If we hit multiple failures in a row, trigger a full table rebuild on the next iteration.
-					// This can help in case we are trying to make a change that is incompatible with the current table state.
-					t.logCxt.Warn("Recreating table due to prior nftables programming error")
-					tx := t.nft.NewTransaction()
-					tx.Delete(&knftables.Table{})
-					tx.Add(&knftables.Table{})
-
-					if err := t.runTransaction(tx); err != nil {
-						t.logCxt.WithError(err).Warn("Failed to delete table, continuing anyway")
-					}
+				if retries < 6 && !t.disabled {
+					// If we hit multiple failures in a row, rebuild the table from scratch on the next
+					// iteration. This can help in case we are trying to make a change that is
+					// incompatible with the current table state.
+					t.logCxt.Warn("Queueing table recreate due to prior nftables programming error")
+					t.queueTableRecreate()
+				} else {
+					// Reload the data plane state in case we're out of sync.
+					t.loadDataplaneState()
 				}
-
-				// Reload the data plane state in case we're out of sync.
-				t.loadDataplaneState()
 
 				retries--
 				t.logCxt.WithError(err).Warn("Failed to program nftables, will retry")
@@ -1194,6 +1192,35 @@ func (t *NftablesTable) Apply() (rescheduleAfter time.Duration) {
 	return
 }
 
+// queueTableRecreate arranges for the next applyUpdates to delete and re-add the table in the same
+// transaction that rewrites the whole ruleset, so the table is never left without its base chains.
+func (t *NftablesTable) queueTableRecreate() {
+	t.recreatePending = true
+
+	// Nothing in the table survives the recreate, so drop our view of it and mark everything we
+	// want back as dirty.
+	t.chainToDataplaneHashes = map[string][]string{}
+	t.dirtyChains = set.New[string]()
+	for chainName := range t.chainNameToChain {
+		if _, present := t.desiredStateOfChain(chainName); present {
+			t.markChainDirty(chainName)
+		}
+	}
+	for chainName := range t.baseChainDefs {
+		t.dirtyBaseChains.Add(chainName)
+	}
+	t.flowtableDirty = t.flowtableEnabled
+
+	// Sets and maps live in the table too, and each layer programs them in its own transaction, so
+	// tell both that what they think they programmed is gone.
+	t.IPSetsDataplane.QueueResync()
+	t.MapsDataplane.InvalidateMapsCache()
+
+	// We already know what the table will contain, so there is nothing to be gained from reading
+	// it back before the retry.
+	t.inSyncWithDataPlane = true
+}
+
 func (t *NftablesTable) applyUpdates() error {
 	// If needed, detect the dataplane features.
 	features := t.featureDetector.GetFeatures()
@@ -1212,9 +1239,18 @@ func (t *NftablesTable) applyUpdates() error {
 	// - Add elements to maps.
 	mapUpdates := t.MapUpdates()
 
-	if !t.disabled && len(t.chainToDataplaneHashes) == 0 {
-		// Table is enabled, but doesn't exist in the dataplane yet.
-		tx.Add(&knftables.Table{})
+	if !t.disabled {
+		if t.recreatePending {
+			// nftables commits the whole transaction or none of it, so folding the recreate in with
+			// the rewrite below means the table is never left standing without its base chains. The
+			// leading Add keeps the Delete from failing if the table is already gone.
+			tx.Add(&knftables.Table{})
+			tx.Delete(&knftables.Table{})
+			tx.Add(&knftables.Table{})
+		} else if len(t.chainToDataplaneHashes) == 0 {
+			// Table is enabled, but doesn't exist in the dataplane yet.
+			tx.Add(&knftables.Table{})
+		}
 	}
 
 	// Add in any new maps we need to create.
@@ -1436,6 +1472,7 @@ func (t *NftablesTable) applyUpdates() error {
 	// was actually a no-op update.
 	t.dirtyChains = set.New[string]()
 	t.dirtyBaseChains = set.New[string]()
+	t.recreatePending = false
 	if !keepFlowtableDirty {
 		t.flowtableDirty = false
 

--- a/felix/nftables/table_layer.go
+++ b/felix/nftables/table_layer.go
@@ -187,3 +187,7 @@ func (t *tableLayer) FinishMapUpdates(updates *MapUpdates) {
 func (t *tableLayer) LoadDataplaneState(ctx context.Context, mapNames []string) error {
 	return t.maps.LoadDataplaneState(ctx, mapNames)
 }
+
+func (t *tableLayer) InvalidateMapsCache() {
+	t.maps.InvalidateMapsCache()
+}

--- a/felix/nftables/table_test.go
+++ b/felix/nftables/table_test.go
@@ -246,6 +246,39 @@ var _ = Describe("Table with an empty dataplane", func() {
 		}))
 	})
 
+	It("Should re-add the table's maps in the transaction that recreates it", func() {
+		m := nftables.MapMetadata{Name: "cali-map", Type: nftables.MapTypeInterfaceMatch}
+		table.AddOrReplaceMap(m, map[string][]string{"cali1234": {"jump cali-foobar"}})
+		table.UpdateChain(&generictables.Chain{
+			Name:  "cali-foobar",
+			Rules: []generictables.Rule{{Match: nftables.Match(), Action: nftables.AcceptAction{}}},
+		})
+		table.InsertOrAppendRules("filter-FORWARD", []generictables.Rule{
+			{Match: nftables.Match(), Action: nftables.JumpAction{Target: "cali-foobar"}},
+		})
+		table.Apply()
+		Expect(f.List(context.TODO(), "map")).To(ContainElement("cali-map"))
+
+		// Dirty the table, then fail enough writes to trigger a recreate.
+		table.UpdateChain(&generictables.Chain{
+			Name:  "cali-foobar",
+			Rules: []generictables.Rule{{Match: nftables.Match(), Action: nftables.DropAction{}}},
+		})
+		f.RunErrors = 6
+		Expect(func() {
+			table.Apply()
+		}).NotTo(Panic())
+
+		// The delete takes the maps with it, so the same transaction has to put them back. If the
+		// map survived while our cached view said it was gone, re-adding its members would fail.
+		lastTx := f.transactions[len(f.transactions)-1].String()
+		Expect(lastTx).To(ContainSubstring("delete table"))
+		Expect(strings.Index(lastTx, "delete table")).To(
+			BeNumerically("<", strings.Index(lastTx, "add map")),
+			"the table delete must be emitted before the map is re-added")
+		Expect(f.List(context.TODO(), "map")).To(ContainElement("cali-map"))
+	})
+
 	It("should not reload the dataplane on a no-op Apply()", func() {
 		// Drive to a settled, in-sync state. The first Apply() reads the dataplane
 		// once to learn what's there, then writes the base chains; after that the

--- a/felix/nftables/table_test.go
+++ b/felix/nftables/table_test.go
@@ -164,6 +164,88 @@ var _ = Describe("Table with an empty dataplane", func() {
 		}).To(Panic())
 	})
 
+	It("Should keep the base chains programmed while retrying nft failures", func() {
+		// Settle, so the table is fully programmed before we break it.
+		table.Apply()
+		table.ApplyUpdates(nil)
+		chains, err := f.List(context.TODO(), "chain")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(chains).To(ConsistOf(expectedBaseChains))
+
+		// Insert rules into a non-existent chain to make every subsequent write fail.
+		table.InsertOrAppendRules("badchain", []generictables.Rule{
+			{Match: nftables.Match(), Action: nftables.DropAction{}},
+		})
+		Expect(func() {
+			table.Apply()
+		}).To(Panic())
+
+		// The retry loop recreates the table after repeated failures. Each recreate must be part of
+		// the transaction that writes the whole ruleset back, so that a failed attempt leaves the
+		// table alone rather than stripping its hooks.
+		recreates := 0
+		for _, tx := range f.transactions {
+			s := tx.String()
+			if !strings.Contains(s, "delete table") {
+				continue
+			}
+			recreates++
+			for _, chain := range expectedBaseChains {
+				Expect(s).To(ContainSubstring("add chain ip calico %s ", chain))
+			}
+		}
+		Expect(recreates).To(BeNumerically(">", 0), "expected the retry loop to attempt a table recreate")
+
+		// The property that matters: nothing was committed, so the dataplane still has our hooks.
+		chains, err = f.List(context.TODO(), "chain")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(chains).To(ConsistOf(expectedBaseChains))
+
+		// The recreate would have dropped the IP sets too, so a resync must be queued for them.
+		listCalls := f.ListCallCount
+		table.ApplyUpdates(nil)
+		Expect(f.ListCallCount).To(BeNumerically(">", listCalls), "expected an IP set resync to have been queued")
+	})
+
+	It("Should recreate the table and reprogram everything after repeated nft failures", func() {
+		table.UpdateChain(&generictables.Chain{
+			Name:  "cali-foobar",
+			Rules: []generictables.Rule{{Match: nftables.Match(), Action: nftables.AcceptAction{}}},
+		})
+		table.InsertOrAppendRules("filter-FORWARD", []generictables.Rule{
+			{Match: nftables.Match(), Action: nftables.JumpAction{Target: "cali-foobar"}},
+		})
+		table.Apply()
+		Expect(f.List(context.TODO(), "chain")).To(ConsistOf(append(expectedBaseChains, "cali-foobar")))
+
+		table.UpdateChain(&generictables.Chain{
+			Name:  "cali-foobar",
+			Rules: []generictables.Rule{{Match: nftables.Match(), Action: nftables.DropAction{}}},
+		})
+
+		// Six consecutive write failures is enough to trigger a recreate. The seventh attempt goes
+		// through, and must restore the whole ruleset rather than just the part that was dirty.
+		f.RunErrors = 6
+		Expect(func() {
+			table.Apply()
+		}).NotTo(Panic())
+		Expect(f.RunErrors).To(BeZero(), "expected the retry loop to consume every injected error")
+
+		lastTx := f.transactions[len(f.transactions)-1].String()
+		Expect(lastTx).To(ContainSubstring("delete table"))
+		Expect(f.List(context.TODO(), "chain")).To(ConsistOf(append(expectedBaseChains, "cali-foobar")))
+		Expect(f.ListRules(context.TODO(), "filter-FORWARD")).To(nftables.ContainRule(knftables.Rule{
+			Chain:   "filter-FORWARD",
+			Rule:    "counter jump cali-foobar",
+			Comment: ptr("cali:5BWf2dLBa-ZMC-kf;"),
+		}))
+		Expect(f.ListRules(context.TODO(), "cali-foobar")).To(nftables.ContainRule(knftables.Rule{
+			Chain:   "cali-foobar",
+			Rule:    "counter drop",
+			Comment: ptr("cali:qEazjD2XdAvzH1n5;"),
+		}))
+	})
+
 	It("should not reload the dataplane on a no-op Apply()", func() {
 		// Drive to a settled, in-sync state. The first Apply() reads the dataplane
 		// once to learn what's there, then writes the base chains; after that the

--- a/felix/nftables/utils.go
+++ b/felix/nftables/utils.go
@@ -45,7 +45,8 @@ var MinKernelVersionForNftables = environment.MustParseVersion("5.13")
 //   - a kernel of at least MinKernelVersionForNftables.
 //
 // It is used to resolve NFTablesMode=Auto on hosts that run no kube-proxy,
-// where the kube-proxy-based detection gives no signal.
+// where the kube-proxy-based detection gives no signal. The only caller is in
+// calico-private, which has the non-cluster host deployment that open source lacks.
 // Both dependencies are injectable for testing; pass nil for the defaults.
 func HostNftablesSupportedFn(newDataplane NewNftablesDataplaneFn, getKernelVersion func() (*environment.Version, error)) func() bool {
 	if newDataplane == nil {


### PR DESCRIPTION
When Felix cannot program nftables, the retry loop deletes and re-adds the table in its own transaction before trying again. Between that commit and the next successful write the table has no base chains, so nothing Calico programs is filtering, and if every retry fails Felix panics with the table left empty until the node restarts.

This folds the delete and re-add into the same transaction as the rewrite of every chain and rule, so either the whole ruleset lands or nothing changes. The IP sets and maps in the table are queued for reprogramming at the same time.

CORE-13251

```release-note
Fixes a window in nftables mode where a failure to program the dataplane could leave Calico's chains missing, so traffic went unfiltered until Felix recovered or restarted.
```
