### PR TITLE
[v3.32] Fail and retry when the v1 ClusterInformation lock cannot be set

### DIFF
--- a/kube-controllers/pkg/controllers/migration/controller.go
+++ b/kube-controllers/pkg/controllers/migration/controller.go
@@ -48,6 +48,7 @@ import (
 	"github.com/projectcalico/calico/kube-controllers/pkg/discovery"
 	"github.com/projectcalico/calico/libcalico-go/lib/backend/api"
 	"github.com/projectcalico/calico/libcalico-go/lib/backend/model"
+	cerrors "github.com/projectcalico/calico/libcalico-go/lib/errors"
 	"github.com/projectcalico/calico/libcalico-go/lib/names"
 )
 
@@ -261,6 +262,7 @@ func (m *migrationController) processNextWorkItem() bool {
 			m.queue.Forget(key)
 		} else {
 			logrus.WithError(err).Error("Migration reconcile error, will retry")
+			m.handleRetryableError(err)
 			m.queue.AddRateLimited(key)
 		}
 		return true
@@ -282,6 +284,21 @@ func (m *migrationController) handleTerminalError(err error) {
 	m.setFailedStatus(dm, err.Error())
 	if updateErr := m.updateStatus(dm); updateErr != nil {
 		logrus.WithError(updateErr).Error("Failed to update CR status for terminal error")
+	}
+}
+
+// handleRetryableError records the error in the CR's status message so a stuck
+// migration shows why instead of showing the last progress message forever. The
+// phase is left alone since the workqueue will retry.
+func (m *migrationController) handleRetryableError(err error) {
+	dm := &DatastoreMigration{}
+	if getErr := m.rtClient.Get(m.ctx, types.NamespacedName{Name: defaultMigrationName}, dm); getErr != nil {
+		logrus.WithError(getErr).Error("Failed to fetch CR for retryable error status update")
+		return
+	}
+	dm.Status.Message = err.Error()
+	if updateErr := m.updateStatus(dm); updateErr != nil {
+		logrus.WithError(updateErr).Error("Failed to update CR status for retryable error")
 	}
 }
 
@@ -762,8 +779,14 @@ func (m *migrationController) handleAbort(logCtx *logrus.Entry, dm *DatastoreMig
 
 	// Step 2: Restore v1 ClusterInformation to DatastoreReady=true so components
 	// reading from crd.projectcalico.org/v1 resume normal operation.
+	// This is the only unlock: nothing on the success path clears the v1 lock,
+	// so giving up here leaves the datastore locked with no CR left to retry from.
 	if err := m.setV1ClusterInfoReady(logCtx, true); err != nil {
-		logCtx.WithError(err).Warn("Failed to restore v1 ClusterInformation during abort (may not exist)")
+		var doesNotExist cerrors.ErrorResourceDoesNotExist
+		if !errors.As(err, &doesNotExist) {
+			return fmt.Errorf("restoring v1 ClusterInformation: %w", err)
+		}
+		logCtx.WithError(err).Info("No v1 ClusterInformation to restore")
 	}
 
 	// Step 3: Delete the v3 ClusterInformation if it was created with
@@ -969,9 +992,11 @@ func (m *migrationController) lockDatastore(logCtx *logrus.Entry) error {
 		logCtx.Debug("v3 ClusterInformation already locked")
 	}
 
-	// Lock v1 ClusterInformation via the backend client.
+	// Lock v1 ClusterInformation via the backend client. Every failure here,
+	// including not-found, has to be retried: migrating while v1 is still
+	// writable loses the IPAM allocations CNI makes in the meantime.
 	if err := m.setV1ClusterInfoReady(logCtx, false); err != nil {
-		logCtx.WithError(err).Warn("Failed to lock v1 ClusterInformation (may not exist)")
+		return fmt.Errorf("locking v1 ClusterInformation: %w", err)
 	}
 
 	return nil
@@ -1040,7 +1065,7 @@ func (m *migrationController) unlockV3CRDDatastore(logCtx *logrus.Entry) error {
 }
 
 // setV1ClusterInfoReady sets DatastoreReady on the v1 ClusterInformation via the
-// libcalico-go backend client. If the v1 resource doesn't exist, this is a no-op.
+// libcalico-go backend client.
 func (m *migrationController) setV1ClusterInfoReady(logCtx *logrus.Entry, ready bool) error {
 	key := model.ResourceKey{
 		Kind: apiv3.KindClusterInformation,
@@ -1060,9 +1085,13 @@ func (m *migrationController) setV1ClusterInfoReady(logCtx *logrus.Entry, ready 
 		return nil
 	}
 
+	// Write a copy so a failed update doesn't leave what Get returned claiming
+	// a state the datastore never reached.
+	ci = ci.DeepCopy()
 	ci.Spec.DatastoreReady = &ready
-	kvp.Value = ci
-	_, err = m.backendClient.Update(m.ctx, kvp)
+	updated := *kvp
+	updated.Value = ci
+	_, err = m.backendClient.Update(m.ctx, &updated)
 	if err != nil {
 		return fmt.Errorf("updating v1 ClusterInformation: %w", err)
 	}

--- a/kube-controllers/pkg/controllers/migration/controller_fv_test.go
+++ b/kube-controllers/pkg/controllers/migration/controller_fv_test.go
@@ -428,8 +428,9 @@ func TestLifecycle_Rollback(t *testing.T) {
 	g.Expect(apiSvc.Spec.Service).NotTo(BeNil(), "restored APIService should be aggregated (have a Service ref)")
 
 	// Verify v1 ClusterInformation was unlocked.
-	g.Expect(bc.clusterInfo).NotTo(BeNil())
-	v1CI, ok := bc.clusterInfo.Value.(*apiv3.ClusterInformation)
+	v1KVP := bc.getClusterInfo()
+	g.Expect(v1KVP).NotTo(BeNil())
+	v1CI, ok := v1KVP.Value.(*apiv3.ClusterInformation)
 	g.Expect(ok).To(BeTrue())
 	g.Expect(v1CI.Spec.DatastoreReady).To(Equal(ptr.To(true)), "v1 ClusterInformation should be unlocked after abort")
 

--- a/kube-controllers/pkg/controllers/migration/lock_errors_test.go
+++ b/kube-controllers/pkg/controllers/migration/lock_errors_test.go
@@ -1,0 +1,257 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package migration
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	apiv3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/util/workqueue"
+	fakeapiregclient "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/fake"
+	"k8s.io/utils/ptr"
+	rtclient "sigs.k8s.io/controller-runtime/pkg/client"
+	rtfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/projectcalico/calico/kube-controllers/pkg/controllers/migration/migrators"
+	"github.com/projectcalico/calico/libcalico-go/lib/backend/model"
+	cerrors "github.com/projectcalico/calico/libcalico-go/lib/errors"
+)
+
+// recordingMigrator is a no-op ResourceMigrator that records whether the
+// migration actually reached the copy phase.
+type recordingMigrator struct {
+	listV1Called bool
+}
+
+func (r *recordingMigrator) Kind() string {
+	return apiv3.KindTier
+}
+
+func (r *recordingMigrator) Order() int {
+	return 1
+}
+
+func (r *recordingMigrator) ListV1(_ context.Context) ([]rtclient.Object, error) {
+	r.listV1Called = true
+	return nil, nil
+}
+
+func (r *recordingMigrator) GetV3(_ context.Context, _, _ string) (rtclient.Object, error) {
+	return nil, nil
+}
+
+func (r *recordingMigrator) CreateV3(_ context.Context, _ rtclient.Object) error {
+	return nil
+}
+
+func (r *recordingMigrator) UpdateV3(_ context.Context, _ rtclient.Object) error {
+	return nil
+}
+
+func (r *recordingMigrator) ListV3(_ context.Context) ([]rtclient.Object, error) {
+	return nil, nil
+}
+
+func (r *recordingMigrator) DeleteV3(_ context.Context, _ rtclient.Object) error {
+	return nil
+}
+
+func (r *recordingMigrator) SpecsEqual(_, _ rtclient.Object) bool {
+	return true
+}
+
+var _ migrators.ResourceMigrator = &recordingMigrator{}
+
+// lockedV1ClusterInfo returns a v1 ClusterInformation KVPair with
+// DatastoreReady=false, as it appears once migration has locked the datastore.
+func lockedV1ClusterInfo() *model.KVPair {
+	kvp := mainlineV1ClusterInfo()
+	ci, ok := kvp.Value.(*apiv3.ClusterInformation)
+	if !ok {
+		panic("unexpected ClusterInformation type")
+	}
+	ci.Spec.DatastoreReady = ptr.To(false)
+	return kvp
+}
+
+// v1DatastoreReady returns DatastoreReady from the v1 ClusterInformation the
+// mock backend currently has stored.
+func v1DatastoreReady(g Gomega, bc *mockBackendClient) *bool {
+	kvp := bc.getClusterInfo()
+	g.ExpectWithOffset(1, kvp).NotTo(BeNil())
+	ci, ok := kvp.Value.(*apiv3.ClusterInformation)
+	g.ExpectWithOffset(1, ok).To(BeTrue())
+	return ci.Spec.DatastoreReady
+}
+
+// savedAPIServiceJSON serializes an aggregated APIService for the
+// saved-apiservice annotation, so the abort path has something to restore.
+func savedAPIServiceJSON(t *testing.T) string {
+	t.Helper()
+	data, err := json.Marshal(newAggregatedAPIServiceObj())
+	if err != nil {
+		t.Fatalf("marshalling APIService: %v", err)
+	}
+	return string(data)
+}
+
+// newErrorTestController builds a migration controller backed by a fake
+// controller-runtime client, an empty fake apiregistration client, and a single
+// recording migrator. It returns the controller plus both for assertions.
+func newErrorTestController(
+	t *testing.T,
+	bc *mockBackendClient,
+	dm *DatastoreMigration,
+) (*migrationController, *fakeapiregclient.Clientset, *recordingMigrator) {
+	t.Helper()
+
+	scheme := runtime.NewScheme()
+	for _, add := range []func(*runtime.Scheme) error{clientgoscheme.AddToScheme, apiv3.AddToScheme, AddToScheme} {
+		if err := add(scheme); err != nil {
+			t.Fatalf("building scheme: %v", err)
+		}
+	}
+
+	rtCli := rtfake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(dm).
+		WithStatusSubresource(&DatastoreMigration{}).
+		Build()
+
+	rec := &recordingMigrator{}
+	fakeAPIReg := fakeapiregclient.NewSimpleClientset()
+	m := &migrationController{
+		ctx:           context.Background(),
+		backendClient: bc,
+		rtClient:      rtCli,
+		apiregClient:  fakeAPIReg.ApiregistrationV1(),
+		migrators:     []migrators.ResourceMigrator{rec},
+		queue:         workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[string]()),
+	}
+	t.Cleanup(m.queue.ShutDown)
+	return m, fakeAPIReg, rec
+}
+
+// migratingCR returns a DatastoreMigration CR in the Migrating phase with the
+// finalizer and a saved APIService annotation.
+func migratingCR(t *testing.T) *DatastoreMigration {
+	t.Helper()
+	return &DatastoreMigration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        defaultMigrationName,
+			Finalizers:  []string{finalizerName},
+			Annotations: map[string]string{savedAPIServiceAnnotation: savedAPIServiceJSON(t)},
+		},
+		Spec:   DatastoreMigrationSpec{Type: DatastoreMigrationTypeAPIServerToCRDs},
+		Status: DatastoreMigrationStatus{Phase: DatastoreMigrationPhaseMigrating},
+	}
+}
+
+// TestLockDatastore_BackendUpdateError verifies that a failure to lock the v1
+// ClusterInformation aborts the Migrating phase and is retried, rather than
+// letting the migration copy the datastore while CNI can still allocate IPs.
+func TestLockDatastore_BackendUpdateError(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+
+	bc := &mockBackendClient{
+		clusterInfo:          mainlineV1ClusterInfo(),
+		clusterInfoUpdateErr: errors.New("simulated backend unavailable"),
+	}
+	m, _, rec := newErrorTestController(t, bc, migratingCR(t))
+
+	m.queue.Add(defaultMigrationName)
+	g.Expect(m.processNextWorkItem()).To(BeTrue())
+
+	g.Expect(rec.listV1Called).To(BeFalse(), "no migrator should run while the v1 lock is unset")
+	g.Expect(m.queue.NumRequeues(defaultMigrationName)).To(Equal(1), "the failure should be retried, not dropped")
+
+	dm := &DatastoreMigration{}
+	g.Expect(m.rtClient.Get(ctx, types.NamespacedName{Name: defaultMigrationName}, dm)).To(Succeed())
+	g.Expect(dm.Status.Phase).To(Equal(DatastoreMigrationPhaseMigrating))
+	g.Expect(dm.Status.Message).To(ContainSubstring("locking v1 ClusterInformation"))
+	g.Expect(dm.Status.Message).To(ContainSubstring("simulated backend unavailable"))
+
+	g.Expect(v1DatastoreReady(g, bc)).To(Equal(ptr.To(true)), "a failed lock must not record the datastore as locked")
+}
+
+// TestAbort_BackendUpdateError verifies that a failure to unlock the v1
+// ClusterInformation during abort holds the finalizer and leaves the APIService
+// unrestored, so the workqueue can retry the unlock.
+func TestAbort_BackendUpdateError(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+
+	bc := &mockBackendClient{
+		clusterInfo:          lockedV1ClusterInfo(),
+		clusterInfoUpdateErr: cerrors.ErrorResourceUpdateConflict{Identifier: clusterInfoName},
+	}
+	m, fakeAPIReg, _ := newErrorTestController(t, bc, migratingCR(t))
+
+	dm := &DatastoreMigration{}
+	g.Expect(m.rtClient.Get(ctx, types.NamespacedName{Name: defaultMigrationName}, dm)).To(Succeed())
+	g.Expect(m.rtClient.Delete(ctx, dm)).To(Succeed())
+
+	m.queue.Add(defaultMigrationName)
+	g.Expect(m.processNextWorkItem()).To(BeTrue())
+
+	g.Expect(m.queue.NumRequeues(defaultMigrationName)).To(Equal(1), "the failed unlock should be retried")
+
+	g.Expect(m.rtClient.Get(ctx, types.NamespacedName{Name: defaultMigrationName}, dm)).To(Succeed())
+	g.Expect(hasFinalizer(dm)).To(BeTrue(), "finalizer must hold until v1 is unlocked")
+
+	_, err := fakeAPIReg.ApiregistrationV1().APIServices().Get(ctx, apiServiceName, metav1.GetOptions{})
+	g.Expect(kerrors.IsNotFound(err)).To(BeTrue(), "APIService must not be restored while v1 is still locked")
+
+	g.Expect(v1DatastoreReady(g, bc)).To(Equal(ptr.To(false)), "a failed unlock must not record the datastore as unlocked")
+}
+
+// TestAbort_V1ClusterInfoDoesNotExist verifies that a missing v1
+// ClusterInformation is tolerated: there is nothing to unlock, so the abort
+// restores the APIService and drops the finalizer.
+func TestAbort_V1ClusterInfoDoesNotExist(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+
+	bc := &mockBackendClient{
+		clusterInfoGetErr: cerrors.ErrorResourceDoesNotExist{Identifier: clusterInfoName},
+	}
+	m, fakeAPIReg, _ := newErrorTestController(t, bc, migratingCR(t))
+
+	dm := &DatastoreMigration{}
+	g.Expect(m.rtClient.Get(ctx, types.NamespacedName{Name: defaultMigrationName}, dm)).To(Succeed())
+	g.Expect(m.rtClient.Delete(ctx, dm)).To(Succeed())
+
+	m.queue.Add(defaultMigrationName)
+	g.Expect(m.processNextWorkItem()).To(BeTrue())
+
+	g.Expect(m.queue.NumRequeues(defaultMigrationName)).To(Equal(0), "abort should have succeeded")
+
+	err := m.rtClient.Get(ctx, types.NamespacedName{Name: defaultMigrationName}, &DatastoreMigration{})
+	g.Expect(kerrors.IsNotFound(err)).To(BeTrue(), "finalizer should be removed so the CR is collected")
+
+	apiSvc, err := fakeAPIReg.ApiregistrationV1().APIServices().Get(ctx, apiServiceName, metav1.GetOptions{})
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(apiSvc.Spec.Service).NotTo(BeNil())
+}

--- a/kube-controllers/pkg/controllers/migration/mock_backend_test.go
+++ b/kube-controllers/pkg/controllers/migration/mock_backend_test.go
@@ -35,7 +35,7 @@ type mockBackendClient struct {
 	resources   map[string][]*model.KVPair
 	clusterInfo *model.KVPair
 
-	// mu guards listErrors, listErrorAfter, and listCounts for concurrent
+	// mu guards clusterInfo and the error-injection fields for concurrent
 	// access from the controller goroutine and test assertions.
 	mu sync.Mutex
 
@@ -47,6 +47,26 @@ type mockBackendClient struct {
 	listErrors     map[string]error
 	listErrorAfter int
 	listCounts     map[string]int
+
+	// clusterInfoGetErr and clusterInfoUpdateErr, when set, are returned from
+	// Get/Update for the ClusterInformation resource.
+	clusterInfoGetErr    error
+	clusterInfoUpdateErr error
+}
+
+// getClusterInfo returns a copy of the stored v1 ClusterInformation KVPair, so callers
+// can read it without racing the controller goroutine.
+func (m *mockBackendClient) getClusterInfo() *model.KVPair {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.clusterInfo == nil {
+		return nil
+	}
+	copied := *m.clusterInfo
+	if ci, ok := m.clusterInfo.Value.(*apiv3.ClusterInformation); ok {
+		copied.Value = ci.DeepCopy()
+	}
+	return &copied
 }
 
 func (m *mockBackendClient) List(_ context.Context, list model.ListInterface, _ string) (*model.KVPairList, error) {
@@ -76,16 +96,28 @@ func (m *mockBackendClient) List(_ context.Context, list model.ListInterface, _ 
 }
 
 func (m *mockBackendClient) Get(_ context.Context, key model.Key, _ string) (*model.KVPair, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	rk, ok := key.(model.ResourceKey)
-	if ok && rk.Kind == apiv3.KindClusterInformation && m.clusterInfo != nil {
-		return m.clusterInfo, nil
+	if ok && rk.Kind == apiv3.KindClusterInformation {
+		if m.clusterInfoGetErr != nil {
+			return nil, m.clusterInfoGetErr
+		}
+		if m.clusterInfo != nil {
+			return m.clusterInfo, nil
+		}
 	}
 	return nil, fmt.Errorf("not found: %v", key)
 }
 
 func (m *mockBackendClient) Update(_ context.Context, kvp *model.KVPair) (*model.KVPair, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	rk, ok := kvp.Key.(model.ResourceKey)
 	if ok && rk.Kind == apiv3.KindClusterInformation {
+		if m.clusterInfoUpdateErr != nil {
+			return nil, m.clusterInfoUpdateErr
+		}
 		m.clusterInfo = kvp
 		return kvp, nil
 	}


### PR DESCRIPTION
Cherry-pick of https://github.com/projectcalico/calico/pull/13421 onto `release-v3.32`, where the datastore migration shipped as tech preview.

A failed v1 ClusterInformation lock was swallowed, so the migration went on to copy the datastore while CNI could still allocate IPs into it. The lock failure now fails the reconcile and retries.

Related: [CORE-13247](https://tigera.atlassian.net/browse/CORE-13247)

```release-note
Fixes a datastore migration continuing after it failed to lock the v1 datastore, which allowed writes into storage the migration was copying.
```


[CORE-13247]: https://tigera.atlassian.net/browse/CORE-13247?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ