### PR TITLE
BPF QoS connlimit: cover connlimit first SYN, IPv6 and dual-stack in unit tests

### DIFF
--- a/felix/bpf/conntrack/connlimit_scanner_test.go
+++ b/felix/bpf/conntrack/connlimit_scanner_test.go
@@ -72,16 +72,30 @@ func (f *fakeQoSMap) BatchUpdate(ks, vs [][]byte, flags uint64) (int, error) {
 // reads or writes.
 func (f *fakeQoSMap) seed(t *testing.T, ifindex uint32, direction uint16, maxConn, current uint32) {
 	t.Helper()
-	k := qos.NewKey(ifindex, direction, qos.IPFamilyV4).AsBytes()
-	v := qos.NewConnValue(maxConn, current).AsBytes()
-	f.contents[string(k)] = v[:]
+	f.seedFamily(t, ifindex, direction, qos.IPFamilyV4, maxConn, current)
 }
 
 func (f *fakeQoSMap) currentCount(t *testing.T, ifindex uint32, direction uint16) uint32 {
 	t.Helper()
-	bytes, err := f.Get(qos.NewKey(ifindex, direction, qos.IPFamilyV4).AsBytes())
+	return f.currentCountFamily(t, ifindex, direction, qos.IPFamilyV4)
+}
+
+// seedFamily is seed for an explicit IP family. v4 and v6 share one
+// cali_qos_conn map and are separated only by the family field of the key, so
+// tests that care about that separation must address the two entries
+// explicitly.
+func (f *fakeQoSMap) seedFamily(t *testing.T, ifindex uint32, direction, family uint16, maxConn, current uint32) {
+	t.Helper()
+	k := qos.NewKey(ifindex, direction, family).AsBytes()
+	v := qos.NewConnValue(maxConn, current).AsBytes()
+	f.contents[string(k)] = v[:]
+}
+
+func (f *fakeQoSMap) currentCountFamily(t *testing.T, ifindex uint32, direction, family uint16) uint32 {
+	t.Helper()
+	bytes, err := f.Get(qos.NewKey(ifindex, direction, family).AsBytes())
 	if err != nil {
-		t.Fatalf("fake Get for (%d,%d) failed: %v", ifindex, direction, err)
+		t.Fatalf("fake Get for (%d,%d,v%d) failed: %v", ifindex, direction, family, err)
 	}
 	return qos.ConnValueFromBytes(bytes).CurrentCount()
 }
@@ -112,6 +126,20 @@ func established(opener bool) Leg {
 // makeKey creates a TCP CT key for the given IPs and ports.
 func makeKey(ipA, ipB string, portA, portB uint16) Key {
 	return NewKey(6, net.ParseIP(ipA).To4(), portA, net.ParseIP(ipB).To4(), portB)
+}
+
+// makeKeyV6 creates a TCP CT key for the given IPv6 addresses and ports.
+func makeKeyV6(ipA, ipB string, portA, portB uint16) KeyV6 {
+	return NewKeyV6(6, net.ParseIP(ipA).To16(), portA, net.ParseIP(ipB).To16(), portB)
+}
+
+// makeEstablishedValueV6 is makeEstablishedValue for an IPv6 flow. Leg is
+// shared between families, so only the value constructor differs.
+func makeEstablishedValueV6() ValueV6 {
+	return NewValueV6Normal(time.Duration(0), 0,
+		established(true),  // A is opener
+		established(false), // B is responder
+	)
 }
 
 // makeEstablishedValue creates a NORMAL CT value with both legs established.
@@ -212,6 +240,51 @@ func TestConnLimitScannerCountsEgressConnection(t *testing.T) {
 	expected := connlimitKey{ifindex: 9, direction: 0}
 	if scanner.counts[expected] != 1 {
 		t.Errorf("expected egress count 1 for ifindex 9, got counts: %v", scanner.counts)
+	}
+}
+
+// TestConnLimitScannerV6WritesBackToItsOwnFamily verifies that a v6 scanner
+// counts a v6 flow and writes the result to the v6 cali_qos_conn entry,
+// leaving the v4 entry for the same (ifindex, direction) untouched.
+//
+// v4 and v6 share a single cali_qos_conn map, separated only by the family
+// field of the key, and each family runs its own scanner — NewConnLimitScanner
+// takes the family and prepareUpdate builds its write key from it. Getting
+// that wrong would send one stack's recount to the other stack's counter,
+// silently, and only on dual-stack clusters. The family dimension in the key
+// exists precisely to prevent that overwrite, so it is worth pinning: a test
+// that only ever exercises one family would pass even if the dimension were
+// dropped entirely.
+func TestConnLimitScannerV6WritesBackToItsOwnFamily(t *testing.T) {
+	podIP := "dead:beef::2"
+	remoteIP := "dead:beef::3"
+
+	fake := newFakeQoSMap()
+	// A dual-stack pod: same ifindex and direction, one entry per family. The
+	// v4 side is mid-flight with four connections of its own.
+	fake.seedFamily(t, 9, 1, qos.IPFamilyV4, 5, 4)
+	fake.seedFamily(t, 9, 1, qos.IPFamilyV6, 5, 0)
+
+	scanner := NewConnLimitScanner(fake, func() map[string]ConnLimitPodInfo {
+		return map[string]ConnLimitPodInfo{
+			string(net.ParseIP(podIP).To16()): podInfo(9, true, false),
+		}
+	}, qos.IPFamilyV6)
+
+	// Pod is AddrB (responder), remote is AddrA (opener), so this counts
+	// against the pod's ingress limit.
+	scanner.IterationStart()
+	verdict, _ := scanner.Check(makeKeyV6(remoteIP, podIP, 54321, 8080), makeEstablishedValueV6(), nil)
+	if verdict != ScanVerdictOK {
+		t.Fatalf("expected ScanVerdictOK, got %d", verdict)
+	}
+	scanner.IterationEnd()
+
+	if got := fake.currentCountFamily(t, 9, 1, qos.IPFamilyV6); got != 1 {
+		t.Errorf("v6 ingress counter: expected 1, got %d", got)
+	}
+	if got := fake.currentCountFamily(t, 9, 1, qos.IPFamilyV4); got != 4 {
+		t.Errorf("v4 counter must be untouched by a v6 scanner: expected 4, got %d", got)
 	}
 }
 

--- a/felix/bpf/ut/qos_test.go
+++ b/felix/bpf/ut/qos_test.go
@@ -756,3 +756,427 @@ func TestQoSConnLimitIngressRetransmissionOfAccepted(t *testing.T) {
 	// ingress check does NOT call qos_connlimit_check_and_increment.
 	Expect(readQoSCount()).To(Equal(uint32(1)))
 }
+
+// TestQoSConnLimitIngressFirstSYN covers the plain first-SYN admission
+// decision at to-wep, both outcomes. The sibling tests in this file all cover
+// retransmission and recycle cases; this is the base case they build on.
+//
+// "First SYN" here means the first SYN seen at *this* hook, not the first in
+// the system: the ingress block in tc.c is gated on is_tcp_syn(), which reads
+// CT_RES_SYN, and calico_ct_lookup only sets that on a lookup hit. The
+// source-side program (from-wep or from-hep) has therefore already created the
+// CT entry by the time the SYN reaches to-wep. What distinguishes a first SYN
+// is that the entry carries neither CONNLIMIT_INGRESS nor
+// CONNLIMIT_INGRESS_REJECTED yet.
+func TestQoSConnLimitIngressFirstSYN(t *testing.T) {
+	RegisterTestingT(t)
+
+	bpfIfaceName = "HWfsi"
+	defer func() { bpfIfaceName = "" }()
+
+	const (
+		ifIndex               = 1
+		maxConnections        = 3
+		srcPort        uint16 = 23460 // remote opener
+		dstPort        uint16 = 8055  // workload listening port
+	)
+
+	rtKey := routes.NewKey(srcV4CIDR).AsBytes()
+	rtVal := routes.NewValueWithIfIndex(routes.FlagsLocalWorkload|routes.FlagInIPAMPool, ifIndex).AsBytes()
+	Expect(rtMap.Update(rtKey, rtVal)).NotTo(HaveOccurred())
+	rtKey = routes.NewKey(dstV4CIDR).AsBytes()
+	rtVal = routes.NewValueWithIfIndex(routes.FlagsRemoteWorkload|routes.FlagInIPAMPool, ifIndex).AsBytes()
+	Expect(rtMap.Update(rtKey, rtVal)).NotTo(HaveOccurred())
+	defer resetRTMap(rtMap)
+
+	ctMap := conntrack.Map()
+	Expect(ctMap.EnsureExists()).NotTo(HaveOccurred())
+	defer resetCTMap(ctMap)
+
+	k := ctv4.NewKey(6, srcIP, srcPort, dstIP, dstPort)
+	qosKey := qos.NewKey(uint32(ifIndex), 1 /* ingress */, qos.IPFamilyV4)
+
+	readQoSCount := func() uint32 {
+		b, err := qosConnMap.Get(qosKey.AsBytes())
+		Expect(err).NotTo(HaveOccurred())
+		return qos.ConnValueFromBytes(b).CurrentCount()
+	}
+
+	readCTFlags := func() uint32 {
+		b, err := ctMap.Get(k.AsBytes())
+		Expect(err).NotTo(HaveOccurred())
+		return ctv4.ValueFromBytes(b).Flags()
+	}
+
+	// The CT entry the source-side program created: opener has sent its SYN,
+	// the responder has not replied, and no connlimit flag has been set yet.
+	// current is the counter value this sub-case starts from.
+	seed := func(current uint32) {
+		resetCTMap(ctMap)
+		resetQoSMap(qosConnMap)
+
+		legA := ctv4.Leg{SynSeen: true, Opener: true}
+		legB := ctv4.Leg{Ifindex: ifIndex}
+		v := ctv4.NewValueNormal(time.Duration(0), 0 /* no connlimit flags */, legA, legB)
+		Expect(ctMap.Update(k.AsBytes(), v.AsBytes()[:])).NotTo(HaveOccurred())
+
+		Expect(qosConnMap.Update(qosKey.AsBytes(),
+			qos.NewConnValue(maxConnections, current).AsBytes())).NotTo(HaveOccurred())
+	}
+
+	_, _, _, _, synPkt, err := testPacketTCPV4WithPayload(dstIP, srcPort, dstPort, true /* syn */, nil)
+	Expect(err).NotTo(HaveOccurred())
+
+	t.Run("under the limit: counted and admitted", func(t *testing.T) {
+		RegisterTestingT(t)
+		seed(1)
+		defer resetQoSMap(qosConnMap)
+
+		skbMark = tcdefs.MarkSeen
+		runBpfTest(t, "calico_to_workload_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+			res, err := bpfrun(synPkt)
+			Expect(err).NotTo(HaveOccurred())
+			// Admitted: no TCP_RST tail call, packet proceeds normally.
+			Expect(res.Retval).To(Equal(resTC_ACT_UNSPEC))
+		}, withIngressQoSConnLimit())
+
+		Expect(readQoSCount()).To(Equal(uint32(2)), "first SYN was not counted")
+		Expect(readCTFlags()&ctv4.FlagConnLimitIn).To(Equal(ctv4.FlagConnLimitIn),
+			"admitted SYN must stamp CONNLIMIT_INGRESS, or nothing can decrement it on close")
+		Expect(readCTFlags() & ctv4.FlagConnLimitInRej).To(Equal(uint32(0)))
+	})
+
+	t.Run("at the limit: rejected and not counted", func(t *testing.T) {
+		RegisterTestingT(t)
+		seed(maxConnections)
+		defer resetQoSMap(qosConnMap)
+
+		skbMark = tcdefs.MarkSeen
+		runBpfTest(t, "calico_to_workload_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+			res, err := bpfrun(synPkt)
+			Expect(err).NotTo(HaveOccurred())
+			// Reject path tail-calls PROG_INDEX_TCP_RST, which builds the RST
+			// and forwards it; the final return is TC_ACT_UNSPEC.
+			Expect(res.Retval).To(Equal(resTC_ACT_UNSPEC))
+		}, withIngressQoSConnLimit())
+
+		// The failed check must not increment.
+		Expect(readQoSCount()).To(Equal(uint32(maxConnections)))
+		// Guard against a vacuous pass: REJECTED proves the check ran and
+		// failed, rather than the SYN never reaching the block.
+		Expect(readCTFlags()&ctv4.FlagConnLimitInRej).To(Equal(ctv4.FlagConnLimitInRej),
+			"rejected SYN must stamp CONNLIMIT_INGRESS_REJECTED")
+		Expect(readCTFlags() & ctv4.FlagConnLimitIn).To(Equal(uint32(0)))
+	})
+}
+
+// TestQoSConnLimitEgressFirstSYN covers the plain first-SYN admission decision
+// at from-wep, both outcomes.
+//
+// The egress path differs from ingress in more than direction: the check sits
+// in a different block (tc.c, after policy rather than at to-wep), there is no
+// pre-existing CT entry — this is a genuinely new flow — and CONNLIMIT_EGRESS
+// is applied through ct_ctx_nat->flags as the entry is created rather than
+// stamped onto an existing one. So ingress passing is not evidence that egress
+// does.
+func TestQoSConnLimitEgressFirstSYN(t *testing.T) {
+	RegisterTestingT(t)
+
+	bpfIfaceName = "HWfse"
+	defer func() { bpfIfaceName = "" }()
+
+	const (
+		ifIndex               = 1
+		maxConnections        = 3
+		srcPort        uint16 = 12349
+		dstPort        uint16 = 8055
+	)
+
+	rtKey := routes.NewKey(srcV4CIDR).AsBytes()
+	rtVal := routes.NewValueWithIfIndex(routes.FlagsLocalWorkload|routes.FlagInIPAMPool, ifIndex).AsBytes()
+	Expect(rtMap.Update(rtKey, rtVal)).NotTo(HaveOccurred())
+	rtKey = routes.NewKey(dstV4CIDR).AsBytes()
+	rtVal = routes.NewValueWithIfIndex(routes.FlagsRemoteWorkload|routes.FlagInIPAMPool, ifIndex).AsBytes()
+	Expect(rtMap.Update(rtKey, rtVal)).NotTo(HaveOccurred())
+	defer resetRTMap(rtMap)
+
+	ctMap := conntrack.Map()
+	Expect(ctMap.EnsureExists()).NotTo(HaveOccurred())
+	defer resetCTMap(ctMap)
+
+	k := ctv4.NewKey(6, srcIP, srcPort, dstIP, dstPort)
+	qosKey := qos.NewKey(uint32(ifIndex), 0 /* egress */, qos.IPFamilyV4)
+
+	readQoSCount := func() uint32 {
+		b, err := qosConnMap.Get(qosKey.AsBytes())
+		Expect(err).NotTo(HaveOccurred())
+		return qos.ConnValueFromBytes(b).CurrentCount()
+	}
+
+	// No CT entry: a genuinely new outbound flow.
+	seed := func(current uint32) {
+		resetCTMap(ctMap)
+		resetQoSMap(qosConnMap)
+		Expect(qosConnMap.Update(qosKey.AsBytes(),
+			qos.NewConnValue(maxConnections, current).AsBytes())).NotTo(HaveOccurred())
+	}
+
+	_, _, _, _, synPkt, err := testPacketTCPV4WithPayload(dstIP, srcPort, dstPort, true /* syn */, nil)
+	Expect(err).NotTo(HaveOccurred())
+
+	t.Run("under the limit: counted and admitted", func(t *testing.T) {
+		RegisterTestingT(t)
+		seed(1)
+		defer resetQoSMap(qosConnMap)
+
+		skbMark = 0
+		runBpfTest(t, "calico_from_workload_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+			res, err := bpfrun(synPkt)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(res.Retval).To(Equal(resTC_ACT_REDIRECT))
+		}, withEgressQoSConnLimit())
+
+		Expect(readQoSCount()).To(Equal(uint32(2)), "first SYN was not counted")
+
+		// The new CT entry must carry CONNLIMIT_EGRESS, or the close and
+		// cleanup paths cannot decrement it.
+		b, err := ctMap.Get(k.AsBytes())
+		Expect(err).NotTo(HaveOccurred(), "no CT entry was created for the admitted flow")
+		Expect(ctv4.ValueFromBytes(b).Flags()&ctv4.FlagConnLimitOut).
+			To(Equal(ctv4.FlagConnLimitOut), "admitted flow must be stamped CONNLIMIT_EGRESS")
+	})
+
+	t.Run("at the limit: rejected and not counted", func(t *testing.T) {
+		RegisterTestingT(t)
+		seed(maxConnections)
+		defer resetQoSMap(qosConnMap)
+
+		skbMark = 0
+		runBpfTest(t, "calico_from_workload_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+			res, err := bpfrun(synPkt)
+			Expect(err).NotTo(HaveOccurred())
+			// Note the return code does NOT distinguish reject from admit on
+			// egress: the reject path tail-calls PROG_INDEX_TCP_RST, which
+			// builds the RST and redirects it back to the workload, so both
+			// outcomes return TC_ACT_REDIRECT. Do not use it as the signal
+			// that the limit fired.
+			Expect(res.Retval).To(Equal(resTC_ACT_REDIRECT))
+		}, withEgressQoSConnLimit())
+
+		Expect(readQoSCount()).To(Equal(uint32(maxConnections)))
+
+		// This is the discriminator instead. The check sits ahead of the CT
+		// create, and a rejected SYN goes straight to deny, so the flow
+		// leaves no conntrack state — whereas the admitted case above ends
+		// with an entry stamped CONNLIMIT_EGRESS. Without this the assertion
+		// on the counter would pass just as happily if the SYN had never
+		// reached the check at all.
+		_, err := ctMap.Get(k.AsBytes())
+		Expect(err).To(HaveOccurred(),
+			"rejected SYN must not create a CT entry")
+	})
+}
+
+// TestQoSConnLimitV6FirstSYN is the IPv6 counterpart of the first-SYN tests
+// above. The v4 and v6 dataplanes are the same C source compiled twice
+// (IPVER6), so the admission *logic* cannot differ between them; what can
+// differ is whether the v6 programs reach the check at all and which
+// cali_qos_conn entry they address, since family is part of that map's key.
+// Those are what this covers, which is why it does not port every v4 case —
+// the retransmission and recycle paths are family-agnostic and already
+// covered.
+func TestQoSConnLimitV6FirstSYN(t *testing.T) {
+	RegisterTestingT(t)
+
+	hostIP = node1ipV6
+	defer func() { hostIP = node1ip }()
+
+	bpfIfaceName = "HWfs6"
+	defer func() { bpfIfaceName = "" }()
+
+	const (
+		ifIndex               = 1
+		maxConnections        = 3
+		srcPort        uint16 = 23461
+		dstPort        uint16 = 8055
+	)
+
+	rtKey := routes.NewKeyV6(srcV6CIDR).AsBytes()
+	rtVal := routes.NewValueV6WithIfIndex(routes.FlagsLocalWorkload|routes.FlagInIPAMPool, ifIndex).AsBytes()
+	Expect(rtMapV6.Update(rtKey, rtVal)).NotTo(HaveOccurred())
+	rtKey = routes.NewKeyV6(dstV6CIDR).AsBytes()
+	rtVal = routes.NewValueV6WithIfIndex(routes.FlagsRemoteWorkload|routes.FlagInIPAMPool, ifIndex).AsBytes()
+	Expect(rtMapV6.Update(rtKey, rtVal)).NotTo(HaveOccurred())
+	defer resetRTMap(rtMapV6)
+
+	ctMap := conntrack.MapV6()
+	Expect(ctMap.EnsureExists()).NotTo(HaveOccurred())
+	defer resetCTMap(ctMap)
+
+	k := conntrack.NewKeyV6(6, srcIPv6, srcPort, dstIPv6, dstPort)
+	// Family is part of the cali_qos_conn key: a v6 program must address the
+	// family=6 entry, not the v4 one.
+	ingressKey := qos.NewKey(uint32(ifIndex), 1, qos.IPFamilyV6)
+	egressKey := qos.NewKey(uint32(ifIndex), 0, qos.IPFamilyV6)
+
+	readCount := func(qk qos.Key) uint32 {
+		b, err := qosConnMap.Get(qk.AsBytes())
+		Expect(err).NotTo(HaveOccurred())
+		return qos.ConnValueFromBytes(b).CurrentCount()
+	}
+
+	readCTFlags := func() uint32 {
+		b, err := ctMap.Get(k.AsBytes())
+		Expect(err).NotTo(HaveOccurred())
+		return ctv4.ValueV6FromBytes(b).Flags()
+	}
+
+	_, _, _, _, synPkt, err := testPacketTCPV6WithPayload(dstIPv6, srcPort, dstPort, true /* syn */, nil)
+	Expect(err).NotTo(HaveOccurred())
+
+	t.Run("ingress under the limit: counted and admitted", func(t *testing.T) {
+		RegisterTestingT(t)
+		resetCTMap(ctMap)
+		resetQoSMap(qosConnMap)
+		defer resetQoSMap(qosConnMap)
+
+		// The CT entry the source-side program created, not yet counted.
+		legA := ctv4.Leg{SynSeen: true, Opener: true}
+		legB := ctv4.Leg{Ifindex: ifIndex}
+		v := conntrack.NewValueV6Normal(time.Duration(0), 0, legA, legB)
+		Expect(ctMap.Update(k.AsBytes(), v.AsBytes()[:])).NotTo(HaveOccurred())
+		Expect(qosConnMap.Update(ingressKey.AsBytes(),
+			qos.NewConnValue(maxConnections, 1).AsBytes())).NotTo(HaveOccurred())
+
+		skbMark = tcdefs.MarkSeen
+		runBpfTest(t, "calico_to_workload_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+			res, err := bpfrun(synPkt)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(res.Retval).To(Equal(resTC_ACT_UNSPEC))
+		}, withIngressQoSConnLimit(), withIPv6())
+
+		Expect(readCount(ingressKey)).To(Equal(uint32(2)), "v6 first SYN was not counted")
+		Expect(readCTFlags() & ctv4.FlagConnLimitIn).To(Equal(ctv4.FlagConnLimitIn))
+	})
+
+	t.Run("ingress at the limit: rejected and not counted", func(t *testing.T) {
+		RegisterTestingT(t)
+		resetCTMap(ctMap)
+		resetQoSMap(qosConnMap)
+		defer resetQoSMap(qosConnMap)
+
+		legA := ctv4.Leg{SynSeen: true, Opener: true}
+		legB := ctv4.Leg{Ifindex: ifIndex}
+		v := conntrack.NewValueV6Normal(time.Duration(0), 0, legA, legB)
+		Expect(ctMap.Update(k.AsBytes(), v.AsBytes()[:])).NotTo(HaveOccurred())
+		Expect(qosConnMap.Update(ingressKey.AsBytes(),
+			qos.NewConnValue(maxConnections, maxConnections).AsBytes())).NotTo(HaveOccurred())
+
+		skbMark = tcdefs.MarkSeen
+		runBpfTest(t, "calico_to_workload_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+			res, err := bpfrun(synPkt)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(res.Retval).To(Equal(resTC_ACT_UNSPEC))
+		}, withIngressQoSConnLimit(), withIPv6())
+
+		Expect(readCount(ingressKey)).To(Equal(uint32(maxConnections)))
+		// REJECTED proves the check ran and failed, rather than the SYN never
+		// reaching the block — the counter alone cannot tell those apart.
+		Expect(readCTFlags() & ctv4.FlagConnLimitInRej).To(Equal(ctv4.FlagConnLimitInRej))
+	})
+
+	t.Run("egress under the limit: counted and admitted", func(t *testing.T) {
+		RegisterTestingT(t)
+		resetCTMap(ctMap)
+		resetQoSMap(qosConnMap)
+		defer resetQoSMap(qosConnMap)
+
+		// No CT entry: a genuinely new outbound v6 flow.
+		Expect(qosConnMap.Update(egressKey.AsBytes(),
+			qos.NewConnValue(maxConnections, 1).AsBytes())).NotTo(HaveOccurred())
+
+		skbMark = 0
+		runBpfTest(t, "calico_from_workload_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+			res, err := bpfrun(synPkt)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(res.Retval).To(Equal(resTC_ACT_REDIRECT))
+		}, withEgressQoSConnLimit(), withIPv6())
+
+		Expect(readCount(egressKey)).To(Equal(uint32(2)), "v6 first SYN was not counted")
+		Expect(readCTFlags()&ctv4.FlagConnLimitOut).To(Equal(ctv4.FlagConnLimitOut),
+			"admitted v6 flow must be stamped CONNLIMIT_EGRESS")
+	})
+}
+
+// TestQoSConnLimitV6DualStackCountersAreIndependent verifies that a v6
+// connection increments the family=6 counter and leaves the family=4 counter
+// for the same interface and direction untouched.
+//
+// There is one cali_qos_conn map for both families; they are separated only by
+// the family field of the key, which the C side fills from the compile-time
+// IPVER6 and the Go side from the scanner's configured family. This is the
+// invariant that separation exists for, and it is the one thing a v4-only or
+// v6-only test cannot catch: either would pass unchanged if the family
+// dimension were dropped from the key altogether, because each would simply
+// find the single remaining entry.
+func TestQoSConnLimitV6DualStackCountersAreIndependent(t *testing.T) {
+	RegisterTestingT(t)
+
+	hostIP = node1ipV6
+	defer func() { hostIP = node1ip }()
+
+	bpfIfaceName = "HWds6"
+	defer func() { bpfIfaceName = "" }()
+
+	const (
+		ifIndex               = 1
+		maxConnections        = 3
+		srcPort        uint16 = 12350
+		dstPort        uint16 = 8055
+	)
+
+	rtKey := routes.NewKeyV6(srcV6CIDR).AsBytes()
+	rtVal := routes.NewValueV6WithIfIndex(routes.FlagsLocalWorkload|routes.FlagInIPAMPool, ifIndex).AsBytes()
+	Expect(rtMapV6.Update(rtKey, rtVal)).NotTo(HaveOccurred())
+	rtKey = routes.NewKeyV6(dstV6CIDR).AsBytes()
+	rtVal = routes.NewValueV6WithIfIndex(routes.FlagsRemoteWorkload|routes.FlagInIPAMPool, ifIndex).AsBytes()
+	Expect(rtMapV6.Update(rtKey, rtVal)).NotTo(HaveOccurred())
+	defer resetRTMap(rtMapV6)
+
+	ctMap := conntrack.MapV6()
+	Expect(ctMap.EnsureExists()).NotTo(HaveOccurred())
+	defer resetCTMap(ctMap)
+	resetCTMap(ctMap)
+
+	// A dual-stack pod: one egress entry per family on the same ifindex. The
+	// v4 side is mid-flight with two connections of its own.
+	defer resetQoSMap(qosConnMap)
+	resetQoSMap(qosConnMap)
+	v4Key := qos.NewKey(uint32(ifIndex), 0, qos.IPFamilyV4)
+	v6Key := qos.NewKey(uint32(ifIndex), 0, qos.IPFamilyV6)
+	Expect(qosConnMap.Update(v4Key.AsBytes(),
+		qos.NewConnValue(maxConnections, 2).AsBytes())).NotTo(HaveOccurred())
+	Expect(qosConnMap.Update(v6Key.AsBytes(),
+		qos.NewConnValue(maxConnections, 0).AsBytes())).NotTo(HaveOccurred())
+
+	readCount := func(qk qos.Key) uint32 {
+		b, err := qosConnMap.Get(qk.AsBytes())
+		Expect(err).NotTo(HaveOccurred())
+		return qos.ConnValueFromBytes(b).CurrentCount()
+	}
+
+	_, _, _, _, synPkt, err := testPacketTCPV6WithPayload(dstIPv6, srcPort, dstPort, true /* syn */, nil)
+	Expect(err).NotTo(HaveOccurred())
+
+	skbMark = 0
+	runBpfTest(t, "calico_from_workload_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+		res, err := bpfrun(synPkt)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.Retval).To(Equal(resTC_ACT_REDIRECT))
+	}, withEgressQoSConnLimit(), withIPv6())
+
+	Expect(readCount(v6Key)).To(Equal(uint32(1)),
+		"the v6 connection should have been counted against the v6 entry")
+	Expect(readCount(v4Key)).To(Equal(uint32(2)),
+		"a v6 connection must not touch the v4 counter for the same interface")
+}

--- a/felix/design/bpf-observability.md
+++ b/felix/design/bpf-observability.md
@@ -344,6 +344,30 @@ on connection close.
   residual drift the fast/cleanup paths missed and skips entries
   with `CONNLIMIT_DEC` already set so it doesn't double-count.
 
+**Host-originated traffic is exempt from the ingress limit.** A packet
+from the local host to a workload takes the `skip_policy` path in
+`tc.c` ("host to workload traffic always allowed"), which sets
+`CALI_ST_SKIP_POLICY`; the ingress admission check is gated on
+`!policy_skipped`, so such a connection is neither counted nor
+limited. This includes traffic from host-networked pods, which are
+indistinguishable from the host at this point.
+
+**iptables and nftables behave the same**, by a different mechanism:
+the connlimit rule is rendered into the workload's `cali-tw-<iface>`
+chain (`felix/rules/endpoints.go`), and `StaticFilterOutputChains`
+(`felix/rules/static.go`) returns from the OUTPUT chain for traffic
+leaving a workload interface, so that chain is never reached for
+host-origin traffic. Dispatch to `cali-tw-` happens only from the
+FORWARD chain and the IPVS endpoint-mark chain.
+
+The exemption is thus consistent across all three dataplanes, but note
+that it is inherited from a *policy* rationale — policing host to
+workload traffic "doesn't really protect", since the host can bypass
+policy anyway — rather than one argued for a *resource* control.
+Host-origin connections consume a pod's sockets like any other. This
+is worth revisiting if host-networked clients ever need to count
+against a workload's limit.
+
 The per-direction `INGRESS_CONN_LIMIT_CONFIGURED` /
 `EGRESS_CONN_LIMIT_CONFIGURED` flags gate the BPF connlimit code
 path entirely when no limit is configured for that attach point.
@@ -392,6 +416,12 @@ global, `ISTIO_DSCP`; see Istio ambient mode integration for the integration.
   `calico_ct_lookup`) and the cleanup path (BPF conntrack cleanup
   scanner) set it before decrementing, and the Go scanner skips
   entries that carry it. Without that, drift accumulates upward.
+- Extending the ingress limit to host-originated traffic requires a
+  change in every dataplane, and a different one in each: BPF exempts
+  it via the `skip_policy` path, iptables/nftables by returning from
+  the OUTPUT chain before the `cali-tw-` dispatch. Changing one and
+  not the others is a cross-dataplane divergence, which this feature
+  does not currently have.
 - ep_mgr writes to `cali_qos` / `cali_qos_conn` must skip the
   UpdateWithFlags when the configured fields match the existing
   entry. The dataplane owns the dynamic fields between configuration

--- a/felix/design/bpf-observability.md
+++ b/felix/design/bpf-observability.md
@@ -344,29 +344,12 @@ on connection close.
   residual drift the fast/cleanup paths missed and skips entries
   with `CONNLIMIT_DEC` already set so it doesn't double-count.
 
-**Host-originated traffic is exempt from the ingress limit.** A packet
-from the local host to a workload takes the `skip_policy` path in
-`tc.c` ("host to workload traffic always allowed"), which sets
-`CALI_ST_SKIP_POLICY`; the ingress admission check is gated on
-`!policy_skipped`, so such a connection is neither counted nor
-limited. This includes traffic from host-networked pods, which are
-indistinguishable from the host at this point.
-
-**iptables and nftables behave the same**, by a different mechanism:
-the connlimit rule is rendered into the workload's `cali-tw-<iface>`
-chain (`felix/rules/endpoints.go`), and `StaticFilterOutputChains`
-(`felix/rules/static.go`) returns from the OUTPUT chain for traffic
-leaving a workload interface, so that chain is never reached for
-host-origin traffic. Dispatch to `cali-tw-` happens only from the
-FORWARD chain and the IPVS endpoint-mark chain.
-
-The exemption is thus consistent across all three dataplanes, but note
-that it is inherited from a *policy* rationale — policing host to
-workload traffic "doesn't really protect", since the host can bypass
-policy anyway — rather than one argued for a *resource* control.
-Host-origin connections consume a pod's sockets like any other. This
-is worth revisiting if host-networked clients ever need to count
-against a workload's limit.
+Host-originated traffic — including from host-networked pods — is
+exempt from the ingress limit: it takes the `skip_policy` path in
+`tc.c` and the admission check is gated on `!policy_skipped`, so it is
+neither counted nor limited. Same in iptables/nftables, where the
+connlimit rule sits in `cali-tw-<iface>`, a chain host-origin traffic
+never reaches.
 
 The per-direction `INGRESS_CONN_LIMIT_CONFIGURED` /
 `EGRESS_CONN_LIMIT_CONFIGURED` flags gate the BPF connlimit code
@@ -416,12 +399,6 @@ global, `ISTIO_DSCP`; see Istio ambient mode integration for the integration.
   `calico_ct_lookup`) and the cleanup path (BPF conntrack cleanup
   scanner) set it before decrementing, and the Go scanner skips
   entries that carry it. Without that, drift accumulates upward.
-- Extending the ingress limit to host-originated traffic requires a
-  change in every dataplane, and a different one in each: BPF exempts
-  it via the `skip_policy` path, iptables/nftables by returning from
-  the OUTPUT chain before the `cali-tw-` dispatch. Changing one and
-  not the others is a cross-dataplane divergence, which this feature
-  does not currently have.
 - ep_mgr writes to `cali_qos` / `cali_qos_conn` must skip the
   UpdateWithFlags when the configured fields match the existing
   entry. The dataplane owns the dynamic fields between configuration


### PR DESCRIPTION
Reviewing the eBPF QoS max-connections coverage turned up two gaps. The BPF unit tests exercised only the retransmission and recycle paths -- the plain first-SYN admission decision had no UT in either direction, only FV. And nothing exercised IPv6 at any level, despite the feature being family-aware: cali_qos_conn is keyed by family and the C is the plain first-SYN admission decision had no UT in either direction, only FV. And nothing exercised IPv6 at any level, despite the feature being family-aware: cali_qos_conn is keyed by family and the C is compiled twice via IPVER6, so v4 and v6 are separate code paths with independent counters.

Adds to felix/bpf/ut/qos_test.go:
- TestQoSConnLimit{Ingress,Egress}FirstSYN, both outcomes each.
- TestQoSConnLimitV6FirstSYN, the v6 counterpart.
- TestQoSConnLimitV6DualStackCountersAreIndependent.

Adds to felix/bpf/conntrack/connlimit_scanner_test.go:
- TestConnLimitScannerV6WritesBackToItsOwnFamily, plus family-aware helpers on the fake QoS map (the existing ones now delegate, so no call site changed).

The two dual-stack tests are the ones that could not be written as a port of an existing case: they seed both families for one interface and assert the untouched family stays untouched. A single-family test would pass unchanged even if the family dimension were dropped from the key, since it would simply find the one remaining entry.

The retransmission and recycle paths are deliberately not ported to v6 -- that logic is the same source compiled twice and cannot differ by family.

Also documents in felix/design/bpf-observability.md that host-originated traffic is exempt from the ingress connection limit, and that iptables and nftables behave the same way by a different mechanism: BPF via the skip_policy path, the others by returning from the OUTPUT chain before the cali-tw dispatch. That was previously undocumented and reads as a cross-dataplane divergence when found in only one of them.

Tests and documentation only; no dataplane behaviour change.

<!-- Describe your changes, including the type of change (bug fix, feature, etc.),
why it should be merged, testing done, and links to related issues. -->

<!-- For any user-visible change, replace TBD with a one-line description. -->
**Release note:**
```release-note
TBD
```
