### PR TITLE
release: make RPM signing work on rpm 4

### DIFF
--- a/release/internal/utils/gpg.go
+++ b/release/internal/utils/gpg.go
@@ -18,7 +18,9 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"strings"
+	"sync"
 
 	"github.com/sirupsen/logrus"
 
@@ -40,8 +42,7 @@ func GetGPGPubKey(gpgKeyID string) (string, error) {
 
 // SignRPMFiles takes a GPG key ID, which must have already been
 // imported into the RPM database, and uses it to sign a list of
-// RPM files. We use --rpmv4 here to ensure that, even on newer
-// RPM versions, we're using backwards-compatible RPM signatures.
+// RPM files.
 func SignRPMFiles(gpgKeyID string, rpmFiles []string) error {
 	if len(rpmFiles) == 0 {
 		return fmt.Errorf("list of RPM files to sign is empty")
@@ -57,18 +58,53 @@ func SignRPMFiles(gpgKeyID string, rpmFiles []string) error {
 		return fmt.Errorf("no regular RPM files to sign in the provided list")
 	}
 	logrus.Infof("Signing RPM files with GPG key %s", gpgKeyID)
-	cmdArgs := []string{
-		"-D", fmt.Sprintf("%%_openpgp_sign_id %s", gpgKeyID),
-		"--resign",
-		"--rpmv4",
-	}
-	cmdArgs = append(cmdArgs, filteredRpmFiles...)
+	cmdArgs := signArgs(gpgKeyID, filteredRpmFiles)
 	logrus.Debugf("Running rpmsign with args %s", strings.Join(cmdArgs, " "))
 	if _, err := command.Run("rpmsign", cmdArgs); err != nil {
 		return fmt.Errorf("unable to sign RPM files: %w", err)
 	}
 	return nil
 }
+
+// signArgs builds the rpmsign arguments for signing the given files. rpm 4 and
+// rpm 6 disagree on all three of the naming, the signing binary and the
+// signature format, so the arguments accommodate both rather than assuming one.
+func signArgs(gpgKeyID string, rpmFiles []string) []string {
+	// The macro naming the signing key was renamed: rpm 4 reads %_gpg_name, rpm 6
+	// reads %_openpgp_sign_id, and each ignores the other's. Define both.
+	args := []string{
+		"-D", fmt.Sprintf("%%_gpg_name %s", gpgKeyID),
+		"-D", fmt.Sprintf("%%_openpgp_sign_id %s", gpgKeyID),
+	}
+	// rpm 4 shells out to %__gpg, which Debian and Ubuntu build as /usr/bin/gpg2 —
+	// a path their gnupg package does not install, so signing fails to exec it.
+	if gpgPath, err := exec.LookPath("gpg"); err == nil {
+		args = append(args, "-D", fmt.Sprintf("%%__gpg %s", gpgPath))
+	}
+	args = append(args, "--resign")
+	// --rpmv4 keeps signatures backwards compatible on rpm 6, which otherwise
+	// writes v6 header signatures. Only rpm 6 has the option; 4.17 and 4.20 reject
+	// it outright and write v4 signatures anyway.
+	if rpmsignSupportsRPMV4() {
+		args = append(args, "--rpmv4")
+	}
+	return append(args, rpmFiles...)
+}
+
+// rpmsignSupportsRPMV4 reports whether the installed rpmsign accepts --rpmv4. It
+// asks rpmsign rather than comparing versions, so a version that gains or loses
+// the option needs no change here. Held in a var so tests can replace it, and
+// resolved once because it cannot change while the release runs.
+var rpmsignSupportsRPMV4 = sync.OnceValue(func() bool {
+	out, err := command.Run("rpmsign", []string{"--help"})
+	if err != nil {
+		// Signing itself reports a usable error if rpmsign is missing or broken;
+		// here, assume the option is absent rather than fail the help probe.
+		logrus.WithError(err).Debug("Could not ask rpmsign for its options, assuming --rpmv4 is unsupported")
+		return false
+	}
+	return strings.Contains(out, "--rpmv4")
+})
 
 // CheckRPMSig takes an RPM filename/path and runs rpmkeys --checksig
 // on it to ensure that the signature and package digest are correct.

--- a/release/internal/utils/gpg_test.go
+++ b/release/internal/utils/gpg_test.go
@@ -267,6 +267,7 @@ func TestSignArgs(t *testing.T) {
 // TestSignArgsOverridesGPGPath verifies rpmsign is pointed at the gpg that is
 // installed. rpm 4 on Debian and Ubuntu defaults %__gpg to /usr/bin/gpg2, which
 // their gnupg package does not ship, and signing dies trying to exec it.
+func TestSignArgsOverridesGPGPath(t *testing.T) {
 	original := rpmsignSupportsRPMV4
 	t.Cleanup(func() { rpmsignSupportsRPMV4 = original })
 	rpmsignSupportsRPMV4 = func() bool { return false }

--- a/release/internal/utils/gpg_test.go
+++ b/release/internal/utils/gpg_test.go
@@ -267,7 +267,10 @@ func TestSignArgs(t *testing.T) {
 // TestSignArgsOverridesGPGPath verifies rpmsign is pointed at the gpg that is
 // installed. rpm 4 on Debian and Ubuntu defaults %__gpg to /usr/bin/gpg2, which
 // their gnupg package does not ship, and signing dies trying to exec it.
-func TestSignArgsOverridesGPGPath(t *testing.T) {
+	original := rpmsignSupportsRPMV4
+	t.Cleanup(func() { rpmsignSupportsRPMV4 = original })
+	rpmsignSupportsRPMV4 = func() bool { return false }
+
 	gpgPath, err := exec.LookPath("gpg")
 	if err != nil {
 		t.Skip("gpg not on PATH; nothing to point rpmsign at")

--- a/release/internal/utils/gpg_test.go
+++ b/release/internal/utils/gpg_test.go
@@ -18,6 +18,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 )
@@ -218,6 +219,62 @@ func TestSignRPMFilesNoFiles(t *testing.T) {
 func TestSignRPMFilesAllFiltered(t *testing.T) {
 	if err := SignRPMFiles("SOMEKEYID", []string{t.TempDir()}); err == nil {
 		t.Error("SignRPMFiles: expected an error when no regular files remain, got nil")
+	}
+}
+
+// TestSignArgs verifies the rpmsign invocation works on both rpm generations:
+// the key is named by the macro each one reads, and --rpmv4 is passed only where
+// it exists. rpm gained that option in 6.0, and passing it to rpm 4 fails the
+// whole signing step with "unknown option". The probe is replaced here so both
+// cases are covered whatever rpm this machine has.
+func TestSignArgs(t *testing.T) {
+	original := rpmsignSupportsRPMV4
+	t.Cleanup(func() { rpmsignSupportsRPMV4 = original })
+
+	for _, tc := range []struct {
+		name      string
+		supported bool
+	}{
+		{name: "rpmsign accepts --rpmv4", supported: true},
+		{name: "rpmsign rejects --rpmv4", supported: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rpmsignSupportsRPMV4 = func() bool { return tc.supported }
+			args := signArgs("SOMEKEYID", []string{"one.rpm", "two.rpm"})
+
+			if got := slices.Contains(args, "--rpmv4"); got != tc.supported {
+				t.Errorf("--rpmv4 present = %v, want %v, in: %v", got, tc.supported, args)
+			}
+			// Whichever rpm runs this, one of the two key macros is the one it
+			// reads, so both must be defined, and the rest of the invocation and
+			// the packages it signs are the same either way.
+			for _, want := range []string{
+				"--resign",
+				"%_gpg_name SOMEKEYID",
+				"%_openpgp_sign_id SOMEKEYID",
+			} {
+				if !slices.Contains(args, want) {
+					t.Errorf("expected %q in args, got: %v", want, args)
+				}
+			}
+			if files := args[len(args)-2:]; !slices.Equal(files, []string{"one.rpm", "two.rpm"}) {
+				t.Errorf("expected the packages last, got: %v", files)
+			}
+		})
+	}
+}
+
+// TestSignArgsOverridesGPGPath verifies rpmsign is pointed at the gpg that is
+// installed. rpm 4 on Debian and Ubuntu defaults %__gpg to /usr/bin/gpg2, which
+// their gnupg package does not ship, and signing dies trying to exec it.
+func TestSignArgsOverridesGPGPath(t *testing.T) {
+	gpgPath, err := exec.LookPath("gpg")
+	if err != nil {
+		t.Skip("gpg not on PATH; nothing to point rpmsign at")
+	}
+	args := signArgs("SOMEKEYID", []string{"one.rpm"})
+	if want := "%__gpg " + gpgPath; !slices.Contains(args, want) {
+		t.Errorf("expected %q in args, got: %v", want, args)
 	}
 }
 


### PR DESCRIPTION
`SignRPMFiles` assumes rpm 6, so signing fails outright on rpm 4 — including the 4.17 that Ubuntu
22.04 ships, which is what our release agents run. There are three separate incompatibilities,
stacked, each only visible once the previous one is cleared:

```
rpmsign: --rpmv4: unknown option
You must set "%_gpg_name" in your macro file
error: Could not exec gpg: No such file or directory
```

This fixes all three:

| | problem | fix |
|---|---|---|
| `--rpmv4` | only rpm 6 has the option | pass it only when `rpmsign --help` lists it |
| key macro | rpm 4 reads `%_gpg_name`, rpm 6 reads `%_openpgp_sign_id` | define both; each version ignores the other's |
| `%__gpg` | Debian/Ubuntu build rpm 4 with `%__gpg` = `/usr/bin/gpg2`, which their `gnupg` package does not install | point it at the `gpg` on `PATH` |

`--rpmv4` is still passed where it exists, so the backwards-compatibility intent behind it is
preserved on rpm 6. On rpm 4 it is unnecessary as well as unsupported — those versions write v4
signatures anyway. Asking `rpmsign` what it accepts rather than comparing version numbers means a
future version that gains or loses the option needs no change here.

**Testing.** Unit tests cover the argument construction with the capability probe stubbed both ways,
so both branches are exercised regardless of which rpm the machine running the tests has, plus the
`%__gpg` override. The existing signing integration tests are unchanged and still skip when the rpm
tooling is absent.

Behaviour was verified against real rpm in containers, since this is a version incompatibility no
unit test would have caught:

| rpm | `--rpmv4` in `rpmsign --help` | outcome |
|---|---|---|
| 4.17.0 (Ubuntu 22.04) | absent | with this change: signs, key imports, `rpmkeys --checksig` → `Header V4 RSA/SHA512 Signature ... OK` |
| 4.20.1 (Fedora 41) | absent (only `--rpmv3`) | signs with the same invocation |
| 6.0.92 (Fedora rawhide) | present, alongside `--rpmv3`/`--rpmv6` | probe finds it, so v4 signatures are still requested |

**Release note:**
```release-note
None
```
