### PR TITLE
argoci: run one BPF matrix entry on netkit pod interfaces

### DIFF
--- a/.argoci/cron/e2e-bpf.yaml
+++ b/.argoci/cron/e2e-bpf.yaml
@@ -217,7 +217,7 @@ steps:
       - http-cache-proxy
     env:
       - name: CLUSTER_IMAGE
-        value: ubuntu-2404-lts
+        value: ubuntu-2404-lts-amd64
       - name: CLUSTER_NODES
         value: "3"
       - name: ENABLE_EXTERNAL_NODE

--- a/.argoci/cron/e2e-bpf.yaml
+++ b/.argoci/cron/e2e-bpf.yaml
@@ -217,7 +217,7 @@ steps:
       - http-cache-proxy
     env:
       - name: CLUSTER_IMAGE
-        value: ubuntu-2204-lts
+        value: ubuntu-2404-lts
       - name: CLUSTER_NODES
         value: "3"
       - name: ENABLE_EXTERNAL_NODE
@@ -235,10 +235,12 @@ steps:
         env:
           - name: USE_VXLAN
             value: "true"
-      - name: "false"
+      - name: false-netkit
         env:
           - name: USE_VXLAN
             value: "false"
+          - name: LINUX_POD_INTERFACE_TYPE
+            value: Netkit
     commands: |
       .argoci/scripts/body_standard.sh
   - name: bpf-run-matrix-aks-w-aks-cni


### PR DESCRIPTION
Gives netkit pod interfaces (`device_type: netkit`) e2e coverage on the BPF dataplane at **zero added runs**, by repointing one existing matrix entry rather than adding a step.

`bpf-run-matrix-gcp-bpf-dp-encap-w-nodelocal-dnscache` has two entries differing only in `USE_VXLAN`. The `false` entry becomes `false-netkit` and gains `LINUX_POD_INTERFACE_TYPE: Netkit`.

Both entries move to `ubuntu-2404-lts` (netkit needs Linux 6.7+; 22.04 ships 5.15). Moving *both* keeps the image out of the comparison — a `false-netkit` failure then means netkit, not a distro bump — and leaves `CLUSTER_IMAGE` at step level, so nothing depends on entry-env-overrides-step-env, which no cron here currently exercises.

`DATAPLANE=CalicoBPF` and `INSTALLER=operator` come from `globalPrologue`; the focus/skip regex is untouched, since netkit should pass the same suite as veth and divergence is the finding.

## Coverage traded

`USE_VXLAN=false` here isn't no-encap — on gcp-kubeadm + calico + ipv4 it falls through to the operator default, IPIP. So this gives up *BPF + IPIP + veth + nodelocal-dnscache* on 22.04:

| Ingredient | Still covered by |
|---|---|
| BPF + IPIP + veth on gcp-kubeadm | `bpf-run-matrix-gcp-bpf-dp-dsr` (also IPIP), with DSR on |
| BPF + IPIP + veth generally | `bpf-run-matrix-aws-encap`, `bpf-run-matrix-aws-lb-bpf` |
| nodelocal-dnscache + veth | the surviving `USE_VXLAN=true` entry |
| gcp-kubeadm on 22.04 | every gcp-kubeadm step that doesn't pin an image, plus `distro-support` in `e2e-iptables.yaml` |

## banzai-core dependency: satisfied

`LINUX_POD_INTERFACE_TYPE` landed in banzai-core [#1740](https://github.com/tigera/banzai-core/pull/1740) and `stable-v0.9` now points at that merge (`6885391b`), which is what `bz` clones — so this entry gets a banzai-core that understands the variable.

banzai-core's guardrails make the run trustworthy rather than merely green: it validates the value at `init` and again at `install:before`, gates on Linux 6.7+ before installing, and after install asserts the host-side `cali*` devices really are netkit — so a silent veth fallback fails the step.

Release Note
```release-note
NONE
```
