### PR TITLE
Bump bundled Envoy images to clear CVEs (release-v3.31)

### DIFF
--- a/third_party/envoy-gateway/Makefile
+++ b/third_party/envoy-gateway/Makefile
@@ -7,7 +7,7 @@ BUILD_IMAGES ?= $(ENVOY_GATEWAY_IMAGE)
 
 # For updating this version please see
 # https://github.com/tigera/operator/blob/master/docs/common_tasks.md#updating-the-bundled-version-of-envoy-gateway
-ENVOY_GATEWAY_VERSION=v1.8.0
+ENVOY_GATEWAY_VERSION=v1.8.2
 
 ##############################################################################
 # Include lib.Makefile before anything else
@@ -25,7 +25,8 @@ ENVOY_GATEWAY_DOWNLOADED=.envoy-gateway.downloaded
 init-source: $(ENVOY_GATEWAY_DOWNLOADED)
 $(ENVOY_GATEWAY_DOWNLOADED):
 	mkdir -p envoy-gateway
-	curl -sfL https://github.com/envoyproxy/gateway/archive/refs/tags/$(ENVOY_GATEWAY_VERSION).tar.gz | tar xz --strip-components 1 -C envoy-gateway
+	curl -sSfL --retry 5 -o /tmp/envoy-gateway.tar.gz https://github.com/envoyproxy/gateway/archive/refs/tags/$(ENVOY_GATEWAY_VERSION).tar.gz
+	tar xz --strip-components 1 -C envoy-gateway -f /tmp/envoy-gateway.tar.gz && rm -f /tmp/envoy-gateway.tar.gz
 
 # 	Apply patches for the specified Envoy Gateway version if patches directory exists.
 # 	This code checks for the presence of a patches directory corresponding to ENVOY_GATEWAY_VERSION.
@@ -51,17 +52,17 @@ LD_FLAGS = \
 # tree, so we need GOTOOLCHAIN here to let Go auto-download a newer toolchain
 # inside the build container.
 #
-# Pin minimum 1.26.4 (not bare `auto`) for defensive parity: plain `auto`
-# resolves to upstream's exact `go` directive (today 1.26.3), so pinning a
-# floor protects us if a future v1.8.x/v1.9.x cut regresses that directive.
-# The `+auto` suffix still lets a higher go.mod directive win without editing
-# this line.
+# Pin minimum 1.26.6 (not bare `auto`): upstream's `go` directive (1.26.3)
+# and plain `auto` would build with a toolchain whose stdlib still carries
+# CVEs flagged by the scan (GO-2026-4970, CVE-2026-39822, fixed in 1.26.5).
+# Pinning 1.26.6 (latest) clears those; the `+auto` suffix still lets a higher
+# go.mod directive win without editing this line.
 #
-# Remove this override once release-v3.31 picks up GO_VERSION >= 1.26.4.
+# Remove this override once release-v3.31 picks up GO_VERSION >= 1.26.6.
 bin/envoy-gateway-$(ARCH): init-source
 	$(DOCKER_GO_BUILD) \
 		sh -c '$(GIT_CONFIG_SSH) \
-			CGO_ENABLED=0 GOTOOLCHAIN=go1.26.4+auto go build -C envoy-gateway -buildvcs=false -o ../$@ -v -tags=$(TAGS) -ldflags="$(LD_FLAGS) -s -w" github.com/envoyproxy/gateway/cmd/envoy-gateway'
+			CGO_ENABLED=0 GOTOOLCHAIN=go1.26.6+auto go build -C envoy-gateway -buildvcs=false -o ../$@ -v -tags=$(TAGS) -ldflags="$(LD_FLAGS) -s -w" github.com/envoyproxy/gateway/cmd/envoy-gateway'
 
 .PHONY: clean
 clean:

--- a/third_party/envoy-gateway/patches/0001-CVE-dependency-fixes.patch
+++ b/third_party/envoy-gateway/patches/0001-CVE-dependency-fixes.patch
@@ -1,138 +1,121 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tigera <noreply@tigera.io>
-Date: Mon, 09 Jun 2026 09:00:00 -0700
-Subject: [PATCH] Update dependencies for CVE fixes (refreshed for v1.8.0)
+Date: Wed, 12 Aug 2026 09:00:00 -0700
+Subject: [PATCH] Update dependencies for CVE fixes
 
-Refreshed against envoy-gateway v1.8.0. Upstream v1.8.0 already absorbs
-the prior grpc, otel, go-jose and spdystream CVE bumps, so the only
-changes carried here advance the golang.org/x modules past the versions
-v1.8.0 pins:
+Applied on top of the pinned envoyproxy/gateway release
+(ENVOY_GATEWAY_VERSION). Advances modules past the versions v1.8.2 pins
+to clear CVEs in the bundled image:
 
-  golang.org/x/net    v0.53.0 -> v0.55.0  (CVE-2026-33814, HTTP/2
-                                           SETTINGS infinite loop)
-  golang.org/x/crypto v0.50.0 -> v0.53.0
-  golang.org/x/sys    v0.43.0 -> v0.46.0
+  golang.org/x/net       v0.55.0 -> v0.56.0
+  golang.org/x/text      v0.38.0 -> v0.39.0
+  google.golang.org/grpc v1.81.1 -> v1.82.1
 
-plus the transitive ripple from `go mod tidy -e`:
-  golang.org/x/mod   v0.35.0 -> v0.36.0
-  golang.org/x/sync  v0.20.0 -> v0.21.0
-  golang.org/x/term  v0.42.0 -> v0.44.0
-  golang.org/x/text  v0.36.0 -> v0.38.0
-  golang.org/x/tools v0.44.0 -> v0.45.0
+- x/net clears GO-2026-5942 (panic parsing an invalid SVCB or HTTPS DNS
+  RR in golang.org/x/net/dns/dnsmessage), still at v0.55.0 in v1.8.2.
+- x/text clears CVE-2026-56852 / GO-2026-5970 (infinite loop in norm.Iter
+  on invalid UTF-8), reachable from the gateway-api schema validation
+  path. Bumping x/text also advances x/mod v0.37.0 and x/tools v0.47.0,
+  which its go.mod requires.
+- grpc clears GO-2026-6061, fixed in v1.82.1 (v1.8.2 ships v1.81.1).
 
-The `-e` flag is needed because upstream v1.8.0's `test/` sub-module (a
-separate Go module shipped in the same repo) requires a newer Go than
-tidy's reachability check tolerates; that sub-module is not in the build
-graph for cmd/envoy-gateway, so the partial tidy is sufficient.
+The earlier CVE-2026-33814 (x/net v0.53.0) is already in the v1.8.2
+baseline. This keeps the bundled gateway image in lockstep with the
+envoy-ratelimit image, whose patch lands on the same x/net v0.56.0 /
+x/text v0.39.0 / grpc v1.82.1.
 
-Verified `patch -p1 --dry-run` clean against the upstream v1.8.0 tarball.
----
+Regenerated via `go get golang.org/x/net@v0.56.0 golang.org/x/text@v0.39.0
+google.golang.org/grpc@v1.82.1 && go mod tidy` against the pinned upstream
+ref. The go directive is unchanged (the build supplies a newer toolchain
+via GOTOOLCHAIN).
+diff --git a/go.mod b/go.mod
+index da6ddce..ae28834 100644
 --- a/go.mod
 +++ b/go.mod
-@@ -55,7 +55,7 @@
- 	go.opentelemetry.io/proto/otlp v1.10.0
- 	go.uber.org/zap v1.28.0
- 	golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f
--	golang.org/x/sync v0.20.0
-+	golang.org/x/sync v0.21.0
+@@ -58,7 +58,7 @@ require (
+ 	golang.org/x/sync v0.21.0
  	gomodules.xyz/jsonpatch/v2 v2.5.0
- 	google.golang.org/genproto/googleapis/api v0.0.0-20260401024825-9d38bb4040a9
- 	google.golang.org/grpc v1.80.0
-@@ -282,15 +282,15 @@
- 	go.uber.org/multierr v1.11.0 // indirect
+ 	google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa
+-	google.golang.org/grpc v1.81.1
++	google.golang.org/grpc v1.82.1
+ 	google.golang.org/grpc/security/advancedtls v1.0.0
+ 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af
+ 	gopkg.in/yaml.v3 v3.0.1
+@@ -263,14 +263,14 @@ require (
  	go.yaml.in/yaml/v2 v2.4.4 // indirect
  	go.yaml.in/yaml/v3 v3.0.4 // indirect
--	golang.org/x/crypto v0.50.0 // indirect
--	golang.org/x/mod v0.35.0 // indirect
--	golang.org/x/net v0.53.0 // indirect
-+	golang.org/x/crypto v0.53.0 // indirect
-+	golang.org/x/mod v0.36.0 // indirect
-+	golang.org/x/net v0.55.0 // indirect
+ 	golang.org/x/crypto v0.53.0 // indirect
+-	golang.org/x/mod v0.36.0 // indirect
+-	golang.org/x/net v0.55.0 // indirect
++	golang.org/x/mod v0.37.0 // indirect
++	golang.org/x/net v0.56.0 // indirect
  	golang.org/x/oauth2 v0.36.0 // indirect
--	golang.org/x/sys v0.43.0 // indirect
--	golang.org/x/term v0.42.0 // indirect
--	golang.org/x/text v0.36.0 // indirect
-+	golang.org/x/sys v0.46.0 // indirect
-+	golang.org/x/term v0.44.0 // indirect
-+	golang.org/x/text v0.38.0 // indirect
+ 	golang.org/x/sys v0.46.0 // indirect
+ 	golang.org/x/term v0.44.0 // indirect
+-	golang.org/x/text v0.38.0 // indirect
++	golang.org/x/text v0.39.0 // indirect
  	golang.org/x/time v0.15.0 // indirect
--	golang.org/x/tools v0.44.0 // indirect
-+	golang.org/x/tools v0.45.0 // indirect
- 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260401024825-9d38bb4040a9 // indirect
+-	golang.org/x/tools v0.45.0 // indirect
++	golang.org/x/tools v0.47.0 // indirect
+ 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa // indirect
  	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
  	gopkg.in/inf.v0 v0.9.1 // indirect
+diff --git a/go.sum b/go.sum
+index 48a4006..f4144cb 100644
 --- a/go.sum
 +++ b/go.sum
-@@ -709,14 +709,14 @@
- golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
- golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
- golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
--golang.org/x/crypto v0.50.0 h1:zO47/JPrL6vsNkINmLoo/PH1gcxpls50DNogFvB5ZGI=
--golang.org/x/crypto v0.50.0/go.mod h1:3muZ7vA7PBCE6xgPX7nkzzjiUq87kRItoJQM1Yo8S+Q=
-+golang.org/x/crypto v0.53.0 h1:QZ4Muo8THX6CizN2vPPd5fBGHyogrdK9fG4wLPFUsto=
-+golang.org/x/crypto v0.53.0/go.mod h1:DNLU434OwVakk9PzuwV8w62mAJpRJL3vsgcfp4Qnsio=
- golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f h1:W3F4c+6OLc6H2lb//N1q4WpJkhzJCK5J6kUi1NTVXfM=
+@@ -687,8 +687,8 @@ golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f h1:W3F4c+6OLc6H2lb//N1q4WpJk
  golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f/go.mod h1:J1xhfL/vlindoeF/aINzNzt2Bket5bjo9sdOYzOsU80=
  golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
  golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
--golang.org/x/mod v0.35.0 h1:Ww1D637e6Pg+Zb2KrWfHQUnH2dQRLBQyAtpr/haaJeM=
--golang.org/x/mod v0.35.0/go.mod h1:+GwiRhIInF8wPm+4AoT6L0FA1QWAad3OMdTRx4tFYlU=
-+golang.org/x/mod v0.36.0 h1:JJjpVx6myfUsUdAzZuOSTTmRE0PfZeNWzzvKrP7amb4=
-+golang.org/x/mod v0.36.0/go.mod h1:moc6ELqsWcOw5Ef3xVprK5ul/MvtVvkIXLziUOICjUQ=
+-golang.org/x/mod v0.36.0 h1:JJjpVx6myfUsUdAzZuOSTTmRE0PfZeNWzzvKrP7amb4=
+-golang.org/x/mod v0.36.0/go.mod h1:moc6ELqsWcOw5Ef3xVprK5ul/MvtVvkIXLziUOICjUQ=
++golang.org/x/mod v0.37.0 h1:vF1DjpVEshcIqoEaauuHebaLk1O1forxjxBaVn884JQ=
++golang.org/x/mod v0.37.0/go.mod h1:m8S8VeM9r4dzDwjrKO0a1sZP3YjeMamRRlD+fmR2Q/0=
  golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
  golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
  golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
-@@ -724,16 +724,16 @@
- golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+@@ -697,8 +697,8 @@ golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLL
  golang.org/x/net v0.0.0-20200520004742-59133d7f0dd7/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
  golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
--golang.org/x/net v0.53.0 h1:d+qAbo5L0orcWAr0a9JweQpjXF19LMXJE8Ey7hwOdUA=
--golang.org/x/net v0.53.0/go.mod h1:JvMuJH7rrdiCfbeHoo3fCQU24Lf5JJwT9W3sJFulfgs=
-+golang.org/x/net v0.55.0 h1:bcvxaJn3e1U6InsFWt1JUq1aSjnRxLzT2rtD2KfkDF8=
-+golang.org/x/net v0.55.0/go.mod h1:L5U2KuzuOe1lY7Z+aWVIKK6qEeJXnXV9yzGA+WCHJww=
+ golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+-golang.org/x/net v0.55.0 h1:bcvxaJn3e1U6InsFWt1JUq1aSjnRxLzT2rtD2KfkDF8=
+-golang.org/x/net v0.55.0/go.mod h1:L5U2KuzuOe1lY7Z+aWVIKK6qEeJXnXV9yzGA+WCHJww=
++golang.org/x/net v0.56.0 h1:Rw8j/hFzGvJUZwNBXnAtf5sVDVt+65SK2C7IxCxZt5o=
++golang.org/x/net v0.56.0/go.mod h1:D3Ku6r+V6JROoZK144D2XfMHFcMq/0zSfLelVTCFKec=
  golang.org/x/oauth2 v0.36.0 h1:peZ/1z27fi9hUOFCAZaHyrpWG5lwe0RJEEEeH0ThlIs=
  golang.org/x/oauth2 v0.36.0/go.mod h1:YDBUJMTkDnJS+A4BP4eZBjCqtokkg1hODuPjwiGPO7Q=
  golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
- golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
- golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
- golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
--golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
--golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
-+golang.org/x/sync v0.21.0 h1:HLII4xRRTtCRkxYp4HNFF0Js/Og6q2i++KXbg0gHCwM=
-+golang.org/x/sync v0.21.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
- golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
- golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
- golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
-@@ -752,15 +752,15 @@
- golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
- golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
- golang.org/x/sys v0.10.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
--golang.org/x/sys v0.43.0 h1:Rlag2XtaFTxp19wS8MXlJwTvoh8ArU6ezoyFsMyCTNI=
--golang.org/x/sys v0.43.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
--golang.org/x/term v0.42.0 h1:UiKe+zDFmJobeJ5ggPwOshJIVt6/Ft0rcfrXZDLWAWY=
--golang.org/x/term v0.42.0/go.mod h1:Dq/D+snpsbazcBG5+F9Q1n2rXV8Ma+71xEjTRufARgY=
-+golang.org/x/sys v0.46.0 h1:noSf2Fq6F8DBgS+LysIkx7rIExoNHJsxOAtPp4rthXw=
-+golang.org/x/sys v0.46.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
-+golang.org/x/term v0.44.0 h1:0rLvDRCtNj0gZkyIXhCyOb2OAzEhLVqc4B+hrsBhrmc=
-+golang.org/x/term v0.44.0/go.mod h1:7ze4MdzUzLXpSAoFP1H0bOI9aXDqveSvatT5vKcFh2Y=
- golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
- golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
+@@ -739,8 +739,8 @@ golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
  golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
--golang.org/x/text v0.36.0 h1:JfKh3XmcRPqZPKevfXVpI1wXPTqbkE5f7JA92a55Yxg=
--golang.org/x/text v0.36.0/go.mod h1:NIdBknypM8iqVmPiuco0Dh6P5Jcdk8lJL0CUebqK164=
-+golang.org/x/text v0.38.0 h1:sXmwo9DwP3OK9EZ7PqAdaooSGozfl/3a6/xJcbzPRhE=
-+golang.org/x/text v0.38.0/go.mod h1:YXZt3QhHUKYT53r2lLKFIVi6Ao1jdzrTR/KQ09qyxF4=
+ golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+ golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
+-golang.org/x/text v0.38.0 h1:sXmwo9DwP3OK9EZ7PqAdaooSGozfl/3a6/xJcbzPRhE=
+-golang.org/x/text v0.38.0/go.mod h1:YXZt3QhHUKYT53r2lLKFIVi6Ao1jdzrTR/KQ09qyxF4=
++golang.org/x/text v0.39.0 h1:UbZz4pLOvn600D6Oh6GGEI6VAmndrEBLv8/6BEXzyus=
++golang.org/x/text v0.39.0/go.mod h1:3UwRclnC2g0TU9x8PZiyfOajCd1zaUNHF9cvqcQZ+ZM=
  golang.org/x/time v0.15.0 h1:bbrp8t3bGUeFOx08pvsMYRTCVSMk89u4tKbNOZbp88U=
  golang.org/x/time v0.15.0/go.mod h1:Y4YMaQmXwGQZoFaVFk4YpCt4FLQMYKZe9oeV/f4MSno=
  golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
-@@ -768,8 +768,8 @@
+@@ -748,8 +748,8 @@ golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtn
  golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
  golang.org/x/tools v0.0.0-20201224043029-2b0845dc783e/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
  golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
--golang.org/x/tools v0.44.0 h1:UP4ajHPIcuMjT1GqzDWRlalUEoY+uzoZKnhOjbIPD2c=
--golang.org/x/tools v0.44.0/go.mod h1:KA0AfVErSdxRZIsOVipbv3rQhVXTnlU6UhKxHd1seDI=
-+golang.org/x/tools v0.45.0 h1:18qN3FAooORvApf5XjCXgsuayZOEtXf6JK18I3+ONa8=
-+golang.org/x/tools v0.45.0/go.mod h1:LuUGqqaXcXMEFEruIVJVm5mgDD8vww/z/SR1gQ4uE/0=
+-golang.org/x/tools v0.45.0 h1:18qN3FAooORvApf5XjCXgsuayZOEtXf6JK18I3+ONa8=
+-golang.org/x/tools v0.45.0/go.mod h1:LuUGqqaXcXMEFEruIVJVm5mgDD8vww/z/SR1gQ4uE/0=
++golang.org/x/tools v0.47.0 h1:7Kn5x/d1svx/PzryTsqeoZN4TZwqeH5pGWjefhLi/1Q=
++golang.org/x/tools v0.47.0/go.mod h1:dFHnyTvFWY212G+h7ZY4Vsp/K3U4/7W9TyVaAul8uCA=
  golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
  golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
  golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+@@ -762,8 +762,8 @@ google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa h1:
+ google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa/go.mod h1:q4lMZS6kskjT5HvCPrnnypcDPVJqT/f4nfxmkE7gryY=
+ google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa h1:mZHHdPZl0dbGHCflZgAq/Q468DWVFcU2whhB2KAo8fk=
+ google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
+-google.golang.org/grpc v1.81.1 h1:VnnIIZ88UzOOKLukQi+ImGz8O1Wdp8nAGGnvOfEIWQQ=
+-google.golang.org/grpc v1.81.1/go.mod h1:xGH9GfzOyMTGIOXBJmXt+BX/V0kcdQbdcuwQ/zNw42I=
++google.golang.org/grpc v1.82.1 h1:NnAxzGRA0677vCa4BUkOAnO5+FfQqVl9iUXeD0IqcGE=
++google.golang.org/grpc v1.82.1/go.mod h1:yzTZ1TB1Z3SG+LIYaI+WiE8D5+PZ3ArnrSp8zF3+/ZA=
+ google.golang.org/grpc/examples v0.0.0-20250407062114-b368379ef8f6 h1:ExN12ndbJ608cboPYflpTny6mXSzPrDLh0iTaVrRrds=
+ google.golang.org/grpc/examples v0.0.0-20250407062114-b368379ef8f6/go.mod h1:6ytKWczdvnpnO+m+JiG9NjEDzR1FJfsnmJdG7B8QVZ8=
+ google.golang.org/grpc/security/advancedtls v1.0.0 h1:/KQ7VP/1bs53/aopk9QhuPyFAp9Dm9Ejix3lzYkCrDA=

--- a/third_party/envoy-proxy/Makefile
+++ b/third_party/envoy-proxy/Makefile
@@ -8,7 +8,7 @@ BUILD_IMAGES ?= $(ENVOY_PROXY_IMAGE)
 # For updating this version please see
 # https://github.com/tigera/operator/blob/master/docs/common_tasks.md#updating-the-bundled-version-of-envoy-gateway
 # See https://gateway.envoyproxy.io/news/releases/matrix/ for version compatibility.
-ENVOYBINARY_IMAGE ?= quay.io/tigera/envoybinary:v1.38.0-ef1b67e315
+ENVOYBINARY_IMAGE ?= quay.io/tigera/envoybinary:v1.38.3-a1e8aefd3a
 
 EXCLUDEARCH ?= ppc64le s390x
 

--- a/third_party/envoy-ratelimit/Makefile
+++ b/third_party/envoy-ratelimit/Makefile
@@ -37,21 +37,19 @@ build: bin/envoy-ratelimit-$(ARCH)
 # pins GO_VERSION=1.25.x for the rest of the tree, so we need GOTOOLCHAIN here to
 # let Go auto-download a newer toolchain inside the build container.
 #
-# Pin minimum 1.26.4 (not bare `auto`) because plain `auto` resolves to the
-# go.mod directive's exact 1.26.2, which still ships these 5 stdlib HIGHs:
-#   CVE-2026-33811  LookupCNAME cgo DoS
-#   CVE-2026-33814  HTTP/2 SETTINGS infinite loop
-#   CVE-2026-39820  net/mail consumeComment DoS
-#   CVE-2026-39836  Dial / LookupPort NUL byte handling
-#   CVE-2026-42499  net/mail consumePhrase DoS
-# All five are fixed in Go 1.26.3. The `+auto` suffix lets a future go.mod
-# directive higher than 1.26.4 still win without re-editing this line.
+# Pin minimum 1.26.6 (not bare `auto`) because plain `auto` resolves to the
+# go.mod directive's exact 1.26.2, which still ships stdlib HIGHs. The prior
+# floor 1.26.4 cleared the original five (CVE-2026-33811/33814/39820/39836/
+# 42499, fixed in 1.26.3) but the scan now also flags GO-2026-4970 and
+# CVE-2026-39822, fixed in 1.26.5. Pinning 1.26.6 (latest) clears all of them;
+# the `+auto` suffix lets a future go.mod directive higher than 1.26.6 still
+# win without re-editing this line.
 #
-# Remove this override once release-v3.31 picks up GO_VERSION >= 1.26.4.
+# Remove this override once release-v3.31 picks up GO_VERSION >= 1.26.6.
 bin/envoy-ratelimit-$(ARCH): init-source
 	$(DOCKER_GO_BUILD) \
 		sh -c '$(GIT_CONFIG_SSH) \
-			CGO_ENABLED=0 GOTOOLCHAIN=go1.26.4+auto go build -C envoy-ratelimit -buildvcs=false -o ../$@ -v -tags=$(TAGS) -ldflags="$(LD_FLAGS) -s -w" github.com/envoyproxy/ratelimit/src/service_cmd'
+			CGO_ENABLED=0 GOTOOLCHAIN=go1.26.6+auto go build -C envoy-ratelimit -buildvcs=false -o ../$@ -v -tags=$(TAGS) -ldflags="$(LD_FLAGS) -s -w" github.com/envoyproxy/ratelimit/src/service_cmd'
 
 .PHONY: clean
 clean:

--- a/third_party/envoy-ratelimit/patches/0001-CVE-dependency-fixes.patch
+++ b/third_party/envoy-ratelimit/patches/0001-CVE-dependency-fixes.patch
@@ -1,69 +1,127 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tigera <noreply@tigera.io>
-Date: Tue, 10 Jun 2026 09:00:00 -0700
-Subject: [PATCH] Update dependencies for CVE fixes (refreshed for ff287602, x/net v0.55.0)
+Date: Wed, 12 Aug 2026 09:00:00 -0700
+Subject: [PATCH] Update dependencies for CVE fixes
 
-Refreshed against envoy-ratelimit pin ff287602 ("build: pin
-golang:1.26.2 to multi-arch index digest", 2026-05-07) — the ref
-pinned by the Envoy Gateway v1.8.0 helm chart.
+Applied on top of the pinned envoyproxy/ratelimit commit
+(ENVOY_RATELIMIT_VERSION). Advances modules past the versions upstream
+pins to clear CVEs in the bundled image:
 
-Upstream ff287602 already carries the prior refresh's go-control-plane,
-otel, grpc, protobuf, and client_model bumps, so the only changes
-carried here advance the golang.org/x modules past the versions the
-pinned ref ships. This keeps the bundled ratelimit image in lockstep
-with the envoy-gateway image, whose patch lands on the same x/ versions.
+  golang.org/x/net                            v0.52.0 -> v0.56.0
+  golang.org/x/sys                            v0.42.0 -> v0.46.0
+  golang.org/x/text                           v0.35.0 -> v0.39.0
+  google.golang.org/grpc                      v1.80.0 -> v1.82.1
+  github.com/envoyproxy/go-control-plane/envoy v1.36.0 -> v1.37.0
 
-Carried bump:
-  golang.org/x/net   v0.52.0 -> v0.55.0  (GO-2026-4918 / CVE-2026-33814,
-                                          HTTP/2 SETTINGS infinite loop)
-plus the transitive ripple from `go mod tidy`:
-  golang.org/x/sys   v0.42.0 -> v0.46.0
-  golang.org/x/text  v0.35.0 -> v0.38.0
+- x/net clears CVE-2026-33814 (HTTP/2 SETTINGS infinite loop, fixed in
+  v0.53.0) and GO-2026-5942 (panic parsing an invalid SVCB or HTTPS DNS
+  RR in golang.org/x/net/dns/dnsmessage, fixed in v0.56.0).
+- x/text clears CVE-2026-56852 / GO-2026-5970 (infinite loop in norm.Iter
+  on invalid UTF-8), fixed in v0.39.0.
+- grpc clears GO-2026-6061, fixed in v1.82.1.
 
-Verified `patch -p1 --dry-run` clean against the upstream ff287602
-checkout.
+The grpc bump also advances the direct dependency
+github.com/envoyproxy/go-control-plane/envoy (v1.36.0 -> v1.37.0) and its
+transitive deps (cncf/xds, protoc-gen-validate, genproto) via
+`go mod tidy`. This keeps the bundled ratelimit image in lockstep with the
+envoy-gateway image, whose patch lands on the same x/net v0.56.0 /
+x/text v0.39.0 / grpc v1.82.1.
 
----
- go.mod |  6 +++---
- go.sum | 12 ++++++------
- 2 files changed, 9 insertions(+), 9 deletions(-)
-
+Regenerated via `go get golang.org/x/net@v0.56.0 golang.org/x/text@v0.39.0
+google.golang.org/grpc@v1.82.1 && go mod tidy` against the pinned upstream
+ref. The module's `go` directive is unchanged at 1.26.2 (the build
+supplies a newer toolchain via GOTOOLCHAIN).
 diff --git a/go.mod b/go.mod
-index 4a05be8..5f0d423 100644
+index 4a05be8..d2ac64e 100644
 --- a/go.mod
 +++ b/go.mod
-@@ -35,7 +35,7 @@ require (
+@@ -8,7 +8,7 @@ require (
+ 	github.com/bradfitz/gomemcache v0.0.0-20230905024940-24af94b03874
+ 	github.com/coocood/freecache v1.2.4
+ 	github.com/envoyproxy/go-control-plane v0.14.0
+-	github.com/envoyproxy/go-control-plane/envoy v1.36.0
++	github.com/envoyproxy/go-control-plane/envoy v1.37.0
+ 	github.com/envoyproxy/go-control-plane/ratelimit v0.1.1-0.20250812085011-4cf7e8485428
+ 	github.com/go-kit/log v0.2.1
+ 	github.com/golang/mock v1.6.0
+@@ -35,8 +35,8 @@ require (
  	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.43.0
  	go.opentelemetry.io/otel/sdk v1.43.0
  	go.opentelemetry.io/otel/trace v1.43.0
 -	golang.org/x/net v0.52.0
-+	golang.org/x/net v0.55.0
- 	google.golang.org/grpc v1.80.0
+-	google.golang.org/grpc v1.80.0
++	golang.org/x/net v0.56.0
++	google.golang.org/grpc v1.82.1
  	google.golang.org/protobuf v1.36.11
  	gopkg.in/yaml.v2 v2.4.0
-@@ -66,8 +66,8 @@ require (
+ )
+@@ -48,9 +48,9 @@ require (
+ 	github.com/beorn7/perks v1.0.1 // indirect
+ 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
+ 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+-	github.com/cncf/xds/go v0.0.0-20251210132809-ee656c7534f5 // indirect
++	github.com/cncf/xds/go v0.0.0-20260202195803-dba9d589def2 // indirect
+ 	github.com/davecgh/go-spew v1.1.1 // indirect
+-	github.com/envoyproxy/protoc-gen-validate v1.3.0 // indirect
++	github.com/envoyproxy/protoc-gen-validate v1.3.3 // indirect
+ 	github.com/fsnotify/fsnotify v1.7.0 // indirect
+ 	github.com/go-logfmt/logfmt v0.6.0 // indirect
+ 	github.com/go-logr/logr v1.4.3 // indirect
+@@ -66,9 +66,9 @@ require (
  	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
  	go.opentelemetry.io/otel/metric v1.43.0 // indirect
  	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
 -	golang.org/x/sys v0.42.0 // indirect
 -	golang.org/x/text v0.35.0 // indirect
+-	google.golang.org/genproto/googleapis/api v0.0.0-20260401024825-9d38bb4040a9 // indirect
+-	google.golang.org/genproto/googleapis/rpc v0.0.0-20260401024825-9d38bb4040a9 // indirect
 +	golang.org/x/sys v0.46.0 // indirect
-+	golang.org/x/text v0.38.0 // indirect
- 	google.golang.org/genproto/googleapis/api v0.0.0-20260401024825-9d38bb4040a9 // indirect
- 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260401024825-9d38bb4040a9 // indirect
++	golang.org/x/text v0.39.0 // indirect
++	google.golang.org/genproto/googleapis/api v0.0.0-20260414002931-afd174a4e478 // indirect
++	google.golang.org/genproto/googleapis/rpc v0.0.0-20260414002931-afd174a4e478 // indirect
  	gopkg.in/yaml.v3 v3.0.1 // indirect
+ )
 diff --git a/go.sum b/go.sum
-index 55358ed..119cf3f 100644
+index 55358ed..666242e 100644
 --- a/go.sum
 +++ b/go.sum
+@@ -23,8 +23,8 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
+ github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
+ github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
+-github.com/cncf/xds/go v0.0.0-20251210132809-ee656c7534f5 h1:6xNmx7iTtyBRev0+D/Tv1FZd4SCg8axKApyNyRsAt/w=
+-github.com/cncf/xds/go v0.0.0-20251210132809-ee656c7534f5/go.mod h1:KdCmV+x/BuvyMxRnYBlmVaq4OLiKW6iRQfvC62cvdkI=
++github.com/cncf/xds/go v0.0.0-20260202195803-dba9d589def2 h1:aBangftG7EVZoUb69Os8IaYg++6uMOdKK83QtkkvJik=
++github.com/cncf/xds/go v0.0.0-20260202195803-dba9d589def2/go.mod h1:qwXFYgsP6T7XnJtbKlf1HP8AjxZZyzxMmc+Lq5GjlU4=
+ github.com/coocood/freecache v1.2.4 h1:UdR6Yz/X1HW4fZOuH0Z94KwG851GWOSknua5VUbb/5M=
+ github.com/coocood/freecache v1.2.4/go.mod h1:RBUWa/Cy+OHdfTGFEhEuE1pMCMX51Ncizj7rthiQ3vk=
+ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+@@ -35,13 +35,13 @@ github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.m
+ github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
+ github.com/envoyproxy/go-control-plane v0.14.0 h1:hbG2kr4RuFj222B6+7T83thSPqLjwBIfQawTkC++2HA=
+ github.com/envoyproxy/go-control-plane v0.14.0/go.mod h1:NcS5X47pLl/hfqxU70yPwL9ZMkUlwlKxtAohpi2wBEU=
+-github.com/envoyproxy/go-control-plane/envoy v1.36.0 h1:yg/JjO5E7ubRyKX3m07GF3reDNEnfOboJ0QySbH736g=
+-github.com/envoyproxy/go-control-plane/envoy v1.36.0/go.mod h1:ty89S1YCCVruQAm9OtKeEkQLTb+Lkz0k8v9W0Oxsv98=
++github.com/envoyproxy/go-control-plane/envoy v1.37.0 h1:u3riX6BoYRfF4Dr7dwSOroNfdSbEPe9Yyl09/B6wBrQ=
++github.com/envoyproxy/go-control-plane/envoy v1.37.0/go.mod h1:DReE9MMrmecPy+YvQOAOHNYMALuowAnbjjEMkkWOi6A=
+ github.com/envoyproxy/go-control-plane/ratelimit v0.1.1-0.20250812085011-4cf7e8485428 h1:AkYCu5lno5OO4HujsRKIDJ1XnqymM3saXdBoQ+lpWhk=
+ github.com/envoyproxy/go-control-plane/ratelimit v0.1.1-0.20250812085011-4cf7e8485428/go.mod h1:EWppLjKDYW2tcLcDYvR1kDWCZWeMVxH/0v6vaYXo0eA=
+ github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
+-github.com/envoyproxy/protoc-gen-validate v1.3.0 h1:TvGH1wof4H33rezVKWSpqKz5NXWg5VPuZ0uONDT6eb4=
+-github.com/envoyproxy/protoc-gen-validate v1.3.0/go.mod h1:HvYl7zwPa5mffgyeTUHA9zHIH36nmrm7oCbo4YKoSWA=
++github.com/envoyproxy/protoc-gen-validate v1.3.3 h1:MVQghNeW+LZcmXe7SY1V36Z+WFMDjpqGAGacLe2T0ds=
++github.com/envoyproxy/protoc-gen-validate v1.3.3/go.mod h1:TsndJ/ngyIdQRhMcVVGDDHINPLWB7C82oDArY51KfB0=
+ github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
+ github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=
+ github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
 @@ -201,8 +201,8 @@ golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLL
  golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
  golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
  golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
 -golang.org/x/net v0.52.0 h1:He/TN1l0e4mmR3QqHMT2Xab3Aj3L9qjbhRm78/6jrW0=
 -golang.org/x/net v0.52.0/go.mod h1:R1MAz7uMZxVMualyPXb+VaqGSa3LIaUqk0eEt3w36Sw=
-+golang.org/x/net v0.55.0 h1:bcvxaJn3e1U6InsFWt1JUq1aSjnRxLzT2rtD2KfkDF8=
-+golang.org/x/net v0.55.0/go.mod h1:L5U2KuzuOe1lY7Z+aWVIKK6qEeJXnXV9yzGA+WCHJww=
++golang.org/x/net v0.56.0 h1:Rw8j/hFzGvJUZwNBXnAtf5sVDVt+65SK2C7IxCxZt5o=
++golang.org/x/net v0.56.0/go.mod h1:D3Ku6r+V6JROoZK144D2XfMHFcMq/0zSfLelVTCFKec=
  golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
  golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
  golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -80,8 +138,32 @@ index 55358ed..119cf3f 100644
  golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 -golang.org/x/text v0.35.0 h1:JOVx6vVDFokkpaq1AEptVzLTpDe9KGpj5tR4/X+ybL8=
 -golang.org/x/text v0.35.0/go.mod h1:khi/HExzZJ2pGnjenulevKNX1W67CUy0AsXcNubPGCA=
-+golang.org/x/text v0.38.0 h1:sXmwo9DwP3OK9EZ7PqAdaooSGozfl/3a6/xJcbzPRhE=
-+golang.org/x/text v0.38.0/go.mod h1:YXZt3QhHUKYT53r2lLKFIVi6Ao1jdzrTR/KQ09qyxF4=
++golang.org/x/text v0.39.0 h1:UbZz4pLOvn600D6Oh6GGEI6VAmndrEBLv8/6BEXzyus=
++golang.org/x/text v0.39.0/go.mod h1:3UwRclnC2g0TU9x8PZiyfOajCd1zaUNHF9cvqcQZ+ZM=
  golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
  golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
  golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3HoIrodX9oNMXvdceNzlUR8zjMvY=
+@@ -252,17 +252,17 @@ google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7
+ google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
+ google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55/go.mod h1:DMBHOl98Agz4BDEuKkezgsaosCRResVns1a3J2ZsMNc=
+ google.golang.org/genproto v0.0.0-20200423170343-7949de9c1215/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=
+-google.golang.org/genproto/googleapis/api v0.0.0-20260401024825-9d38bb4040a9 h1:VPWxll4HlMw1Vs/qXtN7BvhZqsS9cdAittCNvVENElA=
+-google.golang.org/genproto/googleapis/api v0.0.0-20260401024825-9d38bb4040a9/go.mod h1:7QBABkRtR8z+TEnmXTqIqwJLlzrZKVfAUm7tY3yGv0M=
+-google.golang.org/genproto/googleapis/rpc v0.0.0-20260401024825-9d38bb4040a9 h1:m8qni9SQFH0tJc1X0vmnpw/0t+AImlSvp30sEupozUg=
+-google.golang.org/genproto/googleapis/rpc v0.0.0-20260401024825-9d38bb4040a9/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
++google.golang.org/genproto/googleapis/api v0.0.0-20260414002931-afd174a4e478 h1:yQugLulqltosq0B/f8l4w9VryjV+N/5gcW0jQ3N8Qec=
++google.golang.org/genproto/googleapis/api v0.0.0-20260414002931-afd174a4e478/go.mod h1:C6ADNqOxbgdUUeRTU+LCHDPB9ttAMCTff6auwCVa4uc=
++google.golang.org/genproto/googleapis/rpc v0.0.0-20260414002931-afd174a4e478 h1:RmoJA1ujG+/lRGNfUnOMfhCy5EipVMyvUE+KNbPbTlw=
++google.golang.org/genproto/googleapis/rpc v0.0.0-20260414002931-afd174a4e478/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
+ google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
+ google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
+ google.golang.org/grpc v1.25.1/go.mod h1:c3i+UQWmh7LiEpx4sFZnkU36qjEYZ0imhYfXVyQciAY=
+ google.golang.org/grpc v1.27.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
+ google.golang.org/grpc v1.29.1/go.mod h1:itym6AZVZYACWQqET3MqgPpjcuV5QH3BxFS3IjizoKk=
+-google.golang.org/grpc v1.80.0 h1:Xr6m2WmWZLETvUNvIUmeD5OAagMw3FiKmMlTdViWsHM=
+-google.golang.org/grpc v1.80.0/go.mod h1:ho/dLnxwi3EDJA4Zghp7k2Ec1+c2jqup0bFkw07bwF4=
++google.golang.org/grpc v1.82.1 h1:NnAxzGRA0677vCa4BUkOAnO5+FfQqVl9iUXeD0IqcGE=
++google.golang.org/grpc v1.82.1/go.mod h1:yzTZ1TB1Z3SG+LIYaI+WiE8D5+PZ3ArnrSp8zF3+/ZA=
+ google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=
+ google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
+ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
Bumps the bundled Envoy images on release-v3.31 to clear CVEs flagged in the latest security scan.

## Changes
- **envoy-gateway**: v1.8.0 -> v1.8.2 (clears CVE-2026-53713)
- **envoy-proxy** (envoybinary): v1.38.0 -> v1.38.3 (clears CVE-2026-47774, CVE-2026-47220, CVE-2026-48706)
- **envoy-gateway** and **envoy-ratelimit** CVE-dependency patches refreshed to advance:
  - golang.org/x/net v0.56.0 (GO-2026-5942)
  - golang.org/x/text v0.39.0 (CVE-2026-56852)
  - google.golang.org/grpc v1.82.1 (GO-2026-6061)

## Notes
- Target versions match master.
- Both source-built binaries (envoy-gateway, envoy-ratelimit) were built locally to verify the dependency bumps compile; the envoybinary v1.38.3 image is confirmed present (multi-arch).
- The dependency patches apply cleanly against the pinned upstream sources.

```release-note
Update bundled Envoy images (envoy-gateway v1.8.2, envoy-proxy v1.38.3) and refresh dependency patches to remediate CVEs.
```
