### PR TITLE
Expose Typha server write timeout

### DIFF
--- a/typha/pkg/config/config_params.go
+++ b/typha/pkg/config/config_params.go
@@ -126,6 +126,7 @@ type Config struct {
 	ServerPingIntervalSecs               time.Duration `config:"seconds;10"`   //nolint:staticcheck // Ignore ST1011 don't use unit-specific suffix
 	ServerPongTimeoutSecs                time.Duration `config:"seconds;60"`   //nolint:staticcheck // Ignore ST1011 don't use unit-specific suffix
 	ServerHandshakeTimeoutSecs           time.Duration `config:"seconds;10"`   //nolint:staticcheck // Ignore ST1011 don't use unit-specific suffix
+	ServerWriteTimeoutSecs               time.Duration `config:"seconds;120"`  //nolint:staticcheck // Ignore ST1011 don't use unit-specific suffix
 	ServerPort                           int           `config:"int(0,65535);0"`
 	ServerHost                           string        `config:"host-address;"`
 

--- a/typha/pkg/config/config_params_test.go
+++ b/typha/pkg/config/config_params_test.go
@@ -16,6 +16,7 @@ package config_test
 
 import (
 	"reflect"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -81,6 +82,9 @@ var _ = DescribeTable("Config parsing",
 	Entry("PrometheusMetricsPort", "PrometheusMetricsPort", "1234", int(1234)),
 	Entry("PrometheusGoMetricsEnabled", "PrometheusGoMetricsEnabled", "false", false),
 	Entry("PrometheusProcessMetricsEnabled", "PrometheusProcessMetricsEnabled", "false", false),
+
+	Entry("ServerWriteTimeoutSecs", "ServerWriteTimeoutSecs", "600", 600*time.Second),
+	Entry("ServerWriteTimeoutSecs default", "ServerWriteTimeoutSecs", "", 120*time.Second),
 )
 
 var _ = DescribeTable("Config validation",

--- a/typha/pkg/daemon/daemon.go
+++ b/typha/pkg/daemon/daemon.go
@@ -323,6 +323,7 @@ func (t *TyphaDaemon) CreateServer() {
 			PingInterval:                   t.ConfigParams.ServerPingIntervalSecs,
 			PongTimeout:                    t.ConfigParams.ServerPongTimeoutSecs,
 			HandshakeTimeout:               t.ConfigParams.ServerHandshakeTimeoutSecs,
+			WriteTimeout:                   t.ConfigParams.ServerWriteTimeoutSecs,
 			DropInterval:                   t.ConfigParams.ConnectionDropIntervalSecs,
 			ShutdownTimeout:                t.ConfigParams.ShutdownTimeoutSecs,
 			ShutdownMaxDropInterval:        t.ConfigParams.ShutdownConnectionDropIntervalMaxSecs,


### PR DESCRIPTION
Fixes: https://github.com/projectcalico/calico/issues/13369

Expose Typha's WriteTimeout to allow admins to tune it without rebuilding Typha.

**Release note:**
```release-note
Added a new config field to tune Typha's server write timeout.
```
