### PR TITLE
[v3.32] Fix spurious IP set member removal in nftables overlap dedup

### DIFF
--- a/felix/calc/calc_graph_fv_test.go
+++ b/felix/calc/calc_graph_fv_test.go
@@ -173,6 +173,15 @@ var baseTests = []StateList{
 		hostEp1WithPolicyAndTwoNetworkSets,
 	},
 
+	// Overlap-suppression dedup remove path (CORE-13009): add a broad CIDR, nest CIDRs under it
+	// (suppressed), then remove a middle CIDR while the ancestor still covers the leaf. The removed
+	// CIDR was never programmed, so nothing must be emitted and the leaf must stay suppressed.
+	{
+		hostEp1WithPolicyAndOverlapAncestor,
+		hostEp1WithPolicyAndOverlapNested,
+		hostEp1WithPolicyAndOverlapMiddleRemoved,
+	},
+
 	// Untracked policy on its own.
 	{hostEp1WithUntrackedPolicy},
 	// Mixed policy.

--- a/felix/calc/resources_for_test.go
+++ b/felix/calc/resources_for_test.go
@@ -774,6 +774,43 @@ var (
 	}
 )
 
+// netSetOverlap* model a NetworkSet whose CIDRs nest inside one another, exercising the
+// overlap-suppression dedup (CORE-13009). The a=="b" label matches all() (allSelectorId) but not
+// b=="b" (bEqBSelectorId), so the CIDRs land only in the all() IP set.
+var (
+	netSetOverlapKey = model.NetworkSetKey{Name: "netset-overlap"}
+
+	netSetOverlapAncestor = model.NetworkSet{
+		Nets: []net.IPNet{
+			mustParseNet("10.65.0.0/16"),
+		},
+		Labels: uniquelabels.Make(map[string]string{
+			"a": "b",
+		}),
+	}
+
+	netSetOverlapNested = model.NetworkSet{
+		Nets: []net.IPNet{
+			mustParseNet("10.65.0.0/16"), // ancestor
+			mustParseNet("10.65.1.0/24"), // nested under ancestor
+			mustParseNet("10.65.1.5/32"), // nested under both
+		},
+		Labels: uniquelabels.Make(map[string]string{
+			"a": "b",
+		}),
+	}
+
+	netSetOverlapMiddleRemoved = model.NetworkSet{
+		Nets: []net.IPNet{
+			mustParseNet("10.65.0.0/16"), // ancestor still present
+			mustParseNet("10.65.1.5/32"), // leaf still present, middle /24 gone
+		},
+		Labels: uniquelabels.Make(map[string]string{
+			"a": "b",
+		}),
+	}
+)
+
 var (
 	netSet3Key = model.NetworkSetKey{Name: "netset-3"}
 	netSet3    = model.NetworkSet{

--- a/felix/calc/states_for_test.go
+++ b/felix/calc/states_for_test.go
@@ -1545,6 +1545,50 @@ var hostEp1WithPolicyAndANetworkSetMatchingBEqB = hostEp1WithPolicy.withKVUpdate
 	"12.1.0.0/24",
 })
 
+// The next three states exercise overlap-suppression dedup on the remove path (CORE-13009). When
+// NFTables mode is not disabled (the FV default is "Auto"), the all() IP set is programmed as an
+// nftables interval set, which rejects overlapping CIDRs, so Felix suppresses nested CIDRs upstream:
+// only the broadest CIDR covering each address is programmed. The interesting transition is removing
+// a CIDR while a broader ancestor still covers it — the removed CIDR was never its own set member, so
+// nothing must be emitted, and descendants the ancestor still covers must stay suppressed.
+
+// hostEp1WithPolicyAndOverlapAncestor adds a NetworkSet contributing a single broad CIDR.
+var hostEp1WithPolicyAndOverlapAncestor = hostEp1WithPolicy.withKVUpdates(
+	KVPair{Key: netSetOverlapKey, Value: &netSetOverlapAncestor},
+).withIPSet(allSelectorId, []string{
+	"10.0.0.1/32", // ep1
+	"fc00:fe11::1/128",
+	"10.0.0.2/32", // ep1 and ep2
+	"fc00:fe11::2/128",
+	"10.65.0.0/16", // ancestor CIDR
+}).withName("host ep1, policy, overlap netset ancestor only")
+
+// hostEp1WithPolicyAndOverlapNested adds two further CIDRs nested inside the ancestor; both are
+// suppressed, so the programmed all() set is unchanged from the ancestor-only state.
+var hostEp1WithPolicyAndOverlapNested = hostEp1WithPolicyAndOverlapAncestor.withKVUpdates(
+	KVPair{Key: netSetOverlapKey, Value: &netSetOverlapNested},
+).withIPSet(allSelectorId, []string{
+	"10.0.0.1/32",
+	"fc00:fe11::1/128",
+	"10.0.0.2/32",
+	"fc00:fe11::2/128",
+	"10.65.0.0/16", // ancestor; the nested /24 and /32 are suppressed.
+}).withName("host ep1, policy, overlap netset ancestor + nested (suppressed)")
+
+// hostEp1WithPolicyAndOverlapMiddleRemoved drops the middle /24 while the ancestor and leaf remain.
+// The removed /24 was never programmed and the leaf is still covered by the ancestor, so the
+// programmed all() set must be unchanged. The buggy remove path re-exposed the leaf and emitted a
+// spurious removal of the /24, both of which this state catches.
+var hostEp1WithPolicyAndOverlapMiddleRemoved = hostEp1WithPolicyAndOverlapNested.withKVUpdates(
+	KVPair{Key: netSetOverlapKey, Value: &netSetOverlapMiddleRemoved},
+).withIPSet(allSelectorId, []string{
+	"10.0.0.1/32",
+	"fc00:fe11::1/128",
+	"10.0.0.2/32",
+	"fc00:fe11::2/128",
+	"10.65.0.0/16", // ancestor still covers the leaf, so nothing changes.
+}).withName("host ep1, policy, overlap netset middle removed under live ancestor")
+
 // RouteUpdate expected for ipPoolWithVXLAN.
 var routeUpdateIPPoolVXLAN = types.RouteUpdate{
 	Types:       proto.RouteType_CIDR_INFO,

--- a/felix/labelindex/dedup_overlap_repro_test.go
+++ b/felix/labelindex/dedup_overlap_repro_test.go
@@ -1,0 +1,105 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package labelindex_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/projectcalico/calico/felix/ip"
+	"github.com/projectcalico/calico/felix/labelindex"
+)
+
+const dedupTestSet = "test-set"
+
+// TestOverlapSuppressorRemoveCoveredByAncestor reproduces CORE-13009: removing a CIDR that a broader
+// ancestor still covers must emit nothing, because the removed CIDR was never programmed as its own
+// interval element and the ancestor keeps masking its descendants.
+func TestOverlapSuppressorRemoveCoveredByAncestor(t *testing.T) {
+	RegisterTestingT(t)
+
+	s := labelindex.NewMemberOverlapSuppressor()
+	broad := ip.MustParseCIDROrIP("10.0.0.0/16")
+	nested := ip.MustParseCIDROrIP("10.0.1.0/24")
+
+	add, removes := s.Add(dedupTestSet, broad)
+	Expect(add).To(Equal(broad), "broad CIDR should be programmed")
+	Expect(removes).To(BeEmpty())
+
+	add, removes = s.Add(dedupTestSet, nested)
+	Expect(add).To(BeNil(), "nested CIDR is covered by the ancestor, so must be suppressed")
+	Expect(removes).To(BeEmpty())
+
+	rem, adds := s.Remove(dedupTestSet, nested)
+	Expect(rem).To(BeNil(), "nested CIDR was never programmed, so its removal must not be emitted")
+	Expect(adds).To(BeEmpty(), "ancestor still covers the range, so nothing is re-exposed")
+}
+
+// TestOverlapSuppressorRemoveAncestorReExposesDescendants proves the teardown direction: removing the
+// ancestor re-exposes the descendants it had been masking.
+func TestOverlapSuppressorRemoveAncestorReExposesDescendants(t *testing.T) {
+	RegisterTestingT(t)
+
+	s := labelindex.NewMemberOverlapSuppressor()
+	broad := ip.MustParseCIDROrIP("10.0.0.0/16")
+	nested := ip.MustParseCIDROrIP("10.0.1.0/24")
+
+	s.Add(dedupTestSet, broad)
+	s.Add(dedupTestSet, nested)
+
+	rem, adds := s.Remove(dedupTestSet, broad)
+	Expect(rem).To(Equal(broad), "ancestor was programmed, so its removal must be emitted")
+	Expect(adds).To(ConsistOf(nested), "previously masked descendant must be re-exposed")
+}
+
+// TestOverlapSuppressorRemoveWithoutAncestorEmits is the negative-direction case: with no ancestor
+// coverage the removal IS emitted, and any masked descendant is re-exposed.
+func TestOverlapSuppressorRemoveWithoutAncestorEmits(t *testing.T) {
+	RegisterTestingT(t)
+
+	s := labelindex.NewMemberOverlapSuppressor()
+	parent := ip.MustParseCIDROrIP("10.0.1.0/24")
+	child := ip.MustParseCIDROrIP("10.0.1.5/32")
+
+	add, _ := s.Add(dedupTestSet, parent)
+	Expect(add).To(Equal(parent))
+
+	add, _ = s.Add(dedupTestSet, child)
+	Expect(add).To(BeNil(), "child is covered by the parent, so must be suppressed")
+
+	rem, adds := s.Remove(dedupTestSet, parent)
+	Expect(rem).To(Equal(parent), "no ancestor covers the parent, so its removal must be emitted")
+	Expect(adds).To(ConsistOf(child), "child is no longer masked and must be re-exposed")
+}
+
+// TestOverlapSuppressorRemoveMiddleCoveredByAncestor covers a three-level trie: with a broad ancestor
+// present, removing a middle CIDR must emit nothing and must not re-expose the still-covered leaf.
+func TestOverlapSuppressorRemoveMiddleCoveredByAncestor(t *testing.T) {
+	RegisterTestingT(t)
+
+	s := labelindex.NewMemberOverlapSuppressor()
+	broad := ip.MustParseCIDROrIP("10.0.0.0/16")
+	middle := ip.MustParseCIDROrIP("10.0.1.0/24")
+	leaf := ip.MustParseCIDROrIP("10.0.1.5/32")
+
+	s.Add(dedupTestSet, broad)
+	s.Add(dedupTestSet, middle)
+	s.Add(dedupTestSet, leaf)
+
+	rem, adds := s.Remove(dedupTestSet, middle)
+	Expect(rem).To(BeNil(), "middle CIDR was suppressed by the ancestor, so its removal must not be emitted")
+	Expect(adds).To(BeEmpty(), "the ancestor still covers the leaf, so nothing is re-exposed")
+}

--- a/felix/labelindex/named_port_index.go
+++ b/felix/labelindex/named_port_index.go
@@ -1072,13 +1072,17 @@ func (t *memberDeduplicator) Remove(set string, cidr ip.CIDR) (ip.CIDR, []ip.CID
 	v6 := strings.Contains(cidr.String(), ":")
 	trie := t.getTrie(set, v6)
 
-	// If this node has children that are masked by this CIDR, we need to
-	// advertise them against as part of this deletion.
+	// Capture the descendants this CIDR was masking before we delete it; they may need re-advertising.
 	t.buf = t.buf[:0]
 	masked := trie.ClosestDescendants(t.buf, cidr)
 
-	// Remove from the trie.
 	trie.Delete(cidr)
+
+	// A broader ancestor still covering this CIDR means it was never programmed as its own interval
+	// element (Add suppressed it), and that same ancestor still masks the descendants. Emit nothing.
+	if trie.Covers(cidr) {
+		return nil, nil
+	}
 
 	return cidr, masked
 }


### PR DESCRIPTION
**Cherry-pick history**
- Pick onto **release-v3.32**: projectcalico/calico#13274

In nftables mode, IP sets containing overlapping CIDRs could fail to program correctly after a member was removed. nftables interval sets reject overlapping entries, so Felix deduplicates them before programming - but when a nested CIDR was removed while a broader CIDR still covered it, the deduplicator emitted a removal for a member that was never programmed on its own.

This fixes the removal path to emit nothing while a broader CIDR still covers the removed one. Includes a unit repro and a calc-graph FV state covering the add / remove-under-ancestor sequence.

Related: CORE-13009

**Release note:**
```release-note
Fixes an issue where IP sets containing overlapping CIDRs could fail to program correctly in nftables mode after a member was removed.
```

