### PR TITLE
Refuse to start a datastore migration when a built-in tier is drifted

### DIFF
--- a/kube-controllers/pkg/controllers/migration/controller.go
+++ b/kube-controllers/pkg/controllers/migration/controller.go
@@ -95,6 +95,10 @@ const (
 	// MaxItems (64 in types.go) so the cap here is what's actually hit, not the
 	// apiserver rejecting the write.
 	maxConflictConditions = 32
+
+	// tierDriftMessagePrefix opens the status message naming built-in tiers the
+	// v3 API would reject.
+	tierDriftMessagePrefix = "Correct the following v1 tiers before migration can start: "
 )
 
 // ControllerConfig holds all dependencies for creating the migration controller.
@@ -624,11 +628,16 @@ func (m *migrationController) checkBuiltInTiers(logCtx *logrus.Entry, dm *migrat
 		return false, fmt.Errorf("validating built-in tiers: %w", err)
 	}
 	if len(drift) == 0 {
+		// Don't leave the CR asking for a fix that has already landed.
+		if strings.HasPrefix(dm.Status.Message, tierDriftMessagePrefix) {
+			dm.Status.Message = ""
+			return false, m.updateStatus(dm)
+		}
 		return false, nil
 	}
 
 	logCtx.WithField("tiers", drift).Warn("Built-in tiers do not match the values the v3 API enforces")
-	dm.Status.Message = fmt.Sprintf("Correct the following v1 tiers before migration can start: %s", strings.Join(drift, "; "))
+	dm.Status.Message = tierDriftMessagePrefix + strings.Join(drift, "; ")
 	return true, m.updateStatus(dm)
 }
 

--- a/kube-controllers/pkg/controllers/migration/controller.go
+++ b/kube-controllers/pkg/controllers/migration/controller.go
@@ -526,20 +526,18 @@ func (m *migrationController) builtInTierDrift() ([]string, error) {
 			continue
 		}
 
-		if tier.Spec.Order == nil {
-			drift = append(drift, fmt.Sprintf("tier %q has no order, expected %s", tier.Name, formatTierOrder(want.order)))
-		} else if *tier.Spec.Order != want.order {
-			drift = append(drift, fmt.Sprintf("tier %q has order %s, expected %s", tier.Name, formatTierOrder(*tier.Spec.Order), formatTierOrder(want.order)))
+		// Name the value to set, not the value we read: the backend defaults
+		// unset fields on read.
+		if tier.Spec.Order == nil || *tier.Spec.Order != want.order {
+			drift = append(drift, fmt.Sprintf("tier %q must have order %s", tier.Name, formatTierOrder(want.order)))
 		}
 
-		// The v3 CRD defaults an unset defaultAction to Deny, so an unset value
-		// is only conformant on the default tier.
 		action := apiv3.Deny
 		if tier.Spec.DefaultAction != nil {
 			action = *tier.Spec.DefaultAction
 		}
 		if action != want.defaultAction {
-			drift = append(drift, fmt.Sprintf("tier %q has defaultAction %q, expected %q", tier.Name, action, want.defaultAction))
+			drift = append(drift, fmt.Sprintf("tier %q must have defaultAction %q", tier.Name, want.defaultAction))
 		}
 	}
 	sort.Strings(drift)

--- a/kube-controllers/pkg/controllers/migration/controller.go
+++ b/kube-controllers/pkg/controllers/migration/controller.go
@@ -418,19 +418,11 @@ func (m *migrationController) handlePending(logCtx *logrus.Entry, dm *DatastoreM
 		return err
 	}
 
-	// Pre-validation: the v3 Tier CRD pins order and defaultAction on the
-	// built-in tiers via CEL, so a drifted one would fail its create partway
-	// through the copy with the datastore already locked.
-	drift, err := m.checkBuiltInTiers()
+	wait, err := m.checkBuiltInTiers(logCtx, dm)
 	if err != nil {
-		return fmt.Errorf("validating built-in tiers: %w", err)
+		return err
 	}
-	if len(drift) > 0 {
-		logCtx.WithField("tiers", drift).Warn("Built-in tiers do not match the values the v3 API enforces")
-		dm.Status.Message = fmt.Sprintf("Correct the following v1 tiers before migration can start: %s", strings.Join(drift, "; "))
-		if err := m.updateStatus(dm); err != nil {
-			return err
-		}
+	if wait {
 		return requeueAfter(m.waitingPollInterval)
 	}
 
@@ -486,9 +478,27 @@ var builtInTierRequirements = map[string]builtInTierRequirement{
 	names.KubeBaselineTierName: {order: apiv3.KubeBaselineTierOrder, defaultAction: apiv3.Pass},
 }
 
-// checkBuiltInTiers returns a description of every built-in tier in v1 that the
+// checkBuiltInTiers reports whether the caller should wait for a human to fix a
+// built-in v1 tier the v3 API rejects.
+func (m *migrationController) checkBuiltInTiers(logCtx *logrus.Entry, dm *DatastoreMigration) (bool, error) {
+	// The v3 Tier CRD pins order and defaultAction via CEL, so a drifted
+	// built-in fails mid-copy.
+	drift, err := m.builtInTierDrift()
+	if err != nil {
+		return false, fmt.Errorf("validating built-in tiers: %w", err)
+	}
+	if len(drift) == 0 {
+		return false, nil
+	}
+
+	logCtx.WithField("tiers", drift).Warn("Built-in tiers do not match the values the v3 API enforces")
+	dm.Status.Message = fmt.Sprintf("Correct the following v1 tiers before migration can start: %s", strings.Join(drift, "; "))
+	return true, m.updateStatus(dm)
+}
+
+// builtInTierDrift returns a description of every built-in tier in v1 that the
 // v3 API would reject.
-func (m *migrationController) checkBuiltInTiers() ([]string, error) {
+func (m *migrationController) builtInTierDrift() ([]string, error) {
 	var tierMigrator migrators.ResourceMigrator
 	for _, mig := range m.migrators {
 		if mig.Kind() == apiv3.KindTier {

--- a/kube-controllers/pkg/controllers/migration/controller.go
+++ b/kube-controllers/pkg/controllers/migration/controller.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -417,6 +418,22 @@ func (m *migrationController) handlePending(logCtx *logrus.Entry, dm *DatastoreM
 		return err
 	}
 
+	// Pre-validation: the v3 Tier CRD pins order and defaultAction on the
+	// built-in tiers via CEL, so a drifted one would fail its create partway
+	// through the copy with the datastore already locked.
+	drift, err := m.checkBuiltInTiers()
+	if err != nil {
+		return fmt.Errorf("validating built-in tiers: %w", err)
+	}
+	if len(drift) > 0 {
+		logCtx.WithField("tiers", drift).Warn("Built-in tiers do not match the values the v3 API enforces")
+		dm.Status.Message = fmt.Sprintf("Correct the following v1 tiers before migration can start: %s", strings.Join(drift, "; "))
+		if err := m.updateStatus(dm); err != nil {
+			return err
+		}
+		return requeueAfter(m.waitingPollInterval)
+	}
+
 	// Save and delete the APIService to unregister the API server. This will
 	// route future requests to the projectcalico.org/v3 API to CRDs instead.
 	if err := m.saveAndDeleteAPIService(logCtx, dm); err != nil {
@@ -454,6 +471,75 @@ func (m *migrationController) handlePending(logCtx *logrus.Entry, dm *DatastoreM
 	dm.Status.StartedAt = &now
 	setPhaseMetric(DatastoreMigrationPhaseMigrating)
 	return m.updateStatus(dm)
+}
+
+// builtInTierRequirement is the order and default action that the v3 Tier CRD's
+// CEL rules pin a built-in tier to.
+type builtInTierRequirement struct {
+	order         float64
+	defaultAction apiv3.Action
+}
+
+var builtInTierRequirements = map[string]builtInTierRequirement{
+	names.DefaultTierName:      {order: apiv3.DefaultTierOrder, defaultAction: apiv3.Deny},
+	names.KubeAdminTierName:    {order: apiv3.KubeAdminTierOrder, defaultAction: apiv3.Pass},
+	names.KubeBaselineTierName: {order: apiv3.KubeBaselineTierOrder, defaultAction: apiv3.Pass},
+}
+
+// checkBuiltInTiers returns a description of every built-in tier in v1 that the
+// v3 API would reject.
+func (m *migrationController) checkBuiltInTiers() ([]string, error) {
+	var tierMigrator migrators.ResourceMigrator
+	for _, mig := range m.migrators {
+		if mig.Kind() == apiv3.KindTier {
+			tierMigrator = mig
+			break
+		}
+	}
+	if tierMigrator == nil {
+		return nil, nil
+	}
+
+	tiers, err := tierMigrator.ListV1(m.ctx)
+	if err != nil {
+		return nil, fmt.Errorf("listing v1 tiers: %w", err)
+	}
+
+	var drift []string
+	for _, obj := range tiers {
+		tier, ok := obj.(*apiv3.Tier)
+		if !ok {
+			return nil, fmt.Errorf("unexpected type for v1 Tier: %T", obj)
+		}
+		want, builtIn := builtInTierRequirements[tier.Name]
+		if !builtIn {
+			continue
+		}
+
+		if tier.Spec.Order == nil {
+			drift = append(drift, fmt.Sprintf("tier %q has no order, expected %s", tier.Name, formatTierOrder(want.order)))
+		} else if *tier.Spec.Order != want.order {
+			drift = append(drift, fmt.Sprintf("tier %q has order %s, expected %s", tier.Name, formatTierOrder(*tier.Spec.Order), formatTierOrder(want.order)))
+		}
+
+		// The v3 CRD defaults an unset defaultAction to Deny, so an unset value
+		// is only conformant on the default tier.
+		action := apiv3.Deny
+		if tier.Spec.DefaultAction != nil {
+			action = *tier.Spec.DefaultAction
+		}
+		if action != want.defaultAction {
+			drift = append(drift, fmt.Sprintf("tier %q has defaultAction %q, expected %q", tier.Name, action, want.defaultAction))
+		}
+	}
+	sort.Strings(drift)
+	return drift, nil
+}
+
+// formatTierOrder renders a tier order without scientific notation, which %v
+// would produce for the large built-in values.
+func formatTierOrder(order float64) string {
+	return strconv.FormatFloat(order, 'f', -1, 64)
 }
 
 // handleMigrating runs the core migration logic.

--- a/kube-controllers/pkg/controllers/migration/controller.go
+++ b/kube-controllers/pkg/controllers/migration/controller.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"os"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -593,7 +594,90 @@ func (m *migrationController) runPendingPrechecks(logCtx *logrus.Entry, dm *migr
 		"installType":      installType,
 	}).Info("Detected installation details")
 
-	return false, m.ensureV3CRDs(logCtx)
+	if err := m.ensureV3CRDs(logCtx); err != nil {
+		return false, err
+	}
+
+	drift, err := m.checkBuiltInTiers()
+	if err != nil {
+		return false, fmt.Errorf("validating built-in tiers: %w", err)
+	}
+	if len(drift) > 0 {
+		logCtx.WithField("tiers", drift).Warn("Built-in tiers do not match the values the v3 API enforces")
+		dm.Status.Message = fmt.Sprintf("Correct the following v1 tiers before migration can start: %s", strings.Join(drift, "; "))
+		return true, m.updateStatus(dm)
+	}
+
+	return false, nil
+}
+
+// builtInTierRequirement is the order and default action that the v3 Tier CRD's
+// CEL rules pin a built-in tier to.
+type builtInTierRequirement struct {
+	order         float64
+	defaultAction apiv3.Action
+}
+
+var builtInTierRequirements = map[string]builtInTierRequirement{
+	names.DefaultTierName:      {order: apiv3.DefaultTierOrder, defaultAction: apiv3.Deny},
+	names.KubeAdminTierName:    {order: apiv3.KubeAdminTierOrder, defaultAction: apiv3.Pass},
+	names.KubeBaselineTierName: {order: apiv3.KubeBaselineTierOrder, defaultAction: apiv3.Pass},
+}
+
+// checkBuiltInTiers returns a description of every built-in tier in v1 that the
+// v3 API would reject.
+func (m *migrationController) checkBuiltInTiers() ([]string, error) {
+	var tierMigrator migrators.ResourceMigrator
+	for _, mig := range m.migrators {
+		if mig.Kind() == apiv3.KindTier {
+			tierMigrator = mig
+			break
+		}
+	}
+	if tierMigrator == nil {
+		return nil, nil
+	}
+
+	tiers, err := tierMigrator.ListV1(m.ctx)
+	if err != nil {
+		return nil, fmt.Errorf("listing v1 tiers: %w", err)
+	}
+
+	var drift []string
+	for _, obj := range tiers {
+		tier, ok := obj.(*apiv3.Tier)
+		if !ok {
+			return nil, fmt.Errorf("unexpected type for v1 Tier: %T", obj)
+		}
+		want, builtIn := builtInTierRequirements[tier.Name]
+		if !builtIn {
+			continue
+		}
+
+		if tier.Spec.Order == nil {
+			drift = append(drift, fmt.Sprintf("tier %q has no order, expected %s", tier.Name, formatTierOrder(want.order)))
+		} else if *tier.Spec.Order != want.order {
+			drift = append(drift, fmt.Sprintf("tier %q has order %s, expected %s", tier.Name, formatTierOrder(*tier.Spec.Order), formatTierOrder(want.order)))
+		}
+
+		// The v3 CRD defaults an unset defaultAction to Deny, so an unset value
+		// is only conformant on the default tier.
+		action := apiv3.Deny
+		if tier.Spec.DefaultAction != nil {
+			action = *tier.Spec.DefaultAction
+		}
+		if action != want.defaultAction {
+			drift = append(drift, fmt.Sprintf("tier %q has defaultAction %q, expected %q", tier.Name, action, want.defaultAction))
+		}
+	}
+	sort.Strings(drift)
+	return drift, nil
+}
+
+// formatTierOrder renders a tier order without scientific notation, which %v
+// would produce for the large built-in values.
+func formatTierOrder(order float64) string {
+	return strconv.FormatFloat(order, 'f', -1, 64)
 }
 
 // handleMigrating runs the core migration logic.

--- a/kube-controllers/pkg/controllers/migration/controller.go
+++ b/kube-controllers/pkg/controllers/migration/controller.go
@@ -662,20 +662,18 @@ func (m *migrationController) builtInTierDrift() ([]string, error) {
 			continue
 		}
 
-		if tier.Spec.Order == nil {
-			drift = append(drift, fmt.Sprintf("tier %q has no order, expected %s", tier.Name, formatTierOrder(want.order)))
-		} else if *tier.Spec.Order != want.order {
-			drift = append(drift, fmt.Sprintf("tier %q has order %s, expected %s", tier.Name, formatTierOrder(*tier.Spec.Order), formatTierOrder(want.order)))
+		// Name the value to set, not the value we read: the backend defaults
+		// unset fields on read.
+		if tier.Spec.Order == nil || *tier.Spec.Order != want.order {
+			drift = append(drift, fmt.Sprintf("tier %q must have order %s", tier.Name, formatTierOrder(want.order)))
 		}
 
-		// The v3 CRD defaults an unset defaultAction to Deny, so an unset value
-		// is only conformant on the default tier.
 		action := apiv3.Deny
 		if tier.Spec.DefaultAction != nil {
 			action = *tier.Spec.DefaultAction
 		}
 		if action != want.defaultAction {
-			drift = append(drift, fmt.Sprintf("tier %q has defaultAction %q, expected %q", tier.Name, action, want.defaultAction))
+			drift = append(drift, fmt.Sprintf("tier %q must have defaultAction %q", tier.Name, want.defaultAction))
 		}
 	}
 	sort.Strings(drift)

--- a/kube-controllers/pkg/controllers/migration/controller.go
+++ b/kube-controllers/pkg/controllers/migration/controller.go
@@ -598,17 +598,7 @@ func (m *migrationController) runPendingPrechecks(logCtx *logrus.Entry, dm *migr
 		return false, err
 	}
 
-	drift, err := m.checkBuiltInTiers()
-	if err != nil {
-		return false, fmt.Errorf("validating built-in tiers: %w", err)
-	}
-	if len(drift) > 0 {
-		logCtx.WithField("tiers", drift).Warn("Built-in tiers do not match the values the v3 API enforces")
-		dm.Status.Message = fmt.Sprintf("Correct the following v1 tiers before migration can start: %s", strings.Join(drift, "; "))
-		return true, m.updateStatus(dm)
-	}
-
-	return false, nil
+	return m.checkBuiltInTiers(logCtx, dm)
 }
 
 // builtInTierRequirement is the order and default action that the v3 Tier CRD's
@@ -624,9 +614,27 @@ var builtInTierRequirements = map[string]builtInTierRequirement{
 	names.KubeBaselineTierName: {order: apiv3.KubeBaselineTierOrder, defaultAction: apiv3.Pass},
 }
 
-// checkBuiltInTiers returns a description of every built-in tier in v1 that the
+// checkBuiltInTiers reports whether the caller should wait for a human to fix a
+// built-in v1 tier the v3 API rejects.
+func (m *migrationController) checkBuiltInTiers(logCtx *logrus.Entry, dm *migrationv1.DatastoreMigration) (bool, error) {
+	// The v3 Tier CRD pins order and defaultAction via CEL, so a drifted
+	// built-in fails mid-copy.
+	drift, err := m.builtInTierDrift()
+	if err != nil {
+		return false, fmt.Errorf("validating built-in tiers: %w", err)
+	}
+	if len(drift) == 0 {
+		return false, nil
+	}
+
+	logCtx.WithField("tiers", drift).Warn("Built-in tiers do not match the values the v3 API enforces")
+	dm.Status.Message = fmt.Sprintf("Correct the following v1 tiers before migration can start: %s", strings.Join(drift, "; "))
+	return true, m.updateStatus(dm)
+}
+
+// builtInTierDrift returns a description of every built-in tier in v1 that the
 // v3 API would reject.
-func (m *migrationController) checkBuiltInTiers() ([]string, error) {
+func (m *migrationController) builtInTierDrift() ([]string, error) {
 	var tierMigrator migrators.ResourceMigrator
 	for _, mig := range m.migrators {
 		if mig.Kind() == apiv3.KindTier {

--- a/kube-controllers/pkg/controllers/migration/controller_fv_test.go
+++ b/kube-controllers/pkg/controllers/migration/controller_fv_test.go
@@ -186,8 +186,6 @@ func TestLifecycle_Mainline(t *testing.T) {
 	// Tiers should exist in v3 with the internal annotation stripped.
 	tier1 := &apiv3.Tier{}
 	h.getV3Resource("default", tier1)
-	// The default tier's order is normalised to DefaultTierOrder during migration
-	// regardless of the v1 value, because the v3 API enforces this requirement.
 	g.Expect(tier1.Spec.Order).To(Equal(ptr.To(apiv3.DefaultTierOrder)))
 	g.Expect(tier1.Annotations).NotTo(HaveKey("projectcalico.org/metadata"))
 

--- a/kube-controllers/pkg/controllers/migration/controller_fv_test.go
+++ b/kube-controllers/pkg/controllers/migration/controller_fv_test.go
@@ -191,8 +191,6 @@ func TestLifecycle_Mainline(t *testing.T) {
 	// Tiers should exist in v3 with the internal annotation stripped.
 	tier1 := &apiv3.Tier{}
 	h.getV3Resource("default", tier1)
-	// The default tier's order is normalised to DefaultTierOrder during migration
-	// regardless of the v1 value, because the v3 API enforces this requirement.
 	g.Expect(tier1.Spec.Order).To(Equal(ptr.To(apiv3.DefaultTierOrder)))
 	g.Expect(tier1.Annotations).NotTo(HaveKey("projectcalico.org/metadata"))
 

--- a/kube-controllers/pkg/controllers/migration/migrators/convert.go
+++ b/kube-controllers/pkg/controllers/migration/migrators/convert.go
@@ -27,13 +27,6 @@ import (
 // internal metadata. It is filtered out during conversion.
 const internalMetadataAnnotation = "projectcalico.org/metadata"
 
-// DefaultConvert is the exported form of defaultConvert. It is intended for
-// resource-specific converters that need to augment the standard deep-copy
-// and metadata-cleaning step with additional normalisation logic.
-func DefaultConvert[T any](kvp *model.KVPair) (*T, error) {
-	return defaultConvert[T](kvp)
-}
-
 // defaultConvert performs a deep copy of the v1 resource and cleans server-side
 // metadata fields. The UID and OwnerReferences are preserved so callers can
 // use them for UID mapping and OwnerRef remapping before creation.

--- a/kube-controllers/pkg/controllers/migration/mock_backend_test.go
+++ b/kube-controllers/pkg/controllers/migration/mock_backend_test.go
@@ -23,6 +23,7 @@ import (
 
 	bapi "github.com/projectcalico/calico/libcalico-go/lib/backend/api"
 	"github.com/projectcalico/calico/libcalico-go/lib/backend/model"
+	"github.com/projectcalico/calico/libcalico-go/lib/resources"
 )
 
 // TODO: Remove this mock when the backend client supports injecting client mocks.
@@ -100,8 +101,31 @@ func (m *mockBackendClient) List(_ context.Context, list model.ListInterface, _ 
 			}
 		}
 		m.mu.Unlock()
-		return &model.KVPairList{KVPairs: m.resources[rlo.Kind]}, nil
+		kvps := m.resources[rlo.Kind]
+		if rlo.Kind == apiv3.KindTier {
+			kvps = defaultTierKVPs(kvps)
+		}
+		return &model.KVPairList{KVPairs: kvps}, nil
 	}
+}
+
+// defaultTierKVPs applies the defaulting the real backend does on the tier read
+// path, so tests see the shape production sees.
+func defaultTierKVPs(kvps []*model.KVPair) []*model.KVPair {
+	out := make([]*model.KVPair, 0, len(kvps))
+	for _, kvp := range kvps {
+		tier, ok := kvp.Value.(*apiv3.Tier)
+		if !ok {
+			out = append(out, kvp)
+			continue
+		}
+		defaulted := tier.DeepCopy()
+		resources.DefaultTierFields(defaulted)
+		copied := *kvp
+		copied.Value = defaulted
+		out = append(out, &copied)
+	}
+	return out
 }
 
 func (m *mockBackendClient) Get(_ context.Context, key model.Key, _ string) (*model.KVPair, error) {

--- a/kube-controllers/pkg/controllers/migration/mock_backend_test.go
+++ b/kube-controllers/pkg/controllers/migration/mock_backend_test.go
@@ -100,13 +100,21 @@ func (m *mockBackendClient) List(_ context.Context, list model.ListInterface, _ 
 				return nil, err
 			}
 		}
-		m.mu.Unlock()
 		kvps := m.resources[rlo.Kind]
+		m.mu.Unlock()
 		if rlo.Kind == apiv3.KindTier {
 			kvps = defaultTierKVPs(kvps)
 		}
 		return &model.KVPairList{KVPairs: kvps}, nil
 	}
+}
+
+// setResources replaces the stored KVPairs for a kind while the controller is
+// running.
+func (m *mockBackendClient) setResources(kind string, kvps []*model.KVPair) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.resources[kind] = kvps
 }
 
 // defaultTierKVPs applies the defaulting the real backend does on the tier read

--- a/kube-controllers/pkg/controllers/migration/mock_backend_test.go
+++ b/kube-controllers/pkg/controllers/migration/mock_backend_test.go
@@ -23,6 +23,7 @@ import (
 
 	bapi "github.com/projectcalico/calico/libcalico-go/lib/backend/api"
 	"github.com/projectcalico/calico/libcalico-go/lib/backend/model"
+	"github.com/projectcalico/calico/libcalico-go/lib/resources"
 )
 
 // TODO: Remove this mock when the backend client supports injecting client mocks.
@@ -71,8 +72,31 @@ func (m *mockBackendClient) List(_ context.Context, list model.ListInterface, _ 
 			}
 		}
 		m.mu.Unlock()
-		return &model.KVPairList{KVPairs: m.resources[rlo.Kind]}, nil
+		kvps := m.resources[rlo.Kind]
+		if rlo.Kind == apiv3.KindTier {
+			kvps = defaultTierKVPs(kvps)
+		}
+		return &model.KVPairList{KVPairs: kvps}, nil
 	}
+}
+
+// defaultTierKVPs applies the defaulting the real backend does on the tier read
+// path, so tests see the shape production sees.
+func defaultTierKVPs(kvps []*model.KVPair) []*model.KVPair {
+	out := make([]*model.KVPair, 0, len(kvps))
+	for _, kvp := range kvps {
+		tier, ok := kvp.Value.(*apiv3.Tier)
+		if !ok {
+			out = append(out, kvp)
+			continue
+		}
+		defaulted := tier.DeepCopy()
+		resources.DefaultTierFields(defaulted)
+		copied := *kvp
+		copied.Value = defaulted
+		out = append(out, &copied)
+	}
+	return out
 }
 
 func (m *mockBackendClient) Get(_ context.Context, key model.Key, _ string) (*model.KVPair, error) {

--- a/kube-controllers/pkg/controllers/migration/resources.go
+++ b/kube-controllers/pkg/controllers/migration/resources.go
@@ -19,7 +19,6 @@ import (
 
 	apiv3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/projectcalico/calico/kube-controllers/pkg/controllers/migration/migrators"
@@ -52,9 +51,7 @@ const (
 // handling.
 func NewMigrators(bc api.Client, rt client.Client) []migrators.ResourceMigrator {
 	return []migrators.ResourceMigrator{
-		migrators.New[apiv3.Tier, apiv3.TierList](apiv3.KindTier, OrderTiers, bc, rt,
-			migrators.WithConvert(convertTier),
-		),
+		migrators.New[apiv3.Tier, apiv3.TierList](apiv3.KindTier, OrderTiers, bc, rt),
 		migrators.New[apiv3.FelixConfiguration, apiv3.FelixConfigurationList](apiv3.KindFelixConfiguration, OrderConfigSingletons, bc, rt),
 		migrators.New[apiv3.BGPConfiguration, apiv3.BGPConfigurationList](apiv3.KindBGPConfiguration, OrderConfigSingletons, bc, rt),
 		migrators.New[apiv3.KubeControllersConfiguration, apiv3.KubeControllersConfigurationList](apiv3.KindKubeControllersConfiguration, OrderConfigSingletons, bc, rt),
@@ -84,21 +81,6 @@ func NewMigrators(bc api.Client, rt client.Client) []migrators.ResourceMigrator 
 		),
 		migrators.New[apiv3.CalicoNodeStatus, apiv3.CalicoNodeStatusList](apiv3.KindCalicoNodeStatus, OrderCalicoNodeStatus, bc, rt),
 	}
-}
-
-// convertTier converts a v1 Tier KVPair to a v3 Tier. It performs the standard
-// deep-copy and metadata cleanup, then normalises the default tier's Order to
-// apiv3.DefaultTierOrder. The v3 API server enforces this value for the default
-// tier, but v1 representations may carry a different order.
-func convertTier(kvp *model.KVPair) (*apiv3.Tier, error) {
-	tier, err := migrators.DefaultConvert[apiv3.Tier](kvp)
-	if err != nil {
-		return nil, err
-	}
-	if tier.Name == names.DefaultTierName {
-		tier.Spec.Order = ptr.To(apiv3.DefaultTierOrder)
-	}
-	return tier, nil
 }
 
 // convertIPAMBlock converts a model.AllocationBlock KVPair to a v3 IPAMBlock.

--- a/kube-controllers/pkg/controllers/migration/tier_preflight_fv_test.go
+++ b/kube-controllers/pkg/controllers/migration/tier_preflight_fv_test.go
@@ -27,6 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 
+	migrationv1 "github.com/projectcalico/calico/kube-controllers/pkg/apis/migration/v1"
 	"github.com/projectcalico/calico/libcalico-go/lib/backend/model"
 )
 
@@ -124,12 +125,12 @@ func expectBlockedInPending(t *testing.T, ctx context.Context, g *WithT, bc *moc
 	createMigrationCR(t, ctx)
 
 	g.Eventually(func(g Gomega) {
-		dm := &DatastoreMigration{}
+		dm := &migrationv1.DatastoreMigration{}
 		g.Expect(fvRTClient.Get(ctx, dmKey, dm)).To(Succeed())
 		for _, s := range substrings {
 			g.Expect(dm.Status.Message).To(ContainSubstring(s))
 		}
-		g.Expect(dm.Status.Phase).To(BeElementOf(DatastoreMigrationPhase(""), DatastoreMigrationPhasePending))
+		g.Expect(dm.Status.Phase).To(BeElementOf(migrationv1.DatastoreMigrationPhase(""), migrationv1.DatastoreMigrationPhasePending))
 	}, 15*time.Second, 200*time.Millisecond).Should(Succeed())
 
 	// The block must happen before anything destructive, so the aggregated
@@ -138,13 +139,13 @@ func expectBlockedInPending(t *testing.T, ctx context.Context, g *WithT, bc *moc
 	g.Expect(err).NotTo(HaveOccurred(), "APIService should not be deleted while the pre-flight check is blocking")
 
 	// Stays blocked rather than sliding into Migrating on a later reconcile.
-	g.Consistently(func() DatastoreMigrationPhase {
-		dm := &DatastoreMigration{}
+	g.Consistently(func() migrationv1.DatastoreMigrationPhase {
+		dm := &migrationv1.DatastoreMigration{}
 		if err := fvRTClient.Get(ctx, dmKey, dm); err != nil {
-			return DatastoreMigrationPhaseFailed
+			return migrationv1.DatastoreMigrationPhaseFailed
 		}
 		return dm.Status.Phase
-	}, 2*time.Second, 200*time.Millisecond).Should(BeElementOf(DatastoreMigrationPhase(""), DatastoreMigrationPhasePending))
+	}, 2*time.Second, 200*time.Millisecond).Should(BeElementOf(migrationv1.DatastoreMigrationPhase(""), migrationv1.DatastoreMigrationPhasePending))
 }
 
 // TestPreflight_DriftedKubeAdminOrderBlocks verifies that a kube-admin tier
@@ -240,7 +241,7 @@ func TestPreflight_ConformantBuiltInTiersProceed(t *testing.T) {
 
 	g.Eventually(func(g Gomega) {
 		fvh := newFVHelper(t, g, ctx)
-		fvh.expectPhase(DatastoreMigrationPhaseConverged)
+		fvh.expectPhase(migrationv1.DatastoreMigrationPhaseConverged)
 	}, 30*time.Second, 200*time.Millisecond).Should(Succeed())
 
 	for _, name := range []string{"default", "kube-admin", "kube-baseline"} {
@@ -287,6 +288,40 @@ func TestPreflight_UnsetDefaultTierFieldsProceed(t *testing.T) {
 
 	g.Eventually(func(g Gomega) {
 		fvh := newFVHelper(t, g, ctx)
-		fvh.expectPhase(DatastoreMigrationPhaseConverged)
+		fvh.expectPhase(migrationv1.DatastoreMigrationPhaseConverged)
 	}, 30*time.Second, 200*time.Millisecond).Should(Succeed())
+}
+
+// TestPreflight_MessageClearedOnceTiersCorrected verifies that fixing the
+// drifted tier both unblocks the migration and drops the request to fix it.
+func TestPreflight_MessageClearedOnceTiersCorrected(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+
+	bc := &mockBackendClient{
+		resources: tierOnlyV1Resources(
+			v1TierKVP("default", ptr.To(apiv3.DefaultTierOrder), apiv3.Deny),
+			v1TierKVP("kube-admin", ptr.To(float64(42)), apiv3.Pass),
+		),
+		clusterInfo: mainlineV1ClusterInfo(),
+	}
+
+	ensureV1CRD(t, ctx)
+	startController(t, ctx, bc, nil)
+	createMigrationCR(t, ctx)
+
+	g.Eventually(func(g Gomega) {
+		dm := &migrationv1.DatastoreMigration{}
+		g.Expect(fvRTClient.Get(ctx, dmKey, dm)).To(Succeed())
+		g.Expect(dm.Status.Message).To(ContainSubstring(`tier "kube-admin" must have order 1000`))
+	}, 15*time.Second, 200*time.Millisecond).Should(Succeed())
+
+	bc.setResources(apiv3.KindTier, conformantBuiltInTiers())
+
+	g.Eventually(func(g Gomega) {
+		dm := &migrationv1.DatastoreMigration{}
+		g.Expect(fvRTClient.Get(ctx, dmKey, dm)).To(Succeed())
+		g.Expect(dm.Status.Message).NotTo(ContainSubstring("must have order"))
+		g.Expect(dm.Status.Phase).To(Equal(migrationv1.DatastoreMigrationPhaseConverged))
+	}, 45*time.Second, 200*time.Millisecond).Should(Succeed())
 }

--- a/kube-controllers/pkg/controllers/migration/tier_preflight_fv_test.go
+++ b/kube-controllers/pkg/controllers/migration/tier_preflight_fv_test.go
@@ -41,6 +41,14 @@ func v1TierKVP(name string, order *float64, action apiv3.Action) *model.KVPair {
 	}
 }
 
+// v1TierKVPUnsetAction builds a v1 Tier KVPair with no defaultAction, which the v3
+// CRD defaults to Deny.
+func v1TierKVPUnsetAction(name string, order *float64) *model.KVPair {
+	kvp := v1TierKVP(name, order, apiv3.Deny)
+	kvp.Value.(*apiv3.Tier).Spec.DefaultAction = nil
+	return kvp
+}
+
 // tierOnlyV1Resources returns backend data containing just the given tiers.
 func tierOnlyV1Resources(tiers ...*model.KVPair) map[string][]*model.KVPair {
 	return map[string][]*model.KVPair{
@@ -239,4 +247,46 @@ func TestPreflight_ConformantBuiltInTiersProceed(t *testing.T) {
 		tier := &apiv3.Tier{}
 		h.getV3Resource(name, tier)
 	}
+}
+
+// TestPreflight_UnsetDefaultActionBlocks verifies that an unset defaultAction is
+// treated as Deny, which is drift on the tiers that require Pass.
+func TestPreflight_UnsetDefaultActionBlocks(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+
+	bc := &mockBackendClient{
+		resources: tierOnlyV1Resources(
+			v1TierKVP("default", ptr.To(apiv3.DefaultTierOrder), apiv3.Deny),
+			v1TierKVPUnsetAction("kube-admin", ptr.To(apiv3.KubeAdminTierOrder)),
+		),
+		clusterInfo: mainlineV1ClusterInfo(),
+	}
+
+	expectBlockedInPending(t, ctx, g, bc, `tier "kube-admin" has defaultAction "Deny", expected "Pass"`)
+}
+
+// TestPreflight_UnsetDefaultActionOnDefaultTierProceeds verifies that an unset
+// defaultAction is conformant on the default tier, which requires Deny.
+func TestPreflight_UnsetDefaultActionOnDefaultTierProceeds(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+
+	bc := &mockBackendClient{
+		resources: tierOnlyV1Resources(
+			v1TierKVPUnsetAction("default", ptr.To(apiv3.DefaultTierOrder)),
+			v1TierKVP("kube-admin", ptr.To(apiv3.KubeAdminTierOrder), apiv3.Pass),
+			v1TierKVP("kube-baseline", ptr.To(apiv3.KubeBaselineTierOrder), apiv3.Pass),
+		),
+		clusterInfo: mainlineV1ClusterInfo(),
+	}
+
+	ensureV1CRD(t, ctx)
+	startController(t, ctx, bc, nil)
+	createMigrationCR(t, ctx)
+
+	g.Eventually(func(g Gomega) {
+		fvh := newFVHelper(t, g, ctx)
+		fvh.expectPhase(DatastoreMigrationPhaseConverged)
+	}, 30*time.Second, 200*time.Millisecond).Should(Succeed())
 }

--- a/kube-controllers/pkg/controllers/migration/tier_preflight_fv_test.go
+++ b/kube-controllers/pkg/controllers/migration/tier_preflight_fv_test.go
@@ -1,0 +1,242 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package migration
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+	apiv3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+
+	"github.com/projectcalico/calico/libcalico-go/lib/backend/model"
+)
+
+// v1TierKVP builds a v1 Tier KVPair for the mock backend.
+func v1TierKVP(name string, order *float64, action apiv3.Action) *model.KVPair {
+	return &model.KVPair{
+		Key: model.ResourceKey{Kind: apiv3.KindTier, Name: name},
+		Value: &apiv3.Tier{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Annotations: v1InternalAnnotations},
+			Spec:       apiv3.TierSpec{Order: order, DefaultAction: actionPtr(action)},
+		},
+	}
+}
+
+// tierOnlyV1Resources returns backend data containing just the given tiers.
+func tierOnlyV1Resources(tiers ...*model.KVPair) map[string][]*model.KVPair {
+	return map[string][]*model.KVPair{
+		apiv3.KindTier:               tiers,
+		apiv3.KindClusterInformation: {},
+	}
+}
+
+// conformantBuiltInTiers returns the three built-in tiers with the order and
+// default action the v3 API enforces.
+func conformantBuiltInTiers() []*model.KVPair {
+	return []*model.KVPair{
+		v1TierKVP("default", ptr.To(apiv3.DefaultTierOrder), apiv3.Deny),
+		v1TierKVP("kube-admin", ptr.To(apiv3.KubeAdminTierOrder), apiv3.Pass),
+		v1TierKVP("kube-baseline", ptr.To(apiv3.KubeBaselineTierOrder), apiv3.Pass),
+	}
+}
+
+// ensureV1CRD makes sure at least one crd.projectcalico.org CRD exists.
+// TestLifecycle_DeletionBlockedThenCompleted deletes them all, and handlePending
+// refuses to start a migration with no v1 CRDs to copy.
+func ensureV1CRD(t *testing.T, ctx context.Context) {
+	t.Helper()
+	crd := &apiextv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{Name: "tiers.crd.projectcalico.org"},
+		Spec: apiextv1.CustomResourceDefinitionSpec{
+			Group: "crd.projectcalico.org",
+			Scope: apiextv1.ClusterScoped,
+			Names: apiextv1.CustomResourceDefinitionNames{
+				Plural:   "tiers",
+				Singular: "tier",
+				Kind:     "Tier",
+				ListKind: "TierList",
+			},
+			Versions: []apiextv1.CustomResourceDefinitionVersion{
+				{
+					Name:    "v1",
+					Served:  true,
+					Storage: true,
+					Schema: &apiextv1.CustomResourceValidation{
+						OpenAPIV3Schema: &apiextv1.JSONSchemaProps{
+							Type:                   "object",
+							XPreserveUnknownFields: ptr.To(true),
+						},
+					},
+				},
+			},
+		},
+	}
+	crds := fvCRDClient.ApiextensionsV1().CustomResourceDefinitions()
+	NewWithT(t).Eventually(func() error {
+		existing, err := crds.Get(ctx, crd.Name, metav1.GetOptions{})
+		if err == nil {
+			if existing.DeletionTimestamp != nil {
+				return fmt.Errorf("CRD %s is still terminating", crd.Name)
+			}
+			return nil
+		}
+		if !kerrors.IsNotFound(err) {
+			return err
+		}
+		_, err = crds.Create(ctx, crd.DeepCopy(), metav1.CreateOptions{})
+		return err
+	}, 30*time.Second, 200*time.Millisecond).Should(Succeed())
+}
+
+// expectBlockedInPending waits for the controller to report the given substrings
+// in the CR's status message without leaving the Pending phase, and asserts the
+// APIService was left in place.
+func expectBlockedInPending(t *testing.T, ctx context.Context, g *WithT, bc *mockBackendClient, substrings ...string) {
+	t.Helper()
+
+	ensureV1CRD(t, ctx)
+	fakeAPIReg := startController(t, ctx, bc, nil)
+	createMigrationCR(t, ctx)
+
+	g.Eventually(func(g Gomega) {
+		dm := &DatastoreMigration{}
+		g.Expect(fvRTClient.Get(ctx, dmKey, dm)).To(Succeed())
+		for _, s := range substrings {
+			g.Expect(dm.Status.Message).To(ContainSubstring(s))
+		}
+		g.Expect(dm.Status.Phase).To(BeElementOf(DatastoreMigrationPhase(""), DatastoreMigrationPhasePending))
+	}, 15*time.Second, 200*time.Millisecond).Should(Succeed())
+
+	// The block must happen before anything destructive, so the aggregated
+	// APIService is still registered.
+	_, err := fakeAPIReg.ApiregistrationV1().APIServices().Get(ctx, apiServiceName, metav1.GetOptions{})
+	g.Expect(err).NotTo(HaveOccurred(), "APIService should not be deleted while the pre-flight check is blocking")
+
+	// Stays blocked rather than sliding into Migrating on a later reconcile.
+	g.Consistently(func() DatastoreMigrationPhase {
+		dm := &DatastoreMigration{}
+		if err := fvRTClient.Get(ctx, dmKey, dm); err != nil {
+			return DatastoreMigrationPhaseFailed
+		}
+		return dm.Status.Phase
+	}, 2*time.Second, 200*time.Millisecond).Should(BeElementOf(DatastoreMigrationPhase(""), DatastoreMigrationPhasePending))
+}
+
+// TestPreflight_DriftedKubeAdminOrderBlocks verifies that a kube-admin tier
+// carrying an order the v3 CEL rules reject stops the migration in Pending.
+func TestPreflight_DriftedKubeAdminOrderBlocks(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+
+	bc := &mockBackendClient{
+		resources: tierOnlyV1Resources(
+			v1TierKVP("default", ptr.To(apiv3.DefaultTierOrder), apiv3.Deny),
+			v1TierKVP("kube-admin", ptr.To(float64(42)), apiv3.Pass),
+		),
+		clusterInfo: mainlineV1ClusterInfo(),
+	}
+
+	expectBlockedInPending(t, ctx, g, bc, `tier "kube-admin" has order 42, expected 1000`)
+}
+
+// TestPreflight_DriftedDefaultActionBlocks verifies that a built-in tier with
+// the wrong defaultAction stops the migration in Pending.
+func TestPreflight_DriftedDefaultActionBlocks(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+
+	bc := &mockBackendClient{
+		resources: tierOnlyV1Resources(
+			v1TierKVP("default", ptr.To(apiv3.DefaultTierOrder), apiv3.Deny),
+			v1TierKVP("kube-baseline", ptr.To(apiv3.KubeBaselineTierOrder), apiv3.Deny),
+		),
+		clusterInfo: mainlineV1ClusterInfo(),
+	}
+
+	expectBlockedInPending(t, ctx, g, bc, `tier "kube-baseline" has defaultAction "Deny", expected "Pass"`)
+}
+
+// TestPreflight_MultipleDriftedTiersReported verifies that every offending tier
+// is named in a single status message so the user can fix them in one pass.
+func TestPreflight_MultipleDriftedTiersReported(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+
+	bc := &mockBackendClient{
+		resources: tierOnlyV1Resources(
+			v1TierKVP("default", ptr.To(apiv3.DefaultTierOrder), apiv3.Pass),
+			v1TierKVP("kube-admin", ptr.To(float64(42)), apiv3.Deny),
+			v1TierKVP("kube-baseline", nil, apiv3.Pass),
+		),
+		clusterInfo: mainlineV1ClusterInfo(),
+	}
+
+	expectBlockedInPending(t, ctx, g, bc,
+		`tier "default" has defaultAction "Pass", expected "Deny"`,
+		`tier "kube-admin" has order 42, expected 1000`,
+		`tier "kube-admin" has defaultAction "Deny", expected "Pass"`,
+		`tier "kube-baseline" has no order, expected 10000000`,
+	)
+}
+
+// TestPreflight_DriftedDefaultTierOrderBlocks verifies that the default tier is
+// held to the same standard as the other built-ins.
+func TestPreflight_DriftedDefaultTierOrderBlocks(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+
+	bc := &mockBackendClient{
+		resources: tierOnlyV1Resources(
+			v1TierKVP("default", ptr.To(float64(42)), apiv3.Deny),
+		),
+		clusterInfo: mainlineV1ClusterInfo(),
+	}
+
+	expectBlockedInPending(t, ctx, g, bc, `tier "default" has order 42, expected 1000000`)
+}
+
+// TestPreflight_ConformantBuiltInTiersProceed verifies that conformant built-in
+// tiers migrate as before.
+func TestPreflight_ConformantBuiltInTiersProceed(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	h := newFVHelper(t, g, ctx)
+
+	bc := &mockBackendClient{
+		resources:   tierOnlyV1Resources(conformantBuiltInTiers()...),
+		clusterInfo: mainlineV1ClusterInfo(),
+	}
+
+	ensureV1CRD(t, ctx)
+	startController(t, ctx, bc, nil)
+	createMigrationCR(t, ctx)
+
+	g.Eventually(func(g Gomega) {
+		fvh := newFVHelper(t, g, ctx)
+		fvh.expectPhase(DatastoreMigrationPhaseConverged)
+	}, 30*time.Second, 200*time.Millisecond).Should(Succeed())
+
+	for _, name := range []string{"default", "kube-admin", "kube-baseline"} {
+		tier := &apiv3.Tier{}
+		h.getV3Resource(name, tier)
+	}
+}

--- a/kube-controllers/pkg/controllers/migration/tier_preflight_fv_test.go
+++ b/kube-controllers/pkg/controllers/migration/tier_preflight_fv_test.go
@@ -41,8 +41,8 @@ func v1TierKVP(name string, order *float64, action apiv3.Action) *model.KVPair {
 	}
 }
 
-// v1TierKVPUnsetAction builds a v1 Tier KVPair with no defaultAction, which the v3
-// CRD defaults to Deny.
+// v1TierKVPUnsetAction builds a v1 Tier KVPair with no defaultAction, which the
+// backend read path defaults to Deny.
 func v1TierKVPUnsetAction(name string, order *float64) *model.KVPair {
 	kvp := v1TierKVP(name, order, apiv3.Deny)
 	kvp.Value.(*apiv3.Tier).Spec.DefaultAction = nil
@@ -67,9 +67,8 @@ func conformantBuiltInTiers() []*model.KVPair {
 	}
 }
 
-// ensureV1CRD makes sure at least one crd.projectcalico.org CRD exists.
-// TestLifecycle_DeletionBlockedThenCompleted deletes them all, and handlePending
-// refuses to start a migration with no v1 CRDs to copy.
+// ensureV1CRD makes sure at least one crd.projectcalico.org CRD exists, since
+// handlePending refuses to migrate without one.
 func ensureV1CRD(t *testing.T, ctx context.Context) {
 	t.Helper()
 	crd := &apiextv1.CustomResourceDefinition{
@@ -115,9 +114,8 @@ func ensureV1CRD(t *testing.T, ctx context.Context) {
 	}, 30*time.Second, 200*time.Millisecond).Should(Succeed())
 }
 
-// expectBlockedInPending waits for the controller to report the given substrings
-// in the CR's status message without leaving the Pending phase, and asserts the
-// APIService was left in place.
+// expectBlockedInPending asserts the controller reports the given substrings,
+// stays in Pending, and leaves the APIService in place.
 func expectBlockedInPending(t *testing.T, ctx context.Context, g *WithT, bc *mockBackendClient, substrings ...string) {
 	t.Helper()
 
@@ -163,7 +161,7 @@ func TestPreflight_DriftedKubeAdminOrderBlocks(t *testing.T) {
 		clusterInfo: mainlineV1ClusterInfo(),
 	}
 
-	expectBlockedInPending(t, ctx, g, bc, `tier "kube-admin" has order 42, expected 1000`)
+	expectBlockedInPending(t, ctx, g, bc, `tier "kube-admin" must have order 1000`)
 }
 
 // TestPreflight_DriftedDefaultActionBlocks verifies that a built-in tier with
@@ -180,11 +178,11 @@ func TestPreflight_DriftedDefaultActionBlocks(t *testing.T) {
 		clusterInfo: mainlineV1ClusterInfo(),
 	}
 
-	expectBlockedInPending(t, ctx, g, bc, `tier "kube-baseline" has defaultAction "Deny", expected "Pass"`)
+	expectBlockedInPending(t, ctx, g, bc, `tier "kube-baseline" must have defaultAction "Pass"`)
 }
 
 // TestPreflight_MultipleDriftedTiersReported verifies that every offending tier
-// is named in a single status message so the user can fix them in one pass.
+// is named in one status message, so they can be fixed in one pass.
 func TestPreflight_MultipleDriftedTiersReported(t *testing.T) {
 	g := NewWithT(t)
 	ctx := context.Background()
@@ -193,16 +191,18 @@ func TestPreflight_MultipleDriftedTiersReported(t *testing.T) {
 		resources: tierOnlyV1Resources(
 			v1TierKVP("default", ptr.To(apiv3.DefaultTierOrder), apiv3.Pass),
 			v1TierKVP("kube-admin", ptr.To(float64(42)), apiv3.Deny),
+
+			// An unset order defaults to 1000000, which is drift for kube-baseline.
 			v1TierKVP("kube-baseline", nil, apiv3.Pass),
 		),
 		clusterInfo: mainlineV1ClusterInfo(),
 	}
 
 	expectBlockedInPending(t, ctx, g, bc,
-		`tier "default" has defaultAction "Pass", expected "Deny"`,
-		`tier "kube-admin" has order 42, expected 1000`,
-		`tier "kube-admin" has defaultAction "Deny", expected "Pass"`,
-		`tier "kube-baseline" has no order, expected 10000000`,
+		`tier "default" must have defaultAction "Deny"`,
+		`tier "kube-admin" must have order 1000`,
+		`tier "kube-admin" must have defaultAction "Pass"`,
+		`tier "kube-baseline" must have order 10000000`,
 	)
 }
 
@@ -219,7 +219,7 @@ func TestPreflight_DriftedDefaultTierOrderBlocks(t *testing.T) {
 		clusterInfo: mainlineV1ClusterInfo(),
 	}
 
-	expectBlockedInPending(t, ctx, g, bc, `tier "default" has order 42, expected 1000000`)
+	expectBlockedInPending(t, ctx, g, bc, `tier "default" must have order 1000000`)
 }
 
 // TestPreflight_ConformantBuiltInTiersProceed verifies that conformant built-in
@@ -263,18 +263,18 @@ func TestPreflight_UnsetDefaultActionBlocks(t *testing.T) {
 		clusterInfo: mainlineV1ClusterInfo(),
 	}
 
-	expectBlockedInPending(t, ctx, g, bc, `tier "kube-admin" has defaultAction "Deny", expected "Pass"`)
+	expectBlockedInPending(t, ctx, g, bc, `tier "kube-admin" must have defaultAction "Pass"`)
 }
 
-// TestPreflight_UnsetDefaultActionOnDefaultTierProceeds verifies that an unset
-// defaultAction is conformant on the default tier, which requires Deny.
-func TestPreflight_UnsetDefaultActionOnDefaultTierProceeds(t *testing.T) {
+// TestPreflight_UnsetDefaultTierFieldsProceed verifies that the historical
+// default tier, carrying neither order nor defaultAction, is still conformant.
+func TestPreflight_UnsetDefaultTierFieldsProceed(t *testing.T) {
 	g := NewWithT(t)
 	ctx := context.Background()
 
 	bc := &mockBackendClient{
 		resources: tierOnlyV1Resources(
-			v1TierKVPUnsetAction("default", ptr.To(apiv3.DefaultTierOrder)),
+			v1TierKVPUnsetAction("default", nil),
 			v1TierKVP("kube-admin", ptr.To(apiv3.KubeAdminTierOrder), apiv3.Pass),
 			v1TierKVP("kube-baseline", ptr.To(apiv3.KubeBaselineTierOrder), apiv3.Pass),
 		),


### PR DESCRIPTION
A datastore migration on a cluster whose built-in tiers have drifted from the order and default action the v3 API enforces fails partway through, after the datastore is locked and the aggregated API server unregistered, and then retries against the locked datastore forever. The same rules only reached the v1 tier CRD in #12441 and are not applied retroactively, so older clusters can still be carrying drift.

The migration now checks the built-in tiers while still pending and refuses to start, naming every offending tier in one message; it stays pending rather than failing, so correcting the tiers in place lets it continue.

This also drops the special-case that rewrote the default tier's order during the copy. A default tier with an explicitly drifted order used to migrate silently under the enforced order, and now blocks like the other built-ins, since quietly changing that order changes tier precedence and therefore policy evaluation.

Related: [CORE-13256](https://tigera.atlassian.net/browse/CORE-13256)

```release-note
Fixes datastore migration failing partway through, with the datastore left locked, on clusters where one of the built-in tiers has a non-conformant order or default action. The migration now refuses to start and reports which tiers need correcting. A default tier with a non-conformant order was previously rewritten during the migration, and now has to be corrected by hand before the migration will start.
```

[CORE-13256]: https://tigera.atlassian.net/browse/CORE-13256?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
