### PR TITLE
[v3.32] Deep copy IP pools before writing and requeue failed writes

### DIFF
--- a/kube-controllers/cmd/kube-controllers/main.go
+++ b/kube-controllers/cmd/kube-controllers/main.go
@@ -489,7 +489,8 @@ func (cc *controllerControl) InitControllers(
 	namespaceInformer := factory.Core().V1().Namespaces().Informer()
 
 	if v3c != nil {
-		// Create informers for Calico resources.
+		// Create informers for Calico resources. The resync period doubles as the recovery path
+		// for controllers that drop work after max retries.
 		calicoFactory := externalversions.NewSharedInformerFactory(v3c, 5*time.Minute)
 		poolInformer := calicoFactory.Projectcalico().V3().IPPools().Informer()
 		blockInformer := calicoFactory.Projectcalico().V3().IPAMBlocks().Informer()

--- a/kube-controllers/pkg/controllers/ippool/pool_controller.go
+++ b/kube-controllers/pkg/controllers/ippool/pool_controller.go
@@ -19,13 +19,17 @@ import (
 	"fmt"
 	"slices"
 	"strings"
+	"time"
 
 	v3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
 	"github.com/projectcalico/api/pkg/client/clientset_generated/clientset"
 	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	uruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
 
 	"github.com/projectcalico/calico/felix/ip"
 	"github.com/projectcalico/calico/kube-controllers/pkg/controllers/controller"
@@ -35,6 +39,14 @@ import (
 
 const (
 	IPPoolFinalizer = "projectcalico.org/ippool-finalizer"
+
+	// maxRetries is how many times a failed reconcile is retried before we fall back
+	// to the informer resync in run.go.
+	maxRetries = 5
+
+	// reconcileKey is the single workqueue key this controller uses. Overlap detection is global
+	// across all pools, so there is nothing to gain from per-pool keys.
+	reconcileKey = "reconcile"
 )
 
 // IPPoolController is responsible for watching IPPool and IPAMBlock resources and managing the finalization / deletion
@@ -47,8 +59,9 @@ type IPPoolController struct {
 	poolInformer  cache.SharedIndexInformer
 	blockInformer cache.SharedIndexInformer
 
-	cli  clientset.Interface
-	ipam ipam.Interface
+	cli   clientset.Interface
+	ipam  ipam.Interface
+	queue workqueue.TypedRateLimitingInterface[string]
 }
 
 func NewController(
@@ -64,64 +77,23 @@ func NewController(
 		poolInformer:  poolInformer,
 		blockInformer: blockInformer,
 		ipam:          ipam,
+		queue:         workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[string]()),
 	}
 
-	// Configure events for new IP pools.
+	// Every pool event triggers the same global reconcile, so the handlers just enqueue the
+	// sentinel key and let the workqueue collapse bursts into a single pass.
 	poolHandlers := cache.ResourceEventHandlerFuncs{
-		DeleteFunc: func(obj any) {
-			logrus.WithField("name", obj.(*v3.IPPool).Name).Info("Handling pool deletion")
-			if err := c.Reconcile(obj.(*v3.IPPool)); err != nil {
-				logrus.WithError(err).Error("Error handling pool deletion")
-			}
-		},
-		AddFunc: func(obj any) {
-			logrus.WithField("name", obj.(*v3.IPPool).Name).Info("Handling pool add")
-			if err := c.Reconcile(obj.(*v3.IPPool)); err != nil {
-				logrus.WithError(err).Error("Error handling pool add")
-			}
-		},
-		UpdateFunc: func(oldObj, newObj any) {
-			logrus.WithField("name", newObj.(*v3.IPPool).Name).Info("Handling pool update")
-			if err := c.Reconcile(newObj.(*v3.IPPool)); err != nil {
-				logrus.WithError(err).Error("Error handling pool update")
-			}
-		},
+		AddFunc:    func(obj any) { c.queue.Add(reconcileKey) },
+		UpdateFunc: func(oldObj, newObj any) { c.queue.Add(reconcileKey) },
+		DeleteFunc: func(obj any) { c.queue.Add(reconcileKey) },
 	}
 	if _, err := poolInformer.AddEventHandler(poolHandlers); err != nil {
 		logrus.WithError(err).Fatal("Failed to register event handler for IPPool")
 	}
 
-	// Configure handlers for IPAM block updates. We need to trigger a reconcile for any
-	// deleting IP pools when blocks are deleted, to ensure we can finalize the pool.
+	// Block deletions can unblock finalization of a deleting pool, so they need a reconcile too.
 	blockHandlers := cache.ResourceEventHandlerFuncs{
-		DeleteFunc: func(obj any) {
-			block := obj.(*v3.IPAMBlock)
-
-			// Find any pools that might be associated with this block and trigger a reconcile.
-			for _, i := range poolInformer.GetIndexer().List() {
-				pool := i.(*v3.IPPool)
-				if pool.DeletionTimestamp == nil {
-					// Pool is not being deleted, skip it.
-					continue
-				}
-				_, poolNet, err := cnet.ParseCIDR(pool.Spec.CIDR)
-				if err != nil {
-					logrus.WithError(err).WithField("cidr", pool.Spec.CIDR).Error("Failed to parse CIDR from IPPool")
-					continue
-				}
-				_, blockNet, err := cnet.ParseCIDR(block.Spec.CIDR)
-				if err != nil {
-					logrus.WithError(err).WithField("cidr", block.Spec.CIDR).Error("Failed to parse CIDR from IPAMBlock")
-					continue
-				}
-				if poolNet.Contains(blockNet.IP) {
-					logrus.WithField("name", pool.Name).Debug("Triggering reconcile for finalizing pool due to block deletion")
-					if err := c.Reconcile(pool); err != nil {
-						logrus.WithError(err).Error("Error handling pool reconcile due to block deletion")
-					}
-				}
-			}
-		},
+		DeleteFunc: func(obj any) { c.queue.Add(reconcileKey) },
 	}
 	if _, err := blockInformer.AddEventHandler(blockHandlers); err != nil {
 		logrus.WithError(err).Fatal("Failed to register event handler for IPAMBlock")
@@ -130,10 +102,11 @@ func NewController(
 	return c
 }
 
-// Run starts the node controller. It does start-of-day preparation
+// Run starts the IP pool controller. It does start-of-day preparation
 // and then launches worker threads.
 func (c *IPPoolController) Run(stopCh chan struct{}) {
 	defer uruntime.HandleCrash()
+	defer c.queue.ShutDown()
 
 	logrus.Info("Starting IPPool controller")
 
@@ -146,35 +119,92 @@ func (c *IPPoolController) Run(stopCh chan struct{}) {
 
 	logrus.Debug("Finished syncing with Kubernetes API")
 
+	// Run once against a consistent view of both caches now that they are synced.
+	c.queue.Add(reconcileKey)
+
+	go wait.Until(c.runWorker, time.Second, stopCh)
+
 	<-stopCh
 	logrus.Info("Stopping IPPool controller")
 }
 
-func (c *IPPoolController) Reconcile(p *v3.IPPool) error {
-	ctx := context.TODO()
-	logCtx := logrus.WithFields(logrus.Fields{
-		"name":         p.Name,
-		"cidr":         p.Spec.CIDR,
-		"hasFinalizer": hasFinalizer(p),
-	})
-	logCtx.Debug("Reconciling IPPool")
-
-	// First, check for overlapping IP pools and update their status accordingly.
-	if err := c.reconcileConditions(ctx); err != nil {
-		logCtx.WithError(err).Warn("Failed to reconcile pool overlaps")
+func (c *IPPoolController) runWorker() {
+	for c.processNextItem() {
 	}
-
-	// Next, ensure that the finalizer is added / removed as needed.
-	if err := c.reconcileFinalizer(ctx, logCtx, p); err != nil {
-		return fmt.Errorf("failed to reconcile finalizer for IPPool: %w", err)
-	}
-	return nil
 }
 
-// reconcileConditions checks for various conditions that should be set on each IP pool.
-func (c *IPPoolController) reconcileConditions(ctx context.Context) error {
-	pools := c.poolInformer.GetIndexer().List()
+func (c *IPPoolController) processNextItem() bool {
+	key, quit := c.queue.Get()
+	if quit {
+		return false
+	}
+	defer c.queue.Done(key)
+
+	err := c.reconcile()
+	c.handleErr(err, key)
+	return true
+}
+
+func (c *IPPoolController) handleErr(err error, key string) {
+	if err == nil {
+		c.queue.Forget(key)
+		return
+	}
+	if c.queue.NumRequeues(key) < maxRetries {
+		logrus.WithError(err).Warning("Error reconciling IP pools, will retry")
+		c.queue.AddRateLimited(key)
+		return
+	}
+	c.queue.Forget(key)
+	logrus.WithError(err).Error("Dropping IP pool reconcile out of queue after max retries")
+}
+
+// reconcile derives the desired state for every pool. Overlap detection is global, so a single
+// pass covers all pools rather than keying off whichever pool triggered the event.
+func (c *IPPoolController) reconcile() error {
+	var errs []error
+
+	// Conditions first: whether a pool is allocatable decides whether it should carry a finalizer.
+	pools, err := c.reconcileConditions(c.ctx)
+	if err != nil {
+		errs = append(errs, err)
+	}
+
+	for _, p := range pools {
+		logCtx := logrus.WithFields(logrus.Fields{
+			"name":         p.Name,
+			"cidr":         p.Spec.CIDR,
+			"hasFinalizer": hasFinalizer(p),
+		})
+		if err := c.reconcileFinalizer(c.ctx, logCtx, p); err != nil {
+			logCtx.WithError(err).Error("Failed to reconcile finalizer for IPPool")
+			errs = append(errs, fmt.Errorf("reconcile finalizer for IPPool %s: %w", p.Name, err))
+		}
+	}
+
+	return utilerrors.NewAggregate(errs)
+}
+
+// reconcileConditions checks for various conditions that should be set on each IP pool. It returns
+// the pools with the derived conditions applied, so the finalizer pass acts on what we just wrote
+// rather than on the informer cache, which will not have caught up yet.
+func (c *IPPoolController) reconcileConditions(ctx context.Context) ([]*v3.IPPool, error) {
+	// Copy up front. Objects in the indexer are shared with the informer and every other handler,
+	// so mutating one in place both races and leaves the cache asserting state the API server may
+	// have rejected, which would suppress every future write attempt.
+	objs := c.poolInformer.GetIndexer().List()
+	pools := make([]*v3.IPPool, 0, len(objs))
+	for _, obj := range objs {
+		p, ok := obj.(*v3.IPPool)
+		if !ok {
+			logrus.WithField("type", fmt.Sprintf("%T", obj)).Error("Unexpected object type in IPPool cache")
+			continue
+		}
+		pools = append(pools, p.DeepCopy())
+	}
 	slices.SortFunc(pools, poolSortFunc)
+
+	var errs []error
 
 	// Every time an IP pool is added, updated, or deleted, we need to check if it changes the active set of pools. We only
 	// allow a single IP pool covering a given CIDR to be active at a time, and so we need to ensure that:
@@ -186,9 +216,7 @@ func (c *IPPoolController) reconcileConditions(ctx context.Context) error {
 	triev6 := ip.NewCIDRTrie()
 	active := map[string]*v3.IPPool{}
 	overlapping := map[string]*v3.IPPool{}
-	for _, p := range pools {
-		pool := p.(*v3.IPPool)
-
+	for _, pool := range pools {
 		cidr, err := ip.CIDRFromString(pool.Spec.CIDR)
 		if err != nil {
 			logrus.WithError(err).WithField("cidr", pool.Spec.CIDR).Error("Failed to parse CIDR from IPPool")
@@ -212,6 +240,7 @@ func (c *IPPoolController) reconcileConditions(ctx context.Context) error {
 			}
 			if err := updateCondition(ctx, c.cli, pool, cond); err != nil {
 				logrus.WithError(err).WithField("pool", pool.Name).Error("Failed to update status of IPPool")
+				errs = append(errs, err)
 			}
 			continue
 		}
@@ -224,6 +253,7 @@ func (c *IPPoolController) reconcileConditions(ctx context.Context) error {
 			}
 			if err := updateCondition(ctx, c.cli, pool, cond); err != nil {
 				logrus.WithError(err).WithField("pool", pool.Name).Error("Failed to update status of IPPool")
+				errs = append(errs, err)
 			}
 			// If the pool is being deleted, we still want to consider it for overlaps.
 			// This ensures we don't preemptively enable another pool that might overlap with it until this pool
@@ -258,6 +288,7 @@ func (c *IPPoolController) reconcileConditions(ctx context.Context) error {
 		}
 		if err := updateCondition(ctx, c.cli, pool, cond); err != nil {
 			logrus.WithError(err).WithField("pool", pool.Name).Error("Failed to update status of IPPool")
+			errs = append(errs, err)
 		}
 	}
 
@@ -269,27 +300,16 @@ func (c *IPPoolController) reconcileConditions(ctx context.Context) error {
 			Reason:  v3.IPPoolReasonOK,
 			Message: "IPPool is available for IP allocation.",
 		}
-		if setConditionOnPool(pool, cond) {
-			logrus.WithField("pool", pool.Name).Infof("Setting condition %s to %s", cond.Type, cond.Status)
-			if _, err := c.cli.ProjectcalicoV3().IPPools().UpdateStatus(ctx, pool, metav1.UpdateOptions{}); err != nil {
-				logrus.WithError(err).WithField("otherPool", pool.Name).Error("Failed to update status of IPPool")
-			}
-
-			// If this pool was previously disabled, we need to ensure the finalizer is correctly set on it since
-			// it would not have had one applied when it was disabled.
-			if err := c.reconcileFinalizer(ctx, logrus.WithField("pool", pool.Name), pool); err != nil {
-				logrus.WithError(err).WithField("otherPool", pool.Name).Error("Failed to reconcile finalizer for IPPool")
-			}
+		if err := updateCondition(ctx, c.cli, pool, cond); err != nil {
+			logrus.WithError(err).WithField("pool", pool.Name).Error("Failed to update status of IPPool")
+			errs = append(errs, err)
 		}
 	}
 
-	return nil
+	return pools, utilerrors.NewAggregate(errs)
 }
 
-func poolSortFunc(a, b any) int {
-	poolA := a.(*v3.IPPool)
-	poolB := b.(*v3.IPPool)
-
+func poolSortFunc(poolA, poolB *v3.IPPool) int {
 	aCat := poolSortCategory(poolA)
 	bCat := poolSortCategory(poolB)
 	if aCat != bCat {
@@ -344,8 +364,7 @@ func (c *IPPoolController) reconcileFinalizer(ctx context.Context, logCtx *logru
 			// pool if the user tries to delete it to resolve the overlap.
 			if hasFinalizer(p) {
 				logCtx.Info("IPPool is not active, removing finalizer")
-				p.Finalizers = slices.DeleteFunc(p.Finalizers, func(s string) bool { return s == IPPoolFinalizer })
-				if _, err = c.cli.ProjectcalicoV3().IPPools().Update(ctx, p, metav1.UpdateOptions{}); err != nil {
+				if err = c.updateFinalizers(ctx, p, withoutFinalizer(p)); err != nil {
 					logCtx.WithError(err).Error("Failed to remove finalizer from IPPool")
 					return err
 				}
@@ -356,8 +375,7 @@ func (c *IPPoolController) reconcileFinalizer(ctx context.Context, logCtx *logru
 		// If the IP pool is not being deleted, add a finalizer to it so we can insert ourselves into the deletion flow.
 		if !hasFinalizer(p) {
 			logCtx.Info("Adding finalizer to IPPool")
-			p.SetFinalizers(append(p.Finalizers, IPPoolFinalizer))
-			if _, err = c.cli.ProjectcalicoV3().IPPools().Update(ctx, p, metav1.UpdateOptions{}); err != nil {
+			if err = c.updateFinalizers(ctx, p, append(slices.Clone(p.Finalizers), IPPoolFinalizer)); err != nil {
 				logCtx.WithError(err).Error("Failed to add finalizer to IPPool")
 				return err
 			}
@@ -389,12 +407,24 @@ func (c *IPPoolController) reconcileFinalizer(ctx context.Context, logCtx *logru
 	}
 
 	logCtx.Info("No IPAM blocks left in pool, removing finalizer")
-	p.Finalizers = slices.DeleteFunc(p.Finalizers, func(s string) bool { return s == IPPoolFinalizer })
-	if _, err := c.cli.ProjectcalicoV3().IPPools().Update(ctx, p, metav1.UpdateOptions{}); err != nil {
+	if err := c.updateFinalizers(ctx, p, withoutFinalizer(p)); err != nil {
 		logCtx.WithError(err).Error("Failed to remove finalizer from IPPool")
 		return err
 	}
 	return nil
+}
+
+// updateFinalizers writes p with the given finalizer set, leaving p itself untouched so that a
+// failed write cannot strand a mutation on an object we may not own.
+func (c *IPPoolController) updateFinalizers(ctx context.Context, p *v3.IPPool, finalizers []string) error {
+	updated := p.DeepCopy()
+	updated.Finalizers = finalizers
+	_, err := c.cli.ProjectcalicoV3().IPPools().Update(ctx, updated, metav1.UpdateOptions{})
+	return err
+}
+
+func withoutFinalizer(p *v3.IPPool) []string {
+	return slices.DeleteFunc(slices.Clone(p.Finalizers), func(s string) bool { return s == IPPoolFinalizer })
 }
 
 func (c *IPPoolController) blocksInPool(cidr cnet.IPNet) bool {
@@ -432,14 +462,20 @@ func hasCondition(p *v3.IPPool, conditionType string, status metav1.ConditionSta
 }
 
 // updateCondition updates the given condition on the IP pool if it has changed, and updates the status of the pool if needed.
+// It mutates p, so p must be a copy the caller owns rather than an object from the informer cache.
 func updateCondition(ctx context.Context, cli clientset.Interface, p *v3.IPPool, condition metav1.Condition) error {
-	if setConditionOnPool(p, condition) {
-		logrus.WithField("pool", p.Name).Infof("Updating condition %s to %s", condition.Type, condition.Status)
-		if _, err := cli.ProjectcalicoV3().IPPools().UpdateStatus(ctx, p, metav1.UpdateOptions{}); err != nil {
-			logrus.WithError(err).WithField("pool", p.Name).Error("Failed to update status of IPPool")
-			return err
-		}
+	if !setConditionOnPool(p, condition) {
+		return nil
 	}
+
+	logrus.WithField("pool", p.Name).Infof("Updating condition %s to %s", condition.Type, condition.Status)
+	updated, err := cli.ProjectcalicoV3().IPPools().UpdateStatus(ctx, p, metav1.UpdateOptions{})
+	if err != nil {
+		return fmt.Errorf("update status of IPPool %s: %w", p.Name, err)
+	}
+
+	// Take the accepted object so a later finalizer write on this pool does not conflict.
+	*p = *updated
 	return nil
 }
 

--- a/kube-controllers/pkg/controllers/ippool/pool_controller_unit_test.go
+++ b/kube-controllers/pkg/controllers/ippool/pool_controller_unit_test.go
@@ -15,12 +15,26 @@
 package ippool
 
 import (
+	"context"
+	"fmt"
 	"slices"
 	"testing"
 	"time"
 
 	v3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
+	"github.com/projectcalico/api/pkg/client/clientset_generated/clientset/fake"
+	"github.com/sirupsen/logrus"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	k8stesting "k8s.io/client-go/testing"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+
+	"github.com/projectcalico/calico/libcalico-go/lib/ipam"
+	cnet "github.com/projectcalico/calico/libcalico-go/lib/net"
 )
 
 func TestPoolSortFunc(t *testing.T) {
@@ -166,5 +180,358 @@ func TestPoolSortFunc(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// fakeSharedIndexInformer wraps a cache.Indexer to satisfy cache.SharedIndexInformer for testing.
+// Only GetIndexer and GetStore are implemented.
+type fakeSharedIndexInformer struct {
+	cache.SharedIndexInformer
+	indexer cache.Indexer
+}
+
+func (f *fakeSharedIndexInformer) GetIndexer() cache.Indexer {
+	return f.indexer
+}
+
+func (f *fakeSharedIndexInformer) GetStore() cache.Store {
+	return f.indexer
+}
+
+// fakeIPAM stubs out the IPAM calls the finalizer path makes for a deleting pool.
+type fakeIPAM struct {
+	ipam.Interface
+}
+
+func (f *fakeIPAM) ReleasePoolAffinities(ctx context.Context, pool cnet.IPNet) error {
+	return nil
+}
+
+// fakeRateLimitingQueue tracks calls for testing handleErr behavior.
+type fakeRateLimitingQueue struct {
+	workqueue.TypedRateLimitingInterface[string]
+	rateLimitedAdds int
+	forgets         int
+	requeues        int
+}
+
+func (f *fakeRateLimitingQueue) AddRateLimited(item string)  { f.rateLimitedAdds++ }
+func (f *fakeRateLimitingQueue) Forget(item string)          { f.forgets++ }
+func (f *fakeRateLimitingQueue) NumRequeues(item string) int { return f.requeues }
+
+// newTestController builds a controller whose pool informer is seeded with the given pools and
+// whose block informer is empty. The returned indexer is the same one the controller reads, so
+// tests can assert on whether the controller mutated the objects it was handed.
+func newTestController(cli *fake.Clientset, pools ...*v3.IPPool) (*IPPoolController, cache.Indexer) {
+	poolIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	for _, p := range pools {
+		if err := poolIndexer.Add(p); err != nil {
+			panic(err)
+		}
+	}
+	blockIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+
+	c := &IPPoolController{
+		ctx:           context.Background(),
+		cli:           cli,
+		poolInformer:  &fakeSharedIndexInformer{indexer: poolIndexer},
+		blockInformer: &fakeSharedIndexInformer{indexer: blockIndexer},
+		ipam:          &fakeIPAM{},
+		queue:         &fakeRateLimitingQueue{},
+	}
+	return c, poolIndexer
+}
+
+func testPool(name, cidr string) *v3.IPPool {
+	return &v3.IPPool{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec:       v3.IPPoolSpec{CIDR: cidr},
+	}
+}
+
+// failOn makes every write matching verb/subresource fail with a conflict, and counts attempts.
+func failOn(cli *fake.Clientset, verb, subresource string, count *int) {
+	cli.PrependReactor(verb, "ippools", func(a k8stesting.Action) (bool, runtime.Object, error) {
+		if a.GetSubresource() != subresource {
+			return false, nil, nil
+		}
+		*count++
+		return true, nil, apierrors.NewConflict(schema.GroupResource{Group: "projectcalico.org", Resource: "ippools"}, "conflict", fmt.Errorf("stale object"))
+	})
+}
+
+// logEntry returns a throwaway log context for functions that require one.
+func logEntry() *logrus.Entry {
+	return logrus.WithField("test", true)
+}
+
+// hasConflict reports whether err, which may be a nested aggregate of wrapped errors, contains a conflict.
+func hasConflict(err error) bool {
+	agg, ok := err.(utilerrors.Aggregate)
+	if !ok {
+		return apierrors.IsConflict(err)
+	}
+	for _, e := range utilerrors.Flatten(agg).Errors() {
+		if apierrors.IsConflict(e) {
+			return true
+		}
+	}
+	return false
+}
+
+func cachedPool(t *testing.T, idx cache.Indexer, name string) *v3.IPPool {
+	t.Helper()
+	obj, exists, err := idx.GetByKey(name)
+	if err != nil || !exists {
+		t.Fatalf("pool %q not in cache (exists=%v, err=%v)", name, exists, err)
+	}
+	return obj.(*v3.IPPool)
+}
+
+// TestReconcileConditions_FailedStatusUpdateDoesNotPoisonCache is the regression test for
+// CORE-13258. A rejected UpdateStatus used to leave the informer-cached pool asserting the
+// condition, after which the idempotency check in setConditionOnPool suppressed every retry.
+func TestReconcileConditions_FailedStatusUpdateDoesNotPoisonCache(t *testing.T) {
+	pool := testPool("pool-1", "192.168.0.0/24")
+	cli := fake.NewClientset(pool)
+	attempts := 0
+	failOn(cli, "update", "status", &attempts)
+
+	c, idx := newTestController(cli, pool)
+
+	if _, err := c.reconcileConditions(c.ctx); err == nil {
+		t.Fatal("expected reconcileConditions to surface the failed status write")
+	}
+	if attempts != 1 {
+		t.Fatalf("expected 1 UpdateStatus attempt, got %d", attempts)
+	}
+
+	// The cached object must not claim a condition the API server rejected.
+	if cp := cachedPool(t, idx, "pool-1"); cp.Status != nil && len(cp.Status.Conditions) > 0 {
+		t.Fatalf("informer cache was mutated by a failed write: %+v", cp.Status.Conditions)
+	}
+
+	// And the next pass must retry rather than short-circuit on the poisoned cache.
+	if _, err := c.reconcileConditions(c.ctx); err == nil {
+		t.Fatal("expected second reconcileConditions to surface the failed status write")
+	}
+	if attempts != 2 {
+		t.Fatalf("expected the second pass to retry the write, got %d total attempts", attempts)
+	}
+}
+
+// TestReconcileConditions_RecoversOnceWriteSucceeds confirms the retry actually lands the
+// condition once the transient failure clears.
+func TestReconcileConditions_RecoversOnceWriteSucceeds(t *testing.T) {
+	pool := testPool("pool-1", "192.168.0.0/24")
+	cli := fake.NewClientset(pool)
+	fail := true
+	attempts := 0
+	cli.PrependReactor("update", "ippools", func(a k8stesting.Action) (bool, runtime.Object, error) {
+		if a.GetSubresource() != "status" {
+			return false, nil, nil
+		}
+		attempts++
+		if fail {
+			return true, nil, apierrors.NewConflict(schema.GroupResource{Resource: "ippools"}, "pool-1", nil)
+		}
+		return false, nil, nil
+	})
+
+	c, _ := newTestController(cli, pool)
+
+	if _, err := c.reconcileConditions(c.ctx); err == nil {
+		t.Fatal("expected first pass to fail")
+	}
+
+	fail = false
+	if _, err := c.reconcileConditions(c.ctx); err != nil {
+		t.Fatalf("expected second pass to succeed, got %v", err)
+	}
+	if attempts != 2 {
+		t.Fatalf("expected 2 attempts, got %d", attempts)
+	}
+
+	updated, err := cli.ProjectcalicoV3().IPPools().Get(context.Background(), "pool-1", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get pool: %v", err)
+	}
+	if !hasCondition(updated, v3.IPPoolConditionAllocatable, metav1.ConditionTrue) {
+		t.Fatalf("expected Allocatable=True to be persisted, got %+v", updated.Status)
+	}
+}
+
+// TestReconcileFinalizer_FailedUpdateDoesNotPoisonCache covers the same mutate-before-write
+// pattern on the finalizer path.
+func TestReconcileFinalizer_FailedUpdateDoesNotPoisonCache(t *testing.T) {
+	pool := testPool("pool-1", "192.168.0.0/24")
+	cli := fake.NewClientset(pool)
+	attempts := 0
+	failOn(cli, "update", "", &attempts)
+
+	c, idx := newTestController(cli, pool)
+
+	if err := c.reconcileFinalizer(c.ctx, logEntry(), pool); err == nil {
+		t.Fatal("expected reconcileFinalizer to return the failed write")
+	}
+	if attempts != 1 {
+		t.Fatalf("expected 1 Update attempt, got %d", attempts)
+	}
+	if cp := cachedPool(t, idx, "pool-1"); hasFinalizer(cp) {
+		t.Fatal("informer cache gained a finalizer from a failed write")
+	}
+
+	// A pool that never got its finalizer written must be retried, not skipped.
+	if err := c.reconcileFinalizer(c.ctx, logEntry(), pool); err == nil {
+		t.Fatal("expected second reconcileFinalizer to return the failed write")
+	}
+	if attempts != 2 {
+		t.Fatalf("expected the second pass to retry, got %d total attempts", attempts)
+	}
+}
+
+// TestReconcileFinalizer_RemovalFailureDoesNotPoisonCache covers the removal branch, which
+// deletes from the finalizer slice rather than appending to it.
+func TestReconcileFinalizer_RemovalFailureDoesNotPoisonCache(t *testing.T) {
+	pool := testPool("pool-1", "192.168.0.0/24")
+	pool.Finalizers = []string{IPPoolFinalizer}
+	pool.Status = &v3.IPPoolStatus{
+		Conditions: []metav1.Condition{{
+			Type:   v3.IPPoolConditionAllocatable,
+			Status: metav1.ConditionFalse,
+			Reason: v3.IPPoolReasonCIDROverlap,
+		}},
+	}
+	cli := fake.NewClientset(pool)
+	attempts := 0
+	failOn(cli, "update", "", &attempts)
+
+	c, idx := newTestController(cli, pool)
+
+	if err := c.reconcileFinalizer(c.ctx, logEntry(), pool); err == nil {
+		t.Fatal("expected reconcileFinalizer to return the failed write")
+	}
+	if cp := cachedPool(t, idx, "pool-1"); !hasFinalizer(cp) {
+		t.Fatal("informer cache lost its finalizer to a failed write")
+	}
+	if err := c.reconcileFinalizer(c.ctx, logEntry(), pool); err == nil {
+		t.Fatal("expected second reconcileFinalizer to return the failed write")
+	}
+	if attempts != 2 {
+		t.Fatalf("expected the second pass to retry, got %d total attempts", attempts)
+	}
+}
+
+// TestReconcile_ConflictRequeues checks the whole loop: a conflicting write must come back
+// through the workqueue rather than being logged and dropped.
+func TestReconcile_ConflictRequeues(t *testing.T) {
+	pool := testPool("pool-1", "192.168.0.0/24")
+	cli := fake.NewClientset(pool)
+	attempts := 0
+	failOn(cli, "update", "status", &attempts)
+
+	c, _ := newTestController(cli, pool)
+
+	err := c.reconcile()
+	if err == nil {
+		t.Fatal("expected reconcile to return the conflict")
+	}
+	if !hasConflict(err) {
+		t.Fatalf("expected a conflict error, got %v", err)
+	}
+
+	c.handleErr(err, reconcileKey)
+	fq := c.queue.(*fakeRateLimitingQueue)
+	if fq.rateLimitedAdds != 1 {
+		t.Fatalf("expected 1 rate-limited requeue, got %d", fq.rateLimitedAdds)
+	}
+	if fq.forgets != 0 {
+		t.Fatalf("expected the key to be kept, got %d forgets", fq.forgets)
+	}
+}
+
+func TestHandleErr_ForgetsOnSuccess(t *testing.T) {
+	c, _ := newTestController(fake.NewClientset())
+
+	c.handleErr(nil, reconcileKey)
+
+	fq := c.queue.(*fakeRateLimitingQueue)
+	if fq.forgets != 1 {
+		t.Fatalf("expected 1 forget, got %d", fq.forgets)
+	}
+	if fq.rateLimitedAdds != 0 {
+		t.Fatalf("expected 0 requeues, got %d", fq.rateLimitedAdds)
+	}
+}
+
+func TestHandleErr_DropsAfterMaxRetries(t *testing.T) {
+	c, _ := newTestController(fake.NewClientset())
+	fq := c.queue.(*fakeRateLimitingQueue)
+	fq.requeues = maxRetries
+
+	c.handleErr(fmt.Errorf("persistent error"), reconcileKey)
+
+	if fq.rateLimitedAdds != 0 {
+		t.Fatalf("expected no requeue past maxRetries, got %d", fq.rateLimitedAdds)
+	}
+	if fq.forgets != 1 {
+		t.Fatalf("expected the key to be forgotten, got %d forgets", fq.forgets)
+	}
+}
+
+// TestReconcile_HappyPath is a sanity check that the restructured reconcile still writes both
+// the condition and the finalizer for a single healthy pool.
+func TestReconcile_HappyPath(t *testing.T) {
+	pool := testPool("pool-1", "192.168.0.0/24")
+	cli := fake.NewClientset(pool)
+	c, idx := newTestController(cli, pool)
+
+	if err := c.reconcile(); err != nil {
+		t.Fatalf("reconcile failed: %v", err)
+	}
+
+	updated, err := cli.ProjectcalicoV3().IPPools().Get(context.Background(), "pool-1", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get pool: %v", err)
+	}
+	if !hasCondition(updated, v3.IPPoolConditionAllocatable, metav1.ConditionTrue) {
+		t.Fatalf("expected Allocatable=True, got %+v", updated.Status)
+	}
+	if !hasFinalizer(updated) {
+		t.Fatal("expected finalizer to be added")
+	}
+
+	// Even on the happy path the controller must not have written through to the shared cache.
+	if cp := cachedPool(t, idx, "pool-1"); hasFinalizer(cp) || cp.Status != nil {
+		t.Fatalf("controller mutated the informer cache: finalizers=%v status=%+v", cp.Finalizers, cp.Status)
+	}
+}
+
+// TestReconcile_FinalizerWriteUsesStatusResourceVersion checks that the finalizer write uses
+// the resourceVersion the status write returned.
+func TestReconcile_FinalizerWriteUsesStatusResourceVersion(t *testing.T) {
+	pool := testPool("pool-1", "192.168.0.0/24")
+	pool.ResourceVersion = "1"
+	cli := fake.NewClientset(pool)
+
+	var finalizerRV string
+	cli.PrependReactor("update", "ippools", func(a k8stesting.Action) (bool, runtime.Object, error) {
+		obj := a.(k8stesting.UpdateAction).GetObject().(*v3.IPPool)
+		if a.GetSubresource() == "status" {
+			accepted := obj.DeepCopy()
+			accepted.ResourceVersion = "2"
+			return true, accepted, nil
+		}
+		finalizerRV = obj.ResourceVersion
+		return true, obj, nil
+	})
+
+	c, _ := newTestController(cli, pool)
+
+	if err := c.reconcile(); err != nil {
+		t.Fatalf("reconcile failed: %v", err)
+	}
+	if finalizerRV != "2" {
+		t.Fatalf("expected finalizer write to use resourceVersion 2, got %q", finalizerRV)
 	}
 }


### PR DESCRIPTION
**Cherry-pick history**
- Pick onto **release-v3.32**: projectcalico/calico#13427

This PR fixes an issue where an IP pool could end up permanently without its Allocatable status condition, so IPAM would keep allocating from a pool that should have been excluded. Without this fix, a rejected status write left the controller's cached copy of the pool claiming a condition the API server never accepted, and the controller then treated the condition as already written and skipped every retry.

The controller now reconciles from a workqueue, works on copies of the pools it reads so a failed write cannot strand a mutation on the shared cache, and requeues failed writes instead of logging and dropping them.

CORE-13258

```release-note
Fixes an issue where an IP pool could be left without its Allocatable status condition, causing IPAM to keep allocating from a disabled or overlapping pool in some setups.
```


Conflicts: the event handlers clashed with tombstone handling that only exists on master, and the informer resync comment goes in `main.go` on this branch rather than `run.go`.
