### PR TITLE
[v3.32] Harden nftables IP set resync against missing table and unparseable members

### DIFF
--- a/felix/nftables/ipsets.go
+++ b/felix/nftables/ipsets.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Tigera, Inc. All rights reserved.
+// Copyright (c) 2024-2026 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -394,10 +394,12 @@ func (s *IPSets) tryResync() error {
 	sets, err := s.nft.List(ctx, "set")
 	if err != nil {
 		if knftables.IsNotFound(err) {
-			// Table doesn't exist - nothing to resync.
-			return nil
+			// Table doesn't exist: treat as no sets programmed so the cleanup
+			// pass below resets every member tracker.
+			sets = nil
+		} else {
+			return fmt.Errorf("error listing nftables sets: %w", err)
 		}
-		return fmt.Errorf("error listing nftables sets: %s", err)
 	}
 
 	// We'll process each set in parallel, so we need a struct to hold the results.
@@ -449,46 +451,62 @@ func (s *IPSets) tryResync() error {
 		// set metadata and extracting the type. However, knftables does not yet support this operation. For now,
 		// assume that we haven't modified the type of an IP set across Felix versions.
 
-		// Build a set of canonicalized elements in the set by first converting to Felix's internal string representation,
-		// and then canonicalizing the members to match the format that we use in the desired state.
-		strElems := []string{}
-		unknownElems := set.New[SetMember]()
+		// Build the set of members currently in the dataplane, converting each element back to
+		// Felix's internal representation. Members this Felix can't parse - an unexpected arity, or
+		// an element the kernel returned in a form we don't recognise (e.g. a range rather than a
+		// CIDR for a hash:net set) - are recorded as unknown so they get reconciled away below.
+		wantIPV6 := s.IPVersionConfig.Family == ipsets.IPFamilyV6
+		elemsSet := set.New[SetMember]()
 		for _, e := range setData.elems {
+			var strElem string
 			switch metadata.Type {
 			case ipsets.IPSetTypeHashIP, ipsets.IPSetTypeHashNet:
-				if len(e.Key) == 1 {
-					// These types are just IP addresses / CIDRs.
-					strElems = append(strElems, e.Key[0])
-				} else {
-					unknownElems.Add(UnknownMember(e.Key))
+				// These types are just IP addresses / CIDRs.
+				if len(e.Key) != 1 {
+					elemsSet.Add(UnknownMember(e.Key))
+					continue
 				}
+				strElem = e.Key[0]
 			case ipsets.IPSetTypeHashIPPort:
-				if len(e.Key) == 3 {
-					// This is a concatination of IP, protocol and port. Format it back into Felix's internal representation.
-					strElems = append(strElems, fmt.Sprintf("%s,%s:%s", e.Key[0], e.Key[1], e.Key[2]))
-				} else {
-					unknownElems.Add(UnknownMember(e.Key))
+				// A concatenation of IP, protocol and port.
+				if len(e.Key) != 3 {
+					elemsSet.Add(UnknownMember(e.Key))
+					continue
 				}
+				strElem = fmt.Sprintf("%s,%s:%s", e.Key[0], e.Key[1], e.Key[2])
 			case ipsets.IPSetTypeBitmapPort:
-				if len(e.Key) == 1 {
-					// A single port.
-					strElems = append(strElems, e.Key[0])
-				} else {
-					unknownElems.Add(UnknownMember(e.Key))
+				// A single port.
+				if len(e.Key) != 1 {
+					elemsSet.Add(UnknownMember(e.Key))
+					continue
 				}
+				strElem = e.Key[0]
 			case ipsets.IPSetTypeHashNetNet:
-				if len(e.Key) == 2 {
-					// This is a concatination of two CIDRs. Format it back into Felix's internal representation.
-					strElems = append(strElems, fmt.Sprintf("%s,%s", e.Key[0], e.Key[1]))
-				} else {
-					unknownElems.Add(UnknownMember(e.Key))
+				// A concatenation of two CIDRs.
+				if len(e.Key) != 2 {
+					elemsSet.Add(UnknownMember(e.Key))
+					continue
 				}
+				strElem = fmt.Sprintf("%s,%s", e.Key[0], e.Key[1])
 			default:
-				unknownElems.Add(UnknownMember(e.Key))
+				elemsSet.Add(UnknownMember(e.Key))
+				continue
 			}
+
+			// Skip members of the wrong IP version, matching the desired-state path's filtering.
+			if wantIPV6 != metadata.Type.IsMemberIPV6(strElem) {
+				continue
+			}
+
+			// Unlike the desired-state path, a member we can't parse here is treated as unknown, not fatal.
+			member, err := parseMember(metadata.Type, strElem)
+			if err != nil {
+				log.WithField("member", strElem).WithError(err).Debug("Treating unparseable IP set member as unknown")
+				elemsSet.Add(UnknownMember(e.Key))
+				continue
+			}
+			elemsSet.Add(member)
 		}
-		elemsSet := s.filterAndCanonicaliseMembers(metadata.Type, strElems)
-		elemsSet.AddAll(unknownElems.Slice())
 
 		memberTracker := s.getOrCreateMemberTracker(setName)
 		numExtrasExpected := memberTracker.PendingDeletions().Len()
@@ -499,7 +517,7 @@ func (s *IPSets) tryResync() error {
 			return nil
 		})
 		if err != nil {
-			return fmt.Errorf("failed to read set memebers: %w", err)
+			return fmt.Errorf("failed to read set members: %w", err)
 		}
 
 		// Mark us as having seen the programmed IP set.
@@ -798,82 +816,111 @@ func (s *IPSets) ipSetNeeded(name string) bool {
 }
 
 // CanonicaliseMember converts the string representation of an nftables set member to a canonical
-// object of some kind that implements the IPSetMember interface.  The object is required to by hashable.
+// object of some kind that implements the SetMember interface. The object is required to be hashable.
+// It panics on a member it can't parse: desired-state members are Felix-generated, so a parse failure
+// is a bug. The dataplane-readback path uses parseMember directly to tolerate bad input instead.
 func CanonicaliseMember(t ipsets.IPSetType, member string) SetMember {
+	m, err := parseMember(t, member)
+	if err != nil {
+		log.WithFields(log.Fields{
+			"type":   string(t),
+			"member": member,
+		}).WithError(err).Panic("Failed to canonicalise IP set member")
+	}
+	return m
+}
+
+// parseMember converts the string representation of an nftables set member to a canonical SetMember,
+// returning an error instead of panicking when it can't parse the member. The error describes what
+// couldn't be parsed so CanonicaliseMember can surface it in its panic.
+func parseMember(t ipsets.IPSetType, member string) (SetMember, error) {
 	switch t {
 	case ipsets.IPSetTypeHashIP:
 		// Convert the string into our ip.Addr type, which is backed by an array.
 		ipAddr := ip.FromIPOrCIDRString(member)
 		if ipAddr == nil {
-			// This should be prevented by validation in libcalico-go.
-			log.WithField("ip", member).Panic("Failed to parse IP")
-			panic("Failed to parse IP part of IP,port member")
+			return nil, fmt.Errorf("failed to parse IP %q", member)
 		}
-		return simpleMember(ipAddr.String())
+		return simpleMember(ipAddr.String()), nil
 	case ipsets.IPSetTypeHashIPPort:
-		// The member should be of the format "IP,protocol:port"
+		// The member should be of the format "IP,protocol:port".
 		parts := strings.Split(member, ",")
 		if len(parts) != 2 {
-			log.WithField("member", member).Panic("Failed to parse IP,proto:port set member")
+			return nil, fmt.Errorf("expected IP,proto:port, got %q", member)
 		}
 		ipAddr := ip.FromIPOrCIDRString(parts[0])
 		if ipAddr == nil {
-			// This should be prevented by validation.
-			log.WithField("member", member).Panic("Failed to parse IP part of IP,port member")
-			panic("Failed to parse IP part of IP,port member")
+			return nil, fmt.Errorf("failed to parse IP part of %q", member)
 		}
-		parts = strings.Split(parts[1], ":")
-		if len(parts) != 2 {
-			log.WithField("member", member).Panic("Failed to parse IP part of IP,port member")
+		portParts := strings.Split(parts[1], ":")
+		if len(portParts) != 2 {
+			return nil, fmt.Errorf("failed to parse proto:port part of %q", member)
 		}
-		proto := parts[0]
-		port, err := strconv.Atoi(parts[1])
+		port, err := strconv.Atoi(portParts[1])
 		if err != nil {
-			log.WithField("member", member).WithError(err).Panic("Bad port")
+			return nil, fmt.Errorf("failed to parse port of %q: %w", member, err)
 		}
-		if port > math.MaxUint16 || port < 0 {
-			log.WithField("member", member).Panic("Bad port range (should be between 0 and 65535)")
+		if port < 0 || port > math.MaxUint16 {
+			return nil, fmt.Errorf("port %d out of range in %q", port, member)
 		}
+		proto := portParts[0]
 
-		// Return a dedicated struct for V4 or V6.  This slightly reduces occupancy over storing
-		// the address as an interface by storing one fewer interface headers.  That is worthwhile
-		// because we store many IP set members.
+		// Return a dedicated struct for V4 or V6. This slightly reduces occupancy over storing the
+		// address as an interface by storing one fewer interface header, which matters because we
+		// store many IP set members.
 		if ipAddr.Version() == 4 {
-			return v4IPPortMember{
-				IP:       ipAddr.(ip.V4Addr),
-				Port:     uint16(port),
-				Protocol: proto,
+			v4, ok := ipAddr.(ip.V4Addr)
+			if !ok {
+				return nil, fmt.Errorf("IP %q is not a v4 address", parts[0])
 			}
-		} else {
-			return v6IPPortMember{
-				IP:       ipAddr.(ip.V6Addr),
-				Port:     uint16(port),
-				Protocol: proto,
-			}
+			return v4IPPortMember{IP: v4, Port: uint16(port), Protocol: proto}, nil
 		}
+		v6, ok := ipAddr.(ip.V6Addr)
+		if !ok {
+			return nil, fmt.Errorf("IP %q is not a v6 address", parts[0])
+		}
+		return v6IPPortMember{IP: v6, Port: uint16(port), Protocol: proto}, nil
 	case ipsets.IPSetTypeHashNet:
-		// Convert the string into our ip.CIDR type, which is backed by a struct.  When
-		// pretty-printing, the hash:net ipset type prints IPs with no "/32" or "/128"
-		// suffix.
-		return simpleMember(ip.MustParseCIDROrIP(member).String())
-	case ipsets.IPSetTypeHashNetNet:
-		cidrs := strings.Split(member, ",")
-		return netNet{
-			net1: ip.MustParseCIDROrIP(cidrs[0]),
-			net2: ip.MustParseCIDROrIP(cidrs[1]),
+		// The hash:net type pretty-prints IPs with no "/32" or "/128" suffix, so canonicalise
+		// through ip.CIDR to match that form.
+		cidr, err := ip.ParseCIDROrIP(member)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse CIDR %q: %w", member, err)
 		}
+		return simpleMember(cidr.String()), nil
+	case ipsets.IPSetTypeHashNetNet:
+		// The member should be a pair of CIDRs, "cidr1,cidr2".
+		cidrs := strings.Split(member, ",")
+		if len(cidrs) != 2 {
+			return nil, fmt.Errorf("expected two CIDRs, got %q", member)
+		}
+		net1, err := ip.ParseCIDROrIP(cidrs[0])
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse first CIDR of %q: %w", member, err)
+		}
+		net2, err := ip.ParseCIDROrIP(cidrs[1])
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse second CIDR of %q: %w", member, err)
+		}
+		return netNet{net1: net1, net2: net2}, nil
 	case ipsets.IPSetTypeBitmapPort:
-		// Trim the family if it exists
-		if member[0] == 'v' {
+		// Trim the family prefix (e.g. "v4,") if present.
+		if len(member) > 0 && member[0] == 'v' {
+			if len(member) < 3 {
+				return nil, fmt.Errorf("truncated family prefix in %q", member)
+			}
 			member = member[3:]
 		}
 		port, err := strconv.Atoi(member)
-		if err == nil && port >= 0 && port <= 0xffff {
-			return simpleMember(member)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse port %q: %w", member, err)
 		}
+		if port < 0 || port > 0xffff {
+			return nil, fmt.Errorf("port %d out of range in %q", port, member)
+		}
+		return simpleMember(member), nil
 	}
-	log.WithField("type", string(t)).Warn("Unknown IPSetType")
-	return nil
+	return nil, fmt.Errorf("unknown IP set type %q", string(t))
 }
 
 // setType returns the nftables type to use for the given IPSetType and IP version.

--- a/felix/nftables/ipsets_test.go
+++ b/felix/nftables/ipsets_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Tigera, Inc. All rights reserved.
+// Copyright (c) 2024-2026 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -143,6 +143,34 @@ var _ = Describe("IPSets with empty data plane", func() {
 		))
 	})
 
+	It("should not panic on a member it cannot parse and should reconcile it away", func() {
+		// Program a hash:net (interval) set. On readback, interval sets can return members in
+		// range form rather than CIDR form (CORE-13011), which Felix's canonicalisation can't
+		// parse. Felix must treat such a member as unknown rather than crash-looping on resync.
+		meta := ipsets.IPSetMetadata{SetID: "test", Type: ipsets.IPSetTypeHashNet}
+		s.AddOrReplaceIPSet(meta, []string{"10.0.0.0/24"})
+		Expect(func() { s.ApplyUpdates(nil) }).NotTo(Panic())
+
+		// Inject a range-form element directly, simulating what the kernel may return on readback.
+		tx := f.NewTransaction()
+		tx.Add(&knftables.Element{
+			Set: "cali40test",
+			Key: []string{"10.0.0.0-10.0.0.255"},
+		})
+		Expect(f.Run(context.Background(), tx)).NotTo(HaveOccurred())
+
+		// Resync must tolerate the unparseable member and reconcile it away.
+		s.QueueResync()
+		Expect(func() { s.ApplyUpdates(nil) }).NotTo(Panic())
+		Expect(s.ApplyDeletions()).To(BeFalse())
+
+		elements, err := f.ListElements(context.Background(), "set", "cali40test")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(elements).To(ConsistOf(
+			&knftables.Element{Set: "cali40test", Key: []string{"10.0.0.0/24"}},
+		))
+	})
+
 	It("should resync with a large number of sets", func() {
 		// Create a large number of sets - larger than the number of gorooutines we limit
 		// ourselves to in the resync code.
@@ -159,6 +187,42 @@ var _ = Describe("IPSets with empty data plane", func() {
 		// Trigger a resync.
 		s.QueueResync()
 		Expect(func() { s.ApplyUpdates(nil) }).NotTo(Panic())
+	})
+
+	It("should reprogram members after the whole table disappears", func() {
+		// Program an IP set with members.
+		meta := ipsets.IPSetMetadata{SetID: "test", Type: ipsets.IPSetTypeHashIP}
+		s.AddOrReplaceIPSet(meta, []string{"10.0.0.1", "10.0.0.2"})
+		Expect(func() { s.ApplyUpdates(nil) }).NotTo(Panic())
+
+		elements, err := f.ListElements(context.Background(), "set", "cali40test")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(elements).To(ConsistOf(
+			&knftables.Element{Set: "cali40test", Key: []string{"10.0.0.1"}},
+			&knftables.Element{Set: "cali40test", Key: []string{"10.0.0.2"}},
+		))
+
+		// Delete the whole table out-of-band, so List returns IsNotFound on the next resync.
+		tx := f.NewTransaction()
+		tx.Delete(&knftables.Table{})
+		Expect(f.Run(context.Background(), tx)).NotTo(HaveOccurred())
+		_, err = f.List(context.Background(), "set")
+		Expect(knftables.IsNotFound(err)).To(BeTrue())
+
+		// Resync and apply. The set and its members should be reprogrammed from scratch.
+		s.QueueResync()
+		Expect(func() { s.ApplyUpdates(nil) }).NotTo(Panic())
+
+		sets, err := f.List(context.Background(), "set")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(sets).To(ConsistOf("cali40test"))
+
+		elements, err = f.ListElements(context.Background(), "set", "cali40test")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(elements).To(ConsistOf(
+			&knftables.Element{Set: "cali40test", Key: []string{"10.0.0.1"}},
+			&knftables.Element{Set: "cali40test", Key: []string{"10.0.0.2"}},
+		))
 	})
 
 	It("should handle unexpected sets with types that are not supported", func() {


### PR DESCRIPTION
**Cherry-pick history**
- Pick onto **release-v3.32**: projectcalico/calico#13275

Two robustness fixes for nftables IP set resync.

First, when the nftables table is missing during a resync (for example after it's been deleted out from under Felix), resync now treats it as no sets programmed, so members are reprogrammed once the table is recreated. Previously Felix kept believing the old members were still present and never re-added them, leaving sets empty in the dataplane.

Second, an IP set member that Felix can't parse when reading back from the dataplane (for example a range-form element in an interval set) is now treated as unknown and reconciled away instead of panicking. A member the current code can't parse no longer crashes Felix on every resync.

Related: CORE-13011, CORE-13012

**Release note:**
```release-note
Fixes an issue in nftables mode where IP set members could be left unprogrammed after the nftables table was deleted and recreated.
```
```release-note
Fixes an issue in nftables mode where Felix could panic when reading back an IP set member it could not parse.
```

