### PR TITLE
lib/kind: allow layering an extra pull secret onto the facade keychain

### DIFF
--- a/lib/kind/localregistry/keychain_test.go
+++ b/lib/kind/localregistry/keychain_test.go
@@ -1,0 +1,94 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+
+package localregistry
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/authn"
+)
+
+// testResource is a minimal authn.Resource (registry host) for keychain lookups.
+type testResource string
+
+func (r testResource) String() string      { return string(r) }
+func (r testResource) RegistryStr() string { return string(r) }
+
+func TestLoadExtraKeychain(t *testing.T) {
+	// Empty path and a missing file both yield nil, so Start can wire the extra
+	// config in unconditionally and fall back to the host keychain alone.
+	if loadExtraKeychain("") != nil {
+		t.Error("empty path should yield nil keychain")
+	}
+	if loadExtraKeychain(filepath.Join(t.TempDir(), "absent.json")) != nil {
+		t.Error("missing file should yield nil keychain")
+	}
+
+	// A config with no auths is treated as nothing to add.
+	empty := filepath.Join(t.TempDir(), "empty.json")
+	if err := os.WriteFile(empty, []byte(`{"auths":{}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if loadExtraKeychain(empty) != nil {
+		t.Error("config with no auths should yield nil keychain")
+	}
+
+	// Entries with no credential material, or a key that normalises to an empty
+	// host, are skipped — so they can't shadow the host keychain with an empty
+	// AuthConfig. With nothing usable left, the result is nil.
+	junk := filepath.Join(t.TempDir(), "junk.json")
+	if err := os.WriteFile(junk, []byte(`{"auths":{"quay.io":{},"https://":{"auth":"dXNlcjpwYXNz"}}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if loadExtraKeychain(junk) != nil {
+		t.Error("config with only empty-cred / empty-host entries should yield nil keychain")
+	}
+
+	// A real cred keyed by a legacy URL, to also exercise registryHost.
+	cfg := filepath.Join(t.TempDir(), "config.json")
+	if err := os.WriteFile(cfg, []byte(`{"auths":{"https://quay.io/v1/":{"auth":"dXNlcjpwYXNz"}}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	kc := loadExtraKeychain(cfg)
+	if kc == nil {
+		t.Fatal("expected a keychain for a config with auths")
+	}
+
+	// quay.io resolves to the configured credential...
+	auth, err := kc.Resolve(testResource("quay.io"))
+	if err != nil {
+		t.Fatalf("resolve quay.io: %v", err)
+	}
+	ac, err := auth.Authorization()
+	if err != nil {
+		t.Fatalf("authorization: %v", err)
+	}
+	if ac.Auth != "dXNlcjpwYXNz" {
+		t.Errorf("quay.io auth = %q, want the config value", ac.Auth)
+	}
+
+	// ...and an unlisted registry falls back to anonymous (so the host keychain,
+	// layered first via NewMultiKeychain, keeps handling e.g. gcr.io).
+	other, err := kc.Resolve(testResource("gcr.io"))
+	if err != nil {
+		t.Fatalf("resolve gcr.io: %v", err)
+	}
+	if other != authn.Anonymous {
+		t.Errorf("unlisted registry should resolve anonymous, got %#v", other)
+	}
+}
+
+func TestRegistryHost(t *testing.T) {
+	for _, tc := range []struct{ in, want string }{
+		{"quay.io", "quay.io"},
+		{"https://quay.io/v1/", "quay.io"},
+		{"http://index.docker.io/v1/", "index.docker.io"},
+		{"gcr.io", "gcr.io"},
+	} {
+		if got := registryHost(tc.in); got != tc.want {
+			t.Errorf("registryHost(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}

--- a/lib/kind/localregistry/registry.go
+++ b/lib/kind/localregistry/registry.go
@@ -40,6 +40,7 @@ package localregistry
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	stdlog "log"
 	"net"
@@ -82,6 +83,12 @@ type Config struct {
 	// For tests and local dev against an http registry only; real upstreams
 	// are https and this must stay false.
 	InsecureUpstream bool
+	// ExtraAuthConfigPath, if set and readable, is a docker config.json whose
+	// `auths` supplement the host keychain (authn.DefaultKeychain) — e.g. a
+	// fetched enterprise pull secret — so private upstream pulls work without
+	// the user editing their own ~/.docker/config.json. A missing or
+	// unparseable file is ignored (the facade falls back to the host keychain).
+	ExtraAuthConfigPath string
 }
 
 // Registry is the running registry. Create it with Start; shut it down with
@@ -125,10 +132,19 @@ func Start(ctx context.Context, cfg Config) (*Registry, error) {
 		return nil, fmt.Errorf("create cache dir %s: %w", cfg.CacheDir, err)
 	}
 
+	// The facade authenticates to upstreams with the host docker keychain
+	// (live, so rotated gcloud/registry tokens are picked up). An optional
+	// extra config (e.g. a fetched enterprise pull secret) is layered on so
+	// private upstreams work without the user editing their own ~/.docker.
+	keychain := authn.Keychain(authn.DefaultKeychain)
+	if extra := loadExtraKeychain(cfg.ExtraAuthConfigPath); extra != nil {
+		keychain = authn.NewMultiKeychain(authn.DefaultKeychain, extra)
+	}
+
 	f := &Registry{
 		cfg:      cfg,
 		log:      log.With("component", "kind-mirror"),
-		keychain: authn.DefaultKeychain,
+		keychain: keychain,
 		cached:   map[string]bool{},
 	}
 
@@ -317,6 +333,76 @@ func (f *Registry) Stop() error {
 		}
 	}
 	return firstErr
+}
+
+// loadExtraKeychain builds an authn.Keychain over the static `auths` in a
+// docker config.json at path. Returns nil (the caller then uses only the host
+// keychain) when path is empty, the file is absent, it doesn't parse, or it
+// yields no usable credential — so wiring it in is always safe. Entries whose
+// key normalises to an empty host, or that carry no credential material, are
+// skipped so they can't shadow the host keychain with an empty AuthConfig.
+func loadExtraKeychain(path string) authn.Keychain {
+	if path == "" {
+		return nil
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+	var dc struct {
+		Auths map[string]struct {
+			Auth          string `json:"auth"`
+			Username      string `json:"username"`
+			Password      string `json:"password"`
+			IdentityToken string `json:"identitytoken"`
+			RegistryToken string `json:"registrytoken"`
+		} `json:"auths"`
+	}
+	if err := json.Unmarshal(b, &dc); err != nil {
+		return nil
+	}
+	auths := make(map[string]authn.AuthConfig, len(dc.Auths))
+	for reg, a := range dc.Auths {
+		host := registryHost(reg)
+		ac := authn.AuthConfig{
+			Auth:          a.Auth,
+			Username:      a.Username,
+			Password:      a.Password,
+			IdentityToken: a.IdentityToken,
+			RegistryToken: a.RegistryToken,
+		}
+		if host == "" || ac == (authn.AuthConfig{}) {
+			continue
+		}
+		auths[host] = ac
+	}
+	if len(auths) == 0 {
+		return nil
+	}
+	return staticKeychain(auths)
+}
+
+// registryHost normalises a docker-config auths key — which may be a bare host
+// ("quay.io") or a legacy URL ("https://quay.io/v1/") — to the host that
+// authn.Resource.RegistryStr reports, so lookups match.
+func registryHost(key string) string {
+	k := strings.TrimPrefix(key, "https://")
+	k = strings.TrimPrefix(k, "http://")
+	if i := strings.IndexByte(k, '/'); i >= 0 {
+		k = k[:i]
+	}
+	return k
+}
+
+// staticKeychain resolves credentials from a fixed registry-host -> AuthConfig
+// map (e.g. one parsed from a pull-secret file).
+type staticKeychain map[string]authn.AuthConfig
+
+func (s staticKeychain) Resolve(res authn.Resource) (authn.Authenticator, error) {
+	if ac, ok := s[res.RegistryStr()]; ok {
+		return authn.FromConfig(ac), nil
+	}
+	return authn.Anonymous, nil
 }
 
 func (f *Registry) pullOpts(ctx context.Context) []crane.Option {


### PR DESCRIPTION
### Description

The `lib/kind` localregistry facade authenticates to upstream registries with
the host docker keychain (`authn.DefaultKeychain`). This adds
`Config.ExtraAuthConfigPath` so a caller can layer a *separate* docker
`config.json` — e.g. a fetched enterprise pull secret — onto that keychain via
a `MultiKeychain`. Private upstream pulls then work without the developer
editing their own `~/.docker/config.json`.

Loading is defensive: a missing, unparseable, or credential-less file is
ignored and the facade falls back to the host keychain alone. Entries whose key
normalises to an empty host, or that carry no credential material, are skipped
so they can't shadow the host keychain with an empty `AuthConfig`.

This is the shared-`lib` half of a Calico Cloud kind-rig "zero-touch pull
secret" improvement; the `cloud/kind-rig` wiring that passes the fetched pull
secret in is a follow-up in the Enterprise repo once this syncs over.

### Related issues/PRs

Supersedes tigera/calico-private#13086 (that change was landed in the fork by
mistake — `lib/` must originate in OSS).

### Release Note

```release-note
None
```
