### PR TITLE
felix: guard the BPF UT mock's trampoline-stride field with its mutex

### DIFF
--- a/felix/dataplane/linux/bpf_ep_mgr_test.go
+++ b/felix/dataplane/linux/bpf_ep_mgr_test.go
@@ -354,7 +354,12 @@ func (m *mockProgMapDP) loadPolicyProgram(progName string,
 			return nil, nil, unix.ERANGE
 		}
 
+		// applyPolicyToWeps loads the ingress and egress programs
+		// concurrently, so this shared field needs the mock's lock like
+		// every other one.
+		m.mutex.Lock()
 		m.finalTrampolineStride = builder.TrampolineStride()
+		m.mutex.Unlock()
 	}
 
 	fdCounterLock.Lock()

--- a/felix/dataplane/linux/bpf_ep_mgr_test.go
+++ b/felix/dataplane/linux/bpf_ep_mgr_test.go
@@ -354,9 +354,6 @@ func (m *mockProgMapDP) loadPolicyProgram(progName string,
 			return nil, nil, unix.ERANGE
 		}
 
-		// applyPolicyToWeps loads the ingress and egress programs
-		// concurrently, so this shared field needs the mock's lock like
-		// every other one.
 		m.mutex.Lock()
 		m.finalTrampolineStride = builder.TrampolineStride()
 		m.mutex.Unlock()

--- a/felix/dataplane/linux/bpf_ep_mgr_test.go
+++ b/felix/dataplane/linux/bpf_ep_mgr_test.go
@@ -87,6 +87,7 @@ type mockDataplane struct {
 
 	jitHarden             bool
 	finalTrampolineStride int
+	erangeCount           int
 }
 
 func newMockDataplane() *mockDataplane {
@@ -296,6 +297,18 @@ func (m *mockDataplane) numOfAttaches(key string) int {
 	return m.numAttaches[key]
 }
 
+func (m *mockDataplane) getFinalTrampolineStride() int {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	return m.finalTrampolineStride
+}
+
+func (m *mockDataplane) getErangeCount() int {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	return m.erangeCount
+}
+
 func (m *mockDataplane) setRoute(cidr ip.CIDR) {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
@@ -351,6 +364,9 @@ func (m *mockProgMapDP) loadPolicyProgram(progName string,
 		}
 
 		if builder.TrampolineStride() > 15000 {
+			m.mutex.Lock()
+			m.erangeCount++
+			m.mutex.Unlock()
 			return nil, nil, unix.ERANGE
 		}
 
@@ -1195,7 +1211,13 @@ var _ = Describe("BPF Endpoint Manager", func() {
 		It("should load program with shorter trampoline jumps", func() {
 			Expect(dp.programAttached("cali12345:ingress")).To(BeTrue())
 			Expect(dp.programAttached("cali12345:egress")).To(BeTrue())
-			Expect(dp.finalTrampolineStride).To(BeNumerically("<=", 15000))
+			// The initial (default-stride) attempt(s) must have been rejected
+			// with ERANGE before the retry loop found a stride that fits;
+			// otherwise finalTrampolineStride's "<= 15000" check below is
+			// trivially true regardless of whether the retry logic ran.
+			Expect(dp.getErangeCount()).To(BeNumerically(">", 0))
+			Expect(dp.getFinalTrampolineStride()).To(BeNumerically(">", 0))
+			Expect(dp.getFinalTrampolineStride()).To(BeNumerically("<=", 15000))
 		})
 	})
 


### PR DESCRIPTION
`mockProgMapDP.loadPolicyProgram` writes `finalTrampolineStride` without holding `mockDataplane.mutex`, the lock that guards every other field of that struct.

`applyPolicyToWeps` loads the ingress program in a goroutine and the egress program on the caller's goroutine:

```go
parallelWG.Go(func() {
    ingressAP, ingressErr = d.wepApplyPolicyToDirection(...)
})
egressAP, egressErr := d.wepApplyPolicyToDirection(...)
parallelWG.Wait()
```

Both paths reach `loadPolicyProgram`, so with jit-harden on, both reach the unguarded write.

🤖 Generated with [Claude Code](https://claude.com/claude-code)