### PR TITLE
[release-v3.32] fix(bpf): read IPv6 NAT affinity timestamp at the right offset

### DIFF
--- a/felix/bpf/nat/affinity_layout_test.go
+++ b/felix/bpf/nat/affinity_layout_test.go
@@ -1,0 +1,78 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nat
+
+import (
+	"encoding/binary"
+	"net"
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+// TestAffinityValueLayout pins the Go view of struct calico_nat_affinity_val
+// (felix/bpf-gpl/nat_types.h) to its C layout: an 8-byte calico_nat_dest
+// followed by the 64-bit ts at offset 8.
+func TestAffinityValueLayout(t *testing.T) {
+	RegisterTestingT(t)
+
+	backend := NewNATBackendValue(net.IPv4(10, 20, 30, 40), 666)
+	ts := uint64(1234567890123)
+
+	var raw [affinityValueSize]byte
+	copy(raw[0:4], backend.Addr().To4())
+	binary.LittleEndian.PutUint16(raw[4:6], backend.Port())
+	// raw[6:8] is the padding at the tail of calico_nat_dest.
+	binary.LittleEndian.PutUint64(raw[8:16], ts)
+
+	v := AffinityValueFromBytes(raw[:])
+	Expect(uint64(v.Timestamp())).To(Equal(ts))
+	Expect(v.Backend()).To(Equal(backend))
+
+	Expect(NewAffinityValue(ts, backend).AsBytes()).To(Equal(raw[:]))
+}
+
+// TestAffinityValueV6Layout pins the Go view of struct calico_nat_affinity_val
+// (felix/bpf-gpl/nat_types.h with IPVER6) to its C layout: a 20-byte
+// calico_nat_dest, 4 bytes of explicit padding that align the 64-bit ts, and
+// the ts at offset 24.
+func TestAffinityValueV6Layout(t *testing.T) {
+	RegisterTestingT(t)
+
+	backend := NewNATBackendValueV6(net.ParseIP("dead:beef::1234"), 666)
+	ts := uint64(1234567890123)
+
+	var raw [affinityValueV6Size]byte
+	copy(raw[0:16], backend.Addr().To16())
+	binary.LittleEndian.PutUint16(raw[16:18], backend.Port())
+	// raw[18:20] is the padding at the tail of calico_nat_dest, raw[20:24]
+	// the explicit __pad that aligns ts.
+	binary.LittleEndian.PutUint64(raw[24:32], ts)
+
+	v := AffinityValueV6FromBytes(raw[:])
+	Expect(uint64(v.Timestamp())).To(Equal(ts))
+	Expect(v.Backend()).To(Equal(backend))
+
+	Expect(NewAffinityValueV6(ts, backend).AsBytes()).To(Equal(raw[:]))
+}
+
+func TestAffinityKeyV6ClientIP(t *testing.T) {
+	RegisterTestingT(t)
+
+	clientIP := net.ParseIP("dead:beef::5678")
+	k := NewAffinityKeyV6(clientIP, NewNATKeyV6(net.ParseIP("dead:beef::1234"), 80, 6))
+
+	Expect(k.ClientIP().To16()).To(Equal(clientIP.To16()))
+}

--- a/felix/bpf/nat/maps6.go
+++ b/felix/bpf/nat/maps6.go
@@ -471,9 +471,9 @@ func BackendMapMemV6Iter(m BackendMapMemV6) func(k, v []byte) {
 	}
 }
 
-// struct calico_nat_v4_affinity_key {
-//    struct calico_nat_v4 nat_key;
-// 	  uint32_t client_ip;
+// struct calico_nat_affinity_key {
+//    struct calico_nat nat_key;
+// 	  ipv6_addr_t client_ip;
 // 	  uint32_t padding;
 // };
 
@@ -494,7 +494,7 @@ func (k FrontEndAffinityKeyV6) String() string {
 }
 
 func (k FrontEndAffinityKeyV6) Proto() uint8 {
-	return k[6]
+	return k[18]
 }
 
 func (k FrontEndAffinityKeyV6) Addr() net.IP {
@@ -518,7 +518,7 @@ func NewAffinityKeyV6(clientIP net.IP, fEndKey FrontendKeyV6) AffinityKeyV6 {
 
 // ClientIP returns the ClientIP part of the key
 func (k AffinityKeyV6) ClientIP() net.IP {
-	return k[frontendAffKeyV6Size : frontendAffKeyV6Size+4]
+	return k[frontendAffKeyV6Size : frontendAffKeyV6Size+16]
 }
 
 // FrontendKeyV6 returns the FrontendKeyV6 part of the key
@@ -548,12 +548,16 @@ func AffinityKeyV6IntfFromBytes(b []byte) AffinityKeyInterface {
 	return AffinityKeyV6FromBytes(b)
 }
 
-// struct calico_nat_v4_affinity_val {
+// struct calico_nat_affinity_val {
 //    struct calico_nat_dest;
+//    uint32_t __pad;
 //    uint64_t ts;
 // };
 
-const affinityValueV6Size = backendValueV6Size + 4 + 8
+// affinityValueV6TsOffset skips the explicit padding that aligns the 64-bit ts
+// field after the 20-byte calico_nat_dest.
+const affinityValueV6TsOffset = backendValueV6Size + 4
+const affinityValueV6Size = affinityValueV6TsOffset + 8
 
 // AffinityValueV6 represents a backend picked by the affinity and the timestamp
 // of its creating
@@ -564,7 +568,7 @@ func NewAffinityValueV6(ts uint64, backend BackendValueV6) AffinityValueV6 {
 	var v AffinityValueV6
 
 	copy(v[:], backend[:])
-	binary.LittleEndian.PutUint64(v[backendValueV6Size:backendValueV6Size+8], ts)
+	binary.LittleEndian.PutUint64(v[affinityValueV6TsOffset:affinityValueV6TsOffset+8], ts)
 
 	return v
 }
@@ -574,7 +578,7 @@ func NewAffinityValueV6(ts uint64, backend BackendValueV6) AffinityValueV6 {
 // - it is the monotonic clock reading, which is compatible with time operations
 // in time package.
 func (v AffinityValueV6) Timestamp() time.Duration {
-	nano := binary.LittleEndian.Uint64(v[backendValueV6Size : backendValueV6Size+8])
+	nano := binary.LittleEndian.Uint64(v[affinityValueV6TsOffset : affinityValueV6TsOffset+8])
 	return time.Duration(nano) * time.Nanosecond
 }
 

--- a/felix/bpf/ut/nat_test.go
+++ b/felix/bpf/ut/nat_test.go
@@ -18,11 +18,13 @@ import (
 	"fmt"
 	"net"
 	"testing"
+	"time"
 
 	"github.com/gopacket/gopacket"
 	"github.com/gopacket/gopacket/layers"
 	. "github.com/onsi/gomega"
 
+	"github.com/projectcalico/calico/felix/bpf"
 	"github.com/projectcalico/calico/felix/bpf/arp"
 	"github.com/projectcalico/calico/felix/bpf/conntrack"
 	v4 "github.com/projectcalico/calico/felix/bpf/conntrack/v4"
@@ -2035,6 +2037,7 @@ func TestNATAffinity(t *testing.T) {
 		Expect(aff).To(HaveKey(affKey))
 		affEntry = aff[affKey]
 		Expect(affEntry.Backend()).To(Equal(nat.NewNATBackendValue(natIP, natPort)))
+		expectRecentKTime(affEntry.Timestamp())
 	})
 	expectMark(tcdefs.MarkSeen)
 	resetCTMap(ctMap)
@@ -2115,6 +2118,80 @@ func TestNATAffinity(t *testing.T) {
 	})
 	expectMark(tcdefs.MarkSeen)
 	resetCTMap(ctMap)
+}
+
+// expectRecentKTime checks that a timestamp written by the BPF dataplane with
+// bpf_ktime_get_ns parses as a monotonic time in the recent past. It guards
+// against the Go parsing disagreeing with the C struct layout.
+func expectRecentKTime(ts time.Duration) {
+	now := time.Duration(bpf.KTimeNanos())
+	ExpectWithOffset(1, ts).To(BeNumerically(">", 0))
+	ExpectWithOffset(1, ts).To(BeNumerically("<=", now))
+	ExpectWithOffset(1, now-ts).To(BeNumerically("<", time.Minute))
+}
+
+func TestNATAffinityV6(t *testing.T) {
+	RegisterTestingT(t)
+
+	cleanUpMaps()
+	defer cleanUpMaps()
+
+	bpfIfaceName = "AFF6"
+	defer func() { bpfIfaceName = "" }()
+
+	_, ipv6, l4, _, pktBytes, err := testPacketUDPDefaultNPV6(node1ipV6)
+	Expect(err).NotTo(HaveOccurred())
+	udp := l4.(*layers.UDP)
+
+	hostIP = node1ipV6
+
+	// The test packet carries a hop-by-hop extension header, so
+	// ipv6.NextHeader is not the L4 protocol.
+	natKey := nat.NewNATKeyV6(ipv6.DstIP, uint16(udp.DstPort), uint8(layers.IPProtocolUDP))
+	err = natMapV6.Update(
+		natKey.AsBytes(),
+		nat.NewNATValueV6(0, 1, 0, 60 /* seconds */).AsBytes(),
+	)
+	Expect(err).NotTo(HaveOccurred())
+
+	natIP := net.ParseIP("abcd::ffff:0808:0808")
+	natPort := uint16(666)
+
+	err = natBEMapV6.Update(
+		nat.NewNATBackendKeyV6(0, 0).AsBytes(),
+		nat.NewNATBackendValueV6(natIP, natPort).AsBytes(),
+	)
+	Expect(err).NotTo(HaveOccurred())
+
+	// Insert a reverse route for the source workload.
+	rtKey := routes.NewKeyV6(srcV6CIDR).AsBytes()
+	rtVal := routes.NewValueV6WithIfIndex(routes.FlagsLocalWorkload|routes.FlagInIPAMPool, 1).AsBytes()
+	err = rtMapV6.Update(rtKey, rtVal)
+	Expect(err).NotTo(HaveOccurred())
+
+	resetCTMapV6(ctMapV6)
+
+	skbMark = 0
+	runBpfTest(t, "calico_from_workload_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+		res, err := bpfrun(pktBytes)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.Retval).To(Equal(resTC_ACT_REDIRECT))
+
+		aff, err := nat.LoadAffinityMapV6(affinityMapV6)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(aff).To(HaveLen(1))
+
+		affKey := nat.NewAffinityKeyV6(ipv6.SrcIP, natKey)
+		Expect(aff).To(HaveKey(affKey))
+
+		affEntry := aff[affKey]
+		Expect(affEntry.Backend()).To(Equal(nat.NewNATBackendValueV6(natIP, natPort)))
+		// The entry was written by the BPF program; this verifies that the
+		// Go representation matches the C struct layout, including the
+		// padding that aligns the 64-bit timestamp.
+		expectRecentKTime(affEntry.Timestamp())
+	}, withIPv6())
+	expectMark(tcdefs.MarkSeen)
 }
 
 func TestNATNodePortIngressDSR(t *testing.T) {


### PR DESCRIPTION
**Cherry-pick history**
- Pick onto **master**: projectcalico/calico#13318 (`871675e967`)
- Pick onto **this release branch**: this PR

Clean cherry-pick of the master commit (`871675e967`) — `git cherry-pick -m 1`, no conflicts, no adaptation.

The IPv6 variant of `struct calico_nat_affinity_val` carries 4 bytes of explicit padding between the 20-byte `calico_nat_dest` and the 64-bit `ts` field, so `ts` lives at offset 24. The Go `AffinityValueV6` parser read it at offset 20, taking the zero padding as the low half and the low half of the real timestamp as the high half.

The parsed value flips sign every ~2.15s of bpf_ktime: about half of the affinity entries written by the BPF dataplane parsed as a huge negative timestamp, so the kube-proxy syncer's `cleanupSticky()` deleted them on the next Apply as expired; the other half parsed as far-future and could never expire. In practice, IPv6 session affinity (`sessionAffinity: ClientIP`) could silently break whenever a service update triggered a sync, re-balancing sticky clients to a different backend. This is also what has been flaking the IPv6 affinity FV tests since the IPv6 BPF dataplane landed (e.g. a corrupted timestamp of `-2245825527061413888` = `0xe0d5399500000000` — low 32 bits exactly zero, high 32 bits the low half of a real ktime).

Only reads were affected in production: the map entries are written by the BPF programs with the correct C layout. The Go constructor is used by tests only, which also made the existing round-trip tests self-consistent and blind to the mismatch.

Also fixes two copy-paste offsets in the v6 key accessors (`ClientIP()` returned only 4 bytes of an IPv6 address, `Proto()` read the v4 offset — both only affected logging), pins the C affinity value layouts with unit tests (verified to fail before the fix), and adds an IPv6 flavor of the BPF affinity UT that checks a C-written timestamp parses as recent ktime.

## Why this branch needs it

`affinityValueV6TsOffset` is absent from **every** release branch in both repos — the bug has been present since the IPv6 BPF dataplane landed (`6bf83e2f5f`, 2023-08), so this branch still reads `ts` at offset 20.

## Verification on this branch

- **C layout confirmed identical to master** — this is the part a backport can get wrong, so it was checked rather than assumed: `struct calico_nat_affinity_val` here carries the same `__u32 __pad` under `#ifdef IPVER6`, and `struct calico_nat_dest` is 20 bytes (`ipv46_addr_t` + `__u16 port` + `__u8 pad[2]`), matching `backendValueV6Size = 20`. The +4 offset is therefore correct on this branch, not merely inherited from master.
- `CGO_ENABLED=0 go test ./felix/bpf/nat/ -run TestAffinity` → **pass** (`TestAffinityValueLayout`, `TestAffinityValueV6Layout`, `TestAffinityKeyV6ClientIP`).
- `gofmt` clean on all three touched files.
- `TestNATAffinityV6` (BPF UT) **not** run locally — kernel 6.17 UT-wedge risk; CI covers it. Note the pick carries `b3dcc4f0dd99`, so the NAT frontend key uses `layers.IPProtocolUDP` rather than `ipv6.NextHeader` — that hop-by-hop-header trap is what made CI round 1 red on master.

**Release note:**
```release-note
ebpf: Fixed IPv6 session affinity entries being randomly deleted (or never expiring) due to a struct layout mismatch when Felix read the affinity timestamp, which could re-balance sticky connections to a different backend.
```
