### PR TITLE
Fix auto-approval of operator CRD sync PRs

### DIFF
--- a/.github/workflows/sync-operator-crds.yml
+++ b/.github/workflows/sync-operator-crds.yml
@@ -77,13 +77,13 @@ jobs:
 
       # The PR author is github-actions[bot] (the GITHUB_TOKEN identity above), so
       # it can't approve its own PR, and the Actions token can't approve PRs anyway.
-      # Approve as marvin-tigera (TIGERA_BOT_PAT) so Marvin merges it once CI is green.
-      # branch protection has dismiss_stale_reviews off, so a single approval persists
-      # across the hourly content updates -- the reviewDecision guard keeps reruns quiet.
+      # Approve as marvin-tigera (MARVIN_PAT) so Marvin merges it once CI is green.
+      # Runs on every sync, not just content changes, so a PR that missed its
+      # approval gets one on the next pass. The reviewDecision guard keeps reruns quiet.
       - name: Auto-approve so Marvin merges once CI passes
-        if: steps.cpr.outputs.pull-request-operation == 'created' || steps.cpr.outputs.pull-request-operation == 'updated'
+        if: steps.cpr.outputs.pull-request-number != ''
         env:
-          GH_TOKEN: ${{ secrets.TIGERA_BOT_PAT }}
+          GH_TOKEN: ${{ secrets.MARVIN_PAT }}
           PR: ${{ steps.cpr.outputs.pull-request-number }}
           REPO: ${{ github.repository }}
         run: |
@@ -92,3 +92,28 @@ jobs:
             exit 0
           fi
           gh pr review "$PR" -R "$REPO" --approve
+
+      # GitHub holds Actions runs on a PR pushed by github-actions[bot] in the
+      # action_required state, which leaves the PR permanently unmergeable.
+      # Release them as marvin-tigera.
+      - name: Approve held workflow runs
+        if: steps.cpr.outputs.pull-request-number != ''
+        env:
+          GH_TOKEN: ${{ secrets.MARVIN_PAT }}
+          PR: ${{ steps.cpr.outputs.pull-request-number }}
+          REPO: ${{ github.repository }}
+        run: |
+          sha=$(gh pr view "$PR" -R "$REPO" --json headRefOid -q .headRefOid)
+          for _ in $(seq 1 6); do
+            runs=$(gh api "repos/$REPO/actions/runs?head_sha=$sha" \
+              --jq '.workflow_runs[] | select(.conclusion == "action_required") | .id')
+            if [ -n "$runs" ]; then
+              for id in $runs; do
+                echo "Approving held run $id"
+                gh api -X POST "repos/$REPO/actions/runs/$id/approve"
+              done
+              break
+            fi
+            echo "No held runs for $sha yet; waiting."
+            sleep 10
+          done


### PR DESCRIPTION
Two things kept the hourly operator CRD sync PRs from merging on their own.

- The approval step ran as `TIGERA_BOT_PAT`, which lacks pull-request write, so `gh pr review --approve` failed with `Resource not accessible by personal access token`. Switched to the org-level `MARVIN_PAT`, same as [the operator fix](https://github.com/tigera/operator/pull/4896).
- GitHub holds Actions runs on PRs pushed by github-actions[bot] in `action_required`, which pins the release note check as pending forever. Added the release step from [tigera/operator#5137](https://github.com/tigera/operator/pull/5137).

The approve step also now runs whenever the PR exists rather than only when the sync changed content, so a PR that missed its approval picks one up on the next hourly pass. https://github.com/projectcalico/calico/pull/13394 is currently stuck in exactly that state.