### PR TITLE
argoci: float half the stable e2e cells onto beta-or-stable

### DIFF
--- a/.argoci/cron/e2e-bpf.yaml
+++ b/.argoci/cron/e2e-bpf.yaml
@@ -200,6 +200,9 @@ steps:
         value: --env EKS_CNI
       - name: K8S_E2E_FLAGS
         value: --ginkgo.focus=(\[sig-calico\]|Conformance|Dataplane:BPF|Feature:NetworkPolicy) --ginkgo.skip=(Slow|Disruptive|calient|allow.ingress.access.from.updated.pod|Dataplane:LB|Feature:SCTP|Feature:Maglev)
+      # The BPF suite's canary on new Kubernetes; the rest of these runs sit on stable-3.
+      - name: K8S_VERSION
+        value: beta-or-stable
       - name: KUBE_PROXY_MANAGEMENT
         value: Enabled
       - name: PROVISIONER

--- a/.argoci/cron/e2e-iptables.yaml
+++ b/.argoci/cron/e2e-iptables.yaml
@@ -302,8 +302,7 @@ steps:
       - name: USE_API_SERVER
         value: "false"
     matrix:
-      # Name no longer matches the value; it is the Lens/OTEL job identity, so it stays.
-      - name: stable
+      - name: beta-or-stable
         env:
           - name: K8S_VERSION
             value: beta-or-stable
@@ -342,7 +341,7 @@ steps:
       - name: USE_HASH_RELEASE
         value: "true"
     matrix:
-      - name: beta-calico-yaml-iptables
+      - name: beta-or-stable-calico-yaml-iptables
         env:
           - name: K8S_VERSION
             value: beta-or-stable
@@ -390,8 +389,7 @@ steps:
       - name: VPC_SUBNETS
         value: '["172.16.101.0/24"]'
     matrix:
-      # Name no longer matches the value; it is the Lens/OTEL job identity, so it stays.
-      - name: stable
+      - name: beta-or-stable
         env:
           - name: K8S_VERSION
             value: beta-or-stable
@@ -771,21 +769,20 @@ steps:
         value: --ginkgo.focus=(\[sig-calico\]|\[Conformance\]) --ginkgo.skip=(\[Slow\]|\[Disruptive\]|\[DataPath\]|WireGuard)
       - name: PROVISIONER
         value: gcp-kubeadm
-    # Names no longer match the value; they are the Lens/OTEL job identity, so they stay.
     matrix:
-      - name: stable-calico-yaml
+      - name: beta-or-stable-calico-yaml
         env:
           - name: K8S_VERSION
             value: beta-or-stable
           - name: MANIFEST_FILE
             value: calico.yaml
-      - name: stable-calico-typha-yaml
+      - name: beta-or-stable-calico-typha-yaml
         env:
           - name: K8S_VERSION
             value: beta-or-stable
           - name: MANIFEST_FILE
             value: calico-typha.yaml
-      - name: stable-canal-yaml
+      - name: beta-or-stable-canal-yaml
         env:
           - name: K8S_VERSION
             value: beta-or-stable

--- a/.argoci/cron/e2e-iptables.yaml
+++ b/.argoci/cron/e2e-iptables.yaml
@@ -304,8 +304,10 @@ steps:
     matrix:
       - name: stable
         env:
+          # Floats onto the next k8s minor's beta/rc when one exists, else current
+          # stable. Cell name is historical — it no longer implies the stable channel.
           - name: K8S_VERSION
-            value: stable
+            value: beta-or-stable
     commands: |
       .argoci/scripts/body_standard.sh
   - name: usage-reporting
@@ -343,8 +345,10 @@ steps:
     matrix:
       - name: beta-calico-yaml-iptables
         env:
+          # Was `beta`, which errors outright when no pre-release exists. Falls back
+          # to current stable instead, so a no-beta window no longer burns the run.
           - name: K8S_VERSION
-            value: beta
+            value: beta-or-stable
           - name: MANIFEST_FILE
             value: calico.yaml
           - name: KUBE_PROXY_MODE
@@ -391,8 +395,10 @@ steps:
     matrix:
       - name: stable
         env:
+          # Floats onto the next k8s minor's beta/rc when one exists, else current
+          # stable. Cell name is historical — it no longer implies the stable channel.
           - name: K8S_VERSION
-            value: stable
+            value: beta-or-stable
     commands: |
       .argoci/scripts/body_standard.sh
   - name: wireguard-k8s-e2e
@@ -769,23 +775,26 @@ steps:
         value: --ginkgo.focus=(\[sig-calico\]|\[Conformance\]) --ginkgo.skip=(\[Slow\]|\[Disruptive\]|\[DataPath\]|WireGuard)
       - name: PROVISIONER
         value: gcp-kubeadm
+    # These three float onto the next k8s minor's beta/rc when one exists, else
+    # current stable. Cell names are historical — they no longer imply the stable
+    # channel. The kdd-old and etcd steps stay pinned as the older-version contrast.
     matrix:
       - name: stable-calico-yaml
         env:
           - name: K8S_VERSION
-            value: stable
+            value: beta-or-stable
           - name: MANIFEST_FILE
             value: calico.yaml
       - name: stable-calico-typha-yaml
         env:
           - name: K8S_VERSION
-            value: stable
+            value: beta-or-stable
           - name: MANIFEST_FILE
             value: calico-typha.yaml
       - name: stable-canal-yaml
         env:
           - name: K8S_VERSION
-            value: stable
+            value: beta-or-stable
           - name: MANIFEST_FILE
             value: canal.yaml
     commands: |

--- a/.argoci/cron/e2e-iptables.yaml
+++ b/.argoci/cron/e2e-iptables.yaml
@@ -302,10 +302,9 @@ steps:
       - name: USE_API_SERVER
         value: "false"
     matrix:
+      # Name no longer matches the value; it is the Lens/OTEL job identity, so it stays.
       - name: stable
         env:
-          # Floats onto the next k8s minor's beta/rc when one exists, else current
-          # stable. Cell name is historical — it no longer implies the stable channel.
           - name: K8S_VERSION
             value: beta-or-stable
     commands: |
@@ -345,8 +344,6 @@ steps:
     matrix:
       - name: beta-calico-yaml-iptables
         env:
-          # Was `beta`, which errors outright when no pre-release exists. Falls back
-          # to current stable instead, so a no-beta window no longer burns the run.
           - name: K8S_VERSION
             value: beta-or-stable
           - name: MANIFEST_FILE
@@ -393,10 +390,9 @@ steps:
       - name: VPC_SUBNETS
         value: '["172.16.101.0/24"]'
     matrix:
+      # Name no longer matches the value; it is the Lens/OTEL job identity, so it stays.
       - name: stable
         env:
-          # Floats onto the next k8s minor's beta/rc when one exists, else current
-          # stable. Cell name is historical — it no longer implies the stable channel.
           - name: K8S_VERSION
             value: beta-or-stable
     commands: |
@@ -775,9 +771,7 @@ steps:
         value: --ginkgo.focus=(\[sig-calico\]|\[Conformance\]) --ginkgo.skip=(\[Slow\]|\[Disruptive\]|\[DataPath\]|WireGuard)
       - name: PROVISIONER
         value: gcp-kubeadm
-    # These three float onto the next k8s minor's beta/rc when one exists, else
-    # current stable. Cell names are historical — they no longer imply the stable
-    # channel. The kdd-old and etcd steps stay pinned as the older-version contrast.
+    # Names no longer match the value; they are the Lens/OTEL job identity, so they stay.
     matrix:
       - name: stable-calico-yaml
         env:

--- a/.argoci/cron/e2e-nftables.yaml
+++ b/.argoci/cron/e2e-nftables.yaml
@@ -40,10 +40,7 @@ steps:
         value: gcp-kubeadm
       - name: STERN_CHECK
         value: DISABLED
-    # Both cells float onto the next k8s minor's beta/rc when one exists, else
-    # current stable. Cell names are historical — they no longer imply the stable
-    # channel. arm64 on a k8s pre-release is the least-proven combination we run:
-    # a provision failure here is more likely a node-image/containerd gap than Calico.
+    # Names no longer match the value; they are the Lens/OTEL job identity, so they stay.
     matrix:
       - name: stable-ubuntu-2204-lts-arm64
         env:

--- a/.argoci/cron/e2e-nftables.yaml
+++ b/.argoci/cron/e2e-nftables.yaml
@@ -40,15 +40,14 @@ steps:
         value: gcp-kubeadm
       - name: STERN_CHECK
         value: DISABLED
-    # Names no longer match the value; they are the Lens/OTEL job identity, so they stay.
     matrix:
-      - name: stable-ubuntu-2204-lts-arm64
+      - name: beta-or-stable-ubuntu-2204-lts-arm64
         env:
           - name: K8S_VERSION
             value: beta-or-stable
           - name: CLUSTER_IMAGE
             value: ubuntu-2204-lts-arm64
-      - name: stable-rocky-linux-9-arm64
+      - name: beta-or-stable-rocky-linux-9-arm64
         env:
           - name: K8S_VERSION
             value: beta-or-stable

--- a/.argoci/cron/e2e-nftables.yaml
+++ b/.argoci/cron/e2e-nftables.yaml
@@ -40,17 +40,21 @@ steps:
         value: gcp-kubeadm
       - name: STERN_CHECK
         value: DISABLED
+    # Both cells float onto the next k8s minor's beta/rc when one exists, else
+    # current stable. Cell names are historical — they no longer imply the stable
+    # channel. arm64 on a k8s pre-release is the least-proven combination we run:
+    # a provision failure here is more likely a node-image/containerd gap than Calico.
     matrix:
       - name: stable-ubuntu-2204-lts-arm64
         env:
           - name: K8S_VERSION
-            value: stable
+            value: beta-or-stable
           - name: CLUSTER_IMAGE
             value: ubuntu-2204-lts-arm64
       - name: stable-rocky-linux-9-arm64
         env:
           - name: K8S_VERSION
-            value: stable
+            value: beta-or-stable
           - name: CLUSTER_IMAGE
             value: rocky-linux-9-arm64
     commands: |


### PR DESCRIPTION
banzai-core [#1734](https://github.com/tigera/banzai-core/pull/1734) added the `beta-or-stable` Kubernetes version keyword — the next minor's beta/rc when one exists, else current stable. It deliberately never errors for lack of a pre-release, and never picks up an alpha. This PR puts it to work in the e2e crons, which was left as an explicit follow-up in that change.

### What changes

Nine cells across three crons. Seven move from `stable` to `beta-or-stable`:

| Cron | Step | Cells |
|---|---|---|
| `e2e-iptables` | `ipvs` | 1 |
| `e2e-iptables` | `wireguard-vxlan-k8s-e2e` | 1 |
| `e2e-iptables` | `datastore-k8s-e2e-kdd-new` | 3 |
| `e2e-nftables` | `nftables-mode-arm64-wg` | 2 |

The eighth, `e2e-iptables` / `k8s-beta-runs`, moves off the **fail-hard `beta`** keyword. That keyword errors outright when no pre-release exists, which burned every run of that job until `v1.37.0-beta.0` published on 2026-07-20.

A ninth, `e2e-bpf` / `bpf-run-matrix-gcp-bpf-dp-dsr`, is promoted from `stable-3` — the one deliberate exception to the eligibility rule below.

### Why BPF needs an exception

Applied mechanically, "only plain-`stable` cells are eligible" gives the BPF dataplane **zero** coverage on a new k8s minor. e2e-bpf has 29 BPF cells and exactly one on plain `stable` (`usage-reporting-with-bpf`); 22 sit on `stable-3`, 19 of those only because the cron sets no `K8S_VERSION` of its own and inherits the shared default. The single eligible cell is then claimed as e2e-bpf's control, leaving nothing to flip.

That is two rules colliding, not a judgement about BPF — and BPF is the most runtime-sensitive dataplane we ship, while the 1.37 story *is* a runtime change (containerd 2.x).

`bpf-run-matrix-gcp-bpf-dp-dsr` was chosen because it is core BPF datapath (DSR, focused on `Dataplane:BPF`/Conformance/NetworkPolicy) on **gcp-kubeadm** — the exact provisioning path #658 validated end-to-end for 1.37, so a failure there is more likely a real BPF finding than provisioning noise. It has no matrix, so nothing needed restructuring.

**Unlike the other eight, this cell does change its no-beta behaviour:** it now tracks plain `stable` rather than `stable-3`, so that config loses its 3-minors-back coverage. Accepted deliberately — 65 of 142 cells sitting on `stable-3` is more coverage than that old a k8s earns.

Each flipped matrix cell is also renamed `stable-*` → `beta-or-stable-*` so its name matches its value. No schedules, step names or new jobs, and no extra CI spend.

### Why only these cells

`beta-or-stable` falls back to *current stable*. Flipping a `stable-1`/`stable-3` cell would therefore silently promote it to `stable` in every no-beta window, destroying the deliberate older-version coverage that the pin exists for. **Only cells already on plain `stable` are eligible** — 27 of the 142 cells in `.argoci/cron/`. The BPF cell above is the single, deliberate exception.

Excluded from those 27:

- **Managed/appliance provisioners** (`azr-aks`, `aws-eks`, `aws-talos`, `azr-aso`) — they map k8s versions themselves and never offer a beta.
- **`local-kind`** — banzai resolves a `kindest/node:` image by matching the k8s minor, and kind v0.32.0 tops out at `v1.36.1`. A 1.37 beta hard-fails at provision.
- **`e2e-benchmarking`** — a floating k8s version underneath tiger-bench poisons the perf trend.
- **`e2e-patch-verification`** — this is the release gate; it must stay deterministic and representative of supported versions. One of its cells is Windows (containerd pinned 1.6.8).

That leaves a 13-cell kubeadm pool, of which 7 flip. Each touched cron keeps at least one plain-`stable` kubeadm run as a control, so a red night can be read against a same-suite sibling.

### Renaming the cells is safe

Cell names are renamed to match their value rather than left reading `stable-*`, because nothing that reads these runs keys off them:

- **Lens** builds its record from `FUNCTIONAL_AREA`, `PROVISIONER`, `CLUSTER_IMAGE`, `DATAPLANE` and the version fields; its only CI-specific fields are `ARGO_`-prefixed env vars, i.e. `ARGO_WORKFLOW_NAME` — the workflow name, not the step or cell.
- **OTEL** spans group by `operationName` (`bz <stage>`) and tags such as `cluster.product`.
- **GCS artifacts** land under `${ARGO_WORKFLOW_NAME}/${HOSTNAME}`.

So the cell name is only the Argo UI node label, and no historical continuity is lost.

### This is not a no-op today

`v1.37.0-beta.0` is live against stable `v1.36.3`, so these cells move onto 1.37 on their next run. Verified end-to-end against the live release feeds with the merged resolver:

```
stable         -> v1.36.3
beta           -> v1.37.0-beta.0
beta-or-stable -> v1.37.0-beta.0
```

These are weekly crons (iptables Thu 21:10 UTC, nftables Mon, bpf Tue), so with 1.37 GA around 2026-08-26 the pre-GA window is roughly three runs each, nine in total. **Expect some red — that is the point of the change**, and it is the signal we do not otherwise get until the 1.38 beta in December.

kubeadm on 1.37 is unblocked by calico-ready-clusters [#658](https://github.com/tigera/calico-ready-clusters/pull/658) (containerd 2.x, kubeadm v1beta4, prerelease apt channel), merged 2026-07-24. That was validated on jammy/amd64 — **the two arm64 cells are the least-proven combination here** and the likeliest to fail first; failure there is a finding about #658's coverage rather than about Calico.

### Testing

- All three cron files parse as YAML; the diff is 9 `value:` changes plus the matching cell renames, and nothing else.
- Resulting distribution confirmed: 9 cells on `beta-or-stable`, 20 still on plain `stable`, 0 remaining on plain `beta`, and BPF now has datapath coverage on the beta.
- Resolver behaviour confirmed live (above). `beta-or-stable`'s fallback and alpha-exclusion are covered by unit tests in banzai-core #1734.
- No `USE_API_SERVER` interaction: `v1.37.0-beta.0` parses cleanly against the version-aware default added in banzai-core #1737, and today's `stable` (v1.36.3) is already ≥1.36, so v3-CRD mode is unchanged either way.

### Rollback

Revert this PR; the keyword remains in banzai-core and is harmless unused. Per-cell rollback is a one-word edit back to `stable`.

**Release note:**
```release-note
NONE
```
