### PR TITLE
node: retain tunnel IP reconciliation triggers while busy

### DIFF
--- a/node/pkg/allocateip/allocateip.go
+++ b/node/pkg/allocateip/allocateip.go
@@ -20,6 +20,7 @@ import (
 	gnet "net"
 	"os"
 	"reflect"
+	"time"
 
 	api "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
 	log "github.com/sirupsen/logrus"
@@ -47,6 +48,16 @@ import (
 //
 // It will assign an address if there are any available, and remove any tunnel addresses
 // that are configured and should no longer be.
+
+// defaultResyncInterval is how often the daemon re-reconciles the tunnel addresses
+// even when the syncer has reported no change.
+//
+// The syncer is purely edge-triggered, so any trigger that is missed is missed
+// permanently: the node keeps running with no tunnel address, and every pod on it
+// is unreachable over that overlay until calico/node happens to restart. A single
+// lost Node status write during an apiserver blip is enough to get there. A cheap
+// periodic resync bounds that window instead of leaving it open indefinitely.
+const defaultResyncInterval = 5 * time.Minute
 
 // Run runs the tunnel IP allocator. In oneshot mode it reconciles once and
 // returns. In daemon mode it watches for IP pool and node configuration
@@ -94,6 +105,10 @@ func run(
 		ch:             make(chan struct{}),
 		data:           make(map[string]any),
 		felixEnvConfig: felixEnvConfig,
+		resyncInterval: defaultResyncInterval,
+	}
+	r.reconcile = func() error {
+		return reconcileTunnelAddrs(r.nodename, r.client, r.felixEnvConfig)
 	}
 
 	// Either create a typha syncclient or a local syncer depending on configuration. This calls back into the
@@ -115,11 +130,22 @@ func run(
 }
 
 func (r reconciler) run(ctx context.Context) error {
+	resync := time.NewTicker(r.resyncInterval)
+	defer resync.Stop()
+
 	for {
 		select {
 		case <-r.ch:
-			if err := reconcileTunnelAddrs(r.nodename, r.client, r.felixEnvConfig); err != nil {
+			if err := r.reconcile(); err != nil {
 				return fmt.Errorf("failed to reconcile tunnel address: %w", err)
+			}
+		case <-resync.C:
+			// Periodic resync. Unlike the event-driven path this does NOT return the
+			// error: the resync exists to recover from transient failures, so making
+			// it fatal would turn a blip that the next tick would have healed into a
+			// calico/node restart. The next tick retries.
+			if err := r.reconcile(); err != nil {
+				log.WithError(err).Warn("Failed to reconcile tunnel addresses during periodic resync, will retry")
 			}
 		case <-ctx.Done():
 			return nil
@@ -137,6 +163,13 @@ type reconciler struct {
 	data                 map[string]any
 	felixEnvConfig       *felixconfig.Config
 	initialSyncCompleted bool
+
+	// resyncInterval is how often to reconcile even with no syncer activity.
+	resyncInterval time.Duration
+
+	// reconcile performs a single reconciliation. It is a field so that tests can
+	// exercise the run loop's triggering without a datastore.
+	reconcile func() error
 }
 
 // OnStatusUpdated handles the syncer status callback method.

--- a/node/pkg/allocateip/allocateip_test.go
+++ b/node/pkg/allocateip/allocateip_test.go
@@ -19,6 +19,8 @@ import (
 	"errors"
 	"fmt"
 	gnet "net"
+	"sync/atomic"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -1018,6 +1020,62 @@ var _ = Describe("Running as daemon", func() {
 		By("shutting down the daemon")
 		cancel()
 		Eventually(completed).Should(BeClosed(), "2s", "200ms")
+	})
+})
+
+var _ = Describe("Periodic resync", func() {
+	// The syncer feeding the reconciler is purely edge-triggered, so a missed
+	// trigger is missed permanently. These exercise the run loop's own timer, with
+	// no syncer activity at all, so they need no datastore.
+
+	newReconciler := func(interval time.Duration, calls *int32, err error) reconciler {
+		return reconciler{
+			ch:             make(chan struct{}),
+			resyncInterval: interval,
+			reconcile: func() error {
+				atomic.AddInt32(calls, 1)
+				return err
+			},
+		}
+	}
+
+	runDaemon := func(r reconciler) (context.CancelFunc, chan struct{}) {
+		ctx, cancel := context.WithCancel(context.Background())
+		completed := make(chan struct{})
+		go func() {
+			defer close(completed)
+			_ = r.run(ctx)
+		}()
+		return cancel, completed
+	}
+
+	It("should reconcile repeatedly when the syncer reports nothing", func() {
+		var calls int32
+		cancel, completed := runDaemon(newReconciler(10*time.Millisecond, &calls, nil))
+		defer cancel()
+
+		Eventually(func() int32 {
+			return atomic.LoadInt32(&calls)
+		}, "5s", "10ms").Should(BeNumerically(">=", 3))
+
+		cancel()
+		Eventually(completed, "5s", "10ms").Should(BeClosed())
+	})
+
+	It("should keep running when a periodic resync fails", func() {
+		// A resync exists to recover from transient failures, so it must not itself
+		// become a new way to kill calico/node. The next tick retries.
+		var calls int32
+		cancel, completed := runDaemon(newReconciler(10*time.Millisecond, &calls, errors.New("transient failure")))
+		defer cancel()
+
+		Eventually(func() int32 {
+			return atomic.LoadInt32(&calls)
+		}, "5s", "10ms").Should(BeNumerically(">=", 3))
+		Expect(completed).NotTo(BeClosed())
+
+		cancel()
+		Eventually(completed, "5s", "10ms").Should(BeClosed())
 	})
 })
 


### PR DESCRIPTION
The tunnel IP reconciler can discard a notification while a reconciliation is in progress. For example, after the worker reads the Node, a label update arrives while it is listing IP pools. `OnUpdates` caches the new labels, but its nonblocking send on the unbuffered channel is dropped because the worker is busy. If that reconcile succeeds, no further pass is scheduled; an identical update is already in the cache and does not trigger one either.

Keep one pending notification in a buffered channel. Multiple changes can coalesce because the next pass reads current datastore state. The production constructor is shared with the regression test so the test exercises the actual channel setup.

This follows #13540's label-change and datastore-timeout fixes and preserves the later missing-node retry behavior. The periodic resync from the original version of this PR has been removed. The earlier explanation attributing the observed cluster outage to a lost syncer update was not established; this change addresses the independently reproduced notification race.

Validation on master `e58a7e44b431c087310e2cc8d9dcb641f6bd486a`:

- The new regression pauses `IPPool.List` after `Node.Get`, delivers a label update, then verifies another reconciliation starts after the first finishes. Restoring only the unbuffered channel makes it fail with exactly one reconciliation.
- The regression and five existing label-trigger/missing-node/run-loop specs pass with the fix.
- Formatting and whitespace checks pass. Tests used Go 1.27.1 on macOS arm64 with `CGO_ENABLED=0`; no live datastore or cluster outage was reproduced.

```sh
CGO_ENABLED=0 go test ./node/pkg/allocateip \
  -run 'TestChangeDuringReconcileQueuesAnotherPass|TestCommands' -count=1 \
  -args -ginkgo.focus='Reconciliation triggers|reconciler run loop'
```

No configuration or API changes; documentation changes are not needed for this internal notification fix.

**Release note:**
```release-note
Fix tunnel IP reconciliation notifications being discarded when configuration changes arrive during an in-progress reconciliation.
```

**AI assistance:** OpenAI Codex assisted with the investigation, implementation, regression test, and writing.
