### PR TITLE
[v3.31] Honor CALICO_IPV6POOL_VXLAN when the IPv4 pool is disabled

### DIFF
--- a/node/pkg/lifecycle/startup/startup.go
+++ b/node/pkg/lifecycle/startup/startup.go
@@ -968,7 +968,6 @@ func configureIPPools(ctx context.Context, client client.Interface, kubeadmConfi
 	if ipv4PoolEnabled {
 		ipv4IpipModeEnvVar = strings.ToLower(os.Getenv("CALICO_IPV4POOL_IPIP"))
 		ipv4VXLANModeEnvVar = strings.ToLower(os.Getenv("CALICO_IPV4POOL_VXLAN"))
-		ipv6VXLANModeEnvVar = strings.ToLower(os.Getenv("CALICO_IPV6POOL_VXLAN"))
 
 		ipv4BlockSizeEnvVar = os.Getenv("CALICO_IPV4POOL_BLOCK_SIZE")
 		if ipv4BlockSizeEnvVar != "" {
@@ -1002,6 +1001,8 @@ func configureIPPools(ctx context.Context, client client.Interface, kubeadmConfi
 	}
 
 	if ipv6PoolEnabled {
+		ipv6VXLANModeEnvVar = strings.ToLower(os.Getenv("CALICO_IPV6POOL_VXLAN"))
+
 		ipv6BlockSizeEnvVar = os.Getenv("CALICO_IPV6POOL_BLOCK_SIZE")
 		if ipv6BlockSizeEnvVar != "" {
 			ipv6BlockSize = parseBlockSizeEnvironment(ipv6BlockSizeEnvVar)

--- a/node/pkg/lifecycle/startup/startup_test.go
+++ b/node/pkg/lifecycle/startup/startup_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016,2021 Tigera, Inc. All rights reserved.
+// Copyright (c) 2016,2021,2026 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -444,6 +444,30 @@ var _ = Describe("FV tests against a real etcd", func() {
 			[]EnvItem{{"CALICO_IPV4POOL_DISABLE_BGP_EXPORT", "false"}, {"CALICO_IPV6POOL_DISABLE_BGP_EXPORT", "false"}},
 			"192.168.0.0/16", randomULAPool, "Off", "Off", "Off", true, false, 26, 122, "all()", "all()", false, false),
 	)
+
+	It("should honor CALICO_IPV6POOL_VXLAN when the IPv4 pool is disabled", func() {
+		cfg, err := apiconfig.LoadClientConfigFromEnvironment()
+		Expect(err).NotTo(HaveOccurred())
+		c, err := client.New(*cfg)
+		Expect(err).NotTo(HaveOccurred())
+		be, err := backend.NewClient(*cfg)
+		Expect(err).NotTo(HaveOccurred())
+		err = be.Clean()
+		Expect(err).NotTo(HaveOccurred())
+
+		defer temporarilySetEnv("CALICO_IPV4POOL_CIDR", "none")()
+		defer temporarilySetEnv("CALICO_IPV6POOL_VXLAN", "Always")()
+
+		configureIPPools(ctx, c, kubeadmConfig)
+
+		poolList, err := c.IPPools().List(ctx, options.ListOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(poolList.Items).To(HaveLen(1))
+
+		pool := poolList.Items[0]
+		Expect(pool.Name).To(Equal(DEFAULT_IPV6_POOL_NAME))
+		Expect(pool.Spec.VXLANMode).To(Equal(apiv3.VXLANModeAlways))
+	})
 
 	It("should properly clear node IPs", func() {
 		cfg, err := apiconfig.LoadClientConfigFromEnvironment()


### PR DESCRIPTION
**Cherry-pick history**
- Pick onto **release-v3.31**: projectcalico/calico#13115

In IPv6-only clusters that disable the IPv4 pool with `CALICO_IPV4POOL_CIDR=none`, `CALICO_IPV6POOL_VXLAN` was silently ignored and the IPv6 pool came up with `vxlanMode: Never`, breaking cross-node pod connectivity over VXLAN. The env var was being read inside the IPv4-pool branch of `configureIPPools`, which is skipped when the IPv4 pool is disabled. This moves the read into the IPv6-pool branch where it belongs.

Added a regression test that disables the IPv4 pool, sets `CALICO_IPV6POOL_VXLAN=Always`, and checks the resulting IPv6 pool. It fails without the fix.

Fixes #12896

**Release note:**
```release-note
Fixes CALICO_IPV6POOL_VXLAN being ignored in IPv6-only clusters where the IPv4 pool is disabled (CALICO_IPV4POOL_CIDR=none), which left the IPv6 pool without VXLAN encapsulation.
```
