### PR TITLE
Bump gopacket to v1.6.1 and fix the BPF UT fallout

### DIFF
--- a/cmd/deps.txt
+++ b/cmd/deps.txt
@@ -85,7 +85,7 @@ github.com/google/gnostic-models v0.7.0
 github.com/google/go-cmp v0.7.0
 github.com/google/safetext v0.0.0-20260330151545-1fb717a317c5
 github.com/google/uuid v1.6.0
-github.com/gopacket/gopacket v1.4.0
+github.com/gopacket/gopacket v1.6.1
 github.com/gorilla/mux v1.8.1
 github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674
 github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus v1.1.0

--- a/felix/bpf/ut/bpf_prog_test.go
+++ b/felix/bpf/ut/bpf_prog_test.go
@@ -73,6 +73,12 @@ func init() {
 	logrusr.ConfigureEarlyLoggingFromEnv("felix")
 	log.SetLevel(log.DebugLevel)
 
+	// These tests use port 666 as an arbitrary NAT backend port and expect
+	// gopacket to leave the UDP payload opaque. gopacket v1.6.1 started
+	// dissecting port 666 as AGUE, which leaves the packet with no
+	// application layer.
+	layers.RegisterUDPPortLayerType(666, gopacket.LayerTypePayload)
+
 	fd := environment.NewFeatureDetector(make(map[string]string))
 	if ok, err := fd.KernelIsAtLeast("5.9.0"); err == nil && ok {
 		canTestMarks = true

--- a/felix/deps.txt
+++ b/felix/deps.txt
@@ -68,7 +68,7 @@ github.com/google/cel-go v0.29.0
 github.com/google/gnostic-models v0.7.0
 github.com/google/go-cmp v0.7.0
 github.com/google/uuid v1.6.0
-github.com/gopacket/gopacket v1.4.0
+github.com/gopacket/gopacket v1.6.1
 github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0
 github.com/ishidawataru/sctp v0.0.0-20251114114122-19ddcbc6aae2

--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,7 @@ require (
 	github.com/google/netstack v0.0.0-20191123085552-55fcc16cd0eb
 	github.com/google/safetext v0.0.0-20260330151545-1fb717a317c5
 	github.com/google/uuid v1.6.0
-	github.com/gopacket/gopacket v1.4.0
+	github.com/gopacket/gopacket v1.6.1
 	github.com/gruntwork-io/terratest v1.0.0
 	github.com/hashicorp/yamux v0.1.2
 	github.com/ishidawataru/sctp v0.0.0-20251114114122-19ddcbc6aae2

--- a/go.sum
+++ b/go.sum
@@ -463,8 +463,8 @@ github.com/googleapis/enterprise-certificate-proxy v0.3.14 h1:yh8ncqsbUY4shRD5dA
 github.com/googleapis/enterprise-certificate-proxy v0.3.14/go.mod h1:vqVt9yG9480NtzREnTlmGSBmFrA+bzb0yl0TxoBQXOg=
 github.com/googleapis/gax-go/v2 v2.21.0 h1:h45NjjzEO3faG9Lg/cFrBh2PgegVVgzqKzuZl/wMbiI=
 github.com/googleapis/gax-go/v2 v2.21.0/go.mod h1:But/NJU6TnZsrLai/xBAQLLz+Hc7fHZJt/hsCz3Fih4=
-github.com/gopacket/gopacket v1.4.0 h1:cr1OlFpzksCkZHNO0eLjaSSOrMQnpPXg0j6qHIY3y2U=
-github.com/gopacket/gopacket v1.4.0/go.mod h1:EpvsxINeehp5qj4YMKMLf2/dekdhKn2IIAO/ZOifS7o=
+github.com/gopacket/gopacket v1.6.1 h1:S19Ok/KVGDFNHVW2uCva5U0vZ+uHqiZQdxteL50v6Ak=
+github.com/gopacket/gopacket v1.6.1/go.mod h1:i3NaGaqfoWKAr1+g7qxEdWsmfT+MXuWkAe9+THv8LME=
 github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
 github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=
 github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 h1:JeSE6pjso5THxAzdVpqr6/geYxZytqFMBCOtn/ujyeo=

--- a/node/deps.txt
+++ b/node/deps.txt
@@ -70,7 +70,7 @@ github.com/google/cel-go v0.29.0
 github.com/google/gnostic-models v0.7.0
 github.com/google/go-cmp v0.7.0
 github.com/google/uuid v1.6.0
-github.com/gopacket/gopacket v1.4.0
+github.com/gopacket/gopacket v1.6.1
 github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0
 github.com/jedib0t/go-pretty/v6 v6.8.1


### PR DESCRIPTION
Bumps `github.com/gopacket/gopacket` from v1.4.0 to v1.6.1 (security release), and fixes the BPF unit test breakage that comes with it.

v1.6.1 added well-known-port dissectors in `layers/ports.go`, including UDP 666 -> `LayerTypeAGUEVar0`. The BPF unit tests use 666 as their stock NAT backend port, so when `udpResponseRaw()` re-parses a packet **after** NAT, gopacket dissects the UDP payload as AGUE (which then fails to decode it as IPv6) instead of leaving it opaque. `pkt.ApplicationLayer()` returns nil and `TestICMPRelatedHostNetBackend` panics.

Fix: register port 666 back to `gopacket.LayerTypePayload` in the test package `init()`. The override table takes precedence over gopacket's built-in port switch.

Verified standalone against v1.6.1: the same packet on port 667 parses to a 27-byte application layer, on 666 it yields nil plus `Invalid ip6 header. Length 27 less than 40`; with the registration, 666 parses correctly again. Confirmed against a real CI run of the same bump in the downstream fork, where all four Felix BPF UT jobs failed on exactly this test.

The failure is the test being repaired, so no new test is added.

Other new mappings that could bite if the test ports ever change: UDP 1000 (APSP), 2123 (GTPv2), 2222/44818 (ENIP), 3868 (Diameter), 5082/5083 (SIP).

**Release note:**
```release-note
None
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)