### PR TITLE
Remove the dead CLUSTER_ROUTING make variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -248,7 +248,6 @@ E2E_OUTPUT_DIR ?= report
 E2E_JUNIT_REPORT ?= e2e_conformance.xml
 K8S_NETPOL_SUPPORTED_FEATURES ?= "ClusterNetworkPolicy,ClusterNetworkPolicyNamedPorts"
 K8S_NETPOL_UNSUPPORTED_FEATURES ?= ""
-CLUSTER_ROUTING ?= BIRD
 
 # rapidclient (packet-size / maglev helper image) for the kind e2e lanes. Fork PRs
 # can't push to quay, so the packet-size lane (e2e-test-bpf) builds the image from PR
@@ -279,7 +278,7 @@ kind-migration-test:
 ## Create a kind cluster and run the conformance e2e tests.
 e2e-test:
 	$(MAKE) -C e2e build
-	CLUSTER_ROUTING=$(CLUSTER_ROUTING) $(MAKE) kind-up
+	$(MAKE) kind-up
 	$(MAKE) e2e-run KUBECONFIG=$(KIND_KUBECONFIG)
 
 ## Create a kind cluster with the BPF dataplane plus an external node, and run
@@ -328,7 +327,7 @@ external-node-load-rapidclient:
 ## Create a kind cluster and run the ClusterNetworkPolicy specific e2e tests.
 e2e-test-clusternetworkpolicy:
 	$(MAKE) -C e2e build
-	CLUSTER_ROUTING=$(CLUSTER_ROUTING) $(MAKE) kind-up
+	$(MAKE) kind-up
 	$(MAKE) e2e-run-cnp KUBECONFIG=$(KIND_KUBECONFIG)
 
 ## Run the general e2e tests against the cluster at $KUBECONFIG.
@@ -433,7 +432,7 @@ e2e-run-gateway-conformance: e2e-gateway-setup
 .PHONY: e2e-test-gateway-conformance
 e2e-test-gateway-conformance:
 	$(MAKE) -C e2e bin/gateway/e2e.test
-	CLUSTER_ROUTING=$(CLUSTER_ROUTING) $(MAKE) kind-up
+	$(MAKE) kind-up
 	$(MAKE) e2e-run-gateway-conformance KUBECONFIG=$(KIND_KUBECONFIG)
 
 ###############################################################################


### PR DESCRIPTION
Pure tidy-up, split out of #13470 to keep that PR smaller. No behaviour change.

`CLUSTER_ROUTING` was defined in the root `Makefile` and passed into the
`kind-up` sub-make by three e2e targets, but nothing ever read it — not
`kind-up`, not `kind-deploy`, not `hack/test/kind/deploy_resources.sh`. The kind
cluster's routing mode is actually selected by layering a helm values overlay via
`EXTRA_VALUES_FILES` (`hack/test/kind/infra/values-felix-routing.yaml`, which
sets `clusterRoutingMode: Felix`).

So `CLUSTER_ROUTING ?= BIRD` never pinned anything to BIRD. It just looked as
though it did — which is worth removing now, because Calico's own default is
about to stop meaning "BIRD for IPIP" (#13470), and a variable that appears to
pin the mode but doesn't is exactly the sort of thing that hides a gap in test
coverage.

Not to be confused with `CLUSTER_ROUTING_MODE`, which is a different and live
variable, declared by the GCP end-to-end pipelines under `.semaphore/end-to-end/`
and `.argoci/cron/` and consumed by that harness. Left alone.

## Testing

`make --dry-run` still resolves `e2e-test`, `e2e-test-clusternetworkpolicy` and
`e2e-test-gateway-conformance` unchanged apart from the dropped variable
assignment. `grep -rn 'CLUSTER_ROUTING\b'` finds no remaining references in the
tree.

Restoring genuine BIRD coverage to the "cluster routing: BIRD" e2e job needs an
explicit overlay that sets `clusterRoutingMode`; that is part of #13470, not
this PR.

**Release note:**
```release-note
None
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
