### PR TITLE
[DO NOT MERGE] one-off beta-or-stable probe crons

### DIFF
--- a/.argoci/cron/e2e-beta-probe-bpf.yaml
+++ b/.argoci/cron/e2e-beta-probe-bpf.yaml
@@ -1,0 +1,54 @@
+# One-off probe sliced verbatim from e2e-bpf.yaml: the beta-or-stable cells only,
+# to verify bz v0.9.30 accepts the keyword and that k8s 1.37-beta provisions.
+# Condensed ArgoCI e2e workflow; cc-argoci-handler expands it into a CronWorkflow at runtime.
+# Migrated from the Semaphore e2e pipeline of the same name — maintained here by hand.
+version: condensed
+generateName: e2e-beta-probe-bpf-
+schedule: 0 0 31 2 *   # never fires; for one-off /argoci cron runs
+globalPrologue: |
+  cd "${CI_HOME}/${CI_GIT_DIR}"
+  export ARGO_WORKFLOW_NAME="{{workflow.name}}"
+  export ARGO_WORKFLOW_UID="{{workflow.uid}}"
+  export DATAPLANE="${DATAPLANE:-CalicoBPF}"
+  export FUNCTIONAL_AREA="${FUNCTIONAL_AREA:-bpf.yml}"
+  export INSTALLER="${INSTALLER:-operator}"
+  export K8S_E2E_FLAGS="${K8S_E2E_FLAGS:---ginkgo.focus=(\[sig-calico\]|\[Conformance\]|Host-Protection) --ginkgo.skip=(\[Slow\]|\[Disruptive\]|Feature:SCTP|Feature:Maglev)}"
+  export PRIVATE_REGISTRY="${PRIVATE_REGISTRY:-quay.io/}"
+  export USE_PRIVATE_REGISTRY="${USE_PRIVATE_REGISTRY:-true}"
+  source .argoci/scripts/global_prologue.sh
+globalEpilogue: |
+  source "${CI_HOME}/${CI_GIT_DIR}/.argoci/scripts/global_epilogue.sh"
+defaults:
+  secretBundles:
+    - banzai-secrets
+steps:
+  - name: bpf-run-matrix-gcp-bpf-dp-dsr
+    services:
+      - docker
+      - http-cache-proxy
+    env:
+      - name: BPF_NETWORK_BOOTSTRAP
+        value: Enabled
+      - name: CLUSTER_NODES
+        value: "3"
+      - name: ENABLE_BPF_DSR
+        value: "true"
+      - name: ENABLE_EXTERNAL_NODE
+        value: "true"
+      - name: ENABLE_IP_FORWARDING
+        value: "true"
+      - name: K8S_E2E_DOCKER_EXTRA_FLAGS
+        value: --env EKS_CNI
+      - name: K8S_E2E_FLAGS
+        value: --ginkgo.focus=(\[sig-calico\]|Conformance|Dataplane:BPF|Feature:NetworkPolicy) --ginkgo.skip=(Slow|Disruptive|calient|allow.ingress.access.from.updated.pod|Dataplane:LB|Feature:SCTP|Feature:Maglev)
+      # The BPF suite's canary on new Kubernetes; the rest of these runs sit on stable-3.
+      - name: K8S_VERSION
+        value: beta-or-stable
+      - name: KUBE_PROXY_MANAGEMENT
+        value: Enabled
+      - name: PROVISIONER
+        value: gcp-kubeadm
+      - name: USE_API_SERVER
+        value: "false"
+    commands: |
+      .argoci/scripts/body_standard.sh

--- a/.argoci/cron/e2e-beta-probe-nftables.yaml
+++ b/.argoci/cron/e2e-beta-probe-nftables.yaml
@@ -1,0 +1,53 @@
+# One-off probe sliced verbatim from e2e-nftables.yaml: the beta-or-stable cells only,
+# to verify bz v0.9.30 accepts the keyword and that k8s 1.37-beta provisions.
+# Condensed ArgoCI e2e workflow; cc-argoci-handler expands it into a CronWorkflow at runtime.
+# Migrated from the Semaphore e2e pipeline of the same name — maintained here by hand.
+version: condensed
+generateName: e2e-beta-probe-nftables-
+schedule: 0 0 31 2 *   # never fires; for one-off /argoci cron runs
+globalPrologue: |
+  cd "${CI_HOME}/${CI_GIT_DIR}"
+  export ARGO_WORKFLOW_NAME="{{workflow.name}}"
+  export ARGO_WORKFLOW_UID="{{workflow.uid}}"
+  export DATAPLANE="${DATAPLANE:-CalicoNftables}"
+  export ENABLE_AUTOHEP="${ENABLE_AUTOHEP:-true}"
+  export FUNCTIONAL_AREA="${FUNCTIONAL_AREA:-nftables.yml}"
+  export INSTALLER="${INSTALLER:-operator}"
+  export K8S_E2E_FLAGS="${K8S_E2E_FLAGS:---ginkgo.focus=(\[sig-calico\]|\[Conformance\]) --ginkgo.skip=(\[Slow\]|\[Disruptive\]|sig-node|sig-apps|sig-storage|sig-scheduling|sig-calico-enterprise|\[DataPath\]|WireGuard)}"
+  export K8S_VERSION="${K8S_VERSION:-stable-3}"
+  export KUBE_PROXY_MODE="${KUBE_PROXY_MODE:-nftables}"
+  export PRIVATE_REGISTRY="${PRIVATE_REGISTRY:-quay.io/}"
+  export USE_PRIVATE_REGISTRY="${USE_PRIVATE_REGISTRY:-true}"
+  source .argoci/scripts/global_prologue.sh
+globalEpilogue: |
+  source "${CI_HOME}/${CI_GIT_DIR}/.argoci/scripts/global_epilogue.sh"
+defaults:
+  secretBundles:
+    - banzai-secrets
+steps:
+  - name: nftables-mode-arm64-wg
+    services:
+      - docker
+      - http-cache-proxy
+    env:
+      - name: ENABLE_WIREGUARD
+        value: "true"
+      - name: GOOGLE_MACHINE_TYPE
+        value: t2a-standard-2
+      - name: GOOGLE_REGION
+        value: us-central1
+      - name: GOOGLE_ZONE
+        value: us-central1-a
+      - name: PROVISIONER
+        value: gcp-kubeadm
+      - name: STERN_CHECK
+        value: DISABLED
+    matrix:
+      - name: beta-or-stable-ubuntu-2204-lts-arm64
+        env:
+          - name: K8S_VERSION
+            value: beta-or-stable
+          - name: CLUSTER_IMAGE
+            value: ubuntu-2204-lts-arm64
+    commands: |
+      .argoci/scripts/body_standard.sh


### PR DESCRIPTION
**Not for merge.** Scratch PR carrying two one-off ArgoCI probe files so they can be fired with `/argoci cron`, which submits a one-off Workflow rather than deploying a CronWorkflow.

### Why

[#13450](https://github.com/projectcalico/calico/pull/13450) pointed nine e2e cells at `K8S_VERSION=beta-or-stable`. All of them then died at `bz init profile`, because bz-cli's `validK8sVersion` had never been taught the keyword — fixed in bz-cli [#217](https://github.com/tigera/bz-cli/pull/217), shipped as v0.9.30, which is now `latest`.

That fix is already proven locally: with the same invocation and `K8S_VERSION=beta-or-stable`, v0.9.29 fails with `unexpected pattern - beta-or-stable`, while v0.9.30 completes `bz init profile` with exit 0.

So this probe is not testing the keyword. It tests the thing still unproven: **whether k8s 1.37.0-beta.0 actually provisions**, on the two combinations it has never run on.

### Scope

| File | Cell | Why this one |
|---|---|---|
| `e2e-beta-probe-nftables.yaml` | `nftables-mode-arm64-wg` / ubuntu-2204-arm64, gcp-kubeadm | arm64 is the least-proven path: calico-ready-clusters [#658](https://github.com/tigera/calico-ready-clusters/pull/658) (containerd 2.x, kubeadm v1beta4) was validated end-to-end only on jammy/amd64 |
| `e2e-beta-probe-bpf.yaml` | `bpf-run-matrix-gcp-bpf-dp-dsr`, gcp-kubeadm | the cell promoted off `stable-3` to give BPF any beta coverage; never run on a pre-release |

Two clusters. The gcp/aws amd64 iptables cells are deliberately left to Monday's scheduled cron — that path is already well covered, so spending clusters on it now buys little.

### How these were built

Text-sliced from `open-source/master`'s `e2e-nftables.yaml` and `e2e-bpf.yaml`, keeping the `globalPrologue`, `globalEpilogue` and `defaults` byte-identical and dropping every step but the one of interest. Prologue equality was asserted programmatically rather than eyeballed. Each cron sets its own `DATAPLANE` / `FUNCTIONAL_AREA` / `K8S_E2E_FLAGS`, which is why these are two files rather than one — merging cells from different crons would mean hand-transcribing a prologue, the most likely way to make a probe fail for reasons unrelated to bz.

`schedule` is `0 0 31 2 *` (Feb 31, the same trick `e2e-test.yaml` uses) so an accidental deploy cannot start a cadence.

### Expected outcome

Both cells should resolve `KUBERNETES_VERSION` to `v1.37.0-beta.0` and get past provisioning. A `v1.36.3` instead means the resolver silently fell back and the run proved nothing. A provisioning failure on the arm64 cell is a finding about #658's coverage rather than about Calico.

Close this without merging once the runs have reported.
