### PR TITLE
felix/fv: re-enable BPF program-recovery test in netkit mode

### DIFF
--- a/felix/fv/bpf_test.go
+++ b/felix/fv/bpf_test.go
@@ -951,9 +951,11 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 
 			if testOpts.protocol != "udp" { // No need to run these tests per-protocol.
 				It("should recover if the BPF programs are removed", func() {
-					if infrastructure.NetkitMode() {
-						Skip("Netkit uses bpf_link; removing pins doesn't detach programs")
-					}
+					// A workload on a netkit device is netkit-attached whatever
+					// BPFAttachType asks for, so its programs are removed by
+					// unpinning the link, and it has no qdisc to delete.
+					tcAttached := BPFAttachType() == "tc" && !infrastructure.NetkitMode()
+
 					flapInterface := func() {
 						By("Flapping interface")
 						tc.Felixes[0].Exec("ip", "link", "set", "down", w[0].InterfaceName)
@@ -974,7 +976,7 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 						cc.ResetExpectations()
 
 						By("handling ingress program removal")
-						if BPFAttachType() == "tc" {
+						if tcAttached {
 							tc.Felixes[0].Exec("tc", "filter", "del", "ingress", "dev", w[0].InterfaceName)
 						} else {
 							tc.Felixes[0].Exec("rm", "-rf", path.Join(bpfProgPinDir(), fmt.Sprintf("%s_ingress", w[0].InterfaceName)))
@@ -991,7 +993,7 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 						cc.CheckConnectivity()
 
 						// Check the program is put back.
-						if BPFAttachType() == "tc" {
+						if tcAttached {
 							Eventually(func() string {
 								out, _ := tc.Felixes[0].ExecOutput("tc", "filter", "show", "ingress", "dev", w[0].InterfaceName)
 								return out
@@ -1006,7 +1008,7 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 						}
 
 						By("handling egress program removal")
-						if BPFAttachType() == "tc" {
+						if tcAttached {
 							tc.Felixes[0].Exec("tc", "filter", "del", "egress", "dev", w[0].InterfaceName)
 						} else {
 							tc.Felixes[0].Exec("rm", "-rf", path.Join(bpfProgPinDir(), fmt.Sprintf("%s_egress", w[0].InterfaceName)))
@@ -1017,7 +1019,7 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 						trigger()
 
 						// Check the program is put back.
-						if BPFAttachType() == "tc" {
+						if tcAttached {
 							Eventually(func() string {
 								out, _ := tc.Felixes[0].ExecOutput("tc", "filter", "show", "egress", "dev", w[0].InterfaceName)
 								return out
@@ -1032,7 +1034,7 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 						}
 						cc.CheckConnectivity()
 
-						if BPFAttachType() == "tc" {
+						if tcAttached {
 							By("Handling qdisc removal")
 							tc.Felixes[0].Exec("tc", "qdisc", "delete", "dev", w[0].InterfaceName, "clsact")
 


### PR DESCRIPTION
The `should recover if the BPF programs are removed` FV was skipped in netkit mode on the grounds that removing a pinned link file does not detach the program, because "the kernel link keeps a reference".

It does detach. A netkit attachment's lifetime is its `bpf_link`, and `attachLinkProgram()` closes its own handle right after pinning, so the bpffs pin is the last reference — removing it releases the link and the kernel detaches the program. Netkit and TCX share that helper, and this same test already exercises the identical pin removal in TCX mode.

Removal now follows the mechanism actually in use rather than `BPFAttachType`. A workload on a netkit device is netkit-attached whatever `BPFAttachType` asks for, because `AttachProgram()` checks `ap.IsNetkit()` before consulting `ap.AttachType`. The netkit CI job sets `FELIX_FV_BPFATTACHTYPE=tc`, so the tc branch ran `tc filter del` against an interface with no clsact qdisc and failed with `Parent Qdisc doesn't exists`. The qdisc-removal sub-step is skipped for the same reason — there is nothing to delete.

Verified in netkit mode on kernel 6.17 (`make -C felix fv-bpf-netkit`, `ipv4 tcp, ct=true, log=debug, tunnel=none, dsr=false`), both with and without `FELIX_FV_BPFATTACHTYPE=tc`. With temporary instrumentation dumping attach state either side of the removal:

- the workload device is genuinely netkit, not a veth fallback:
  ```
  8: cali866cd63afec@if3: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1440 ...
      netkit addrgenmode eui64 numtxqueues 1 numrxqueues 1 ...
  ```
- removing `/sys/fs/bpf/netkit/cali866cd63afec_ingress` drops that pin and no other, and `bpftool link show` loses netkit link `3149` (`attach_type netkit_peer`, prog 104438) while the other three netkit links survive;
- connectivity then breaks for lack of the seen mark, and Felix re-attaches and re-pins, which is what the test asserts.

The `FELIX_FV_BPFATTACHTYPE=tc` combination was also checked in the negative: with the gate left as `BPFAttachType() == "tc"`, that run reproduces the CI failure exactly.

This restores program-recovery coverage, which netkit currently has none of.

CORE-13281

**Release note:**
```release-note
None
```
