### PR TITLE
[v3.32] Detect served MutatingAdmissionPolicy API version in the v3 CRDs chart

### DIFF
--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -17,6 +17,7 @@ rules:
 ignore:
   # template files are not valid yaml
   - charts/calico/templates/
+  - charts/projectcalico.org.v3/templates/admission-policies.yaml
   - charts/tigera-operator/templates/
   - process/testing/aso/infra/templates/
   # these dirs are not owned by us, we don't own yamls that they may contain

--- a/api/admission/protect-builtin-tiers.yaml
+++ b/api/admission/protect-builtin-tiers.yaml
@@ -1,4 +1,3 @@
----
 # ValidatingAdmissionPolicy that prevents deletion of the built-in Calico tiers
 # (default, kube-admin, kube-baseline). These tiers are required for correct
 # operation and should never be deleted.

--- a/charts/projectcalico.org.v3/admission
+++ b/charts/projectcalico.org.v3/admission
@@ -1,0 +1,1 @@
+../../api/admission

--- a/charts/projectcalico.org.v3/templates/admission
+++ b/charts/projectcalico.org.v3/templates/admission
@@ -1,1 +1,0 @@
-../../../api/admission

--- a/charts/projectcalico.org.v3/templates/admission-policies.yaml
+++ b/charts/projectcalico.org.v3/templates/admission-policies.yaml
@@ -1,0 +1,12 @@
+{{- $apiVersion := "admissionregistration.k8s.io/v1beta1" -}}
+{{- if .Capabilities.APIVersions.Has "admissionregistration.k8s.io/v1/MutatingAdmissionPolicy" -}}
+{{- $apiVersion = "admissionregistration.k8s.io/v1" -}}
+{{- else if .Capabilities.APIVersions.Has "admissionregistration.k8s.io/v1beta1/MutatingAdmissionPolicy" -}}
+{{- $apiVersion = "admissionregistration.k8s.io/v1beta1" -}}
+{{- else if .Capabilities.APIVersions.Has "admissionregistration.k8s.io/v1alpha1/MutatingAdmissionPolicy" -}}
+{{- $apiVersion = "admissionregistration.k8s.io/v1alpha1" -}}
+{{- end }}
+{{ range $path, $_ := .Files.Glob "admission/*" }}
+---
+{{ $.Files.Get $path | replace "admissionregistration.k8s.io/v1beta1" $apiVersion }}
+{{- end }}

--- a/manifests/calico-v3-crds.yaml
+++ b/manifests/calico-v3-crds.yaml
@@ -7708,7 +7708,6 @@ spec:
           - stagedglobalnetworkpolicies
 ---
 # Source: calico/templates/admission-policies.yaml
----
 # ValidatingAdmissionPolicy that prevents deletion of the built-in Calico tiers
 # (default, kube-admin, kube-baseline). These tiers are required for correct
 # operation and should never be deleted.

--- a/manifests/generate.sh
+++ b/manifests/generate.sh
@@ -122,6 +122,7 @@ for FILE in $(ls ../charts/projectcalico.org.v3/templates/*.yaml | xargs -n1 bas
 	${HELM} template \
 		--show-only templates/$FILE \
 		--set version=$CALICO_VERSION \
+		--api-versions admissionregistration.k8s.io/v1/MutatingAdmissionPolicy \
 		../charts/projectcalico.org.v3 >> v3_projectcalico_org.yaml
 done
 for FILE in $(ls ../charts/projectcalico.org.v3/templates/calico/*.yaml | xargs -n1 basename); do

--- a/manifests/v3_projectcalico_org.yaml
+++ b/manifests/v3_projectcalico_org.yaml
@@ -1,5 +1,179 @@
 # projectcalico.org/v3 and operator.tigera.io/v1 APIs
 ---
+# Source: projectcalico.org.v3/templates/admission-policies.yaml
+# This MutatingAdmissionPolicy defaults the types/policyTypes field on Calico policy resources.
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingAdmissionPolicy
+metadata:
+  name: "policytypes.policy.projectcalico.org"
+spec:
+  paramKind:
+    kind: NetworkPolicy
+    apiVersion: projectcalico.org/v3
+  matchConditions:
+    # Apply this mutation only if the 'types' field is missing (or policyTypes for stagednetworkpolicies).
+    - name: missing-types
+      expression: "!has(object.spec.types) && !has(object.spec.policyTypes)"
+  matchConstraints:
+    resourceRules:
+      - apiGroups: ["projectcalico.org"]
+        apiVersions: ["v3"]
+        operations: ["CREATE", "UPDATE"]
+        resources:
+          - networkpolicies
+          - globalnetworkpolicies
+          - stagednetworkpolicies
+          - stagedglobalnetworkpolicies
+          - stagedkubernetesnetworkpolicies
+  failurePolicy: Fail
+  reinvocationPolicy: IfNeeded
+  variables:
+    # Determine the policy types based on the presence of ingress and egress rules.
+    # If both are present, set types to ["Ingress", "Egress"].
+    # If only ingress is present, set types to ["Ingress"].
+    # If only egress is present, set types to ["Egress"].
+    # If neither is present, default to ["Ingress"] for backward compatibility with policies from before types were required.
+    - name: defaultTypes
+      expression: |
+        (has(object.spec.ingress) && has(object.spec.egress)) ? ["Ingress", "Egress"] :
+        has(object.spec.egress) ? ["Egress"] : ["Ingress"]
+
+    # The logic for StagedKubernetesNetworkPolicy is slightly different from the above:
+    # - If both ingress and egress are present, set types to ["Ingress", "Egress"].
+    # - If only ingress is present, set types to ["Ingress"].
+    # - If only egress is present, set types to ["Ingress", "Egress"].
+    # - If neither is present, default to ["Ingress"] for backward compatibility.
+    - name: defaultKubeTypes
+      expression: |
+        (has(object.spec.ingress) && has(object.spec.egress)) ? ["Ingress", "Egress"] :
+        has(object.spec.egress) ? ["Ingress", "Egress"] : ["Ingress"]
+
+  mutations:
+    # Add the calculated 'types' field to the spec.
+    - patchType: "JSONPatch"
+      jsonPatch:
+        expression: |
+          [
+            JSONPatch{
+              op: "add",
+              path: object.kind == "StagedKubernetesNetworkPolicy" ? "/spec/policyTypes" : "/spec/types",
+              value: object.kind == "StagedKubernetesNetworkPolicy" ? variables.defaultKubeTypes : variables.defaultTypes
+            }
+          ]
+---
+# Source: projectcalico.org.v3/templates/admission-policies.yaml
+# This MutatingAdmissionPolicy defaults the spec.tier field to "default" if not specified,
+# and sets the projectcalico.org/tier label to match.
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingAdmissionPolicy
+metadata:
+  name: "tierlabel.policy.projectcalico.org"
+spec:
+  matchConstraints:
+    resourceRules:
+      - apiGroups: ["projectcalico.org"]
+        apiVersions: ["v3"]
+        operations: ["CREATE", "UPDATE"]
+        resources:
+          - networkpolicies
+          - globalnetworkpolicies
+          - stagednetworkpolicies
+          - stagedglobalnetworkpolicies
+  failurePolicy: Fail
+  reinvocationPolicy: IfNeeded
+  variables:
+    - name: tierValue
+      expression: |
+        has(object.spec.tier) && object.spec.tier != "" ? object.spec.tier : "default"
+  mutations:
+    # Default spec.tier to "default" if empty or unset.
+    - patchType: "JSONPatch"
+      jsonPatch:
+        expression: |
+          !has(object.spec.tier) || object.spec.tier == "" ?
+            [JSONPatch{op: "add", path: "/spec/tier", value: variables.tierValue}] :
+            []
+    # Set the projectcalico.org/tier label to match spec.tier.
+    # Uses ~1 encoding for the / in the label key per RFC 6901 (JSON Pointer).
+    - patchType: "JSONPatch"
+      jsonPatch:
+        expression: |
+          has(object.metadata.labels) ?
+            [JSONPatch{op: "add", path: "/metadata/labels/projectcalico.org~1tier", value: variables.tierValue}] :
+            [
+              JSONPatch{op: "add", path: "/metadata/labels", value: {}},
+              JSONPatch{op: "add", path: "/metadata/labels/projectcalico.org~1tier", value: variables.tierValue}
+            ]
+---
+# Source: projectcalico.org.v3/templates/admission-policies.yaml
+# This MutatingAdmissionPolicyBinding binds the policy types defaulting mutation to the relevant resources.
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingAdmissionPolicyBinding
+metadata:
+  name: set-policytypes-binding
+spec:
+  policyName: policytypes.policy.projectcalico.org
+  matchResources:
+    resourceRules:
+      - apiGroups: ["projectcalico.org"]
+        apiVersions: ["v3"]
+        operations: ["CREATE", "UPDATE"]
+        resources:
+          - networkpolicies
+          - globalnetworkpolicies
+          - stagednetworkpolicies
+          - stagedglobalnetworkpolicies
+          - stagedkubernetesnetworkpolicies
+---
+# Source: projectcalico.org.v3/templates/admission-policies.yaml
+# This MutatingAdmissionPolicyBinding binds the tier label mutation to the relevant resources.
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingAdmissionPolicyBinding
+metadata:
+  name: set-tier-label-binding
+spec:
+  policyName: tierlabel.policy.projectcalico.org
+  matchResources:
+    resourceRules:
+      - apiGroups: ["projectcalico.org"]
+        apiVersions: ["v3"]
+        operations: ["CREATE", "UPDATE"]
+        resources:
+          - networkpolicies
+          - globalnetworkpolicies
+          - stagednetworkpolicies
+          - stagedglobalnetworkpolicies
+---
+# Source: projectcalico.org.v3/templates/admission-policies.yaml
+# ValidatingAdmissionPolicy that prevents deletion of the built-in Calico tiers
+# (default, kube-admin, kube-baseline). These tiers are required for correct
+# operation and should never be deleted.
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: protect-builtin-tiers.projectcalico.org
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+      - apiGroups: ["projectcalico.org"]
+        apiVersions: ["v3"]
+        resources: ["tiers"]
+        operations: ["DELETE"]
+  validations:
+    - expression: "!(oldObject.metadata.name in ['default', 'kube-admin', 'kube-baseline'])"
+      messageExpression: "'The built-in tier ' + oldObject.metadata.name + ' cannot be deleted'"
+---
+# Source: projectcalico.org.v3/templates/admission-policies.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: protect-builtin-tiers.projectcalico.org
+spec:
+  policyName: protect-builtin-tiers.projectcalico.org
+  validationActions:
+    - Deny
+---
 # Source: projectcalico.org.v3/templates/operator.tigera.io_apiservers.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition


### PR DESCRIPTION
**Cherry-pick history**
- Pick onto **release-v3.32**: projectcalico/calico#13127

The projectcalico.org.v3 helm chart couldn't install on Kubernetes 1.36, where MutatingAdmissionPolicy is only served at v1. The chart symlinked the raw api/admission YAML directly under templates/, so the hard-coded admissionregistration.k8s.io/v1beta1 apiVersion rendered verbatim and the install failed.

The admission policies are part of the projectcalico.org/v3 API surface (defaulting and validation that the aggregated apiserver would otherwise provide), so they belong wherever the v3 CRDs ship. This does two things:

- Renders the chart's admission policies through a template that detects the served API version (the same trick the calico chart already uses): v1 on 1.36+, v1alpha1 when only the alpha API is served, v1beta1 otherwise.
- Fixes the manifest generator, which was only rendering the chart's CRD templates and silently dropping the admission policies from the generated `v3_projectcalico_org.yaml`. It now renders them too, pinned to v1 to match `calico-v3-crds.yaml`.

Also drops a redundant leading document separator from protect-builtin-tiers.yaml so the policies render cleanly under `helm --show-only`.

Fixes #12978

```release-note
HELM: Fix installation of the projectcalico.org.v3 CRDs chart on Kubernetes 1.36+ by rendering the MutatingAdmissionPolicy resources at the API version the cluster actually serves.
```

**Original Commit SHAs**: a20a59dc31