### PR TITLE
Fix the kind migration test's env var, failsafes, and restart timeout

### DIFF
--- a/hack/test/kind/migration/run_test.sh
+++ b/hack/test/kind/migration/run_test.sh
@@ -296,7 +296,9 @@ fi
 ###############################################################################
 log "Step 6: Waiting for migration to complete"
 
-TIMEOUT=300
+# Converged to Complete waits on the operator rolling calico-node and typha,
+# which takes several minutes on a multi-node kind cluster.
+TIMEOUT=900
 INTERVAL=5
 elapsed=0
 

--- a/hack/test/kind/migration/run_test.sh
+++ b/hack/test/kind/migration/run_test.sh
@@ -179,8 +179,8 @@ done
 ###############################################################################
 log "Step 2: Seeding test resources via apiserver"
 
-# The seeded HostEndpoint default-denies host traffic on kind-worker. Add the kind
-# registry and kubelet ports to the failsafes so image pulls and kubectl logs survive.
+# HostEndpoint default-denies host traffic. Felix replaces this list, so it repeats
+# felix/config/config_params.go's defaults plus the kind registry and kubelet ports.
 ${kubectl} patch felixconfigurations.projectcalico.org default --type=merge -p '{
   "spec": {
     "failsafeInboundHostPorts": [
@@ -189,11 +189,11 @@ ${kubectl} patch felixconfigurations.projectcalico.org default --type=merge -p '
       {"protocol": "tcp", "port": 179},
       {"protocol": "tcp", "port": 2379},
       {"protocol": "tcp", "port": 2380},
-      {"protocol": "tcp", "port": 5000},
       {"protocol": "tcp", "port": 5473},
       {"protocol": "tcp", "port": 6443},
       {"protocol": "tcp", "port": 6666},
       {"protocol": "tcp", "port": 6667},
+      {"protocol": "tcp", "port": 5000},
       {"protocol": "tcp", "port": 10250}
     ],
     "failsafeOutboundHostPorts": [
@@ -202,11 +202,11 @@ ${kubectl} patch felixconfigurations.projectcalico.org default --type=merge -p '
       {"protocol": "tcp", "port": 179},
       {"protocol": "tcp", "port": 2379},
       {"protocol": "tcp", "port": 2380},
-      {"protocol": "tcp", "port": 5000},
       {"protocol": "tcp", "port": 5473},
       {"protocol": "tcp", "port": 6443},
       {"protocol": "tcp", "port": 6666},
       {"protocol": "tcp", "port": 6667},
+      {"protocol": "tcp", "port": 5000},
       {"protocol": "tcp", "port": 10250}
     ]
   }

--- a/hack/test/kind/migration/run_test.sh
+++ b/hack/test/kind/migration/run_test.sh
@@ -18,7 +18,7 @@
 #
 # Prerequisites:
 #   - Kind cluster running with v1 CRDs and apiserver:
-#       CALICO_API_GROUP=crd.projectcalico.org/v1 make kind-up
+#       KIND_CALICO_API_GROUP=crd.projectcalico.org/v1 make kind-up
 #
 # What this script does:
 #   1. Deploys client/server pods for continuous connectivity probing
@@ -32,7 +32,7 @@
 #
 # To re-run: destroy the cluster and recreate it, then run this script again:
 #   make kind-down
-#   CALICO_API_GROUP=crd.projectcalico.org/v1 make kind-up
+#   KIND_CALICO_API_GROUP=crd.projectcalico.org/v1 make kind-up
 #   hack/test/kind/migration/run_test.sh
 
 REPO_ROOT=$(cd "$(dirname "$0")/../../../.." && pwd)
@@ -102,14 +102,14 @@ log "Step 0: Preflight checks"
 
 if ! ${kubectl} cluster-info &>/dev/null; then
   echo "ERROR: Cannot connect to kind cluster. Is it running?"
-  echo "  Run: CALICO_API_GROUP=crd.projectcalico.org/v1 make kind-up"
+  echo "  Run: KIND_CALICO_API_GROUP=crd.projectcalico.org/v1 make kind-up"
   exit 1
 fi
 echo "  Kind cluster is reachable"
 
 # Verify v1 CRDs exist.
 if ! ${kubectl} get crd felixconfigurations.crd.projectcalico.org &>/dev/null; then
-  echo "ERROR: v1 CRDs not found. Cluster must be created with CALICO_API_GROUP=crd.projectcalico.org/v1"
+  echo "ERROR: v1 CRDs not found. Cluster must be created with KIND_CALICO_API_GROUP=crd.projectcalico.org/v1"
   exit 1
 fi
 echo "  v1 CRDs (crd.projectcalico.org) found"
@@ -205,6 +205,40 @@ done
 # Step 2: Seed test resources via the apiserver
 ###############################################################################
 log "Step 2: Seeding test resources via apiserver"
+
+# The seeded HostEndpoint default-denies host traffic on kind-worker. Add the kind
+# registry and kubelet ports to the failsafes so image pulls and kubectl logs survive.
+${kubectl} patch felixconfigurations.projectcalico.org default --type=merge -p '{
+  "spec": {
+    "failsafeInboundHostPorts": [
+      {"protocol": "tcp", "port": 22},
+      {"protocol": "udp", "port": 68},
+      {"protocol": "tcp", "port": 179},
+      {"protocol": "tcp", "port": 2379},
+      {"protocol": "tcp", "port": 2380},
+      {"protocol": "tcp", "port": 5000},
+      {"protocol": "tcp", "port": 5473},
+      {"protocol": "tcp", "port": 6443},
+      {"protocol": "tcp", "port": 6666},
+      {"protocol": "tcp", "port": 6667},
+      {"protocol": "tcp", "port": 10250}
+    ],
+    "failsafeOutboundHostPorts": [
+      {"protocol": "udp", "port": 53},
+      {"protocol": "udp", "port": 67},
+      {"protocol": "tcp", "port": 179},
+      {"protocol": "tcp", "port": 2379},
+      {"protocol": "tcp", "port": 2380},
+      {"protocol": "tcp", "port": 5000},
+      {"protocol": "tcp", "port": 5473},
+      {"protocol": "tcp", "port": 6443},
+      {"protocol": "tcp", "port": 6666},
+      {"protocol": "tcp", "port": 6667},
+      {"protocol": "tcp", "port": 10250}
+    ]
+  }
+}'
+echo "  Failsafe ports extended for the kind registry and kubelet"
 
 # Apply the seed resources. The migration-test namespace was already created by connectivity.yaml.
 ${kubectl} apply -f "${SCRIPT_DIR}/seed-resources.yaml"
@@ -351,7 +385,8 @@ if [ "$phase" = "Migrating" ]; then
   echo "  Force-deleting kube-controllers pod..."
   ${kubectl} delete pod -n calico-system -l k8s-app=calico-kube-controllers --force --grace-period=0 2>/dev/null
   echo "  Pod deleted, waiting for replacement..."
-  ${kubectl} wait --for=condition=Available --timeout=120s deployment/calico-kube-controllers -n calico-system
+  # The replacement schedules and pulls while the datastore is locked, so give it room.
+  ${kubectl} wait --for=condition=Available --timeout=300s deployment/calico-kube-controllers -n calico-system
   echo "  kube-controllers restarted"
 elif [ "$phase" = "Converged" ] || [ "$phase" = "Complete" ]; then
   echo "  Migration already past Migrating phase ($phase), skipping disruption"

--- a/hack/test/kind/migration/run_test.sh
+++ b/hack/test/kind/migration/run_test.sh
@@ -20,15 +20,18 @@
 #   - Kind cluster running with v1 CRDs and apiserver:
 #       KIND_CALICO_API_GROUP=crd.projectcalico.org/v1 make kind-up
 #
-# What this script does:
-#   1. Deploys client/server pods for continuous connectivity probing
-#   2. Seeds test resources via the Calico apiserver (stored in v1 CRDs)
-#   3. Snapshots v1 resource counts
-#   4. Installs v3 CRDs alongside v1
-#   5. Installs the DatastoreMigration CRD and creates a migration CR
-#   6. Waits for the migration controller to complete
-#   7. Verifies migrated resources exist in v3 CRDs
-#   8. Verifies zero connectivity loss during migration
+# This script covers only what needs a live cluster:
+#   - The APIService cutover from the aggregated apiserver to CRD-backed serving
+#   - calico-node and typha rolling with CALICO_API_GROUP=projectcalico.org/v3
+#   - Surviving a force-kill of kube-controllers mid-migration
+#   - Zero connectivity loss across the whole migration
+#   - v1 CRD cleanup when the completed DatastoreMigration CR is deleted
+#
+# Everything at the resource level - which types migrate, stored-name handling,
+# namespacing, OwnerReference remapping, progress reporting, conflicts, rollback -
+# is covered by the envtest FV in
+# kube-controllers/pkg/controllers/migration/controller_fv_test.go and
+# controller_v1crd_fv_test.go. Do not re-add those assertions here.
 #
 # To re-run: destroy the cluster and recreate it, then run this script again:
 #   make kind-down
@@ -63,36 +66,6 @@ function fail() {
   echo "  FAIL: $1"
   failed=$((failed + 1))
   errors="${errors}\n  - $1"
-}
-
-function check_resource_exists() {
-  local resource="$1"
-  local name="$2"
-  local namespace="$3"
-  local description="$4"
-
-  local ns_flag=""
-  if [ -n "$namespace" ]; then
-    ns_flag="-n $namespace"
-  fi
-
-  if ${kubectl} get "$resource" $ns_flag "$name" &>/dev/null; then
-    pass "$description"
-  else
-    fail "$description"
-  fi
-}
-
-function check_resource_not_exists() {
-  local resource="$1"
-  local name="$2"
-  local description="$3"
-
-  if ${kubectl} get "$resource" "$name" &>/dev/null; then
-    fail "$description"
-  else
-    pass "$description"
-  fi
 }
 
 ###############################################################################
@@ -240,95 +213,19 @@ ${kubectl} patch felixconfigurations.projectcalico.org default --type=merge -p '
 }'
 echo "  Failsafe ports extended for the kind registry and kubelet"
 
-# Apply the seed resources. The migration-test namespace was already created by connectivity.yaml.
+# Apply the seed resources. The migration-test namespace was already created by
+# connectivity.yaml. These give the migration real data to move while the
+# connectivity probe runs; the FV asserts on what lands in v3.
 ${kubectl} apply -f "${SCRIPT_DIR}/seed-resources.yaml"
 echo "  Seed resources applied"
 
 # Give the apiserver a moment to sync.
 sleep 3
 
-# Patch OwnerReferences onto some resources to test that they survive migration.
-# Two cases:
-#   1. OwnerRef to a native K8s resource (Namespace) — UID should be copied as-is.
-#   2. OwnerRef to a Calico resource (Tier) — UID will be different on the v3 copy,
-#      so the migration controller needs to remap it (or we need to document that it doesn't yet).
-
-NS_UID=$(${kubectl} get namespace migration-test -o jsonpath='{.metadata.uid}')
-TIER_UID=$(${kubectl} get tiers.projectcalico.org security -o jsonpath='{.metadata.uid}')
-echo "  Namespace migration-test UID: ${NS_UID}"
-echo "  Tier security UID: ${TIER_UID}"
-
-# NetworkSet with ownerRef to its Namespace (native K8s owner).
-${kubectl} patch networksets.projectcalico.org test-trusted-ips -n migration-test --type=merge -p "{
-  \"metadata\": {
-    \"ownerReferences\": [{
-      \"apiVersion\": \"v1\",
-      \"kind\": \"Namespace\",
-      \"name\": \"migration-test\",
-      \"uid\": \"${NS_UID}\"
-    }]
-  }
-}"
-echo "  Patched NetworkSet 'test-trusted-ips' with ownerRef to Namespace"
-
-# GlobalNetworkPolicy with ownerRef to the security Tier (Calico owner).
-${kubectl} patch globalnetworkpolicies.projectcalico.org security.test-allow-dns --type=merge -p "{
-  \"metadata\": {
-    \"ownerReferences\": [{
-      \"apiVersion\": \"projectcalico.org/v3\",
-      \"kind\": \"Tier\",
-      \"name\": \"security\",
-      \"uid\": \"${TIER_UID}\"
-    }]
-  }
-}"
-echo "  Patched GNP 'security.test-allow-dns' with ownerRef to Tier"
-
 ###############################################################################
-# Step 3: Snapshot v1 resource state
+# Step 3: Install v3 CRDs alongside v1
 ###############################################################################
-log "Step 3: Snapshotting v1 resource state"
-
-echo "  Tiers:"
-${kubectl} get tiers.projectcalico.org 2>/dev/null || echo "    (none)"
-echo ""
-echo "  GlobalNetworkPolicies:"
-${kubectl} get globalnetworkpolicies.projectcalico.org 2>/dev/null || echo "    (none)"
-echo ""
-echo "  NetworkPolicies (migration-test ns):"
-${kubectl} get networkpolicies.projectcalico.org -n migration-test 2>/dev/null || echo "    (none)"
-echo ""
-echo "  HostEndpoints:"
-${kubectl} get hostendpoints.projectcalico.org 2>/dev/null || echo "    (none)"
-echo ""
-echo "  GlobalNetworkSets:"
-${kubectl} get globalnetworksets.projectcalico.org 2>/dev/null || echo "    (none)"
-echo ""
-echo "  NetworkSets (migration-test ns):"
-${kubectl} get networksets.projectcalico.org -n migration-test 2>/dev/null || echo "    (none)"
-echo ""
-echo "  BGPPeers:"
-${kubectl} get bgppeers.projectcalico.org 2>/dev/null || echo "    (none)"
-echo ""
-echo "  IPPools:"
-${kubectl} get ippools.projectcalico.org 2>/dev/null || echo "    (none)"
-
-# Also snapshot the raw v1 CRD objects to see the actual stored names.
-echo ""
-echo "  --- Raw v1 CRD objects (crd.projectcalico.org) ---"
-echo "  v1 GlobalNetworkPolicies:"
-${kubectl} get globalnetworkpolicies.crd.projectcalico.org --no-headers 2>/dev/null || echo "    (none)"
-echo ""
-echo "  v1 NetworkPolicies:"
-${kubectl} get networkpolicies.crd.projectcalico.org -A --no-headers 2>/dev/null || echo "    (none)"
-echo ""
-echo "  v1 Tiers:"
-${kubectl} get tiers.crd.projectcalico.org --no-headers 2>/dev/null || echo "    (none)"
-
-###############################################################################
-# Step 4: Install v3 CRDs alongside v1
-###############################################################################
-log "Step 4: Installing v3 CRDs (projectcalico.org) alongside v1"
+log "Step 3: Installing v3 CRDs (projectcalico.org) alongside v1"
 
 # The v3 CRDs are in api/config/crd/. While the APIService exists, it takes
 # precedence for the projectcalico.org group. But the CRDs need to be present
@@ -337,9 +234,9 @@ ${kubectl} apply --server-side --force-conflicts -f "${REPO_ROOT}/api/config/crd
 echo "  v3 CRDs installed"
 
 ###############################################################################
-# Step 5: Install migration CRD
+# Step 4: Install migration CRD
 ###############################################################################
-log "Step 5: Installing migration CRD"
+log "Step 4: Installing migration CRD"
 
 # Install the DatastoreMigration CRD (separate from the v3 Calico CRDs — it lives
 # in the migration.projectcalico.org group to avoid APIService conflicts).
@@ -353,9 +250,9 @@ fi
 echo "  DatastoreMigration CRD verified"
 
 ###############################################################################
-# Step 6: Disruption test — force-kill kube-controllers during migration
+# Step 5: Disruption test — force-kill kube-controllers during migration
 ###############################################################################
-log "Step 6: Disruption test — force-kill kube-controllers during migration"
+log "Step 5: Disruption test — force-kill kube-controllers during migration"
 
 # Create the migration CR to kick things off.
 cat <<'EOF' | ${kubectl} apply -f -
@@ -395,9 +292,9 @@ else
 fi
 
 ###############################################################################
-# Step 7: Wait for migration to complete
+# Step 6: Wait for migration to complete
 ###############################################################################
-log "Step 7: Waiting for migration to complete"
+log "Step 6: Waiting for migration to complete"
 
 TIMEOUT=300
 INTERVAL=5
@@ -440,125 +337,17 @@ if [ $elapsed -ge $TIMEOUT ]; then
   exit 1
 fi
 
-# Verify the finalizer was added during the Pending phase.
-finalizers=$(${kubectl} get datastoremigration.migration.projectcalico.org v1-to-v3 -o jsonpath='{.metadata.finalizers}' 2>/dev/null || echo "")
-if echo "$finalizers" | grep -q "migration.projectcalico.org/v1-crd-cleanup"; then
-  pass "Finalizer present on DatastoreMigration CR"
-else
-  fail "Finalizer not found on DatastoreMigration CR (got: $finalizers)"
-fi
-
-# Verify the saved APIService annotation exists.
-saved_apisvc=$(${kubectl} get datastoremigration.migration.projectcalico.org v1-to-v3 -o jsonpath='{.metadata.annotations.migration\.projectcalico\.org/saved-apiservice}' 2>/dev/null || echo "")
-if [ -n "$saved_apisvc" ]; then
-  pass "Saved APIService annotation present on DatastoreMigration CR"
-else
-  fail "Saved APIService annotation not found on DatastoreMigration CR"
-fi
-
 ###############################################################################
-# Step 8: Verify migration results
+# Step 7: Verify the APIService cutover and component reconfiguration
 ###############################################################################
-log "Step 8: Verifying migration results"
+log "Step 7: Verifying APIService cutover and component reconfiguration"
 
 echo ""
-echo "  --- DatastoreMigration Status ---"
-${kubectl} get datastoremigration.migration.projectcalico.org v1-to-v3
-echo ""
-echo "  Wide output (includes priority columns):"
 ${kubectl} get datastoremigration.migration.projectcalico.org v1-to-v3 -o wide
 echo ""
-${kubectl} get datastoremigration.migration.projectcalico.org v1-to-v3 -o jsonpath='{.status}' | python3 -m json.tool 2>/dev/null || \
-  ${kubectl} get datastoremigration.migration.projectcalico.org v1-to-v3 -o jsonpath='{.status}'
-echo ""
 
-# Verify per-type progress was reported.
-type_count=$(${kubectl} get datastoremigration.migration.projectcalico.org v1-to-v3 -o jsonpath='{.status.progress.typeDetails}' 2>/dev/null | python3 -c "import sys, json; print(len(json.load(sys.stdin)))" 2>/dev/null || echo "0")
-completed_types=$(${kubectl} get datastoremigration.migration.projectcalico.org v1-to-v3 -o jsonpath='{.status.progress.completedTypes}' 2>/dev/null || echo "0")
-total_types=$(${kubectl} get datastoremigration.migration.projectcalico.org v1-to-v3 -o jsonpath='{.status.progress.totalTypes}' 2>/dev/null || echo "0")
-
-if [ "$type_count" -gt 0 ]; then
-  pass "Per-type progress reported ($type_count types in typeDetails)"
-else
-  fail "No per-type progress in typeDetails"
-fi
-
-if [ "$completed_types" -gt 0 ] && [ "$completed_types" = "$total_types" ]; then
-  pass "All resource types completed (completedTypes=$completed_types, totalTypes=$total_types)"
-else
-  fail "Type completion mismatch (completedTypes=$completed_types, totalTypes=$total_types)"
-fi
-
-echo ""
-echo "  --- Checking migrated resources ---"
-echo ""
-
-# After the APIService is deleted, projectcalico.org/v3 is now served by the v3 CRDs.
-# Verify that the test resources exist.
-
-# Tiers: "default" (auto-created) and "security" (seeded).
-check_resource_exists "tiers.projectcalico.org" "default" "" \
-  "Tier 'default' exists in v3"
-check_resource_exists "tiers.projectcalico.org" "security" "" \
-  "Tier 'security' migrated to v3"
-
-# GlobalNetworkPolicies: the "default." prefix should be stripped for default-tier policies.
-# "default.test-deny-all" in v1 should become "test-deny-all" in v3.
-check_resource_exists "globalnetworkpolicies.projectcalico.org" "test-deny-all" "" \
-  "GNP 'test-deny-all' migrated (default. prefix stripped)"
-
-# Non-default tier policy should keep its name.
-check_resource_exists "globalnetworkpolicies.projectcalico.org" "security.test-allow-dns" "" \
-  "GNP 'security.test-allow-dns' migrated (non-default tier name preserved)"
-
-# NetworkPolicy: "default.test-allow-web" should become "test-allow-web".
-check_resource_exists "networkpolicies.projectcalico.org" "test-allow-web" "migration-test" \
-  "NP 'test-allow-web' migrated to migration-test namespace (default. prefix stripped)"
-
-# HostEndpoint.
-check_resource_exists "hostendpoints.projectcalico.org" "test-hep" "" \
-  "HostEndpoint 'test-hep' migrated to v3"
-
-# GlobalNetworkSet.
-check_resource_exists "globalnetworksets.projectcalico.org" "test-external-ips" "" \
-  "GlobalNetworkSet 'test-external-ips' migrated to v3"
-
-# NetworkSet (namespaced).
-check_resource_exists "networksets.projectcalico.org" "test-trusted-ips" "migration-test" \
-  "NetworkSet 'test-trusted-ips' migrated to migration-test namespace"
-
-# BGPPeer.
-check_resource_exists "bgppeers.projectcalico.org" "test-peer" "" \
-  "BGPPeer 'test-peer' migrated to v3"
-
-# IPPool — the default pool created by Calico installation should also be migrated.
-# We don't know the exact name, but at least one should exist.
-pool_count=$(${kubectl} get ippools.projectcalico.org --no-headers 2>/dev/null | wc -l)
-if [ "$pool_count" -gt 0 ]; then
-  pass "IPPool(s) migrated to v3 (found $pool_count)"
-else
-  fail "No IPPools found in v3 CRDs"
-fi
-
-# FelixConfiguration — "default" should be migrated.
-check_resource_exists "felixconfigurations.projectcalico.org" "default" "" \
-  "FelixConfiguration 'default' migrated to v3"
-
-# BGPConfiguration — may or may not exist depending on cluster config.
-bgp_count=$(${kubectl} get bgpconfigurations.projectcalico.org --no-headers 2>/dev/null | wc -l)
-bgp_v1_count=$(${kubectl} get bgpconfigurations.crd.projectcalico.org --no-headers 2>/dev/null | wc -l)
-if [ "$bgp_count" -ge "$bgp_v1_count" ]; then
-  pass "BGPConfiguration(s) migrated (v1: $bgp_v1_count, v3: $bgp_count)"
-else
-  fail "BGPConfiguration count mismatch (v1: $bgp_v1_count, v3: $bgp_count)"
-fi
-
-# ClusterInformation — "default" should exist (used for datastore lock/unlock).
-check_resource_exists "clusterinformations.projectcalico.org" "default" "" \
-  "ClusterInformation 'default' exists in v3"
-
-# Verify the aggregated APIService was replaced by a local (CRD-backed) one.
-# K8s auto-creates a local APIService when CRDs exist for a group.
+# The aggregated APIService should be gone. Kubernetes auto-creates an
+# automanaged one in its place once the v3 CRDs are serving the group.
 api_svc_label=$(${kubectl} get apiservice v3.projectcalico.org -o jsonpath='{.metadata.labels.kube-aggregator\.kubernetes\.io/automanaged}' 2>/dev/null || echo "")
 if [ "$api_svc_label" = "true" ]; then
   pass "APIService v3.projectcalico.org is now CRD-backed (automanaged)"
@@ -568,43 +357,49 @@ else
   fail "APIService v3.projectcalico.org still points to aggregated API server"
 fi
 
-# OwnerReference to native K8s resource (Namespace) — UID should be copied as-is.
-ns_ownerref_uid=$(${kubectl} get networksets.projectcalico.org test-trusted-ips -n migration-test -o jsonpath='{.metadata.ownerReferences[0].uid}' 2>/dev/null || echo "")
-if [ "$ns_ownerref_uid" = "$NS_UID" ]; then
-  pass "NetworkSet ownerRef to Namespace preserved (UID: ${ns_ownerref_uid})"
-elif [ -n "$ns_ownerref_uid" ]; then
-  fail "NetworkSet ownerRef to Namespace has wrong UID (got: ${ns_ownerref_uid}, expected: ${NS_UID})"
+# The v3 API group must actually serve reads now that the aggregated apiserver
+# is unregistered.
+if ${kubectl} get tiers.projectcalico.org &>/dev/null; then
+  pass "projectcalico.org/v3 is served by CRDs after cutover"
 else
-  fail "NetworkSet ownerRef to Namespace missing after migration"
+  fail "projectcalico.org/v3 reads failed after cutover"
 fi
 
-# OwnerReference to Calico resource (Tier) — the v3 Tier gets a new UID after
-# migration. The migration controller should remap the ownerRef UID from the
-# old v1 UID to the new v3 UID.
-v3_tier_uid=$(${kubectl} get tiers.projectcalico.org security -o jsonpath='{.metadata.uid}' 2>/dev/null || echo "")
-gnp_ownerref_uid=$(${kubectl} get globalnetworkpolicies.projectcalico.org security.test-allow-dns -o jsonpath='{.metadata.ownerReferences[0].uid}' 2>/dev/null || echo "")
-if [ "$gnp_ownerref_uid" = "$v3_tier_uid" ]; then
-  pass "GNP ownerRef to Tier remapped to v3 UID (UID: ${gnp_ownerref_uid})"
-elif [ "$gnp_ownerref_uid" = "$TIER_UID" ]; then
-  fail "GNP ownerRef to Tier still has stale v1 UID (${TIER_UID}), expected v3 UID (${v3_tier_uid})"
-elif [ -n "$gnp_ownerref_uid" ]; then
-  fail "GNP ownerRef to Tier has unexpected UID (got: ${gnp_ownerref_uid}, expected v3: ${v3_tier_uid})"
+# calico-node and typha must have been rolled with the v3 API group set. The
+# migration only reaches Complete once they have, but assert it directly so a
+# regression names the component.
+node_api_group=$(${kubectl} get daemonset -n calico-system calico-node \
+  -o jsonpath='{.spec.template.spec.containers[?(@.name=="calico-node")].env[?(@.name=="CALICO_API_GROUP")].value}' 2>/dev/null || echo "")
+if [ "$node_api_group" = "projectcalico.org/v3" ]; then
+  pass "calico-node has CALICO_API_GROUP=projectcalico.org/v3"
 else
-  fail "GNP ownerRef to Tier missing after migration"
+  fail "calico-node CALICO_API_GROUP is '$node_api_group', expected 'projectcalico.org/v3'"
 fi
 
-# Verify DatastoreReady is true (datastore unlocked).
-ds_ready=$(${kubectl} get clusterinformations.projectcalico.org default -o jsonpath='{.spec.datastoreReady}' 2>/dev/null || echo "")
-if [ "$ds_ready" = "true" ]; then
-  pass "ClusterInformation.spec.datastoreReady is true (datastore unlocked)"
+node_updated=$(${kubectl} get daemonset -n calico-system calico-node -o jsonpath='{.status.updatedNumberScheduled}' 2>/dev/null || echo "0")
+node_desired=$(${kubectl} get daemonset -n calico-system calico-node -o jsonpath='{.status.desiredNumberScheduled}' 2>/dev/null || echo "0")
+if [ "$node_updated" = "$node_desired" ] && [ "$node_desired" != "0" ]; then
+  pass "calico-node rollout complete ($node_updated/$node_desired updated)"
 else
-  fail "ClusterInformation.spec.datastoreReady is '$ds_ready', expected 'true'"
+  fail "calico-node rollout incomplete ($node_updated/$node_desired updated)"
+fi
+
+if ${kubectl} get deployment -n calico-system calico-typha &>/dev/null; then
+  typha_api_group=$(${kubectl} get deployment -n calico-system calico-typha \
+    -o jsonpath='{.spec.template.spec.containers[?(@.name=="calico-typha")].env[?(@.name=="CALICO_API_GROUP")].value}' 2>/dev/null || echo "")
+  if [ "$typha_api_group" = "projectcalico.org/v3" ]; then
+    pass "calico-typha has CALICO_API_GROUP=projectcalico.org/v3"
+  else
+    fail "calico-typha CALICO_API_GROUP is '$typha_api_group', expected 'projectcalico.org/v3'"
+  fi
+else
+  echo "  calico-typha not deployed, skipping its API group check"
 fi
 
 ###############################################################################
-# Step 9: Verify continuous connectivity
+# Step 8: Verify continuous connectivity
 ###############################################################################
-log "Step 9: Verifying continuous connectivity during migration"
+log "Step 8: Verifying continuous connectivity during migration"
 
 # Give the client a few more seconds to log post-migration probes.
 sleep 5
@@ -635,9 +430,9 @@ else
 fi
 
 ###############################################################################
-# Step 10: Test v1 CRD cleanup via CR deletion (post-completion)
+# Step 9: Test v1 CRD cleanup via CR deletion (post-completion)
 ###############################################################################
-log "Step 10: Testing v1 CRD cleanup via CR deletion"
+log "Step 9: Testing v1 CRD cleanup via CR deletion"
 
 # Count v1 CRDs before deletion.
 v1_crd_count_before=$(${kubectl} get crd -o name 2>/dev/null | grep "crd.projectcalico.org" | wc -l)

--- a/hack/test/kind/migration/seed-resources.yaml
+++ b/hack/test/kind/migration/seed-resources.yaml
@@ -1,15 +1,10 @@
 # Test resources for migration testing. These are applied via the Calico apiserver
-# (which stores them in v1 CRDs). The migration controller should copy them to v3 CRDs.
+# (which stores them in v1 CRDs) so the migration has real data to move while the
+# connectivity probe runs.
 #
-# Resources cover the main types handled by the migration controller:
-# - Tiers (custom, beyond the auto-created "default")
-# - GlobalNetworkPolicy (in default tier — tests "default." prefix stripping)
-# - GlobalNetworkPolicy (in custom tier — tests non-default tier handling)
-# - NetworkPolicy (namespaced, default tier)
-# - HostEndpoint
-# - GlobalNetworkSet
-# - NetworkSet (namespaced)
-# - BGPPeer
+# What lands in v3 is asserted by the envtest FV, not by run_test.sh. See
+# kube-controllers/pkg/controllers/migration/controller_v1crd_fv_test.go, which
+# seeds the same shapes.
 
 ---
 apiVersion: projectcalico.org/v3

--- a/kube-controllers/pkg/controllers/migration/controller_v1crd_fv_test.go
+++ b/kube-controllers/pkg/controllers/migration/controller_v1crd_fv_test.go
@@ -1,0 +1,385 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package migration
+
+import (
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+	apiv3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
+	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	fakeapiregclient "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/fake"
+	"k8s.io/utils/ptr"
+	rtclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+
+	bapi "github.com/projectcalico/calico/libcalico-go/lib/backend/api"
+	"github.com/projectcalico/calico/libcalico-go/lib/backend/k8s"
+	"github.com/projectcalico/calico/libcalico-go/lib/backend/k8s/rawcrdclient"
+	"github.com/projectcalico/calico/libcalico-go/lib/backend/k8s/resources"
+	"github.com/projectcalico/calico/libcalico-go/lib/backend/model"
+	libtestutils "github.com/projectcalico/calico/libcalico-go/lib/testutils"
+)
+
+// seedNamespace holds the namespaced v1 resources, mirroring the namespace the
+// kind migration test seeds into.
+const seedNamespace = "migration-test"
+
+// TestLifecycle_RealV1CRDs migrates real v1 CRDs seeded as the API server
+// stores them. Runs last: the cleanup path deletes those CRDs.
+func TestLifecycle_RealV1CRDs(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	h := newFVHelper(t, g, ctx)
+
+	ensureV1CRDs(t, g)
+	createNamespace(t, ctx, g, seedNamespace)
+
+	bc, err := k8s.NewKubeClientForConfig(fvTestEnv.RestConfig, fvTestEnv.K8sClient, resources.BackingAPIGroupV1, false)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	raw, err := rawcrdclient.New(fvTestEnv.RestConfig, false)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	seed := seedV1CRDs(t, ctx, g, raw, bc)
+
+	fakeAPIReg := fakeapiregclient.NewSimpleClientset(newAggregatedAPIServiceObj())
+	startRealBackendController(t, ctx, bc, fakeAPIReg)
+	createMigrationCR(t, ctx)
+	t.Cleanup(func() { cleanupV1SeedResources(t, ctx) })
+
+	// The migration runs unattended here; wait for it to converge.
+	g.Eventually(func(g Gomega) {
+		newFVHelper(t, g, ctx).expectPhase(DatastoreMigrationPhaseConverged)
+	}, 60*time.Second, 250*time.Millisecond).Should(Succeed())
+
+	// Tiers migrate with the default tier's order normalised by the v3 API.
+	defaultTier := &apiv3.Tier{}
+	h.getV3Resource("default", defaultTier)
+	g.Expect(defaultTier.Spec.Order).To(Equal(ptr.To(apiv3.DefaultTierOrder)))
+
+	securityTier := &apiv3.Tier{}
+	h.getV3Resource("security", securityTier)
+	g.Expect(securityTier.Spec.Order).To(Equal(ptr.To(float64(200))))
+
+	// Default-tier policies lose the stored "default." prefix; other tiers keep theirs.
+	denyAll := &apiv3.GlobalNetworkPolicy{}
+	h.getV3Resource("test-deny-all", denyAll)
+	g.Expect(denyAll.Spec.Tier).To(Equal("default"))
+	g.Expect(fvRTClient.Get(ctx, types.NamespacedName{Name: "default.test-deny-all"}, &apiv3.GlobalNetworkPolicy{})).
+		To(MatchError(kerrors.IsNotFound, "not found"), "the stored name should not have been migrated verbatim")
+
+	allowDNS := &apiv3.GlobalNetworkPolicy{}
+	h.getV3Resource("security.test-allow-dns", allowDNS)
+	g.Expect(allowDNS.Spec.Tier).To(Equal("security"))
+
+	allowWeb := &apiv3.NetworkPolicy{}
+	g.Expect(fvRTClient.Get(ctx, types.NamespacedName{Name: "test-allow-web", Namespace: seedNamespace}, allowWeb)).To(Succeed())
+
+	hep := &apiv3.HostEndpoint{}
+	h.getV3Resource("test-hep", hep)
+	g.Expect(hep.Spec.InterfaceName).To(Equal("eth0"))
+
+	gns := &apiv3.GlobalNetworkSet{}
+	h.getV3Resource("test-external-ips", gns)
+	g.Expect(gns.Spec.Nets).To(ConsistOf("198.51.100.0/24", "203.0.113.0/24"))
+
+	ns := &apiv3.NetworkSet{}
+	g.Expect(fvRTClient.Get(ctx, types.NamespacedName{Name: "test-trusted-ips", Namespace: seedNamespace}, ns)).To(Succeed())
+
+	peer := &apiv3.BGPPeer{}
+	h.getV3Resource("test-peer", peer)
+	g.Expect(peer.Spec.PeerIP).To(Equal("10.0.0.100"))
+
+	// A Calico owner's UID changes when the owner is migrated, so it is remapped.
+	g.Expect(allowDNS.OwnerReferences).To(HaveLen(1))
+	g.Expect(allowDNS.OwnerReferences[0].Kind).To(Equal("Tier"))
+	g.Expect(allowDNS.OwnerReferences[0].UID).To(Equal(securityTier.UID))
+	g.Expect(allowDNS.OwnerReferences[0].UID).NotTo(Equal(seed.securityTierV1UID))
+
+	// A native Kubernetes owner is not migrated, so its UID is copied as-is.
+	g.Expect(ns.OwnerReferences).To(HaveLen(1))
+	g.Expect(ns.OwnerReferences[0].Kind).To(Equal("Namespace"))
+	g.Expect(ns.OwnerReferences[0].UID).To(Equal(seed.namespaceUID))
+
+	// Drive to Complete, then delete the CR and check the finalizer removes v1 CRDs.
+	h.createReadyCalicoNodeDS()
+	g.Eventually(func(g Gomega) {
+		newFVHelper(t, g, ctx).expectPhase(DatastoreMigrationPhaseComplete)
+	}, 30*time.Second, 250*time.Millisecond).Should(Succeed())
+
+	dm := h.getMigration()
+	g.Expect(fvRTClient.Delete(ctx, dm)).To(Succeed())
+
+	g.Eventually(func(g Gomega) {
+		err := fvRTClient.Get(ctx, dmKey, &DatastoreMigration{})
+		g.Expect(kerrors.IsNotFound(err)).To(BeTrue(), "CR should be deleted after cleanup, got: %v", err)
+		g.Expect(countV1CRDs(ctx)).To(Equal(0), "v1 CRDs should have been deleted by the finalizer")
+	}, 60*time.Second, 250*time.Millisecond).Should(Succeed())
+}
+
+// seededV1State records the values the test can only learn after seeding.
+type seededV1State struct {
+	namespaceUID      types.UID
+	securityTierV1UID types.UID
+}
+
+// seedV1CRDs writes the crd.projectcalico.org objects the migration reads.
+// Mirrors hack/test/kind/migration/seed-resources.yaml.
+func seedV1CRDs(t *testing.T, ctx context.Context, g Gomega, raw rtclient.Client, bc bapi.Client) seededV1State {
+	t.Helper()
+
+	seedV1(t, ctx, g, raw, "default", &apiv3.Tier{
+		ObjectMeta: metav1.ObjectMeta{Name: "default"},
+		Spec:       apiv3.TierSpec{Order: ptr.To(apiv3.DefaultTierOrder), DefaultAction: actionPtr(apiv3.Deny)},
+	})
+	seedV1(t, ctx, g, raw, "security", &apiv3.Tier{
+		ObjectMeta: metav1.ObjectMeta{Name: "security"},
+		Spec:       apiv3.TierSpec{Order: ptr.To(float64(200)), DefaultAction: actionPtr(apiv3.Deny)},
+	})
+
+	// An owning policy records the UID the API server reports for the Tier, not
+	// the underlying CRD's.
+	tierKVP, err := bc.Get(ctx, model.ResourceKey{Kind: apiv3.KindTier, Name: "security"}, "")
+	g.Expect(err).NotTo(HaveOccurred())
+	securityTier, ok := tierKVP.Value.(*apiv3.Tier)
+	g.Expect(ok).To(BeTrue())
+
+	nsObj := &corev1.Namespace{}
+	g.Expect(fvRTClient.Get(ctx, types.NamespacedName{Name: seedNamespace}, nsObj)).To(Succeed())
+
+	// No name in the metadata annotation, as pre-v3.30 clusters have it. The
+	// backend strips the "default." prefix on read.
+	denyAll := &apiv3.GlobalNetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-deny-all"},
+		Spec: apiv3.GlobalNetworkPolicySpec{
+			Tier:     "default",
+			Order:    ptr.To(float64(1000)),
+			Selector: "migration-test == 'true'",
+			Types:    []apiv3.PolicyType{apiv3.PolicyTypeIngress, apiv3.PolicyTypeEgress},
+		},
+	}
+	seedV1WithoutStoredName(t, ctx, g, raw, "default.test-deny-all", denyAll)
+
+	seedV1(t, ctx, g, raw, "security.test-allow-dns", &apiv3.GlobalNetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "security.test-allow-dns",
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: "projectcalico.org/v3",
+					Kind:       "Tier",
+					Name:       "security",
+					UID:        securityTier.UID,
+				},
+			},
+		},
+		Spec: apiv3.GlobalNetworkPolicySpec{
+			Tier:     "security",
+			Order:    ptr.To(float64(100)),
+			Selector: "migration-test == 'true'",
+			Types:    []apiv3.PolicyType{apiv3.PolicyTypeEgress},
+			Egress:   []apiv3.Rule{{Action: apiv3.Allow}},
+		},
+	})
+
+	// The v3 name is in the metadata annotation, as v3.30+ clusters have it.
+	// The backend reads it back out.
+	seedV1(t, ctx, g, raw, "default.test-allow-web", &apiv3.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-allow-web", Namespace: seedNamespace},
+		Spec: apiv3.NetworkPolicySpec{
+			Tier:     "default",
+			Order:    ptr.To(float64(500)),
+			Selector: "app == 'web'",
+			Types:    []apiv3.PolicyType{apiv3.PolicyTypeIngress},
+			Ingress:  []apiv3.Rule{{Action: apiv3.Allow}},
+		},
+	})
+
+	seedV1(t, ctx, g, raw, "test-hep", &apiv3.HostEndpoint{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-hep", Labels: map[string]string{"migration-test": "true"}},
+		Spec: apiv3.HostEndpointSpec{
+			Node:          "kind-worker",
+			InterfaceName: "eth0",
+			ExpectedIPs:   []string{"10.0.0.1"},
+		},
+	})
+
+	seedV1(t, ctx, g, raw, "test-external-ips", &apiv3.GlobalNetworkSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-external-ips", Labels: map[string]string{"migration-test": "true"}},
+		Spec:       apiv3.GlobalNetworkSetSpec{Nets: []string{"198.51.100.0/24", "203.0.113.0/24"}},
+	})
+
+	seedV1(t, ctx, g, raw, "test-trusted-ips", &apiv3.NetworkSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-trusted-ips",
+			Namespace: seedNamespace,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: "v1",
+					Kind:       "Namespace",
+					Name:       seedNamespace,
+					UID:        nsObj.UID,
+				},
+			},
+		},
+		Spec: apiv3.NetworkSetSpec{Nets: []string{"10.0.0.0/8"}},
+	})
+
+	seedV1(t, ctx, g, raw, "test-peer", &apiv3.BGPPeer{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-peer"},
+		Spec:       apiv3.BGPPeerSpec{PeerIP: "10.0.0.100", ASNumber: 64512},
+	})
+
+	seedV1(t, ctx, g, raw, clusterInfoName, &apiv3.ClusterInformation{
+		ObjectMeta: metav1.ObjectMeta{Name: clusterInfoName},
+		Spec: apiv3.ClusterInformationSpec{
+			ClusterGUID:    "test-guid-12345",
+			ClusterType:    "k8s,bgp",
+			CalicoVersion:  "v3.30.0",
+			DatastoreReady: ptr.To(true),
+		},
+	})
+
+	return seededV1State{namespaceUID: nsObj.UID, securityTierV1UID: securityTier.UID}
+}
+
+// seedV1 encodes a v3 object into v1 form and writes it under its datastore
+// name.
+func seedV1(t *testing.T, ctx context.Context, g Gomega, raw rtclient.Client, storedName string, obj resources.Resource) {
+	t.Helper()
+	v1Obj := encodeV1(g, storedName, obj)
+	g.ExpectWithOffset(1, raw.Create(ctx, v1Obj)).To(Succeed())
+}
+
+// seedV1WithoutStoredName seeds a policy whose metadata annotation carries no
+// name, forcing the backend down its "default." prefix-stripping path.
+func seedV1WithoutStoredName(t *testing.T, ctx context.Context, g Gomega, raw rtclient.Client, storedName string, obj resources.Resource) {
+	t.Helper()
+	v1Obj := encodeV1(g, storedName, obj)
+
+	annotations := v1Obj.GetAnnotations()
+	meta := &metav1.ObjectMeta{}
+	g.ExpectWithOffset(1, json.Unmarshal([]byte(annotations[v1MetadataAnnotation]), meta)).To(Succeed())
+	meta.Name = ""
+	encoded, err := json.Marshal(meta)
+	g.ExpectWithOffset(1, err).NotTo(HaveOccurred())
+	annotations[v1MetadataAnnotation] = string(encoded)
+	v1Obj.SetAnnotations(annotations)
+
+	g.ExpectWithOffset(1, raw.Create(ctx, v1Obj)).To(Succeed())
+}
+
+// v1MetadataAnnotation is where the v1 backend stashes the v3 metadata.
+const v1MetadataAnnotation = "projectcalico.org/metadata"
+
+// encodeV1 runs a v3 object through the backend's v3-to-v1 encoding. Without
+// the GVK, the encoding drops a policy's stored name.
+func encodeV1(g Gomega, storedName string, obj resources.Resource) rtclient.Object {
+	gvks, _, err := fvRTClient.Scheme().ObjectKinds(obj)
+	g.ExpectWithOffset(2, err).NotTo(HaveOccurred())
+	obj.GetObjectKind().SetGroupVersionKind(gvks[0])
+
+	v1Obj, err := resources.ConvertCalicoResourceToK8sResource(obj)
+	g.ExpectWithOffset(2, err).NotTo(HaveOccurred())
+	v1Obj.GetObjectMeta().SetName(storedName)
+	v1Obj.GetObjectKind().SetGroupVersionKind(schema.GroupVersionKind{})
+
+	rtObj, ok := v1Obj.(rtclient.Object)
+	g.ExpectWithOffset(2, ok).To(BeTrue(), "v1 resource does not implement client.Object")
+	return rtObj
+}
+
+// startRealBackendController starts a migration controller wired to a real
+// libcalico-go backend client, with no phase gate.
+func startRealBackendController(t *testing.T, ctx context.Context, bc bapi.Client, fakeAPIReg *fakeapiregclient.Clientset) {
+	t.Helper()
+	ctrl := NewController(ControllerConfig{
+		Ctx:                 ctx,
+		K8sClient:           fvTestEnv.K8sClient,
+		BackendClient:       bc,
+		RTClient:            fvRTClient,
+		DynamicClient:       fvDynamicClient,
+		APIRegClient:        fakeAPIReg.ApiregistrationV1(),
+		CRDClient:           fvCRDClient,
+		Migrators:           NewMigrators(bc, fvRTClient),
+		WaitingPollInterval: 500 * time.Millisecond,
+		RestartFunc:         func() {},
+	})
+
+	stop := make(chan struct{})
+	t.Cleanup(func() { close(stop) })
+	go ctrl.Run(stop)
+}
+
+// ensureV1CRDs reinstalls the crd.projectcalico.org CRDs that an earlier test
+// deleted. Retries because a terminating CRD cannot be recreated.
+func ensureV1CRDs(t *testing.T, g Gomega) {
+	t.Helper()
+	crdPath := filepath.Join(libtestutils.FindRepoRoot(), "libcalico-go", "config", "crd")
+	g.Eventually(func() error {
+		_, err := envtest.InstallCRDs(fvTestEnv.RestConfig, envtest.CRDInstallOptions{Paths: []string{crdPath}})
+		return err
+	}, 60*time.Second, time.Second).Should(Succeed())
+}
+
+// countV1CRDs returns the number of installed crd.projectcalico.org CRDs.
+func countV1CRDs(ctx context.Context) (int, error) {
+	crds, err := fvCRDClient.ApiextensionsV1().CustomResourceDefinitions().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return 0, err
+	}
+	count := 0
+	for _, crd := range crds.Items {
+		if crd.Spec.Group == "crd.projectcalico.org" {
+			count++
+		}
+	}
+	return count, nil
+}
+
+// createNamespace creates a namespace for the namespaced seed resources.
+func createNamespace(t *testing.T, ctx context.Context, g Gomega, name string) {
+	t.Helper()
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: name}}
+	g.Expect(rtclient.IgnoreAlreadyExists(fvRTClient.Create(ctx, ns))).To(Succeed())
+}
+
+// cleanupV1SeedResources removes the v3 resources the migration created. The
+// v1 CRDs go with the migration's finalizer.
+func cleanupV1SeedResources(t *testing.T, ctx context.Context) {
+	t.Helper()
+	for _, obj := range []rtclient.Object{
+		&apiv3.Tier{},
+		&apiv3.GlobalNetworkPolicy{},
+		&apiv3.NetworkPolicy{},
+		&apiv3.HostEndpoint{},
+		&apiv3.GlobalNetworkSet{},
+		&apiv3.NetworkSet{},
+		&apiv3.BGPPeer{},
+		&apiv3.ClusterInformation{},
+	} {
+		if err := fvRTClient.DeleteAllOf(ctx, obj); err != nil {
+			t.Logf("cleanup: %v", err)
+		}
+	}
+}

--- a/kube-controllers/pkg/controllers/migration/controller_v1crd_fv_test.go
+++ b/kube-controllers/pkg/controllers/migration/controller_v1crd_fv_test.go
@@ -47,7 +47,7 @@ import (
 const seedNamespace = "migration-test"
 
 // TestLifecycle_RealV1CRDs migrates real v1 CRDs seeded as the API server
-// stores them. Runs last: the cleanup path deletes those CRDs.
+// stores them. Cleanup deletes those CRDs, so it reinstalls them on entry.
 func TestLifecycle_RealV1CRDs(t *testing.T) {
 	g := NewWithT(t)
 	ctx := context.Background()
@@ -372,14 +372,20 @@ func cleanupV1SeedResources(t *testing.T, ctx context.Context) {
 	for _, obj := range []rtclient.Object{
 		&apiv3.Tier{},
 		&apiv3.GlobalNetworkPolicy{},
-		&apiv3.NetworkPolicy{},
 		&apiv3.HostEndpoint{},
 		&apiv3.GlobalNetworkSet{},
-		&apiv3.NetworkSet{},
 		&apiv3.BGPPeer{},
 		&apiv3.ClusterInformation{},
 	} {
 		if err := fvRTClient.DeleteAllOf(ctx, obj); err != nil {
+			t.Logf("cleanup: %v", err)
+		}
+	}
+
+	// DeleteAllOf is namespace-scoped, so the namespaced kinds need the seed
+	// namespace naming them explicitly.
+	for _, obj := range []rtclient.Object{&apiv3.NetworkPolicy{}, &apiv3.NetworkSet{}} {
+		if err := fvRTClient.DeleteAllOf(ctx, obj, rtclient.InNamespace(seedNamespace)); err != nil {
 			t.Logf("cleanup: %v", err)
 		}
 	}

--- a/kube-controllers/pkg/controllers/migration/controller_v1crd_fv_test.go
+++ b/kube-controllers/pkg/controllers/migration/controller_v1crd_fv_test.go
@@ -33,6 +33,7 @@ import (
 	rtclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 
+	migrationv1 "github.com/projectcalico/calico/kube-controllers/pkg/apis/migration/v1"
 	bapi "github.com/projectcalico/calico/libcalico-go/lib/backend/api"
 	"github.com/projectcalico/calico/libcalico-go/lib/backend/k8s"
 	"github.com/projectcalico/calico/libcalico-go/lib/backend/k8s/rawcrdclient"
@@ -70,7 +71,7 @@ func TestLifecycle_RealV1CRDs(t *testing.T) {
 
 	// The migration runs unattended here; wait for it to converge.
 	g.Eventually(func(g Gomega) {
-		newFVHelper(t, g, ctx).expectPhase(DatastoreMigrationPhaseConverged)
+		newFVHelper(t, g, ctx).expectPhase(migrationv1.DatastoreMigrationPhaseConverged)
 	}, 60*time.Second, 250*time.Millisecond).Should(Succeed())
 
 	// Tiers migrate with the default tier's order normalised by the v3 API.
@@ -125,14 +126,14 @@ func TestLifecycle_RealV1CRDs(t *testing.T) {
 	// Drive to Complete, then delete the CR and check the finalizer removes v1 CRDs.
 	h.createReadyCalicoNodeDS()
 	g.Eventually(func(g Gomega) {
-		newFVHelper(t, g, ctx).expectPhase(DatastoreMigrationPhaseComplete)
+		newFVHelper(t, g, ctx).expectPhase(migrationv1.DatastoreMigrationPhaseComplete)
 	}, 30*time.Second, 250*time.Millisecond).Should(Succeed())
 
 	dm := h.getMigration()
 	g.Expect(fvRTClient.Delete(ctx, dm)).To(Succeed())
 
 	g.Eventually(func(g Gomega) {
-		err := fvRTClient.Get(ctx, dmKey, &DatastoreMigration{})
+		err := fvRTClient.Get(ctx, dmKey, &migrationv1.DatastoreMigration{})
 		g.Expect(kerrors.IsNotFound(err)).To(BeTrue(), "CR should be deleted after cleanup, got: %v", err)
 		g.Expect(countV1CRDs(ctx)).To(Equal(0), "v1 CRDs should have been deleted by the finalizer")
 	}, 60*time.Second, 250*time.Millisecond).Should(Succeed())

--- a/libcalico-go/lib/backend/k8s/client.go
+++ b/libcalico-go/lib/backend/k8s/client.go
@@ -91,6 +91,12 @@ func NewKubeClient(ca *apiconfig.CalicoAPIConfigSpec) (api.Client, error) {
 		return nil, err
 	}
 
+	return NewKubeClientForConfig(config, cs, group, ca.K8sUsePodCIDR)
+}
+
+// NewKubeClientForConfig builds a backend client from an existing rest.Config
+// and clientset.
+func NewKubeClientForConfig(config *rest.Config, cs kubernetes.Interface, group resources.BackingAPIGroup, usePodCIDR bool) (api.Client, error) {
 	crdRestClient, err := restClient(*config, group)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build CRD client: %v", err)
@@ -110,7 +116,7 @@ func NewKubeClient(ca *apiconfig.CalicoAPIConfigSpec) (api.Client, error) {
 		ClientSet:                  cs,
 		RESTClient:                 crdRestClient,
 		Group:                      group,
-		UsePodCIDR:                 ca.K8sUsePodCIDR,
+		UsePodCIDR:                 usePodCIDR,
 		ClusterNetworkPolicyClient: cnpClient,
 		VMIMClientFactory: func(namespace string) resources.VMIMClient {
 			return kvClient.VirtualMachineInstanceMigrations(namespace)


### PR DESCRIPTION
## Description

Three fixes to the kind migration test, all pre-existing and all found while verifying the DatastoreMigration v1 promotion on a real cluster.

- The header and the error messages tell you to run `CALICO_API_GROUP=crd.projectcalico.org/v1 make kind-up`. That variable does nothing here, since the Makefile reads `KIND_CALICO_API_GROUP`, so following the documented command silently builds a v3 cluster and the test bails at preflight.
- Seeding a HostEndpoint default-denies host traffic on kind-worker, and neither the kind registry port nor the kubelet port is a failsafe. calico-node on that node then cannot pull its image, so the rollout never finishes and the migration deadlocks waiting to converge. The kubelet port breaks the connectivity assertion the same way whenever the client pod lands there.
- Waiting 120s for the kube-controllers replacement after the mid-migration force-kill is not enough, since the replacement has to schedule and pull while the datastore is locked.

Then the bigger problem: most of what the script asserted did not need a cluster at all. Those assertions move down into an envtest FV and the script keeps only what a live cluster can prove.

New FV drives a real libcalico-go backend over real `crd.projectcalico.org` CRDs rather than the mock backend the other FVs use. It seeds the same shapes as `seed-resources.yaml`, encoded the way the API server writes them, and asserts:

- every type migrates, and deleting a Complete CR removes the v1 CRDs
- the `default.` prefix is stripped while other tier prefixes survive, for both stored-name shapes (the metadata annotation carrying the v3 name, and the pre-v3.30 form without it)
- namespaced resources land in the right namespace
- OwnerReference UIDs are remapped for Calico owners and copied as-is for native ones

The mock backend stays, since the error-injection FV cannot use a real one.

What the script still covers: the APIService cutover from aggregated to CRD-backed, calico-node and typha rolling with `CALICO_API_GROUP` set, the mid-migration kube-controllers force-kill, the connectivity probe, and v1 CRD cleanup on CR delete. The API group check on the two components is new; reaching Complete implied it before, but nothing named the component when it did not.

libcalico-go gains a constructor for building a backend client from an existing rest.Config, so the FV gets the same client the product does.

Related: [CORE-12573](https://tigera.atlassian.net/browse/CORE-12573)

```release-note
None
```


[CORE-12573]: https://tigera.atlassian.net/browse/CORE-12573?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
