### PR TITLE
e2e: run the OSS e2e binary in v3.32 scheduled runs

### DIFF
--- a/.argoci/scripts/phases/run_tests.sh
+++ b/.argoci/scripts/phases/run_tests.sh
@@ -3,16 +3,18 @@
 # to bz tests.
 #
 # release-v3.32 has no `make e2e-run` target and no structured E2E_TEST_CONFIG
-# (both are master-only). Selection matches v3.32's Semaphore body_standard.sh:
-#   - RUN_LOCAL_TESTS set → build the e2e binary from local source and run it
-#     via ginkgo, selecting specs with K8S_E2E_FLAGS (regex focus/skip). On
-#     v3.32 only the `windows` pipeline sets RUN_LOCAL_TESTS.
-#   - Else → `bz tests`. This is the path every scheduled e2e pipeline
-#     (iptables/bpf/nftables/upgrade/aws/aks/certification/…) takes; bz runs the
-#     k8s-e2e suite and produces the JUnit report itself.
+# (both are master-only), so specs are selected with K8S_E2E_FLAGS regexes:
+#   - RUN_LOCAL_TESTS set → build the e2e binary from local source. On v3.32
+#     only the `windows` pipeline sets it.
+#   - TEST_TYPE k8s-e2e → download the OSS e2e binary from the hashrelease.
+#     This is the path the scheduled e2e pipelines take.
+#   - Else (non-e2e test types: benchmarks, certification, …) → `bz tests`,
+#     which runs the suite and produces the JUnit report itself.
 #
 # Required env:
 #   BZ_LOCAL_DIR, BZ_LOGS_DIR, HOME, REPORT_DIR, TEST_TYPE
+# Required for hashrelease downloads:
+#   RELEASE_STREAM
 #
 # Sourced from body_*.sh. Exits with the test exit code.
 
@@ -25,9 +27,27 @@ if [[ -n "${RUN_LOCAL_TESTS:-}" ]]; then
   echo "[INFO] building e2e binary from local source..."
   pushd "${CI_HOME}/${CI_GIT_DIR}" || exit
   make -C e2e build |& tee >(gzip --stdout > "${BZ_LOGS_DIR}/${TEST_TYPE}-build.log.gz")
+  E2E_BINARY=e2e/bin/k8s/e2e.test
+elif [[ "${TEST_TYPE}" == "k8s-e2e" ]]; then
+  # Scheduled e2e: download the pre-built e2e binary from the hashrelease.
+  echo "[INFO] downloading e2e binary from hashrelease..."
+  pushd "${CI_HOME}/${CI_GIT_DIR}" || exit
 
-  # Run in the same calico/go-build image used to compile the binary (it has
-  # the libbpf/libelf/libz runtime deps and uuidgen the e2e scripts need).
+  # Upgrade runs set RELEASE_STREAM to the downlevel version they install
+  # first, but the tests run against the uplevel version.
+  E2E_STREAM=${UPLEVEL_RELEASE_STREAM:-${RELEASE_STREAM}}
+  HASHREL_URL=$(curl --retry 9 --retry-all-errors -fsS "https://latest-os.hashrelease.tools.tigera.net/${E2E_STREAM}.txt")
+  echo "[INFO] hashrelease URL: ${HASHREL_URL}"
+
+  ARCH=$(uname -m); [[ "$ARCH" == "x86_64" ]] && ARCH=amd64; [[ "$ARCH" == "aarch64" ]] && ARCH=arm64
+  mkdir -p e2e/bin/k8s
+  curl --retry 9 --retry-all-errors -fsSL "${HASHREL_URL}/files/e2e/e2e-linux-${ARCH}.test" -o e2e/bin/k8s/e2e.test
+  chmod +x e2e/bin/k8s/e2e.test
+  E2E_BINARY=e2e/bin/k8s/e2e.test
+fi
+
+if [[ -n "${E2E_BINARY:-}" ]]; then
+  # Run in calico/go-build: it has uuidgen and the ginkgo CLI the run below needs.
   GO_BUILD_VER=$(make --no-print-directory -f ./metadata.mk -f - <<<'print:; @echo $(GO_BUILD_VER)' print)
   RUN_IMAGE="calico/go-build:${GO_BUILD_VER}"
 

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -5,13 +5,26 @@ include ../lib.Makefile
 
 SRC_FILES=$(shell find pkg cmd -name '*.go')
 build: bin/k8s/e2e.test bin/clusternetworkpolicy/e2e.test $(SRC_FILES)
-bin/k8s/e2e.test: $(SRC_FILES)
-	mkdir -p bin
-	$(DOCKER_RUN) $(CALICO_BUILD) go test ./cmd/k8s -c -o $@
+
+bin/k8s/e2e.test: bin/k8s/e2e-linux-$(ARCH).test
+	mv $< $@
 
 bin/clusternetworkpolicy/e2e.test: $(SRC_FILES)
 	mkdir -p bin
 	$(DOCKER_RUN) $(CALICO_BUILD) go test ./cmd/clusternetworkpolicy -c -o $@
+
+# Per-arch e2e binary, cross-compiled inside the calico/go-build container.
+bin/k8s/e2e-linux-$(ARCH).test: $(SRC_FILES)
+	mkdir -p bin/k8s
+	$(DOCKER_RUN) $(CALICO_BUILD) go test ./cmd/k8s -c -o $@
+
+.PHONY: build-all
+build-all: $(addprefix sub-build-,$(VALIDARCHES))
+
+# ARCH has to be set on a fresh make command line rather than per-target, since
+# lib.Makefile computes the arch-dependent build variables with := at parse time.
+sub-build-%:
+	$(MAKE) bin/k8s/e2e-linux-$*.test ARCH=$*
 
 ###############################################################################
 # test images

--- a/release/pkg/manager/calico/manager.go
+++ b/release/pkg/manager/calico/manager.go
@@ -330,6 +330,15 @@ func (r *CalicoManager) Build() error {
 		} else {
 			logrus.Info("Skipping building windows archive")
 		}
+
+		// Build multi-arch e2e test binaries and copy them into the output directory.
+		if r.e2eBinaries {
+			if err = r.buildE2EBinaries(); err != nil {
+				return err
+			}
+		} else {
+			logrus.Info("Skipping building e2e test binaries")
+		}
 	} else {
 		if err = r.buildOCPBundle(); err != nil {
 			return err
@@ -1215,6 +1224,43 @@ func (r *CalicoManager) buildReleaseTar() error {
 
 	if _, err := r.runner.RunInDir(r.repoRoot, "tar", []string{"-czvf", releaseTarFilePath, "-C", baseReleaseOutputDir, fmt.Sprintf("release-%s", r.calicoVersion)}, nil); err != nil {
 		return fmt.Errorf("failed to create release tar: %w", err)
+	}
+	return nil
+}
+
+func (r *CalicoManager) buildE2EBinaries() error {
+	logrus.Info("Building multi-arch e2e test binaries")
+	e2eDir := filepath.Join(r.repoRoot, "e2e")
+	env := append(os.Environ(), fmt.Sprintf("VERSION=%s", r.calicoVersion))
+	if len(r.architectures) > 0 {
+		env = append(env, fmt.Sprintf("VALIDARCHES=%s", strings.Join(r.architectures, " ")))
+	}
+	out, err := r.makeInDirectoryWithOutput(e2eDir, "build-all", env...)
+	if err != nil {
+		logrus.Error(out)
+		return fmt.Errorf("failed to build e2e binaries: %w", err)
+	}
+
+	// Hard-link the built binaries into the hashrelease output directory
+	// to avoid duplicating ~1 GB of cross-compiled test binaries on disk.
+	e2eOutputDir := filepath.Join(r.uploadDir(), "files", "e2e")
+	if err := os.MkdirAll(e2eOutputDir, 0o755); err != nil {
+		return fmt.Errorf("failed to create e2e output dir: %w", err)
+	}
+	entries, err := os.ReadDir(filepath.Join(e2eDir, "bin", "k8s"))
+	if err != nil {
+		return fmt.Errorf("reading e2e bin directory: %w", err)
+	}
+	for _, entry := range entries {
+		if !strings.HasPrefix(entry.Name(), "e2e-linux-") {
+			continue
+		}
+		src := filepath.Join(e2eDir, "bin", "k8s", entry.Name())
+		dst := filepath.Join(e2eOutputDir, entry.Name())
+		if err := os.Link(src, dst); err != nil {
+			return fmt.Errorf("linking e2e binary %s: %w", entry.Name(), err)
+		}
+		logrus.Infof("Staged e2e binary: %s", entry.Name())
 	}
 	return nil
 }


### PR DESCRIPTION
## Description

CI only. Scheduled e2e runs on this branch defer to `bz tests`, which runs `gcr.io/unique-caldron-775/k8s-e2e:stable`. That image is built from `tigera/k8s-e2e`, whose `go.mod` replaces `github.com/projectcalico/calico` with `github.com/tigera/calico-private`, so every OSS scheduled run has been executing a test binary compiled from the private tree.

Enterprise-only specs are in there, and they get admitted by focus rather than missed by skip: the Enterprise Maglev suite carries `[Dataplane:BPF]`, which matches `--ginkgo.focus=...Dataplane:BPF` on the AWS single-subnet run. A ginkgo skip is the only thing that can keep them out, and it has to be maintained per run forever.

Master already runs the in-repo binary instead, downloaded from the hashrelease. This does the same on v3.32.

- `e2e/Makefile` gains `build-all` and a per-arch `bin/k8s/e2e-linux-$(ARCH).test` target. No CGO or cross toolchain needed here, unlike master: v3.32's e2e package doesn't import `felix/bpf`, so the binary is pure Go and cross-compiles under the existing `GOARCH_FLAGS`.
- The release manager builds and stages those binaries under `files/e2e/` in the hashrelease output. The `--e2e-binaries` flag, its env vars, and the manager option were already on this branch, but nothing read the field, so the flag did nothing.
- `.argoci/scripts/phases/run_tests.sh` downloads the binary for `TEST_TYPE=k8s-e2e` and runs it through the existing in-repo path. Non-e2e test types (benchmarks, certification) still go to `bz`.

Upgrade runs need one deviation from master: they set `RELEASE_STREAM` to the downlevel version they install first, and the tests run against the uplevel one, so the download prefers `UPLEVEL_RELEASE_STREAM`. Master downloads from `RELEASE_STREAM` there, which on that branch points at v3.29, and no stream older than master publishes this artifact today.

### Testing

- `make -C e2e build-all VALIDARCHES="amd64 arm64"` produces both binaries, and `file` confirms the arm64 one is aarch64.
- `make -C e2e build` still produces `bin/k8s/e2e.test`, which is what the windows pipeline and per-PR CI use, and `--help` shows the OSS `calico.*` flags.
- Nothing exercises the download path until a v3.32 hashrelease carries the artifact, so the first scheduled run after this merges is the real check.

The existing `sig-calico-enterprise` skips become no-ops once the OSS binary is in use. I left them alone rather than widening this PR.

## Release Note

```release-note
None
```
