### PR TITLE
Make _BPF_ imply _BPF-SAFE_ in the Felix BPF FV focus

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -80,7 +80,9 @@ To run a single test:
 - Temporarily change the `It()` block in the file to `FIt()` to "focus" the test.
 - Run the test in iptables mode:
   `make -C felix fv GINKGO_ARGS="-ginkgo.v"`
-- Run the test in eBPF mode with iptables (only tests marked BPF-SAFE should be run in this mode):
+- Run the test in eBPF mode with iptables (in CI, only tests whose name contains
+  `_BPF-SAFE_` or `_BPF_` run in this mode; name a new BPF-mode test accordingly or
+  CI will never run it):
   `make -C felix fv-bpf GINKGO_ARGS="-ginkgo.v"`
 - Run the test in nftables mode:
   `make -C felix fv(-bpf) GINKGO_ARGS="-ginkgo.v" FELIX_FV_NFTABLES=Enabled`

--- a/felix/.semaphore/fv-prologue
+++ b/felix/.semaphore/fv-prologue
@@ -23,9 +23,7 @@ JOB_TAG=""
 TEST_REPORT_NAME=""
 
 # In BPF runs, only run BPF-SAFE tagged tests.  _BPF_ (i.e. "BPF-specific test")
-# implies BPF-SAFE: it is easy to write a _BPF_ test and forget the BPF-SAFE
-# marker, and such a test would then run in no CI job at all (BPF jobs would
-# skip it by focus; other jobs skip it because it self-gates on BPFMode()).
+# implies BPF-SAFE.
 if [[ $FELIX_TEST_GROUP =~ bpf ]]; then
   export FV_FOCUS='BPF-SAFE|_BPF_'
   JOB_TAG+="bpf"

--- a/felix/.semaphore/fv-prologue
+++ b/felix/.semaphore/fv-prologue
@@ -22,8 +22,8 @@ export NUM_FV_BATCHES=8
 JOB_TAG=""
 TEST_REPORT_NAME=""
 
-# In BPF runs, only run BPF-SAFE tagged tests.  _BPF_ (i.e. "BPF-specific test")
-# implies BPF-SAFE.
+# In BPF runs, only run tests tagged for BPF mode: _BPF-SAFE_ (shared FV) or _BPF_ (BPF-specific).
+# (The full BPF job treats _BPF_ as implying _BPF-SAFE_ via the focus regex.)
 if [[ $FELIX_TEST_GROUP =~ bpf ]]; then
   export FV_FOCUS='BPF-SAFE|_BPF_'
   JOB_TAG+="bpf"

--- a/felix/.semaphore/fv-prologue
+++ b/felix/.semaphore/fv-prologue
@@ -22,9 +22,12 @@ export NUM_FV_BATCHES=8
 JOB_TAG=""
 TEST_REPORT_NAME=""
 
-# In BPF runs, only run BPF-SAFE tagged tests
+# In BPF runs, only run BPF-SAFE tagged tests.  _BPF_ (i.e. "BPF-specific test")
+# implies BPF-SAFE: it is easy to write a _BPF_ test and forget the BPF-SAFE
+# marker, and such a test would then run in no CI job at all (BPF jobs would
+# skip it by focus; other jobs skip it because it self-gates on BPFMode()).
 if [[ $FELIX_TEST_GROUP =~ bpf ]]; then
-  export FV_FOCUS=BPF-SAFE
+  export FV_FOCUS='BPF-SAFE|_BPF_'
   JOB_TAG+="bpf"
   TEST_REPORT_NAME+="BPF/"
   FV_NO_PREREQ_TARGET=fv-bpf-no-prereqs

--- a/felix/CLAUDE.md
+++ b/felix/CLAUDE.md
@@ -76,6 +76,8 @@ make fv-bpf GINKGO_FOCUS="TestName"
 
 `fv/bpf_*_test.go` tests carry a matrix prefix (e.g. `"ipv4 udp, ct=true, log=debug, tunnel=none, dsr=false"`) which `GINKGO_FOCUS` can regex-match to slice the matrix when triaging. The matrix axes, the `_BPF-SAFE_` convention for shared FV tests, and the harness conventions for `bpf/ut/` are documented in [`design/bpf-tests.md`](./design/bpf-tests.md).
 
+**Name a new FV test that needs BPF mode `_BPF-SAFE_`, or `_BPF_ _BPF-SAFE_` if it targets the BPF dataplane.** CI's BPF jobs focus on `BPF-SAFE|_BPF_`, so either marker is enough to get the test run; a test with neither marker runs in no BPF job.
+
 ### Nftables Functional Tests
 
 ```bash

--- a/felix/design/bpf-tests.md
+++ b/felix/design/bpf-tests.md
@@ -109,12 +109,7 @@ CI selects the BPF runs by test *name*, using two markers:
   `FV_FOCUS='_BPF_.*ct=true'`), so a BPF-specific test wants it.
 
 `_BPF_` **implies** `_BPF-SAFE_`: the full BPF job's focus is
-`BPF-SAFE|_BPF_` (`felix/.semaphore/fv-prologue`). Without that,
-a test named `_BPF_` but not `_BPF-SAFE_` would run in no job at
-all — the BPF jobs would skip it by focus, and the other jobs skip
-it because a BPF-specific test self-gates on
-`infrastructure.BPFMode()`. Nothing else catches that: an empty
-focus match is a silent pass.
+`BPF-SAFE|_BPF_` (`felix/.semaphore/fv-prologue`).
 
 Ginkgo matches the focus against a spec's full text — every
 enclosing `Describe`/`Context` heading concatenated — so a marker

--- a/felix/design/bpf-tests.md
+++ b/felix/design/bpf-tests.md
@@ -98,6 +98,29 @@ BPF functional tests live alongside the rest of Felix FV in
   network-policy semantics) and are largely the same regardless
   of dataplane. The prefix marks them as runnable under BPF mode.
 
+### The two name markers and how CI selects on them
+
+CI selects the BPF runs by test *name*, using two markers:
+
+- `_BPF-SAFE_` — "run this test in BPF mode". Required on shared
+  FV tests; the BPF jobs' Ginkgo focus is built from it.
+- `_BPF_` — "this test targets the BPF dataplane". The reduced BPF
+  jobs focus on it to run a slice of the BPF tests (e.g.
+  `FV_FOCUS='_BPF_.*ct=true'`), so a BPF-specific test wants it.
+
+`_BPF_` **implies** `_BPF-SAFE_`: the full BPF job's focus is
+`BPF-SAFE|_BPF_` (`felix/.semaphore/fv-prologue`). Without that,
+a test named `_BPF_` but not `_BPF-SAFE_` would run in no job at
+all — the BPF jobs would skip it by focus, and the other jobs skip
+it because a BPF-specific test self-gates on
+`infrastructure.BPFMode()`. Nothing else catches that: an empty
+focus match is a silent pass.
+
+Ginkgo matches the focus against a spec's full text — every
+enclosing `Describe`/`Context` heading concatenated — so a marker
+on any ancestor container covers the specs beneath it. Convention
+for a BPF-specific test is to carry both, `_BPF_ _BPF-SAFE_`.
+
 A test in `fv/bpf_*_test.go` carries a **matrix prefix**
 identifying the dataplane parameter combination it represents:
 


### PR DESCRIPTION
The Felix BPF FV jobs focus Ginkgo on `BPF-SAFE` (`felix/.semaphore/fv-prologue`). A test
named with the `_BPF_` marker but not `_BPF-SAFE_` therefore runs in **no** CI job at all:

- the BPF jobs skip it by focus;
- the iptables/nftables jobs skip it too, because a BPF-specific test self-gates on
  `infrastructure.BPFMode()`.

Nothing catches this — a focus that matches no spec is a silent pass.

This widens the focus to `BPF-SAFE|_BPF_`, so either marker is enough. The two reduced BPF
jobs set `FV_FOCUS` themselves *after* sourcing the prologue, so they are unaffected and
still run their `_BPF_.*ct=true` slice.

Also documents the two markers and how CI selects on them in `felix/design/bpf-tests.md`,
with pointers from `felix/CLAUDE.md` and `.github/copilot-instructions.md`.
