### PR TITLE
[v3.32] felix: suppress and elevate IPv6 workload routes during live migration (CORE-12806)

### DIFF
--- a/felix/dataplane/linux/export_test.go
+++ b/felix/dataplane/linux/export_test.go
@@ -1,0 +1,23 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package intdataplane
+
+// LiveMigrationListenerCount reports how many listeners - in production, endpoint
+// managers - are registered with the live migration monitor.  There must be one per
+// enabled IP version: with the IPv6 endpoint manager missing, IPv6 workload routes
+// are neither suppressed on a migration target nor elevated after cutover.
+func (d *InternalDataplane) LiveMigrationListenerCount() int {
+	return len(d.liveMigrationMonitor.listeners)
+}

--- a/felix/dataplane/linux/int_dataplane.go
+++ b/felix/dataplane/linux/int_dataplane.go
@@ -1197,7 +1197,7 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 	)
 	dp.RegisterManager(epManager)
 	dp.endpointsSourceV4 = epManager
-	dp.liveMigrationMonitor.listener = epManager
+	dp.liveMigrationMonitor.registerListener(epManager)
 	dp.RegisterManager(newFloatingIPManager(natTableV4, ruleRenderer, 4, config.FloatingIPsEnabled))
 	dp.RegisterManager(newMasqManager(ipSetsV4, natTableV4, ruleRenderer, config.MaxIPSetSize, 4))
 
@@ -1388,7 +1388,7 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 		}
 		dp.linkAddrsManagers = append(dp.linkAddrsManagers, linkAddrsManagerV6)
 
-		dp.RegisterManager(newEndpointManager(
+		epManagerV6 := newEndpointManager(
 			&endpointManagerConfig{
 				kubeIPVSSupportEnabled: config.RulesConfig.KubeIPVSSupportEnabled,
 				wlInterfacePrefixes:    config.RulesConfig.WorkloadIfacePrefixes,
@@ -1414,7 +1414,9 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 			linkAddrsManagerV6,
 			nil, // arpTable - ARP is IPv4 only
 			nil, // arpMaps
-		))
+		)
+		dp.RegisterManager(epManagerV6)
+		dp.liveMigrationMonitor.registerListener(epManagerV6)
 		dp.RegisterManager(newFloatingIPManager(natTableV6, ruleRenderer, 6, config.FloatingIPsEnabled))
 		dp.RegisterManager(newMasqManager(ipSetsV6, natTableV6, ruleRenderer, config.MaxIPSetSize, 6))
 		dp.RegisterManager(newServiceLoopManager(filterTableV6, ruleRenderer, 6))

--- a/felix/dataplane/linux/int_dataplane_test.go
+++ b/felix/dataplane/linux/int_dataplane_test.go
@@ -124,6 +124,27 @@ var _ = Describe("Constructor test", func() {
 		Expect(dp).ToNot(BeNil())
 	})
 
+	// The live migration monitor drives per-workload route suppression and priority
+	// elevation through the endpoint managers, of which there is one per IP version.
+	// Each manager tracks its own live migration state, so all of them must be
+	// registered as listeners; registering only the IPv4 one leaves IPv6 workload
+	// routes unsuppressed on a migration target and unelevated after cutover
+	// (CORE-12806).
+	It("should register an endpoint manager per IP version with the live migration monitor", func() {
+		dpConfig.IPv6Enabled = true
+
+		dp := intdataplane.NewIntDataplaneDriver(dpConfig)
+		Expect(dp.LiveMigrationListenerCount()).To(Equal(2),
+			"both endpoint managers should listen for live migration state changes")
+	})
+
+	It("should register only the IPv4 endpoint manager when IPv6 is disabled", func() {
+		dpConfig.IPv6Enabled = false
+
+		dp := intdataplane.NewIntDataplaneDriver(dpConfig)
+		Expect(dp.LiveMigrationListenerCount()).To(Equal(1))
+	})
+
 	Context("when nft is not available", func() {
 		BeforeEach(func() {
 			nftablesDataplane = func(knftables.Family, string, ...knftables.Option) (knftables.Interface, error) {

--- a/felix/dataplane/linux/live_migration.go
+++ b/felix/dataplane/linux/live_migration.go
@@ -45,7 +45,7 @@ type garpHandle interface {
 }
 
 // liveMigrationStateUpdate records a per-workload FSM state change that the
-// liveMigrationMonitor needs to forward to its listener (the endpoint manager).
+// liveMigrationMonitor needs to forward to its listeners (the endpoint managers).
 type liveMigrationStateUpdate struct {
 	ID    types.WorkloadEndpointID
 	State liveMigrationState
@@ -53,13 +53,17 @@ type liveMigrationStateUpdate struct {
 
 // liveMigrationMonitor tracks per-workload live migration state that cannot be inferred
 // statelessly from the datastore.  It sees WorkloadEndpoint updates, extracts the live
-// migration role, and drives a per-workload FSM whose state changes are forwarded to
-// the endpoint manager via the liveMigrationListener interface during ResolveUpdateBatch.
+// migration role, and drives a per-workload FSM whose state changes are forwarded to the
+// endpoint managers via the liveMigrationListener interface during ResolveUpdateBatch.
+//
+// There is one endpoint manager per IP version, and each keeps its own live migration state,
+// so every state change must be forwarded to all of them: a monitor with only the IPv4
+// manager registered would leave IPv6 workload routes unsuppressed and unelevated.
 type liveMigrationMonitor struct {
 	roles           map[types.WorkloadEndpointID]proto.LiveMigrationRole
 	fsms            map[types.WorkloadEndpointID]*liveMigrationFSM
 	pendingUpdates  []liveMigrationStateUpdate
-	listener        liveMigrationListener
+	listeners       []liveMigrationListener
 	timerC          chan types.WorkloadEndpointID
 	garpC           chan types.WorkloadEndpointID
 	ifaceNames      map[types.WorkloadEndpointID]string
@@ -99,13 +103,21 @@ func newLiveMigrationMonitor(convergenceTime time.Duration, ipamClient ipam.Inte
 	}
 }
 
-// ResolveUpdateBatch drains accumulated FSM state changes and forwards them
-// to the endpoint manager via the liveMigrationListener interface.  This runs
-// before CompleteDeferredWork, so the endpoint manager sees the state changes
-// before it programs the dataplane.
+// registerListener adds a listener - in production, one endpoint manager per IP version -
+// that should be told about every FSM state change.
+func (m *liveMigrationMonitor) registerListener(l liveMigrationListener) {
+	m.listeners = append(m.listeners, l)
+}
+
+// ResolveUpdateBatch drains accumulated FSM state changes and forwards them to each
+// registered listener via the liveMigrationListener interface.  This runs before
+// CompleteDeferredWork, so the endpoint managers see the state changes before they
+// program the dataplane.
 func (m *liveMigrationMonitor) ResolveUpdateBatch() error {
 	for _, update := range m.pendingUpdates {
-		m.listener.OnLiveMigrationStateUpdate(update.ID, update.State)
+		for _, l := range m.listeners {
+			l.OnLiveMigrationStateUpdate(update.ID, update.State)
+		}
 	}
 	m.pendingUpdates = m.pendingUpdates[:0]
 	return nil

--- a/felix/dataplane/linux/live_migration_test.go
+++ b/felix/dataplane/linux/live_migration_test.go
@@ -60,13 +60,13 @@ func newTestMonitor(convergenceTime time.Duration) *liveMigrationMonitor {
 	m.newGARPHandle = func(ifaceName string) (garpHandle, error) {
 		return newFakeGARPHandle(), nil
 	}
-	m.listener = &fakeLiveMigrationListener{}
+	m.registerListener(&fakeLiveMigrationListener{})
 	return m
 }
 
 // testListener returns the fake listener from a test monitor.
 func testListener(m *liveMigrationMonitor) *fakeLiveMigrationListener {
-	return m.listener.(*fakeLiveMigrationListener)
+	return m.listeners[0].(*fakeLiveMigrationListener)
 }
 
 // drainUpdates resolves the current batch and returns the updates delivered to
@@ -286,6 +286,25 @@ func TestMonitorOnUpdate(t *testing.T) {
 		m := newTestMonitor(testConvergenceTime)
 		m.OnUpdate(wepUpdate(wepID1, proto.LiveMigrationRole_TARGET))
 		g.Expect(m.ifaceNames[wepID1]).To(Equal("cali" + wepID1.EndpointId))
+	})
+}
+
+func TestMonitorMultipleListeners(t *testing.T) {
+	t.Run("state changes are forwarded to every registered listener", func(t *testing.T) {
+		g := NewWithT(t)
+		m := newTestMonitor(testConvergenceTime)
+
+		// In production the monitor has one listener per IP version; a second
+		// listener here stands in for the IPv6 endpoint manager.
+		second := &fakeLiveMigrationListener{}
+		m.registerListener(second)
+
+		m.OnUpdate(wepUpdate(wepID1, proto.LiveMigrationRole_TARGET))
+		g.Expect(m.ResolveUpdateBatch()).NotTo(HaveOccurred())
+
+		expected := []liveMigrationStateUpdate{{ID: wepID1, State: liveMigrationStateTarget}}
+		g.Expect(testListener(m).drain()).To(Equal(expected))
+		g.Expect(second.drain()).To(Equal(expected))
 	})
 }
 


### PR DESCRIPTION
**Cherry-pick history**
- Pick onto **release-v3.32**: projectcalico/calico#13419

## What this fixes

Live migration route handling was wired up for IPv4 only. `liveMigrationMonitor`
held a single `listener` field, assigned the **IPv4** endpoint manager
(`int_dataplane.go`), and the IPv6 endpoint manager was never registered. Each
endpoint manager keeps its own copy of the live migration state and programs its
own family's routes, so on a dual-stack cluster the IPv6 side did nothing at all:
`pendingLiveMigrationStates` on the v6 manager was always empty, and
`calculateRoutes` therefore never suppressed or elevated IPv6 workload routes.

The fix is to hold a list of listeners and register both endpoint managers.

### Correction to the ticket's stated cause

CORE-12806 hypothesises that the IPv6 FIB treats `RTM_NEWROUTE` more strictly
than IPv4, and that BIRD needs to use `REPLACE`. **That is not what is
happening.** Verified in network namespaces on kernel 6.8: both families behave
identically — a route add returns `EEXIST` iff a route exists with the same
prefix *and* the same metric (a differing nexthop does not help), and succeeds
whenever the metric differs. For IPv6 an unset metric defaults to 1024, which is
why a *non-elevated* route collides with Felix's normal-priority route. The BIRD
filters in `felix/etc/bird/calico-bird6.conf.template` are already correct and
family-symmetric; **no BIRD work is needed**.

The diags from the CI run the ticket cites show the real signature directly: on
the migration target node the VM's IPv4 route is at `metric 512` (elevated)
while its IPv6 route is at `metric 1024` (normal). The `Netlink: File exists`
from bird6 is a downstream symptom — with the target's v6 route left at 1024 the
advertised `bgp_local_pref` is the non-elevated value, so the source computes
`krt_metric` 1024 and collides with its own local route at 1024.

### The more serious half, which the ticket does not mention

Because Target-state *suppression* was also missing for IPv6, the migration
target holds and advertises a local /128 pointing at a tap the VM is not running
on yet, for the entire pre-copy phase. Remote nodes then choose between two
equal-metric paths, so **IPv6 traffic to a migrating VM can black-hole for the
whole migration** — considerably worse than log noise on the source node.

## Changes

- `felix/dataplane/linux/live_migration.go`: `listener` → `listeners []liveMigrationListener`
  plus `registerListener()`; `ResolveUpdateBatch` dispatches to each.
- `felix/dataplane/linux/int_dataplane.go`: register **both** `epManager` and
  `epManagerV6` with the monitor.
- `felix/design/dataplane.md` (Dual stack): new passage plus review notes on the
  invariant this bug is an instance of — a cross-cutting singleton that feeds the
  per-family managers must fan out to *all* of them, and a single-valued
  reference field where a list belongs is the smell.
- `felix/fv/live_migration_test.go`: dual-stack coverage (below), and one
  drive-by — `CurrentSpecReport().Failed()` in place of the Ginkgo-v2-deprecated
  `CurrentGinkgoTestDescription()`, which otherwise prints a warning on every
  run. Only this file, which the PR already rewrites; the remaining occurrences
  in `felix/fv` are left to be fixed opportunistically as those files are next
  touched.

## Testing

All of the following was run on this branch head.

- **Unit**: `42 of 1013` specs green across the constructor and live-migration
  focus. Two new constructor specs assert that one endpoint manager is registered
  per *enabled* IP version — 2 listeners dual-stack, 1 with IPv6 disabled — via a
  `LiveMigrationListenerCount()` test hook. The endpoint manager's own
  suppression/elevation logic was already correct and already covered for both
  families; only the wiring was missing, which is why no existing unit test
  caught this.
- **FV**: the dual-stack live-migration suite is green — `7 of 7 Passed` in 170s,
  covering both the OpenStack-style and KubeVirt-style topologies.
- **Negative controls**, with the `epManagerV6` registration removed to
  reintroduce the bug:
  - unit → `11 Passed | 1 Failed`, on *"both endpoint managers should listen for
    live migration state changes"*;
  - FV → both mainline specs fail on the IPv6 assertion specifically, with
    `IPv6 route: target route should be suppressed before the target VM is live` /
    `Expected <string>: dead:beef::2 metric 1024 pref medium` / `to be empty`,
    IPv4 still passing.

  The FV failure is worth noting for what it demonstrates: the new assertions
  catch the *black-hole condition itself* — an unsuppressed IPv6 route on the
  target while the VM is still on the source — not merely a metric mismatch.
- Reproducing the `Netlink: File exists` symptom is out of scope here: it needs
  BIRD and the OpenStack topology, and it is downstream of the missing elevation.

### Why the FV is dual-stack in place, not IPv6 variants

The migration flow assertions are identical per family, so duplicating the specs
would have doubled a slow suite for no extra coverage. Instead every route
expectation goes through a small `lmRoutes` vocabulary
(`lmEventuallyRoute` / `lmConsistentlyRoute` / `lmExpectRoute`) that asserts each
family and labels failures with it, so a family cannot be forgotten at a call
site. `EnableIPv6` is set in the suite's own `lmTopologyOptions()`, so only these
7 specs run dual-stack — the rest of `felix/fv` is unaffected.

**Release note:**
```release-note
Fix IPv6 route programming during VM live migration: IPv6 workload routes are now suppressed on the migration target until the VM goes live, and elevated in priority after cutover, as was already the case for IPv4.  Previously IPv6 traffic to a migrating VM could black-hole for the duration of the migration on dual-stack clusters.
```

