### PR TITLE
e2e: fail fast when a k8s-e2e cell has no test config

### DIFF
--- a/.argoci/scripts/phases/run_tests.sh
+++ b/.argoci/scripts/phases/run_tests.sh
@@ -44,8 +44,21 @@ fi
 # E2E_BINARY is a set/unset sentinel (its value is not used here -- make
 # e2e-run locates the binary itself). Take the structured path whenever a
 # k8s-e2e binary was acquired above; non-e2e test types fall through to bz
-# tests below. E2E_TEST_CONFIG may be empty (selects the default config).
+# tests below.
 if [[ -n "${E2E_BINARY:-}" ]]; then
+  # An empty config is not "run the defaults". With no focus, no skip and no
+  # label-filter, the upstream framework applies its own default skip of
+  # \[Flaky\]|\[Feature:.+\] (test_context.go CreateGinkgoConfig), and 29 of our
+  # 30 Calico spec files carry a Feature: label -- so the run silently drops
+  # nearly all Calico coverage and still reports green. Fail loudly instead.
+  if [[ -z "${E2E_TEST_CONFIG:-}" ]]; then
+    echo "[ERROR] E2E_TEST_CONFIG is required for k8s-e2e runs."
+    echo "[ERROR] Without it the suite skips every spec labelled Feature:*, which is"
+    echo "[ERROR] almost all of the Calico e2e tests, and still exits 0."
+    echo "[ERROR] Set it on this cell to a config under e2e/config/."
+    exit 1
+  fi
+
   echo "[INFO] starting e2e tests..."
   pushd "${CI_HOME}/${CI_GIT_DIR}" || exit
 

--- a/Makefile
+++ b/Makefile
@@ -243,6 +243,9 @@ push-chart: bin/helm
 ###############################################################################
 E2E_PROCS ?= 4
 E2E_TIMEOUT ?= 90m
+# Local-development default only. CI never reaches it: run_tests.sh always passes
+# E2E_TEST_CONFIG on make's command line, and a command-line assignment overrides
+# ?= even when its value is empty.
 E2E_TEST_CONFIG ?= e2e/config/kind.yaml
 E2E_OUTPUT_DIR ?= report
 E2E_JUNIT_REPORT ?= e2e_conformance.xml


### PR DESCRIPTION
Split out of #13452 at review request — this should land **before** the config tree and the per-cron wiring.

## Why this is not cosmetic

An empty `E2E_TEST_CONFIG` is not "run the defaults".

`run_tests.sh` passes it to `make e2e-run` unconditionally, and a command-line assignment beats `?=` even when the value is empty, so ginkgo receives `--calico.test-config=` and `applyTestConfig` is skipped. With no focus, no skip **and** no label-filter, the upstream framework then applies its own default:

```go
// framework.CreateGinkgoConfig, test_context.go:376 — reached from e2e.go:108
if len(suiteConfig.FocusStrings) == 0 && len(suiteConfig.SkipStrings) == 0 && suiteConfig.LabelFilter == "" {
    suiteConfig.SkipStrings = []string{`\[Flaky\]|\[Feature:.+\]`}
}
```

29 of our 30 Calico spec files carry a `Feature:` label (only `policy/staged_policy.go` doesn't). So an unconfigured cell runs upstream conformance, skips essentially all Calico coverage, and **exits 0**.

Every scheduled `k8s-e2e` cell except the four `kubevirt-e2e-tests` ones is in that state today. Lens bears it out — `master_hashrel` since 2026-07-01, specs actually run per suite (`@tests − @skipped`): iptables 398, patch-verification 417, nftables 416, test 482, against ~1100 in the suite. Not the ~1100 you would see if it really ran everything, and not the 126 that `e2e-gcp.yml` gets by setting a config.

Credit to @caseydavenport for catching this on #13452 — my original diagnosis said an empty config ran the *whole* suite, which was wrong and did not fit those numbers.

## What it does

Fails the test step when a `k8s-e2e` binary was acquired but no config was given.

Keyed on `E2E_BINARY` rather than `TEST_TYPE`, because it is set exactly when the structured path was taken — so the 16 non-e2e cells (`ocp-cert`, `benchmark`, `usage-reporting`, `scale-test`, `openstack-e2e`) still fall through to `bz tests` untouched. Verified against all three cases.

Also comments the `Makefile` default to say CI never reaches it, since that line reads like the fallback and is not.

## Expected effect on merge

Scheduled `k8s-e2e` cells without a config **will go red**, which is the point: they are currently green while testing almost none of Calico. The config tree (#13452) and per-cron wiring follow, and each cron goes green again as it is pointed at its config. The four kubevirt cells already set a config and are unaffected.