### PR TITLE
e2e: keep Enterprise-only specs out of the v3.32 Maglev run

### DIFF
--- a/.argoci/cron/e2e-bpf.yaml
+++ b/.argoci/cron/e2e-bpf.yaml
@@ -131,7 +131,8 @@ steps:
         value: Felix
       # This run supplies what the Maglev tests need -- BPF with DSR, an
       # external node, one subnet, no encapsulation -- so it is the only run
-      # that keeps them. Same filter as the other runs, minus that skip.
+      # that keeps them. Same filter as the other runs, minus that skip, plus a
+      # skip for the Enterprise-only specs the shared test image carries.
       - name: ENABLE_BPF_DSR
         value: "true"
       - name: ENABLE_EXTERNAL_NODE
@@ -143,7 +144,7 @@ steps:
       - name: K8S_E2E_DOCKER_EXTRA_FLAGS
         value: --env EKS_CNI
       - name: K8S_E2E_FLAGS
-        value: --ginkgo.focus=(\[sig-calico\]|Conformance|Dataplane:BPF|Feature:NetworkPolicy) --ginkgo.skip=(Slow|Disruptive|calient|allow.ingress.access.from.updated.pod|Dataplane:LB|Feature:SCTP)
+        value: --ginkgo.focus=(\[sig-calico\]|Conformance|Dataplane:BPF|Feature:NetworkPolicy) --ginkgo.skip=(Slow|Disruptive|calient|allow.ingress.access.from.updated.pod|Dataplane:LB|Feature:SCTP|sig-calico-enterprise)
       - name: KUBE_PROXY_MANAGEMENT
         value: Enabled
       - name: PROVISIONER

--- a/.semaphore/end-to-end/pipelines/bpf.yml
+++ b/.semaphore/end-to-end/pipelines/bpf.yml
@@ -120,9 +120,10 @@ blocks:
           env_vars:
             # This run supplies what the Maglev tests need -- BPF with DSR, an
             # external node, one subnet, no encapsulation -- so it is the only
-            # run that keeps them. Same filter as the block, minus that skip.
+            # run that keeps them. Same filter as the block, minus that skip, plus
+            # a skip for the Enterprise-only specs the shared test image carries.
             - name: K8S_E2E_FLAGS
-              value: --ginkgo.focus=(\[sig-calico\]|Conformance|Dataplane:BPF|Feature:NetworkPolicy) --ginkgo.skip=(Slow|Disruptive|calient|allow.ingress.access.from.updated.pod|Dataplane:LB|Feature:SCTP)
+              value: --ginkgo.focus=(\[sig-calico\]|Conformance|Dataplane:BPF|Feature:NetworkPolicy) --ginkgo.skip=(Slow|Disruptive|calient|allow.ingress.access.from.updated.pod|Dataplane:LB|Feature:SCTP|sig-calico-enterprise)
             - name: ENABLE_BPF_DSR
               value: "true"
             - name: VPC_SUBNETS


### PR DESCRIPTION
CI only. One change to one scheduled run on release-v3.32 — the BPF `AWS single subnet` run, which is the branch's Maglev host.

The shared `k8s-e2e:stable` test image carries the Enterprise test tree, so un-skipping `Feature:Maglev` on this run also admitted two Enterprise-only Maglev specs, and both failed. This adds `sig-calico-enterprise` to that run's skip, as another run in these same files already does.

### Evidence

From the 2026-08-11 scheduled run of this job (`e2e-bpf-release-v3-32-1786475400`):

```
[FAIL] [sig-calico-enterprise] ... [Feature:Maglev] ... Maglev node maintenance tests
/go/pkg/mod/github.com/tigera/calico-private@v1.11.0-...20260629.../e2e/pkg/tests/networking/maglev.go:395
```

That source path is the Enterprise module — those specs do not exist in this repo on any branch (`EnterpriseDescribe` has zero uses in OSS `e2e/`).

Checked against the real spec names: the Enterprise node-maintenance specs are skipped, and both OSS `Maglev load balancing` variants still run.

### Not covered here

This run is IPv4-only (`[INFO] IP_FAMILY is ipv4`), so only the IPv4 half of each Maglev test is exercised. Making it dual-family, to match the equivalent run on master, is deferred to its owner.

Separately, this run is not the only one affected: a sweep of the newest v3.32 scheduled runs found **30 steps** across the BPF and iptables pipelines running Enterprise specs, all of them failing some. That is pre-existing and not addressed here — those runs still skip `Feature:Maglev`, so the specs getting through them are Enterprise policy, audit-log and dashboard tests rather than Maglev ones.

## Release Note

```release-note
None
```
