### PR TITLE
[v3.32] Don't tag a host IP as a workload when it falls within an IPAM block

### DIFF
--- a/felix/calc/l3_route_resolver.go
+++ b/felix/calc/l3_route_resolver.go
@@ -766,6 +766,7 @@ func (c *L3RouteResolver) flush() {
 		var blockTypes proto.RouteType
 		var blockMatchesRoute bool
 		var hasTunnelRef bool
+		var hasHostRef bool
 		for _, entry := range buf {
 			ri := entry.Data.(RouteInfo)
 			if len(ri.Pools) > 0 {
@@ -815,6 +816,7 @@ func (c *L3RouteResolver) flush() {
 			}
 			if len(ri.Host.NodeNames) > 0 {
 				rt.DstNodeName = ri.Host.NodeNames[0]
+				hasHostRef = true
 
 				if rt.DstNodeName == c.myNodeName {
 					logCxt.Debug("Local host route.")
@@ -877,15 +879,19 @@ func (c *L3RouteResolver) flush() {
 			}
 		}
 
-		// Apply the accumulated block workload type flags unless the route is a tunnel
-		// IP that merely falls within a parent block. A tunnel IP inside a larger block
-		// (e.g., a /32 inside a /26) should not get REMOTE_WORKLOAD — that causes
-		// isRemoteTunnelRoute() in the route manager to program a spurious /32 route.
+		// Apply the accumulated block workload type flags, with two exceptions.
 		//
-		// However, if the block is at the same CIDR as the route (e.g., a /32 block from
-		// a dedicated tunnel pool), the workload type is still needed so the route manager
+		// A host IP never inherits the workload type from a containing block, even one at
+		// its exact CIDR. It's reachable via its own host route; tagging it REMOTE_WORKLOAD
+		// makes the route manager program the node's own IP via the tunnel device, which
+		// breaks connectivity to the node.
+		//
+		// A tunnel IP that merely falls within a larger parent block (e.g. a /32 inside a
+		// /24) also skips the workload type, since REMOTE_WORKLOAD makes
+		// isRemoteTunnelRoute() program a spurious /32 route. A tunnel IP whose block is at
+		// the same CIDR (a dedicated /32 tunnel pool) still needs it, so the route manager
 		// programs the correct directly-connected route.
-		if blockSeen && (!hasTunnelRef || blockMatchesRoute) {
+		if blockSeen && !hasHostRef && (blockMatchesRoute || !hasTunnelRef) {
 			rt.Types |= blockTypes
 		}
 

--- a/felix/calc/l3_route_resolver_test.go
+++ b/felix/calc/l3_route_resolver_test.go
@@ -288,6 +288,139 @@ var _ = Describe("L3RouteResolver", func() {
 		})
 	})
 
+	Describe("host IP within IPAM block", func() {
+		var l3RR *L3RouteResolver
+		var eventBuf rtEventsMock
+
+		BeforeEach(func() {
+			eventBuf = make(rtEventsMock, 100)
+			l3RR = NewL3RouteResolver("local-host", eventBuf, true, "CalicoIPAM")
+			l3RR.OnAlive = func() {}
+		})
+
+		drainEvents := func() []*proto.RouteUpdate {
+			var routes []*proto.RouteUpdate
+			for {
+				select {
+				case ev := <-eventBuf:
+					if rt, ok := ev.(*proto.RouteUpdate); ok {
+						routes = append(routes, rt)
+					}
+				default:
+					return routes
+				}
+			}
+		}
+
+		findRoute := func(routes []*proto.RouteUpdate, dst string) *proto.RouteUpdate {
+			for _, rt := range routes {
+				if rt.Dst == dst {
+					return rt
+				}
+			}
+			return nil
+		}
+
+		// A per-node IP pool can put a node's own host IP inside one of its IPAM blocks
+		// (e.g. node IP 10.0.1.1 sits inside the block 10.0.1.0/24 for that node's pool).
+		// The host IP route must not pick up REMOTE_WORKLOAD from the containing block,
+		// otherwise the route manager programs the node's own IP via the tunnel device and
+		// breaks connectivity to the node. See https://github.com/projectcalico/calico/issues/12847.
+		It("should not add REMOTE_WORKLOAD to a host IP just because it falls within a block", func() {
+			poolCIDR, _ := ip.CIDRFromString("10.0.0.0/16")
+			pool := model.IPPool{
+				CIDR:      net.IPNet{IPNet: poolCIDR.ToIPNet()},
+				VXLANMode: encap.Always,
+			}
+			l3RR.OnPoolUpdate(api.Update{
+				KVPair: model.KVPair{
+					Key:   model.IPPoolKey{CIDR: pool.CIDR},
+					Value: &pool,
+				},
+			})
+			drainEvents()
+
+			// The block 10.0.1.0/24 is affined to remote-host, whose own IP (10.0.1.1)
+			// falls within it.
+			remoteAffinity := "host:remote-host"
+			blockCIDR := net.MustParseCIDR("10.0.1.0/24")
+			l3RR.OnBlockUpdate(api.Update{
+				KVPair: model.KVPair{
+					Key: model.BlockKey{CIDR: blockCIDR},
+					Value: &model.AllocationBlock{
+						CIDR:        blockCIDR,
+						Affinity:    &remoteAffinity,
+						Allocations: make([]*int, 256),
+						Unallocated: []int{},
+					},
+				},
+			})
+			drainEvents()
+
+			l3RR.onNodeUpdate("remote-host", &l3rrNodeInfo{
+				V4Addr: ip.FromString("10.0.1.1").(ip.V4Addr),
+			})
+			l3RR.flush()
+
+			routes := drainEvents()
+
+			hostRoute := findRoute(routes, "10.0.1.1/32")
+			Expect(hostRoute).NotTo(BeNil(), "expected a route for the host IP 10.0.1.1/32")
+
+			Expect(hostRoute.Types&proto.RouteType_REMOTE_HOST).NotTo(BeZero(),
+				"host route should have REMOTE_HOST type")
+			Expect(hostRoute.Types&proto.RouteType_REMOTE_WORKLOAD).To(BeZero(),
+				"host route should NOT have REMOTE_WORKLOAD just because it falls within a block")
+		})
+
+		// Regression guard for the suppression above. A remote block that doesn't contain
+		// the node's own host IP is a genuine remote workload route and must keep
+		// REMOTE_WORKLOAD, which it gets solely from the block type flags. Suppressing those
+		// flags unconditionally would pass the host-IP test above but break real workload
+		// routing.
+		It("should still add REMOTE_WORKLOAD to a remote block route", func() {
+			poolCIDR, _ := ip.CIDRFromString("10.0.0.0/16")
+			pool := model.IPPool{
+				CIDR:      net.IPNet{IPNet: poolCIDR.ToIPNet()},
+				VXLANMode: encap.Always,
+			}
+			l3RR.OnPoolUpdate(api.Update{
+				KVPair: model.KVPair{
+					Key:   model.IPPoolKey{CIDR: pool.CIDR},
+					Value: &pool,
+				},
+			})
+
+			remoteAffinity := "host:remote-host"
+			blockCIDR := net.MustParseCIDR("10.0.1.0/24")
+			l3RR.OnBlockUpdate(api.Update{
+				KVPair: model.KVPair{
+					Key: model.BlockKey{CIDR: blockCIDR},
+					Value: &model.AllocationBlock{
+						CIDR:        blockCIDR,
+						Affinity:    &remoteAffinity,
+						Allocations: make([]*int, 256),
+						Unallocated: []int{},
+					},
+				},
+			})
+
+			// The node's host IP is outside the block, so nothing suppresses the block's
+			// workload type.
+			l3RR.onNodeUpdate("remote-host", &l3rrNodeInfo{
+				V4Addr: ip.FromString("192.168.0.2").(ip.V4Addr),
+			})
+			l3RR.flush()
+
+			routes := drainEvents()
+
+			blockRoute := findRoute(routes, "10.0.1.0/24")
+			Expect(blockRoute).NotTo(BeNil(), "expected a route for the block 10.0.1.0/24")
+			Expect(blockRoute.Types&proto.RouteType_REMOTE_WORKLOAD).NotTo(BeZero(),
+				"remote block route should keep REMOTE_WORKLOAD")
+		})
+	})
+
 	It("should not set IpPoolType but still propagate NatOutgoing for LoadBalancer-only pools", func() {
 		eventBuf := make(rtEventsMock, 100)
 		l3RR := NewL3RouteResolver("local-host", eventBuf, false, "CalicoIPAM")


### PR DESCRIPTION
**Cherry-pick history**
- Pick onto **release-v3.32**: projectcalico/calico#13116

When a node's host IP falls inside one of its own Calico IPAM blocks (for example a per-node /24 pool where the node IP is the .1), Felix programs a route for the node's own IP via the VXLAN/IPIP tunnel device. That shadows the real link route and breaks connectivity to the node.

The route resolver was tagging the host IP as a remote workload because it sits inside the containing block. Same root cause as #12180 (tunnel IPs), so this extends the same guard to host IPs: a host IP that merely falls within a parent block no longer picks up the workload route type.

Note that overlapping the node network with a Calico IP pool isn't a supported configuration, but the fix is small and low risk.

Fixes #12847

```release-note
Fixes a loss of connectivity to a node when its host IP falls within a Calico IPAM block, in setups where the node network overlaps a Calico IP pool.
```

**Original Commit SHAs**: 9544ac0259