### PR TITLE
Restore ginkgo focus/skip selection for un-migrated e2e cells

### DIFF
--- a/.argoci/cron/e2e-iptables.yaml
+++ b/.argoci/cron/e2e-iptables.yaml
@@ -255,7 +255,7 @@ steps:
       - name: K8S_E2E_EXTRA_FLAGS
         value: --feature-gates=dualstack=true
       - name: K8S_E2E_FLAGS
-        value: --ginkgo.focus=(\[sig-calico\]|\[Conformance\]) --ginkgo.skip=(\[Slow\]|\[Disruptive\]|\[DataPath\]|WireGuard|EndpointSlice|Tiered RBAC)
+        value: --ginkgo.focus=(\[sig-calico\]|\[Conformance\]) --ginkgo.skip=(\[Slow\]|\[Disruptive\]|\[DataPath\]|WireGuard|EndpointSlice|Tiered.RBAC)
       - name: K8S_VERSION
         value: stable-1
       - name: KIND_CONFIG
@@ -798,7 +798,7 @@ steps:
       - name: INSTALL_ETCD_POD
         value: "true"
       - name: K8S_E2E_FLAGS
-        value: --ginkgo.skip=(Tiered RBAC)
+        value: --ginkgo.focus=(\[sig-calico\]|\[Conformance\]) --ginkgo.skip=(\[Slow\]|\[Disruptive\]|\[DataPath\]|Proxy.version.v1.should.proxy.through.a.service.and.a.pod|WireGuard|Tiered.RBAC)
       - name: MANIFEST_FILE
         value: calico-etcd.yaml
       - name: PROVISIONER

--- a/.argoci/scripts/phases/run_tests.sh
+++ b/.argoci/scripts/phases/run_tests.sh
@@ -5,13 +5,14 @@
 #   - TEST_TYPE == k8s-e2e → run the monorepo e2e binary via `make e2e-run`.
 #     The binary is acquired first: built from local source when RUN_LOCAL_TESTS
 #     is set (per-PR CI), otherwise downloaded from the hashrelease (scheduled
-#     CI). E2E_TEST_CONFIG selects specs and may be empty (default config).
+#     CI). E2E_TEST_CONFIG selects specs; when it is empty, the legacy
+#     K8S_E2E_FLAGS regexes are used instead.
 #   - Else (non-e2e test types: benchmarks, certification, etc.) → `bz tests`.
 #
 # Required env:
 #   BZ_LOCAL_DIR, BZ_LOGS_DIR, HOME, REPORT_DIR, TEST_TYPE
 # Required for local builds:
-#   E2E_TEST_CONFIG
+#   E2E_TEST_CONFIG or K8S_E2E_FLAGS
 # Required for hashrelease downloads:
 #   RELEASE_STREAM
 #
@@ -44,9 +45,20 @@ fi
 # E2E_BINARY is a set/unset sentinel (its value is not used here -- make
 # e2e-run locates the binary itself). Take the structured path whenever a
 # k8s-e2e binary was acquired above; non-e2e test types fall through to bz
-# tests below. E2E_TEST_CONFIG may be empty (selects the default config).
+# tests below.
 if [[ -n "${E2E_BINARY:-}" ]]; then
   echo "[INFO] starting e2e tests..."
+
+  # Pick one selection channel: an empty config runs the whole suite unfiltered.
+  if [[ -n "${E2E_TEST_CONFIG:-}" ]]; then
+    E2E_GINKGO_ARGS=""
+  elif [[ -n "${K8S_E2E_FLAGS:-}" ]]; then
+    E2E_GINKGO_ARGS="${K8S_E2E_FLAGS}"
+  else
+    echo "[ERROR] neither E2E_TEST_CONFIG nor K8S_E2E_FLAGS is set; refusing to run the whole suite"
+    exit 1
+  fi
+
   pushd "${CI_HOME}/${CI_GIT_DIR}" || exit
 
   # Pick a runtime image. The local-build path already pulled
@@ -103,6 +115,7 @@ if [[ -n "${E2E_BINARY:-}" ]]; then
     -e GOPATH=/go \
     -e KUBECONFIG=/kubeconfig \
     -e PRODUCT=${PRODUCT:-calico} \
+    -e E2E_GINKGO_ARGS="${E2E_GINKGO_ARGS}" \
     ${K8S_E2E_DOCKER_EXTRA_FLAGS:-} \
     "${auth_mount[@]}" \
     "${aws_cred_env[@]}" \

--- a/.semaphore/end-to-end/pipelines/iptables.yml
+++ b/.semaphore/end-to-end/pipelines/iptables.yml
@@ -224,7 +224,7 @@ blocks:
             - name: MANIFEST_FILE
               value: calico-etcd.yaml
             - name: K8S_E2E_FLAGS
-              value: --ginkgo.focus=(\[sig-calico\]|\[Conformance\]) --ginkgo.skip=(\[Slow\]|\[Disruptive\]|\[DataPath\]|WireGuard|EndpointSlice|Tiered RBAC)
+              value: --ginkgo.focus=(\[sig-calico\]|\[Conformance\]) --ginkgo.skip=(\[Slow\]|\[Disruptive\]|\[DataPath\]|WireGuard|EndpointSlice|Tiered.RBAC)
       env_vars:
         - name: K8S_VERSION
           value: "stable-1" # Normally this would be stable, but kind doesn't always support stable immediately
@@ -755,7 +755,7 @@ blocks:
               value: calico-etcd.yaml
             # No API server in etcd mode; skip tiered RBAC tests.
             - name: K8S_E2E_FLAGS
-              value: --ginkgo.skip=(Tiered RBAC)
+              value: --ginkgo.focus=(\[sig-calico\]|\[Conformance\]) --ginkgo.skip=(\[Slow\]|\[Disruptive\]|\[DataPath\]|Proxy.version.v1.should.proxy.through.a.service.and.a.pod|WireGuard|Tiered.RBAC)
       env_vars:
         - name: PROVISIONER
           value: gcp-kubeadm

--- a/.semaphore/end-to-end/scripts/phases/run_tests.sh
+++ b/.semaphore/end-to-end/scripts/phases/run_tests.sh
@@ -12,7 +12,7 @@
 # Required env:
 #   BZ_LOCAL_DIR, BZ_LOGS_DIR, HOME, REPORT_DIR, TEST_TYPE
 # Required for local builds:
-#   E2E_TEST_CONFIG
+#   E2E_TEST_CONFIG or K8S_E2E_FLAGS
 # Required for hashrelease downloads:
 #   RELEASE_STREAM
 #
@@ -44,6 +44,17 @@ fi
 
 if [[ -n "${E2E_BINARY:-}" ]]; then
   echo "[INFO] starting e2e tests..."
+
+  # Pick one selection channel: an empty config runs the whole suite unfiltered.
+  if [[ -n "${E2E_TEST_CONFIG:-}" ]]; then
+    E2E_GINKGO_ARGS=""
+  elif [[ -n "${K8S_E2E_FLAGS:-}" ]]; then
+    E2E_GINKGO_ARGS="${K8S_E2E_FLAGS}"
+  else
+    echo "[ERROR] neither E2E_TEST_CONFIG nor K8S_E2E_FLAGS is set; refusing to run the whole suite"
+    exit 1
+  fi
+
   pushd "${HOME}/calico" || exit
 
   # Pick a runtime image. The local-build path already pulled
@@ -119,6 +130,7 @@ if [[ -n "${E2E_BINARY:-}" ]]; then
     -e GOPATH=/go \
     -e KUBECONFIG=/kubeconfig \
     -e PRODUCT=${PRODUCT:-calico} \
+    -e E2E_GINKGO_ARGS="${E2E_GINKGO_ARGS}" \
     ${K8S_E2E_DOCKER_EXTRA_FLAGS:-} \
     "${auth_mount[@]}" \
     -v "$(pwd)":/go/src/github.com/projectcalico/calico:rw \

--- a/.semaphore/end-to-end/scripts/test_scripts/e2e-validation.sh
+++ b/.semaphore/end-to-end/scripts/test_scripts/e2e-validation.sh
@@ -47,3 +47,31 @@ done
 if [ $FAILED = "true" ]; then
     exit 1
 fi
+
+echo [INFO] Checking K8S_E2E_FLAGS survive word splitting
+# run_tests.sh expands these unquoted, so a literal space inside a regex splits
+# it into two arguments. Use "." to match a space instead.
+FAILED="false"
+for file in .semaphore/end-to-end/pipelines/* .argoci/cron/*.yaml
+do
+    [ -f "$file" ] || continue
+    while IFS= read -r flags
+    do
+        # shellcheck disable=SC2086 # deliberate: mimics the unquoted expansion
+        set -- $flags
+        for arg in "$@"
+        do
+            case "$arg" in
+                --ginkgo.*) ;;
+                *)
+                    echo "$file: stray argument '$arg' from: $flags"
+                    FAILED="true"
+                    ;;
+            esac
+        done
+    done < <(grep -oh -- '--ginkgo\..*' "$file" | sed -E 's/[}"'"'"']*$//')
+done
+if [ $FAILED = "true" ]; then
+    exit 1
+fi
+echo "OK"

--- a/Makefile
+++ b/Makefile
@@ -333,10 +333,13 @@ e2e-test-clusternetworkpolicy:
 
 ## Run the general e2e tests against the cluster at $KUBECONFIG.
 ## Callers must set KUBECONFIG explicitly (e.g. $(KIND_KUBECONFIG) for kind).
+## Selection comes from E2E_TEST_CONFIG, or from E2E_GINKGO_ARGS (legacy
+## focus/skip regexes) when it is empty. E2E_GINKGO_ARGS expands in the shell so
+## its regex metacharacters survive.
 e2e-run:
 	@if [ -z "$(KUBECONFIG)" ]; then echo "e2e-run: KUBECONFIG must be set"; exit 1; fi
 	mkdir -p $(E2E_OUTPUT_DIR)
-	KUBECONFIG=$(KUBECONFIG) go run github.com/onsi/ginkgo/v2/ginkgo -procs=$(E2E_PROCS) --timeout=$(E2E_TIMEOUT) --junit-report=$(E2E_JUNIT_REPORT) --output-dir=$(E2E_OUTPUT_DIR)/ ./e2e/bin/k8s/e2e.test -- --calico.test-config=$(abspath $(E2E_TEST_CONFIG))
+	KUBECONFIG=$(KUBECONFIG) go run github.com/onsi/ginkgo/v2/ginkgo -procs=$(E2E_PROCS) --timeout=$(E2E_TIMEOUT) --junit-report=$(E2E_JUNIT_REPORT) --output-dir=$(E2E_OUTPUT_DIR)/ ./e2e/bin/k8s/e2e.test -- $${E2E_GINKGO_ARGS} $(if $(E2E_TEST_CONFIG),--calico.test-config=$(abspath $(E2E_TEST_CONFIG)))
 
 ## Run the ClusterNetworkPolicy specific e2e tests against the cluster at $KUBECONFIG.
 e2e-run-cnp:


### PR DESCRIPTION
## Description

Scheduled e2e cells have not been selecting any Calico tests since #12452 (April), which routed `TEST_TYPE=k8s-e2e` into `make e2e-run`. Those cells set `K8S_E2E_FLAGS`, but that variable is not passed into the runner container and `make e2e-run` has no parameter for it, so the only remaining selection channel is `E2E_TEST_CONFIG`. It is passed empty, and an empty value on make's command line beats the `?=` default, so ginkgo receives no filter at all.

That is worse than running everything. With no focus, skip or label filter set, upstream applies its own default skip of `\[Flaky\]|\[Feature:.+\]` (`test_context.go:376` in `CreateGinkgoConfig`, `k8s.io/kubernetes@v1.37.0-beta.0`). 29 of our 30 spec files use `describe.WithFeature`, so nearly every Calico spec is dropped and the lanes spend their time on upstream Kubernetes instead.

Measured on recent scheduled runs:

| Cell | `--calico.test-config` | Selected |
|---|---|---|
| nftables arm64-wg, eks, talos | *(empty)* | 730 of 1102 |
| patch-verification aks, eks, rke2 | *(empty)* | 730 of 1102 |
| patch-verification kubevirt | `gcp/kubevirt.yaml` | 8 of 1102 |
| PR CI GCP kubeadm | `gcp/bpf.yaml` | 118 of 1102 |

The AKS cell ended `FAIL! - Suite Timeout Elapsed -- 546 Passed | 85 Failed | 471 Skipped`.

730 is specs *selected*. The ~400 per suite that Lens reports is specs *run*, and the two agree: the gap is specs selected but never reached, because the suite times out partway through. The AKS numbers above are the same run counted both ways.

## What this does

`make e2e-run` gains `E2E_GINKGO_ARGS`, and `run_tests.sh` picks exactly one selection channel:

- `E2E_TEST_CONFIG` set: use it, as today.
- Otherwise fall back to the cell's `K8S_E2E_FLAGS`.
- Neither: fail the run rather than silently testing upstream Kubernetes.

`E2E_GINKGO_ARGS` expands as a shell variable at recipe run time rather than as a make variable, so the regexes survive intact. Expanded by make, `(\[sig-calico\]|\[Conformance\])` reaches `/bin/sh` as source text and the parens and pipe are a syntax error.

The `--calico.test-config` flag is now conditional, so an empty config omits it instead of passing `--calico.test-config=` and letting `applyTestConfig` clobber the focus.

The second commit fixes four flag strings that break under the unquoted expansion. `--ginkgo.skip=(Tiered RBAC)` splits into `--ginkgo.skip=(Tiered` and `RBAC)`, giving ginkgo an unterminated group and a stray positional argument. These were equally broken on the pre-#12452 `bz tests` path, which also expanded `${K8S_E2E_FLAGS}` unquoted, so restoring selection would have made a four-month-old bug visible as a fresh mystery. `Tiered.RBAC` matches the space and sidesteps it. The two etcd cells also override the whole flag string and so had no `--ginkgo.focus` at all; they now carry the pipeline default plus their own skip, rather than selecting the entire suite.

`e2e-validation.sh` gains a check that word-splits every `--ginkgo.*` string in the cron and pipeline files and fails on any argument that isn't a ginkgo flag. Confirmed it fails on the old strings and passes on the new ones.

## Migration path

This is groundwork for #13452, which converts cells to config files. Migrating a cell is adding `E2E_TEST_CONFIG` and deleting its `K8S_E2E_FLAGS`; config already wins where both are present. Once every cell has one, the fallback branch, `K8S_E2E_FLAGS` and the new validation check can all go.

Non-e2e cells (benchmarks, certification, openstack) reach `bz tests` and are untouched, as are the enterprise lanes in banzai-calient, which never call `make e2e-run`.

## Caveats

The restored regexes are imperfect beyond the quoting fix. `[DataPath]` and `Dataplane-BPF` match nothing and `sig-calico-enterprise` is inert in OSS, all found in #13452. This gets the lanes from zero Calico specs to most of them, not to correct.

Expect these lanes to get slower and redder. They have been running a partly-passing upstream set for four months, so a real `[sig-calico]` focus will surface whatever has rotted. That is the point, but budget for triage rather than reading the first red run as a regression from this change.

## Testing

CI-script and Makefile change with no unit-testable surface, so verification is the new `e2e-validation.sh` check plus dry runs of both paths.

Regexes reach the binary as two intact arguments:

```
$ E2E_GINKGO_ARGS='--ginkgo.focus=(\[sig-calico\]|\[Conformance\]) --ginkgo.skip=(\[Slow\]|\[Disruptive\])' make -n e2e-run E2E_TEST_CONFIG=
[fakebin]
[--]
[--ginkgo.focus=(\[sig-calico\]|\[Conformance\])]
[--ginkgo.skip=(\[Slow\]|\[Disruptive\])]
```

The new validation check, against the strings as they were before this PR:

```
.argoci/cron/e2e-iptables.yaml: stray argument 'RBAC)' from: --ginkgo.focus=... |EndpointSlice|Tiered RBAC)
exit=1
```

and after: `exit=0`.

Every k8s-e2e lane in `.argoci/cron/` and `.semaphore/end-to-end/pipelines/` sets `K8S_E2E_FLAGS`, so no cell hits the new error path.

```release-note
None
```
