### PR TITLE
[DE-4446] [backport release-v3.30] Update hashrelease base URL to hashrelease.tools.tigera.net

### DIFF
--- a/.argoci/scripts/body_flannel-migration.sh
+++ b/.argoci/scripts/body_flannel-migration.sh
@@ -22,7 +22,7 @@ export MIGRATION_MANIFEST=${MIGRATION_MANIFEST:-"manifests/flannel-migration/mig
 
 if [ "${USE_HASH_RELEASE}" == "true" ]; then
   echo "[INFO] Using hash release for flannel migration"
-  LATEST_HASHREL="https://latest-os.docs.eng.tigera.net/${RELEASE_STREAM}.txt"
+  LATEST_HASHREL="https://latest-os.hashrelease.tools.tigera.net/${RELEASE_STREAM}.txt"
   echo "Checking ${LATEST_HASHREL} for latest hash release url..."
   DOCS_URL=$(curl --retry 9 --retry-all-errors -fsS ${LATEST_HASHREL})
   echo "Using $DOCS_URL for hash release base url"

--- a/.argoci/scripts/test_scripts/operator_migrate.sh
+++ b/.argoci/scripts/test_scripts/operator_migrate.sh
@@ -7,7 +7,7 @@ echo "[INFO] starting operator migration..."
 
 # Get the docs site base url
 if [[ "${USE_HASH_RELEASE}" == "true" ]]; then
-  LATEST_HASHREL="https://latest-os.docs.eng.tigera.net/${RELEASE_STREAM}.txt"
+  LATEST_HASHREL="https://latest-os.hashrelease.tools.tigera.net/${RELEASE_STREAM}.txt"
   echo "Checking ${LATEST_HASHREL} for latest hash release url..."
   BASE_URL=$(curl --retry 9 --retry-all-errors -fsS ${LATEST_HASHREL})
   echo "Using $BASE_URL for hash release base url"

--- a/.semaphore/end-to-end/scripts/body_flannel-migration.sh
+++ b/.semaphore/end-to-end/scripts/body_flannel-migration.sh
@@ -12,7 +12,7 @@ if [ "${USE_HASH_RELEASE}" == "true" ]; then
  echo "[INFO] Using hash release for flannel migration"
   LATEST_HASHREL="https://latest-os.hashrelease.tools.tigera.net/${RELEASE_STREAM}.txt"
   echo "Checking ${LATEST_HASHREL} for latest hash release url..."
-  DOCS_URL=$(curl --retry 9 --retry-all-errors -sS ${LATEST_HASHREL})
+  DOCS_URL=$(curl --retry 9 --retry-all-errors -fsS "${LATEST_HASHREL}")
   echo "Using $DOCS_URL for hash release base url"
 else
   if [[ "${RELEASE_STREAM}" == "master" ]]; then

--- a/.semaphore/end-to-end/scripts/body_flannel-migration.sh
+++ b/.semaphore/end-to-end/scripts/body_flannel-migration.sh
@@ -10,7 +10,7 @@ export MIGRATION_MANIFEST=${MIGRATION_MANIFEST:-"manifests/flannel-migration/mig
 
 if [ "${USE_HASH_RELEASE}" == "true" ]; then
  echo "[INFO] Using hash release for flannel migration"
-  LATEST_HASHREL="https://latest-os.docs.eng.tigera.net/${RELEASE_STREAM}.txt"
+  LATEST_HASHREL="https://latest-os.hashrelease.tools.tigera.net/${RELEASE_STREAM}.txt"
   echo "Checking ${LATEST_HASHREL} for latest hash release url..."
   DOCS_URL=$(curl --retry 9 --retry-all-errors -sS ${LATEST_HASHREL})
   echo "Using $DOCS_URL for hash release base url"

--- a/.semaphore/end-to-end/scripts/test_scripts/operator_migrate.sh
+++ b/.semaphore/end-to-end/scripts/test_scripts/operator_migrate.sh
@@ -7,9 +7,9 @@ echo "[INFO] starting operator migration..."
 
 # Get the docs site base url
 if [[ "${USE_HASH_RELEASE}" == "true" ]]; then
-  LATEST_HASHREL="https://latest-os.docs.eng.tigera.net/${RELEASE_STREAM}.txt"
+  LATEST_HASHREL="https://latest-os.hashrelease.tools.tigera.net/${RELEASE_STREAM}.txt"
   echo "Checking ${LATEST_HASHREL} for latest hash release url..."
-  BASE_URL=$(curl --retry 9 --retry-all-errors -sS ${LATEST_HASHREL})
+  BASE_URL=$(curl --retry 9 --retry-all-errors -fsS ${LATEST_HASHREL})
   echo "Using $BASE_URL for hash release base url"
 else
   if [[ "${RELEASE_STREAM}" == "master" ]]; then

--- a/process/testing/aso/install-calico.sh
+++ b/process/testing/aso/install-calico.sh
@@ -82,11 +82,11 @@ if [ ${HASH_RELEASE} == 'true' ]; then
 	    exit 1
     fi
     if [ ${PRODUCT} == 'calient' ]; then
-      URL_HASH="https://latest-cnx.docs.eng.tigera.net/${RELEASE_STREAM}.txt"
+      URL_HASH="https://latest-cnx.hashrelease.tools.tigera.net/${RELEASE_STREAM}.txt"
     else
-      URL_HASH="https://latest-os.docs.eng.tigera.net/${RELEASE_STREAM}.txt"
+      URL_HASH="https://latest-os.hashrelease.tools.tigera.net/${RELEASE_STREAM}.txt"
     fi
-    RELEASE_BASE_URL=$(curl -sS ${URL_HASH})
+    RELEASE_BASE_URL=$(curl -fsS ${URL_HASH})
 fi
 
 if [[ ${RELEASE_STREAM} != 'local' ]]; then

--- a/release/internal/hashreleaseserver/server.go
+++ b/release/internal/hashreleaseserver/server.go
@@ -33,7 +33,7 @@ import (
 const (
 
 	// BaseDomain is the base URL of the hashrelease
-	BaseDomain = "docs.eng.tigera.net"
+	BaseDomain = "hashrelease.tools.tigera.net"
 
 	releaseLibFileName = "all-releases"
 )


### PR DESCRIPTION
Backport of #13428 to `release-v3.30`.

Hashreleases are moving from `docs.eng.tigera.net` to
`hashrelease.tools.tigera.net`. Both hosts serve during the transition.

Smaller than the master PR: this branch has no
`.semaphore/end-to-end/scripts/phases/` directory and no approved snapshot
files under `release/internal/`, so nothing there needed updating.

```release-note
NONE
```
