### PR TITLE
Export the CI-account cloud env in the ArgoCI e2e prologue

### DIFF
--- a/.argoci/README.md
+++ b/.argoci/README.md
@@ -44,7 +44,7 @@ own prologue, and a missing one fails at provision time, not at startup:
 | `KOPS_STATE_STORE_NAME` | `kops-tigera-dev` (403) | `kops-tigera-dev-ci` |
 | `KOPS_AWS_DNS_ZONE` | `kops.crc.aws.eng.tigera.net` (no zone) | `kops.ci.aws.eng.tigera.net` |
 | `OPENSHIFT_BASE_DOMAIN` | `openshift.crc.aws.eng.tigera.net` (no zone) | `openshift.ci.aws.eng.tigera.net` |
-| `AZ_PROJECT` | `tigera-dev` | `tigera-dev-ci` |
+| `AZ_PROJECT` (a subscription *name*) | `tigera-dev` | `tigera-dev-ci` |
 
 Semaphore vars deliberately **not** ported, so the next audit doesn't re-add
 them: `KOPS_VERSION`/`RKE_VERSION` (banzai-core resolves or pins these, and

--- a/.argoci/README.md
+++ b/.argoci/README.md
@@ -32,6 +32,29 @@ handler also reads crons from a fixed `.argoci/cron/` path, so nesting would
 require a handler change for no gain. Scope ownership with path-specific
 `CODEOWNERS` entries (e.g. `.argoci/cron/`) rather than directories.
 
+## CI-account env must be set here, not left to banzai-core
+
+banzai-core's `Taskvars` defaults point at the **tigera-dev developer** account.
+The CI IAM user can't use them, so any variable whose default names an account
+resource has to be exported by this prologue — Semaphore did the same in its
+own prologue, and a missing one fails at provision time, not at startup:
+
+| Variable | banzai-core default | Needed by CI |
+|---|---|---|
+| `KOPS_STATE_STORE_NAME` | `kops-tigera-dev` (403) | `kops-tigera-dev-ci` |
+| `KOPS_AWS_DNS_ZONE` | `kops.crc.aws.eng.tigera.net` (no zone) | `kops.ci.aws.eng.tigera.net` |
+| `OPENSHIFT_BASE_DOMAIN` | `openshift.crc.aws.eng.tigera.net` (no zone) | `openshift.ci.aws.eng.tigera.net` |
+| `AZ_PROJECT` | `tigera-dev` | `tigera-dev-ci` |
+
+Semaphore vars deliberately **not** ported, so the next audit doesn't re-add
+them: `KOPS_VERSION`/`RKE_VERSION` (banzai-core resolves or pins these, and
+Semaphore's GitHub-API lookup is rate-limit-prone); `DOCKER_EE_*` /
+`DOCKER_UCP_VERSION` (superseded by banzai-core's newer `MKE_VERSION`);
+`AZ_LOCATION`, `ENABLE_ALP` (defaults already match); `NUM_INFRA_NODES`,
+`TEST_TYPE`, `GOOGLE_REGION`, `GOOGLE_ZONE` (set per-job by the crons);
+`BZ_*`, `BANZAI_CORE_BRANCH`, `SEMAPHORE_*` (Semaphore-runner specific — the
+ArgoCI equivalents are `BZ_HOME`/`BZ_LOCAL_DIR`/`BZ_GLOBAL_BIN`).
+
 ## Cron naming (branchless)
 
 Cron filenames and their `generateName` carry **no branch** —

--- a/.argoci/scripts/global_prologue.sh
+++ b/.argoci/scripts/global_prologue.sh
@@ -101,6 +101,11 @@ else
   export TEST_TYPE=${TEST_TYPE:-k8s-e2e}
 fi
 export GOOGLE_PROJECT=${GOOGLE_PROJECT:-unique-caldron-775}
+# Azure counterpart of GOOGLE_PROJECT: azr-aso/azr-capi resolve the subscription
+# by matching this against `az account list` names, and banzai-core defaults it
+# to the developer subscription. azr-aks does not use it, which is why only the
+# ASO/CAPI paths break without it.
+export AZ_PROJECT=${AZ_PROJECT:-tigera-dev-ci}
 
 # GCP placement: gcp-openstack has its own defaults in banzai-core
 # (europe-west3-c in the openstack-calico-test VPC, which carries the
@@ -117,6 +122,15 @@ if [[ "${PROVISIONER}" != "gcp-openstack" ]]; then
   export GOOGLE_NETWORK=${GOOGLE_NETWORK:-semaphore-autotest}
 fi
 export AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION:-us-west-2}
+
+# banzai-core defaults these to the tigera-dev developer account (the
+# kops-tigera-dev bucket and the *.crc.aws.eng.tigera.net zones), which the CI
+# IAM user cannot reach: kops 403s reading its state store and the OpenShift
+# installer finds no matching Route53 zone. Semaphore set them in its own
+# prologue, so the ArgoCI port has to as well.
+export KOPS_STATE_STORE_NAME=${KOPS_STATE_STORE_NAME:-kops-tigera-dev-ci}
+export KOPS_AWS_DNS_ZONE=${KOPS_AWS_DNS_ZONE:-kops.ci.aws.eng.tigera.net}
+export OPENSHIFT_BASE_DOMAIN=${OPENSHIFT_BASE_DOMAIN:-openshift.ci.aws.eng.tigera.net}
 
 # RELEASE_STREAM: release-vX.Y -> vX.Y, else master. BRANCH is passed by the
 # workflow (from the cron's `branch` parameter).

--- a/.argoci/scripts/global_prologue.sh
+++ b/.argoci/scripts/global_prologue.sh
@@ -101,10 +101,11 @@ else
   export TEST_TYPE=${TEST_TYPE:-k8s-e2e}
 fi
 export GOOGLE_PROJECT=${GOOGLE_PROJECT:-unique-caldron-775}
-# Azure counterpart of GOOGLE_PROJECT: azr-aso/azr-capi resolve the subscription
-# by matching this against `az account list` names, and banzai-core defaults it
-# to the developer subscription. azr-aks does not use it, which is why only the
-# ASO/CAPI paths break without it.
+# Despite the name this is an Azure *subscription name*, not a project or a
+# resource group: azr-aso/azr-capi select the subscription by matching it
+# against `az account list` output. The spelling is banzai-core's variable, so
+# it can't be renamed from here. banzai-core defaults it to the developer
+# subscription; azr-aks ignores it, which is why only the ASO/CAPI paths break.
 export AZ_PROJECT=${AZ_PROJECT:-tigera-dev-ci}
 
 # GCP placement: gcp-openstack has its own defaults in banzai-core


### PR DESCRIPTION
The ArgoCI e2e prologue doesn't export the variables whose banzai-core defaults
name **tigera-dev developer** resources. Semaphore's prologue did. Without them
those defaults reach provisioning, where the CI IAM user can't use them.

Confirmed from the archived run logs (`gs://argoci-artifacts`):

**aws-kops** — `e2e-bpf-release-v3-31-1785885000`:
```
Error: error reading cluster configuration "bz-calico-u8bm2.kops.crc.aws.eng.tigera.net":
error reading s3://kops-tigera-dev/.../config: ... StatusCode: 403
AccessDenied: User: arn:aws:iam::<ci-account>:user/<ci-user> is not authorized to
perform: s3:ListBucket on resource: "arn:aws:s3:::kops-tigera-dev"
```

**aws-openshift** — `e2e-certification-master-1785791400`:
```
baseDomain: openshift.crc.aws.eng.tigera.net
level=fatal msg=... getting public zone for "openshift.crc.aws.eng.tigera.net":
no public route53 zone found matching name "openshift.crc.aws.eng.tigera.net"
```

Verified against the CI account:

| Value | Status |
|---|---|
| `s3://kops-tigera-dev` (default) | **AccessDenied** |
| `s3://kops-tigera-dev-ci` | accessible |
| `kops.ci.aws.eng.tigera.net` | public zone exists |
| `openshift.ci.aws.eng.tigera.net` | public zone exists |
| any `*.crc.aws.eng.tigera.net` | **no zone exists** |

`AZ_PROJECT` is included for the same reason: `azr-aso`/`azr-capi` resolve the
subscription by matching it against `az account list` names, and it defaults to
the developer subscription. `azr-aks` doesn't read it, which is why only the
ASO/CAPI paths break.

> Note: unlike the AWS values, `tigera-dev-ci` here is **not** verified against a
> live `az account list` — it's taken from what Semaphore's prologue used. Worth
> a reviewer check. `azr-aso` is only 3 runs/week, so it's not load-bearing for
> the pass-rate impact below.

### Impact

`bz provision` for OSS Calico on ArgoCI ran at **88.2%** last week (636 runs).
`aws-kops` was **0/53** and `aws-openshift` **25%** — between them 35 of the 75
failures. Both are pure env-resolution failures that die before any cloud
resource is created, so this should take provision to roughly **93.7%**.

### Testing

- `bash -n` clean; verified the new exports apply their defaults on a clean env
  and still honour values already set by a cron's per-job `env`.
- Confirmed the bucket/zone reachability in the table above with the CI credentials.
- Not yet observed in a live run — the affected suites are scheduled, so the real
  check is the next `e2e-bpf` (kops) and `e2e-certification` (openshift) run.

### Not ported

`.argoci/README.md` now records which Semaphore variables are deliberately left
out (`KOPS_VERSION`, `RKE_VERSION`, `DOCKER_EE_*`, `AZ_LOCATION`, `ENABLE_ALP`,
`BZ_*`, `SEMAPHORE_*`, and the ones the crons set per-job) so a later parity
audit doesn't re-add them.

Needs the same change on `release-v3.30`, `release-v3.31` and `release-v3.32`,
since the prologue is sourced from the checked-out branch.

**Release note:**
```release-note
NONE
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
