### PR TITLE
Felix: back off the tunnel device sync retries

### DIFF
--- a/felix/dataplane/linux/route_mgr.go
+++ b/felix/dataplane/linux/route_mgr.go
@@ -36,6 +36,14 @@ import (
 	"github.com/projectcalico/calico/lib/logrusr"
 )
 
+const (
+	// Delay before the first retry of a failed tunnel device sync; it doubles
+	// from there while the failure persists (see nextTunnelSyncRetryDelay).
+	tunnelSyncMinRetryDelay = 1 * time.Second
+	// How often to log a tunnel device sync failure that isn't going away.
+	tunnelSyncLogInterval = 1 * time.Minute
+)
+
 type routeManager struct {
 	// Our dependencies.
 	routeTable           routetable.Interface
@@ -517,7 +525,18 @@ func (m *routeManager) keepDeviceInSync(
 	logNextSuccess := true
 	parentIface := ""
 
-	sleepMonitoringChans := func(maxDuration time.Duration) {
+	// Failures here are often permanent rather than transient — the commonest
+	// is a host address that isn't on any local link — so back the retries off
+	// and rate limit their logs rather than repeating both every second for
+	// the lifetime of the process.
+	retryDelay := tunnelSyncMinRetryDelay
+	failureLog := logrusr.NewRateLimitedLogger(
+		logrusr.OptInterval(tunnelSyncLogInterval),
+	).WithFields(m.logCtx.Data)
+
+	// sleepMonitoringChans waits for up to maxDuration, reporting whether it
+	// returned early because our inputs changed.
+	sleepMonitoringChans := func(maxDuration time.Duration) bool {
 		timer := time.NewTimer(maxDuration)
 		defer timer.Stop()
 		select {
@@ -526,27 +545,47 @@ func (m *routeManager) keepDeviceInSync(
 			logrus.Debug("Sleep returning early: context finished.")
 		case <-m.tunnelChangedC:
 			logrus.Debug("Sleep returning early: tunnel changed.")
+			return true
 		}
+		return false
+	}
+
+	// sleepAfterFailure waits before the next attempt, lengthening the wait
+	// while the failure persists.  A change to our inputs is a reason to think
+	// the next attempt will do better, so it starts the back-off over.
+	sleepAfterFailure := func() {
+		if sleepMonitoringChans(retryDelay) {
+			retryDelay = tunnelSyncMinRetryDelay
+			return
+		}
+		retryDelay = nextTunnelSyncRetryDelay(retryDelay, wait)
 	}
 
 	for ctx.Err() == nil {
 		if m.parentIfaceAddr() == "" {
 			m.logCtx.Debug("Missing local information, retrying...")
+			// Arm the success log as the other failure paths do: without an
+			// address there is no parent device to hang the routes off, so
+			// getting one back is a recovery worth reporting.
+			logNextSuccess = true
+			retryDelay = tunnelSyncMinRetryDelay
 			sleepMonitoringChans(10 * time.Second)
 			continue
 		}
 
 		parentDevice, err := m.detectParentIface()
 		if err != nil {
-			m.logCtx.WithError(err).Warn("Failed to find parent device, retrying...")
-			sleepMonitoringChans(1 * time.Second)
+			failureLog.WithError(err).Warn("Failed to find parent device, retrying...")
+			logNextSuccess = true
+			sleepAfterFailure()
 			continue
 		}
 
 		link, addr, err := getDevice(parentDevice)
 		if err != nil {
-			m.logCtx.WithError(err).Warn("Failed to get tunnel device, retrying...")
-			sleepMonitoringChans(1 * time.Second)
+			failureLog.WithError(err).Warn("Failed to get tunnel device, retrying...")
+			logNextSuccess = true
+			sleepAfterFailure()
 			continue
 		}
 
@@ -554,9 +593,9 @@ func (m *routeManager) keepDeviceInSync(
 			m.logCtx.Debug("Configuring tunnel device")
 			err = m.configureTunnelDevice(link, addr, mtu, xsumBroken)
 			if err != nil {
-				m.logCtx.WithError(err).Warn("Failed to configure tunnel device, retrying...")
+				failureLog.WithError(err).Warn("Failed to configure tunnel device, retrying...")
 				logNextSuccess = true
-				sleepMonitoringChans(1 * time.Second)
+				sleepAfterFailure()
 				continue
 			}
 		}
@@ -578,11 +617,23 @@ func (m *routeManager) keepDeviceInSync(
 		}
 
 		if logNextSuccess {
-			m.logCtx.Info("Tunnel device configured")
+			// Force the log so that it isn't rate limited away, and so that it
+			// carries the count of failures we suppressed while broken.
+			failureLog.Force().Info("Tunnel device configured")
 			logNextSuccess = false
 		}
+		retryDelay = tunnelSyncMinRetryDelay
 		sleepMonitoringChans(wait)
 	}
+}
+
+// nextTunnelSyncRetryDelay backs off the retries of keepDeviceInSync, up to the
+// interval it polls at when healthy.  Retrying faster than that forever buys
+// nothing: each attempt costs a netlink LinkList plus an AddrList per link — on
+// a busy node that is one call per veth — and a failure that outlives the first
+// few retries is a configuration problem rather than a transient.
+func nextTunnelSyncRetryDelay(previous, wait time.Duration) time.Duration {
+	return min(previous*2, max(wait, tunnelSyncMinRetryDelay))
 }
 
 func (m *routeManager) configureTunnelDevice(

--- a/felix/dataplane/linux/route_mgr_test.go
+++ b/felix/dataplane/linux/route_mgr_test.go
@@ -15,10 +15,15 @@
 package intdataplane
 
 import (
+	"context"
+	"io"
 	"net"
+	"sync"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
 
 	dpsets "github.com/projectcalico/calico/felix/dataplane/ipsets"
@@ -193,6 +198,93 @@ var _ = Describe("Route manager", func() {
 		})
 	})
 
+	Describe("tunnel device sync retries", func() {
+		// Each failed attempt costs a netlink LinkList plus an AddrList per
+		// link, and the commonest failure — a host address that isn't on any
+		// local link — is permanent.  Retrying that once a second forever is
+		// both a netlink load and a stream of warnings, so the delay grows.
+		It("should back off up to the healthy poll interval", func() {
+			delay := tunnelSyncMinRetryDelay
+			delays := []time.Duration{delay}
+			for range 5 {
+				delay = nextTunnelSyncRetryDelay(delay, 10*time.Second)
+				delays = append(delays, delay)
+			}
+			Expect(delays).To(Equal([]time.Duration{
+				1 * time.Second,
+				2 * time.Second,
+				4 * time.Second,
+				8 * time.Second,
+				10 * time.Second,
+				10 * time.Second,
+			}))
+		})
+
+		// The loop polls every "wait" once it is healthy; retrying a failure
+		// less often than that would leave the device unconfigured for longer
+		// than a working node goes unchecked.
+		It("should not back off beyond the poll interval", func() {
+			Expect(nextTunnelSyncRetryDelay(10*time.Second, 10*time.Second)).
+				To(Equal(10 * time.Second))
+		})
+
+		// A caller with a short (or unset) poll interval must not end up
+		// spinning: the minimum delay wins over the cap.
+		It("should not retry faster than the minimum delay", func() {
+			Expect(nextTunnelSyncRetryDelay(tunnelSyncMinRetryDelay, 0)).
+				To(Equal(tunnelSyncMinRetryDelay))
+			Expect(nextTunnelSyncRetryDelay(tunnelSyncMinRetryDelay, 100*time.Millisecond)).
+				To(Equal(tunnelSyncMinRetryDelay))
+		})
+	})
+
+	Describe("tunnel device sync recovery reporting", func() {
+		// "Tunnel device configured" is how an operator sees that the device
+		// came back, and the failure logs around it are rate limited, so every
+		// path that leaves the device unconfigured has to arm it.  Losing the
+		// host address is one of those paths: it is what takes the parent
+		// device away in the first place.
+		It("should report the recovery after the host address comes back", func() {
+			logs := captureStandardLogs()
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			// Buffered so that the loop's parent-device notification doesn't
+			// block it; it only sends when the device name changes.
+			parentIfaceC := make(chan string, 10)
+			routeMgr.updateParentIfaceAddr("172.0.0.2")
+
+			done := make(chan struct{})
+			go func() {
+				defer GinkgoRecover()
+				defer close(done)
+				routeMgr.keepDeviceInSync(ctx, 1400, false, 10*time.Second, parentIfaceC,
+					func(netlink.Link) (netlink.Link, string, error) {
+						// A nil link means "nothing to configure", which takes
+						// the loop straight to its success bookkeeping.
+						return nil, "", nil
+					})
+			}()
+
+			configured := logs.counter("Tunnel device configured")
+			Eventually(configured).Should(Equal(1))
+
+			// Take the address away, and wait for the loop to notice before
+			// giving it back: it is that iteration which has to arm the log.
+			routeMgr.updateParentIfaceAddr("")
+			Eventually(logs.counter("Missing local information, retrying...")).
+				Should(BeNumerically(">=", 1))
+			Expect(configured()).To(Equal(1))
+
+			routeMgr.updateParentIfaceAddr("172.0.0.2")
+			Eventually(configured).Should(Equal(2))
+
+			cancel()
+			Eventually(done).Should(BeClosed())
+		})
+	})
+
 	Describe("parent device updates", func() {
 		BeforeEach(func() {
 			routeMgr.OnParentDeviceUpdate("eth0")
@@ -255,3 +347,60 @@ var _ = Describe("Route manager", func() {
 		})
 	})
 })
+
+// captureStandardLogs collects the messages logged to the standard logger for
+// the rest of the spec.  keepDeviceInSync builds its own rate-limited logger on
+// top of that logger, so a hook is the only way to see what it reports.
+func captureStandardLogs() *logCapture {
+	logger := logrus.StandardLogger()
+	capture := &logCapture{}
+
+	oldHooks := logger.ReplaceHooks(logrus.LevelHooks{})
+	logger.AddHook(capture)
+	// The loop reports the loss of the host address at debug level, and the
+	// output would otherwise clutter the spec's report.
+	oldLevel, oldOut := logger.GetLevel(), logger.Out
+	logger.SetLevel(logrus.DebugLevel)
+	logger.SetOutput(io.Discard)
+
+	DeferCleanup(func() {
+		logger.ReplaceHooks(oldHooks)
+		logger.SetLevel(oldLevel)
+		logger.SetOutput(oldOut)
+	})
+
+	return capture
+}
+
+// logCapture is a logrus hook that records the messages it is given.
+type logCapture struct {
+	lock     sync.Mutex
+	messages []string
+}
+
+func (c *logCapture) Levels() []logrus.Level {
+	return logrus.AllLevels
+}
+
+func (c *logCapture) Fire(entry *logrus.Entry) error {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.messages = append(c.messages, entry.Message)
+	return nil
+}
+
+// counter returns how many times the message has been logged so far, as a
+// function so that it can be polled by Eventually.
+func (c *logCapture) counter(message string) func() int {
+	return func() int {
+		c.lock.Lock()
+		defer c.lock.Unlock()
+		count := 0
+		for _, m := range c.messages {
+			if m == message {
+				count++
+			}
+		}
+		return count
+	}
+}


### PR DESCRIPTION
`routeManager.keepDeviceInSync` retried every second after a failure, with a `Warn` each time, while a healthy loop polls every ten. The commonest failure is permanent rather than transient (a host address that isn't on any local link), and each attempt costs a netlink `LinkList` plus an `AddrList` per link — one call per veth on a busy node. Felix runs up to five of these goroutines, so a misconfigured node paid that once a second, forever, per goroutine.

The delay now doubles while the failure persists, capped at the interval the loop already polls at when healthy, and resets on success or when the parent address changes, so recovery is no slower than before.

Failure logs are rate limited, so the "Tunnel device configured" log is now what tells an operator the device came back. Every path that leaves the device unconfigured therefore arms it, which previously only a failure to *configure* the device did — recovering from a failure to *find* the parent device, or from the host losing the address that names it, was silent. That last path is the one #13504 makes reachable: clearing a stale parent address is what sends this loop through it.

### Testing

New unit tests in `route_mgr_test.go`:

- the back-off sequence, its cap at the poll interval, and its floor for a short or unset interval;
- the recovery report — the loop is driven through configure → host address lost → address restored, and must log "Tunnel device configured" a second time. This spec fails against the unfixed loop (it times out waiting for the second log), and passed 25/25 runs under `-race`.

`felix/dataplane/linux` is green: 1026 of 1026 specs.

### Related

Split out of #13504, which is now scoped to the `noEncapManager` parent-address fix that motivated this one. The two are independent and can land in either order.

**Release note:**
```release-note
Reduce Felix's netlink and log load when tunnel device configuration keeps failing, by backing off the retries up to the interval the healthy loop already polls at.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
