### PR TITLE
Fix the cold IP GC regression test, and stop the UT job passing with zero tests

### DIFF
--- a/hack/test/spider/main.go
+++ b/hack/test/spider/main.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Tigera, Inc. All rights reserved.
+// Copyright (c) 2021-2026 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -33,6 +33,19 @@ import (
 // packages which need to have their unit tests executed as a result of a given diff.
 
 var shaA, shaB, commitRange, filterDir string
+
+// sentinel marks a completed run, letting callers tell an empty package list
+// apart from a crash.
+const sentinel = "__SPIDER_OK__"
+
+// failClosed reports why the package set is unknown and tells the caller to
+// test everything.
+func failClosed(reason string) {
+	fmt.Fprintf(os.Stderr, "test spider failed, falling back to all tests: %s\n", reason)
+	fmt.Println(".")
+	fmt.Println(sentinel)
+	os.Exit(0)
+}
 
 func init() {
 	flag.StringVar(&shaA, "shaA", "", "First commit in diff calculation")
@@ -72,7 +85,7 @@ func loadPackages() []Package {
 	cmd.Stderr = &stderr
 	err := cmd.Run()
 	if err != nil {
-		panic(fmt.Sprintf("%s: %s", err, stderr.String()))
+		failClosed(fmt.Sprintf("go list: %s: %s", err, stderr.String()))
 	}
 	splits := strings.SplitAfter(out.String(), "}\n")
 
@@ -88,7 +101,7 @@ func loadPackages() []Package {
 		pkg := Package{}
 		err := json.Unmarshal([]byte(s), &pkg)
 		if err != nil {
-			panic(err)
+			failClosed(fmt.Sprintf("parsing go list output: %s", err))
 		}
 
 		// Filter out packages that aren't part of this repo.
@@ -119,7 +132,7 @@ func loadPackages() []Package {
 
 func getCommits() (string, string) {
 	if shaA == "" && shaB == "" && commitRange == "" {
-		panic("No commit information provided!")
+		failClosed("no commit information provided")
 	}
 
 	if shaA != "" && shaB != "" {
@@ -157,7 +170,7 @@ func main() {
 	cmd.Stderr = &stderr
 	err := cmd.Run()
 	if err != nil {
-		panic(fmt.Sprintf("%s: %s", err, stderr.String()))
+		failClosed(fmt.Sprintf("git diff %s %s: %s: %s", c1, c2, err, stderr.String()))
 	}
 
 	// First, check if go.mod has changed. If it has, we can skip building a graph of changed / impacted
@@ -170,11 +183,12 @@ func main() {
 		cmd.Stderr = &stderr
 		err := cmd.Run()
 		if err != nil {
-			panic(fmt.Sprintf("%s: %s", err, stderr.String()))
+			failClosed(fmt.Sprintf("listing test packages: %s: %s", err, stderr.String()))
 		}
 		for p := range strings.SplitSeq(out.String(), "\n") {
 			fmt.Println(p)
 		}
+		fmt.Println(sentinel)
 		return
 	}
 
@@ -230,6 +244,7 @@ func main() {
 	for _, s := range sorted {
 		fmt.Println(s)
 	}
+	fmt.Println(sentinel)
 }
 
 type Package struct {

--- a/kube-controllers/Makefile
+++ b/kube-controllers/Makefile
@@ -56,7 +56,11 @@ gen-files:
 ###############################################################################
 ifeq ($(SEMAPHORE_GIT_REF_TYPE), pull-request)
 # Determine the tests to run using the test spider tool, which emits a list of impacted packages.
-MAYBE_WHAT=$(shell $(DOCKER_GO_BUILD) sh -c 'go run ../hack/test/spider -commit-range=${SEMAPHORE_GIT_COMMIT_RANGE} -filter-dir kube-controllers/')
+SPIDER_OUTPUT:=$(shell $(DOCKER_GO_BUILD) sh -c 'go run ../hack/test/spider -commit-range=${SEMAPHORE_GIT_COMMIT_RANGE} -filter-dir kube-controllers/')
+ifeq ($(filter __SPIDER_OK__,$(SPIDER_OUTPUT)),)
+$(error test spider did not complete - refusing to run zero tests. See its output above)
+endif
+MAYBE_WHAT:=$(filter-out __SPIDER_OK__,$(SPIDER_OUTPUT))
 else
 # By default, run all tests.
 MAYBE_WHAT=.

--- a/kube-controllers/pkg/controllers/node/ipam_test.go
+++ b/kube-controllers/pkg/controllers/node/ipam_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Tigera, Inc. All rights reserved.
+// Copyright (c) 2021-2026 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -2621,6 +2621,8 @@ var _ = Describe("IPAM controller UTs", func() {
 			{"node-gc-a", "10.1.0.0/30", "vxlan-tunnel-addr-node-gc-a"},
 			{"node-gc-b", "10.1.1.0/30", "vxlan-tunnel-addr-node-gc-b"},
 		}
+		// The cold IP GC sweep only visits blocks with an elapsed cooldown IP.
+		releasedAt := metav1.NewTime(time.Now().Add(-2 * time.Hour))
 		for _, n := range nodes {
 			cidr := net.MustParseCIDR(n.cidr)
 			aff := fmt.Sprintf("host:%s", n.name)
@@ -2633,7 +2635,8 @@ var _ = Describe("IPAM controller UTs", func() {
 				Unallocated: []int{1, 2, 3},
 				Attributes: []model.AllocationAttribute{
 					{
-						HandleID: &handle,
+						HandleID:   &handle,
+						ReleasedAt: &releasedAt,
 						ActiveOwnerAttrs: map[string]string{
 							ipam.AttributeNode: n.name,
 							ipam.AttributeType: ipam.AttributeTypeVXLAN,

--- a/node/Makefile
+++ b/node/Makefile
@@ -300,14 +300,6 @@ $(FELIX_GPL_SOURCE): .felix-gpl-source.created
 ###############################################################################
 # FV Tests
 ###############################################################################
-ifeq ($(SEMAPHORE_GIT_REF_TYPE), pull-request)
-# Determine the tests to run using the test spider tool, which emits a list of impacted packages.
-WHAT=$(shell $(DOCKER_GO_BUILD) sh -c 'go run ../hack/test/spider -commit-range=${SEMAPHORE_GIT_COMMIT_RANGE} -filter-dir node/')
-else
-# By default, run all tests.
-WHAT=$(shell find . -name "*_test.go" | xargs dirname | sort -u)
-endif
-
 # Packages to exclude from the UT run. tests/k8st holds the Go k8st system
 # tests, which need a live kind cluster (run via kind-k8st-run-test).
 UT_PACKAGES_TO_SKIP?=tests/k8st


### PR DESCRIPTION
## Description

Fixes the cold IP GC test that has been failing on master since #13404, and closes the CI hole that let it merge green.

- The test's blocks had no release timestamp on their allocations, so neither block was a cooldown candidate and the GC sweep returned early without visiting them. The injected update conflict never fired. Backdating the release timestamp two hours makes the sweep run for real.
- The kube-controllers UT job ran zero tests, which is why nobody saw it. On PRs the package list comes from `hack/test/spider`, invoked from a `$(shell ...)`: it panicked on a commit range referencing an object missing from Semaphore's partial clone, the failure was swallowed, and `run-uts` exited 0 printing "No packages need to be tested".
- Spider now fails closed. On any internal failure it logs the reason and emits `.`, telling the caller to test everything rather than nothing.
- It also prints a sentinel on completion, and kube-controllers' Makefile refuses to build a test list without one, so spider failing to run at all is a hard error too.
- node's Makefile had the same invocation but never used the result (its ut target runs ginkgo recursively over the component regardless), so that one is just deleted.

**Release note:**
```release-note
None
```
