### PR TITLE
Add server TLS support to whisker-backend

### DIFF
--- a/e2e/pkg/tests/policy/staged_policy.go
+++ b/e2e/pkg/tests/policy/staged_policy.go
@@ -3,6 +3,8 @@ package policy
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -16,6 +18,7 @@ import (
 	//nolint:staticcheck // Ignore ST1001: should not use dot imports
 	. "github.com/onsi/gomega"
 	v3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
+	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kubernetes/test/e2e/framework"
@@ -64,6 +67,9 @@ var _ = describe.CalicoDescribe(
 			installed, err := utils.WhiskerInstalled(cli)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(installed).To(BeTrue(), "Whisker is not installed in the cluster")
+
+			whiskerHTTPSClient, err = buildWhiskerHTTPSClient(context.TODO(), cli)
+			Expect(err).NotTo(HaveOccurred())
 		})
 
 		Context("Test presence in flow logs", func() {
@@ -342,8 +348,43 @@ var _ = describe.CalicoDescribe(
 		})
 	})
 
+// whiskerHTTPSClient verifies whisker-backend's certificate against the
+// cluster CA bundle. Populated once the bundle is read in BeforeEach.
+var whiskerHTTPSClient *http.Client
+
+// buildWhiskerHTTPSClient reads the cluster's CA bundle and returns a client
+// that trusts certificates signed by it, such as whisker-backend's.
+func buildWhiskerHTTPSClient(ctx context.Context, cli ctrlclient.Client) (*http.Client, error) {
+	bundle := &corev1.ConfigMap{}
+	err := cli.Get(ctx, ctrlclient.ObjectKey{Namespace: "calico-system", Name: "tigera-ca-bundle"}, bundle)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read tigera-ca-bundle: %w", err)
+	}
+
+	rootCAs := x509.NewCertPool()
+	appended := false
+	for _, pem := range bundle.Data {
+		if rootCAs.AppendCertsFromPEM([]byte(pem)) {
+			appended = true
+		}
+	}
+	if !appended {
+		return nil, fmt.Errorf("no CA certificates found in tigera-ca-bundle")
+	}
+
+	return &http.Client{
+		Transport: &http.Transport{TLSClientConfig: &tls.Config{RootCAs: rootCAs}},
+	}, nil
+}
+
+// whiskerGet fetches a whisker-backend URL over HTTPS, verifying the
+// backend's certificate against the cluster CA bundle.
+func whiskerGet(baseURL string) (*http.Response, error) {
+	return whiskerHTTPSClient.Get("https://" + baseURL)
+}
+
 func buildURL(port int, sourceNamespace, destinationNamespace, startTime string) string {
-	baseURL := fmt.Sprintf("http://localhost:%d/flows", port)
+	baseURL := fmt.Sprintf("localhost:%d/flows", port)
 
 	f := whiskerv1.Filters{
 		SourceNamespaces: whiskerv1.FilterMatches[string]{
@@ -366,7 +407,7 @@ func buildURL(port int, sourceNamespace, destinationNamespace, startTime string)
 func verifyPortForward(url string) {
 	// Port forward should be working and whisker-backend should return 200 status
 	Eventually(func() error {
-		resp, err := http.Get(url)
+		resp, err := whiskerGet(url)
 		if err != nil {
 			return err
 		}
@@ -389,7 +430,7 @@ func verifyFlowCount(url string, count int) {
 	var response apiutil.List[whiskerv1.FlowResponse]
 
 	EventuallyWithOffset(1, func() error {
-		resp, err := http.Get(url)
+		resp, err := whiskerGet(url)
 		if err != nil {
 			return err
 		}
@@ -423,7 +464,7 @@ func verifyFlowContainsStagedPolicy(url, name, tier string, kind whiskerv1.Polic
 	var response apiutil.List[whiskerv1.FlowResponse]
 	containsStagedPolicy := false
 
-	resp, err := http.Get(url)
+	resp, err := whiskerGet(url)
 	ExpectWithOffset(1, err).NotTo(HaveOccurred())
 	defer func() { _ = resp.Body.Close() }()
 

--- a/whisker-backend/cmd/whiskerbackend/app.go
+++ b/whisker-backend/cmd/whiskerbackend/app.go
@@ -50,10 +50,10 @@ func Run(ctx context.Context, cfg *config.Config) {
 		server.WithAddr(cfg.HostAddr()),
 	}
 
-	// TODO maybe we can push getting tls files to the common http utilities package?
-	if cfg.TLSKeyPath != "" && cfg.TLSCertPath != "" {
-		opts = append(opts, server.WithTLSFiles(cfg.TLSCertPath, cfg.TLSKeyPath))
+	if cfg.ServerTLSCertPath == "" || cfg.ServerTLSKeyPath == "" {
+		logrus.Fatal("SERVER_TLS_CERT_PATH and SERVER_TLS_KEY_PATH must be set.")
 	}
+	opts = append(opts, server.WithTLSFiles(cfg.ServerTLSCertPath, cfg.ServerTLSKeyPath))
 
 	flowsAPI := v1.NewFlows(gmCli)
 
@@ -66,9 +66,8 @@ func Run(ctx context.Context, cfg *config.Config) {
 		logrus.WithError(err).Fatal("Failed to create server.")
 	}
 
-	// TODO Should we require that this is TLS? It will be in the same pod as nginx.
 	logrus.Infof("Listening on %s.", cfg.HostAddr())
-	if err := srv.ListenAndServe(ctx); err != nil {
+	if err := srv.ListenAndServeTLS(ctx); err != nil {
 		logrus.WithError(err).Fatal("Failed to start server.")
 	}
 

--- a/whisker-backend/pkg/config/api.go
+++ b/whisker-backend/pkg/config/api.go
@@ -31,10 +31,14 @@ type Config struct {
 	Port         string `default:"8080"`
 	LogLevel     string `default:"info" envconfig:"LOG_LEVEL"`
 
-	// TLS certificate and key for both server TLS and Goldmane client mTLS.
+	// TLS certificate and key for Goldmane client mTLS.
 	TLSCertPath string `default:"" envconfig:"TLS_CERT_PATH"`
 	TLSKeyPath  string `default:"" envconfig:"TLS_KEY_PATH"`
 	CACertPath  string `default:"/etc/pki/tls/certs/ca.crt" envconfig:"CA_CERT_PATH"`
+
+	// TLS certificate and key for serving HTTPS. Required; the server only serves HTTPS.
+	ServerTLSCertPath string `envconfig:"SERVER_TLS_CERT_PATH" required:"true"`
+	ServerTLSKeyPath  string `envconfig:"SERVER_TLS_KEY_PATH" required:"true"`
 }
 
 func NewConfig() (*Config, error) {

--- a/whisker-backend/test/fv/goldmaneintegration_test.go
+++ b/whisker-backend/test/fv/goldmaneintegration_test.go
@@ -68,6 +68,11 @@ func TestGoldmaneIntegration_FlowWatching(t *testing.T) {
 		clientCertFile, clientKeyFile := createKeyCertPair(tmpDir)
 		defer func() { _ = certFile.Close() }()
 		defer func() { _ = keyFile.Close() }()
+
+		// Generate a self-signed certificate for Whisker's HTTPS server.
+		serverCertFile, serverKeyFile := createKeyCertPair(tmpDir)
+		defer func() { _ = serverCertFile.Close() }()
+		defer func() { _ = serverKeyFile.Close() }()
 		aggrWindow := time.Second * 5
 		cfg := gmdaemon.Config{
 			LogLevel:          "debug",
@@ -92,6 +97,9 @@ func TestGoldmaneIntegration_FlowWatching(t *testing.T) {
 			CACertPath:   certFile.Name(),
 			TLSCertPath:  clientCertFile.Name(),
 			TLSKeyPath:   clientKeyFile.Name(),
+
+			ServerTLSCertPath: serverCertFile.Name(),
+			ServerTLSKeyPath:  serverKeyFile.Name(),
 		}
 		whiskerCfg.ConfigureLogging()
 		wg.Go(func() {
@@ -108,7 +116,7 @@ func TestGoldmaneIntegration_FlowWatching(t *testing.T) {
 
 		realtime.Sleep(time.Second * 5)
 
-		req, err := http.NewRequest(http.MethodGet, "http://localhost:8080/flows", nil)
+		req, err := http.NewRequest(http.MethodGet, "https://localhost:8080/flows", nil)
 		Expect(err).ShouldNot(HaveOccurred())
 
 		query := req.URL.Query()
@@ -119,7 +127,7 @@ func TestGoldmaneIntegration_FlowWatching(t *testing.T) {
 		req.URL.RawQuery = query.Encode()
 		req.Header.Set("Accept", "text/event-stream")
 
-		resp, err := http.DefaultClient.Do(req)
+		resp, err := newHTTPSClient(serverCertFile.Name()).Do(req)
 		Expect(err).ShouldNot(HaveOccurred())
 
 		go func() {
@@ -179,6 +187,11 @@ func TestGoldmaneIntegration_FilterHints(t *testing.T) {
 	defer func() { _ = certFile.Close() }()
 	defer func() { _ = keyFile.Close() }()
 
+	// Generate a self-signed certificate for Whisker's HTTPS server.
+	serverCertFile, serverKeyFile := createKeyCertPair(tmpDir)
+	defer func() { _ = serverCertFile.Close() }()
+	defer func() { _ = serverKeyFile.Close() }()
+
 	aggrWindow := time.Second * 5
 	cfg := gmdaemon.Config{
 		LogLevel:          "debug",
@@ -200,6 +213,9 @@ func TestGoldmaneIntegration_FilterHints(t *testing.T) {
 		CACertPath:   certFile.Name(),
 		TLSCertPath:  clientCertFile.Name(),
 		TLSKeyPath:   clientKeyFile.Name(),
+
+		ServerTLSCertPath: serverCertFile.Name(),
+		ServerTLSKeyPath:  serverKeyFile.Name(),
 	}
 	whiskerCfg.ConfigureLogging()
 
@@ -248,7 +264,7 @@ func TestGoldmaneIntegration_FilterHints(t *testing.T) {
 		EndTime:   time.Now().Unix(),
 	}))
 
-	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://localhost:8080/%s", whiskerv1.FlowsFilterHintsPath), nil)
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("https://localhost:8080/%s", whiskerv1.FlowsFilterHintsPath), nil)
 	Expect(err).ShouldNot(HaveOccurred())
 
 	query := req.URL.Query()
@@ -258,7 +274,7 @@ func TestGoldmaneIntegration_FilterHints(t *testing.T) {
 	}))
 	req.URL.RawQuery = query.Encode()
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := newHTTPSClient(serverCertFile.Name()).Do(req)
 	Expect(err).ShouldNot(HaveOccurred())
 	defer func() { _ = resp.Body.Close() }()
 	byts, err := io.ReadAll(resp.Body)

--- a/whisker-backend/test/fv/servertls_test.go
+++ b/whisker-backend/test/fv/servertls_test.go
@@ -1,0 +1,115 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fv
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"sync"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
+
+	gmdaemon "github.com/projectcalico/calico/goldmane/pkg/daemon"
+	"github.com/projectcalico/calico/lib/std/time"
+	"github.com/projectcalico/calico/whisker-backend/cmd/whiskerbackend"
+	whiskerv1 "github.com/projectcalico/calico/whisker-backend/pkg/apis/v1"
+	wconfig "github.com/projectcalico/calico/whisker-backend/pkg/config"
+)
+
+// Verifies that whisker-backend serves HTTPS and rejects plain HTTP on the
+// same port.
+func TestServerTLS(t *testing.T) {
+	var wg sync.WaitGroup
+	defer func() {
+		logrus.Info("Waiting for goroutines to finish...")
+		wg.Wait()
+		logrus.Info("Finished waiting for goroutines to finish.")
+	}()
+
+	ctx, teardown := setup(t)
+	defer teardown()
+
+	tmpDir := os.TempDir()
+
+	// Generate a self-signed certificate for Goldmane.
+	gmCertFile, gmKeyFile := createKeyCertPair(tmpDir)
+	defer func() { _ = gmCertFile.Close() }()
+	defer func() { _ = gmKeyFile.Close() }()
+
+	// Generate a self-signed certificate for Whisker's Goldmane client mTLS.
+	clientCertFile, clientKeyFile := createKeyCertPair(tmpDir)
+	defer func() { _ = clientCertFile.Close() }()
+	defer func() { _ = clientKeyFile.Close() }()
+
+	// Generate a self-signed certificate for Whisker's HTTPS server.
+	serverCertFile, serverKeyFile := createKeyCertPair(tmpDir)
+	defer func() { _ = serverCertFile.Close() }()
+	defer func() { _ = serverKeyFile.Close() }()
+
+	gmCfg := gmdaemon.Config{
+		LogLevel:          "debug",
+		Port:              5445,
+		AggregationWindow: time.Second * 5,
+		ServerCertPath:    gmCertFile.Name(),
+		ServerKeyPath:     gmKeyFile.Name(),
+		CACertPath:        clientCertFile.Name(),
+	}
+
+	wg.Go(func() {
+		gmdaemon.Run(ctx, gmCfg)
+	})
+
+	whiskerCfg := &wconfig.Config{
+		Port:              "8090",
+		LogLevel:          "debug",
+		GoldmaneHost:      "localhost:5445",
+		CACertPath:        gmCertFile.Name(),
+		TLSCertPath:       clientCertFile.Name(),
+		TLSKeyPath:        clientKeyFile.Name(),
+		ServerTLSCertPath: serverCertFile.Name(),
+		ServerTLSKeyPath:  serverKeyFile.Name(),
+	}
+	whiskerCfg.ConfigureLogging()
+
+	wg.Go(func() {
+		whiskerbackend.Run(ctx, whiskerCfg)
+	})
+
+	httpsClient := newHTTPSClient(serverCertFile.Name())
+
+	url := fmt.Sprintf("https://localhost:8090/%s?type=SourceName", whiskerv1.FlowsFilterHintsPath)
+	Eventually(func() error {
+		resp, err := httpsClient.Get(url)
+		if err != nil {
+			return err
+		}
+		defer func() { _ = resp.Body.Close() }()
+		body, _ := io.ReadAll(resp.Body)
+		if resp.StatusCode != http.StatusOK {
+			return fmt.Errorf("unexpected status %d: %s", resp.StatusCode, body)
+		}
+		return nil
+	}, "30s", "1s").Should(Succeed(), "expected whisker-backend to serve HTTPS")
+
+	// Plain HTTP on the TLS port is rejected by the server.
+	resp, err := http.Get(fmt.Sprintf("http://localhost:8090/%s?type=SourceName", whiskerv1.FlowsFilterHintsPath))
+	Expect(err).ShouldNot(HaveOccurred())
+	defer func() { _ = resp.Body.Close() }()
+	Expect(resp.StatusCode).Should(Equal(http.StatusBadRequest))
+}

--- a/whisker-backend/test/fv/util.go
+++ b/whisker-backend/test/fv/util.go
@@ -2,9 +2,11 @@ package fv
 
 import (
 	"bufio"
+	"crypto/tls"
 	"crypto/x509"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"strings"
 	"testing"
@@ -41,6 +43,19 @@ func createKeyCertPair(dir string) (*os.File, *os.File) {
 	Expect(err).ShouldNot(HaveOccurred())
 
 	return certFile, keyFile
+}
+
+// newHTTPSClient returns a client that trusts the certificate at the given path.
+func newHTTPSClient(certPath string) *http.Client {
+	certPEM, err := os.ReadFile(certPath)
+	Expect(err).ShouldNot(HaveOccurred())
+
+	rootCAs := x509.NewCertPool()
+	Expect(rootCAs.AppendCertsFromPEM(certPEM)).Should(BeTrue())
+
+	return &http.Client{
+		Transport: &http.Transport{TLSClientConfig: &tls.Config{RootCAs: rootCAs}},
+	}
 }
 
 // newSSEScanner creates a new scanner for reading "Server Side Events".

--- a/whisker/docker-image/default.conf
+++ b/whisker/docker-image/default.conf
@@ -26,7 +26,8 @@ server {
 
     location /whisker-backend/ {
         rewrite ^/whisker-backend/(.*)$ /$1 break;
-        proxy_pass http://localhost:3002;
+        proxy_pass https://localhost:3002;
+        proxy_ssl_verify off;
         proxy_buffering off;
         proxy_request_buffering off;
         proxy_cache off;


### PR DESCRIPTION
whisker-backend now serves its API over HTTPS only. New required config
options SERVER_TLS_CERT_PATH and SERVER_TLS_KEY_PATH provide the server
certificate; the process fails fast with a clear error when they are
missing. The existing TLS_CERT_PATH / TLS_KEY_PATH options are now used
only for the Goldmane client mTLS, instead of doing double duty.

Also:
- The staged-policy e2e queries whisker-backend over HTTPS, verifying
  its certificate against the cluster's tigera-ca-bundle.
- The goldmane FV tests run the backend with server TLS.
- The standalone whisker image's nginx proxies the backend over https.

Companion operator PR: tigera/operator#5140, which sets the env vars
and switches nginx to TLS.

**Merge order: the operator PR merges first, then this one.** The e2e
here is HTTPS-only and the backend now requires the env vars, so
clusters must have an operator that sets them. A new backend image
under an old operator fails fast (crashloop with a clear message)
rather than silently serving HTTP — the operator must be upgraded
first or together, which is the normal operator-managed flow.

Testing:
- FV (whisker-backend/test/fv): backend serves HTTPS with verified
  certs, plain HTTP on the same port is rejected; goldmane integration
  tests exercise flows and SSE over HTTPS.
- Verified end to end on a kadm cluster with the operator change:
  nginx (8443, TLS) -> whisker-backend (3002, TLS) -> Goldmane
  (7443, mTLS), flows visible in the UI.

**Release note:**
```release-note
Whisker backend now serves HTTPS only; SERVER_TLS_CERT_PATH and SERVER_TLS_KEY_PATH are required.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)