### PR TITLE
go.mod: explain why the kube-openapi replace is still needed

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -435,8 +435,16 @@ replace (
 	k8s.io/externaljwt => k8s.io/externaljwt v0.37.0-beta.0
 	k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.37.0-beta.0
 	k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.37.0-beta.0
-	// kubevirt.io/client-go requires a tagged kube-openapi version that doesn't
-	// exist; pin to the pseudo-version used by the rest of our k8s dependencies.
+
+	// kubevirt.io/client-go requires k8s.io/kube-openapi v0.31.0, which does not
+	// exist: kube-openapi publishes only pseudo-versions.  KubeVirt papers over
+	// that with a replace in their own go.mod, but Go ignores replace directives
+	// from dependency modules, so we have to repeat it here.  Raising our own
+	// require does not help either: MVS takes the maximum, and v0.31.0 sorts
+	// above every v0.0.0-<pseudo>, so the phantom version always wins.  Pin to
+	// the version k8s.io/kubernetes v1.37.0-beta.0 requires.  This is unrelated
+	// to the former Tigera fork of client-go and predates it, so removing the
+	// fork did not make it redundant.  Upstream bug: kubevirt/kubevirt#18792.
 	k8s.io/kube-openapi => k8s.io/kube-openapi v0.0.0-20260618221249-bc653b64f974
 	k8s.io/kube-proxy => k8s.io/kube-proxy v0.37.0-beta.0
 	k8s.io/kube-scheduler => k8s.io/kube-scheduler v0.37.0-beta.0


### PR DESCRIPTION
Comment-only change to `go.mod`, expanding the note on the `k8s.io/kube-openapi` replace.

### Why

While reviewing the cherry-pick of #13401 (which removed the Tigera fork of `kubevirt.io/client-go`), the adjacent `kube-openapi` replace was reasonably queried as "can we remove this now?" — it sits a few lines above the fork replace and its comment also mentions kubevirt.

The two are unrelated, and the existing comment doesn't say enough to make that clear:

```go
// kubevirt.io/client-go requires a tagged kube-openapi version that doesn't
// exist; pin to the pseudo-version used by the rest of our k8s dependencies.
```

### The facts the new comment records

- **It predates the fork.** Added in 651913639f (2026-02-19) against plain upstream `kubevirt.io/client-go v1.7.0`. The fork arrived six days later in 93839b7a35 (2026-02-25). Un-forking doesn't touch it.
- **The phantom version is real and current.** `kubevirt.io/client-go` requires `k8s.io/kube-openapi v0.31.0`, which has never existed — kube-openapi publishes only pseudo-versions. Present in every `client-go` release from v1.3.0 through v1.9.0 and on current `main`. KubeVirt covers it with a `replace` in their own `go.mod`, but Go ignores `replace` directives from dependency modules, so we must repeat it.
- **Removing it breaks the build:**
  ```
  go: k8s.io/kube-openapi@v0.31.0: invalid version: unknown revision v0.31.0
  go: k8s.io/kube-openapi@v0.31.0: missing go.sum entry for go.mod file
  ```
- **A plain `require` bump would not work.** MVS takes the maximum, and `v0.31.0` sorts above every `v0.0.0-<pseudo>`, so the phantom always wins. Only a `replace` can override it.
- **The pin target is correct.** `v0.0.0-20260618221249-bc653b64f974` is exactly what `k8s.io/kubernetes v1.37.0-beta.0` requires, so we stay aligned with the rest of our k8s dependencies.

### Upstream

Filed as kubevirt/kubevirt#18792, asking them to require a version that exists so downstream consumers don't each need this workaround. The comment links it; once fixed and picked up, the replace can go.

### Testing

- `hack/check-go-mod.sh` — passes
- `go mod edit -fmt` — no changes (the blank line and ordering are stable)
- `go list -m k8s.io/kube-openapi` — resolves as before
- `git diff` touches `go.mod` only; `go.sum` unchanged

**Release note:**
```release-note
None
```
