### PR TITLE
felix/bpf/ut: drop the unused per-test _v6 bpffs directory

### DIFF
--- a/felix/bpf/ut/bpf_prog_test.go
+++ b/felix/bpf/ut/bpf_prog_test.go
@@ -371,10 +371,6 @@ func setupAndRun(logger testLogger, loglevel, section string, rules *polprog.Rul
 	Expect(err).NotTo(HaveOccurred())
 	defer os.RemoveAll(bpfFsDir)
 
-	err = os.Mkdir(bpfFsDir+"_v6", os.ModePerm)
-	Expect(err).NotTo(HaveOccurred())
-	defer os.RemoveAll(bpfFsDir + "v6")
-
 	obj := "../../bpf-gpl/bin/test_xdp_debug"
 	if !topts.xdp {
 		obj = "../../bpf-gpl/bin/test_"


### PR DESCRIPTION
`setupAndRun` creates a second bpffs directory next to its per-test pin directory:

```go
err = os.Mkdir(bpfFsDir+"_v6", os.ModePerm)
Expect(err).NotTo(HaveOccurred())
defer os.RemoveAll(bpfFsDir + "v6")   // missing underscore
```

The `defer` removes a path that was never created, so the directory it did create stays behind. A full BPF UT run leaves one stray directory per test in `/sys/fs/bpf` (~2800 on a current run).

Rather than fix the path, this removes the directory. Nothing writes to it: it existed because `objLoad` used to pin IPv6 programs under a separate `_v6` `progDir`, and 6bf83e2f5f ("[BPF] IPv6 data plane code passes basic unittests", 2023-05-31) changed that to `progDir := bpfFsDir` for both families. Only the `_v6` object *filename* suffix survives, which is unrelated to the directory. Confirmed with a repo-wide grep — no other reference to a `<bpfFsDir>_v6` path.

The stray directories are empty, so they hold no BPF program or map references. This is untidiness in bpffs, not a resource leak, and it has no effect on test outcomes.

**Testing:** `make -C felix bin/bpf_ut.test` builds clean. No test accompanies the change — it removes dead setup code in the UT harness itself, and the observable effect (leftover empty directories in the container's bpffs, which is torn down with the container) is not reachable from a test.

**Release note:**
```release-note
NONE
```
