### PR TITLE
Felix: clear the no-encap parent address when the host loses its address

### DIFF
--- a/felix/dataplane/linux/noencap_mgr.go
+++ b/felix/dataplane/linux/noencap_mgr.go
@@ -102,13 +102,6 @@ func (m *noEncapManager) OnUpdate(protoBufMsg any) {
 		} else {
 			addrStr = msg.Ipv6Addr
 		}
-		if addrStr == "" {
-			m.logCtx.WithFields(logrus.Fields{
-				"hostname":  msg.Hostname,
-				"ipVersion": m.ipVersion,
-			}).Debug("Ignoring HostMetadataUpdate with no address for this IP version")
-			return
-		}
 		m.routesNeedUpdate(addrStr)
 	case *proto.HostMetadataRemove:
 		m.logCtx.WithField("hostname", msg.Hostname).Debug("Host removed")

--- a/felix/dataplane/linux/noencap_mgr_test.go
+++ b/felix/dataplane/linux/noencap_mgr_test.go
@@ -256,4 +256,52 @@ var _ = Describe("NoEncap Manager", func() {
 				Protocol: 80,
 			}))
 	})
+
+	It("clears the parent address when the local host loses its IPv4 address", func() {
+		noencapMgr.OnUpdate(&proto.HostMetadataUpdate{
+			Hostname: "node1",
+			Ipv4Addr: "172.0.0.2",
+		})
+		Expect(noencapMgr.routeMgr.parentIfaceAddr()).To(Equal("172.0.0.2"))
+
+		// The Node is still there, but it no longer has an IPv4 address (say
+		// its BGP IPv4Address was removed and it has no v4 InternalIP), so the
+		// calc graph sends an update with an empty address rather than a
+		// remove.  Keeping the old address would leave the device-sync
+		// goroutine hunting for one that is no longer on any link.
+		noencapMgr.OnUpdate(&proto.HostMetadataUpdate{
+			Hostname: "node1",
+		})
+		Expect(noencapMgr.routeMgr.parentIfaceAddr()).To(BeEmpty())
+		_, err := noencapMgr.routeMgr.detectParentIface()
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("clears the parent address when the local host loses its IPv6 address", func() {
+		noencapMgrV6.OnUpdate(&proto.HostMetadataUpdate{
+			Hostname: "node1",
+			Ipv6Addr: "fc00:10:96::2",
+		})
+		Expect(noencapMgrV6.routeMgr.parentIfaceAddr()).To(Equal("fc00:10:96::2"))
+
+		// A single HostMetadataUpdate carries both families, so a node that
+		// drops to IPv4-only shows up at the IPv6 manager as an update with an
+		// empty Ipv6Addr.
+		noencapMgrV6.OnUpdate(&proto.HostMetadataUpdate{
+			Hostname: "node1",
+			Ipv4Addr: "172.0.0.2",
+		})
+		Expect(noencapMgrV6.routeMgr.parentIfaceAddr()).To(BeEmpty())
+	})
+
+	It("ignores host metadata for other hosts", func() {
+		noencapMgr.OnUpdate(&proto.HostMetadataUpdate{
+			Hostname: "node1",
+			Ipv4Addr: "172.0.0.2",
+		})
+		noencapMgr.OnUpdate(&proto.HostMetadataUpdate{
+			Hostname: "node2",
+		})
+		Expect(noencapMgr.routeMgr.parentIfaceAddr()).To(Equal("172.0.0.2"))
+	})
 })


### PR DESCRIPTION
`noEncapManager.OnUpdate` ignored a `HostMetadataUpdate` whose address for its IP version was empty, leaving `parentDeviceAddr` holding the previous value. That skip arrived when the per-family `HostMetadataUpdate`/`HostMetadataV6Update` messages were merged into one message carrying both families — before that, each manager only saw its own family and an empty address cleared the parent address.

An empty address isn't ambiguous: `DataplanePassthru` recomputes both families from the same Node on every update, so it never sends a partial one. Empty means the local host has no address of that family at all. Keeping the old value leaves the device-sync goroutine hunting for an address that is no longer on any link — retrying, and logging, once a second for the life of the process.

The empty address is now passed through, as `ipipManager` and `vxlanManager` already do.

### Testing

New unit tests in `noencap_mgr_test.go`: the parent address is cleared when the host loses its v4 address and when it loses its v6 address, and an empty update for another host leaves the local address alone. The first two fail against the unfixed manager. `felix/dataplane/linux` is green: 1025 of 1025 specs.

### Related

The retry back-off that limits the cost of the resulting netlink scan has moved to #13518. The two are independent and can land in either order.

**Release note:**
```release-note
Fix Felix leaving a stale parent device address for no-encapsulation routes when a node loses its host IP, which caused a repeated netlink scan and warning log thereafter.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
