### PR TITLE
Use MARVIN_RENOVATE_PAT to approve operator CRD sync PRs

### DIFF
--- a/.github/workflows/sync-operator-crds.yml
+++ b/.github/workflows/sync-operator-crds.yml
@@ -77,13 +77,13 @@ jobs:
 
       # The PR author is github-actions[bot] (the GITHUB_TOKEN identity above), so
       # it can't approve its own PR, and the Actions token can't approve PRs anyway.
-      # Approve as marvin-tigera (MARVIN_PAT) so Marvin merges it once CI is green.
+      # Approve as marvin-tigera (MARVIN_RENOVATE_PAT) so Marvin merges it once CI is green.
       # Runs on every sync, not just content changes, so a PR that missed its
       # approval gets one on the next pass. The reviewDecision guard keeps reruns quiet.
       - name: Auto-approve so Marvin merges once CI passes
         if: steps.cpr.outputs.pull-request-number != ''
         env:
-          GH_TOKEN: ${{ secrets.MARVIN_PAT }}
+          GH_TOKEN: ${{ secrets.MARVIN_RENOVATE_PAT }}
           PR: ${{ steps.cpr.outputs.pull-request-number }}
           REPO: ${{ github.repository }}
         run: |
@@ -99,7 +99,7 @@ jobs:
       - name: Approve held workflow runs
         if: steps.cpr.outputs.pull-request-number != ''
         env:
-          GH_TOKEN: ${{ secrets.MARVIN_PAT }}
+          GH_TOKEN: ${{ secrets.MARVIN_RENOVATE_PAT }}
           PR: ${{ steps.cpr.outputs.pull-request-number }}
           REPO: ${{ github.repository }}
         run: |


### PR DESCRIPTION
The operator CRD sync workflow referenced a `MARVIN_PAT` secret that does not exist in this repo, so the auto-approve step ran `gh` with an empty token and failed with `HTTP 401: Bad credentials` on every hourly run. That left the sync PRs unapproved and blocked on branch protection, and skipped the following step that releases held Actions runs. Both steps now use `MARVIN_RENOVATE_PAT`, the marvin-tigera token that is already configured here.

```release-note
None
```
