### PR TITLE
node-driver-registrar: bump grpc/x-net/x-text for CVE fixes (release-v3.31)

### DIFF
--- a/pod2daemon/node-driver-registrar-patches/0001-CVE-dependency-fixes.patch
+++ b/pod2daemon/node-driver-registrar-patches/0001-CVE-dependency-fixes.patch
@@ -1,45 +1,63 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tigera <noreply@tigera.io>
-Date: Mon, 09 Jun 2026 09:00:00 -0700
+Date: Wed, 13 Aug 2026 09:00:00 -0700
 Subject: [PATCH] Update dependencies for CVE fixes
 
 Applied on top of the pinned kubernetes-csi/node-driver-registrar commit
-(UPSTREAM_REGISTRAR_TAG). Advances the golang.org/x modules past the
-versions upstream pins:
+(UPSTREAM_REGISTRAR_TAG). Advances modules past the versions upstream pins
+to clear CVEs flagged in the bundled image:
 
-  golang.org/x/net v0.54.0 -> v0.55.0
-  golang.org/x/sys v0.44.0 -> v0.46.0
+  golang.org/x/net       v0.54.0 -> v0.56.0
+  golang.org/x/sys       v0.44.0 -> v0.46.0
+  golang.org/x/text      v0.37.0 -> v0.39.0
+  google.golang.org/grpc v1.81.0 -> v1.82.1
 
-No transitive ripple (x/text stays v0.37.0) and the module's `go`
-directive is unchanged at 1.25.0, so no GOTOOLCHAIN override is needed.
-upstream does not depend on golang.org/x/crypto, so there is nothing to
-bump there.
+- x/net clears GO-2026-5942 (panic parsing an invalid SVCB or HTTPS DNS RR
+  in golang.org/x/net/dns/dnsmessage, fixed in v0.56.0).
+- x/text clears CVE-2026-56852 / GO-2026-5970 (infinite loop in norm.Iter
+  on invalid UTF-8), fixed in v0.39.0.
+- grpc clears GO-2026-6061, fixed in v1.82.1; this also advances the
+  transitive genproto/googleapis/rpc pin via `go mod tidy`.
+
+The module's `go` directive is unchanged at 1.25.0, so no GOTOOLCHAIN
+override is needed (the build uses the branch Go toolchain). Upstream does
+not depend on golang.org/x/crypto, so there is nothing to bump there.
 
 Verified `patch -p1 --dry-run` clean against the pinned upstream commit.
 ---
+diff --git a/go.mod b/go.mod
+index b1ff16b8..8cc911ee 100644
 --- a/go.mod
 +++ b/go.mod
-@@ -4,7 +4,7 @@
+@@ -4,8 +4,8 @@ go 1.25.0
  
  require (
  	github.com/kubernetes-csi/csi-lib-utils v0.23.2
 -	golang.org/x/sys v0.44.0
+-	google.golang.org/grpc v1.81.0
 +	golang.org/x/sys v0.46.0
- 	google.golang.org/grpc v1.81.0
++	google.golang.org/grpc v1.82.1
  	k8s.io/client-go v0.35.0
  	k8s.io/component-base v0.35.0
-@@ -63,7 +63,7 @@
+ 	k8s.io/klog/v2 v2.140.0
+@@ -63,9 +63,9 @@ require (
  	go.uber.org/zap v1.28.0 // indirect
  	go.yaml.in/yaml/v2 v2.4.4 // indirect
  	go.yaml.in/yaml/v3 v3.0.4 // indirect
 -	golang.org/x/net v0.54.0 // indirect
-+	golang.org/x/net v0.55.0 // indirect
- 	golang.org/x/text v0.37.0 // indirect
- 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260406210006-6f92a3bedf2d // indirect
+-	golang.org/x/text v0.37.0 // indirect
+-	google.golang.org/genproto/googleapis/rpc v0.0.0-20260406210006-6f92a3bedf2d // indirect
++	golang.org/x/net v0.56.0 // indirect
++	golang.org/x/text v0.39.0 // indirect
++	google.golang.org/genproto/googleapis/rpc v0.0.0-20260414002931-afd174a4e478 // indirect
  	google.golang.org/protobuf v1.36.11 // indirect
+ 	gopkg.in/inf.v0 v0.9.1 // indirect
+ 	k8s.io/apimachinery v0.35.0 // indirect
+diff --git a/go.sum b/go.sum
+index cef8b6d6..1ce12bd6 100644
 --- a/go.sum
 +++ b/go.sum
-@@ -140,10 +140,10 @@
+@@ -140,18 +140,18 @@ go.yaml.in/yaml/v2 v2.4.4 h1:tuyd0P+2Ont/d6e2rl3be67goVK4R6deVxCUX5vyPaQ=
  go.yaml.in/yaml/v2 v2.4.4/go.mod h1:gMZqIpDtDqOfM0uNfy0SkpRhvUryYH0Z6wdMYcacYXQ=
  go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
  go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
@@ -47,10 +65,24 @@ Verified `patch -p1 --dry-run` clean against the pinned upstream commit.
 -golang.org/x/net v0.54.0/go.mod h1:Sj4oj8jK6XmHpBZU/zWHw3BV3abl4Kvi+Ut7cQcY+cQ=
 -golang.org/x/sys v0.44.0 h1:ildZl3J4uzeKP07r2F++Op7E9B29JRUy+a27EibtBTQ=
 -golang.org/x/sys v0.44.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
-+golang.org/x/net v0.55.0 h1:bcvxaJn3e1U6InsFWt1JUq1aSjnRxLzT2rtD2KfkDF8=
-+golang.org/x/net v0.55.0/go.mod h1:L5U2KuzuOe1lY7Z+aWVIKK6qEeJXnXV9yzGA+WCHJww=
+-golang.org/x/text v0.37.0 h1:Cqjiwd9eSg8e0QAkyCaQTNHFIIzWtidPahFWR83rTrc=
+-golang.org/x/text v0.37.0/go.mod h1:a5sjxXGs9hsn/AJVwuElvCAo9v8QYLzvavO5z2PiM38=
++golang.org/x/net v0.56.0 h1:Rw8j/hFzGvJUZwNBXnAtf5sVDVt+65SK2C7IxCxZt5o=
++golang.org/x/net v0.56.0/go.mod h1:D3Ku6r+V6JROoZK144D2XfMHFcMq/0zSfLelVTCFKec=
 +golang.org/x/sys v0.46.0 h1:noSf2Fq6F8DBgS+LysIkx7rIExoNHJsxOAtPp4rthXw=
 +golang.org/x/sys v0.46.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
- golang.org/x/text v0.37.0 h1:Cqjiwd9eSg8e0QAkyCaQTNHFIIzWtidPahFWR83rTrc=
- golang.org/x/text v0.37.0/go.mod h1:a5sjxXGs9hsn/AJVwuElvCAo9v8QYLzvavO5z2PiM38=
++golang.org/x/text v0.39.0 h1:UbZz4pLOvn600D6Oh6GGEI6VAmndrEBLv8/6BEXzyus=
++golang.org/x/text v0.39.0/go.mod h1:3UwRclnC2g0TU9x8PZiyfOajCd1zaUNHF9cvqcQZ+ZM=
  gonum.org/v1/gonum v0.17.0 h1:VbpOemQlsSMrYmn7T2OUvQ4dqxQXU+ouZFQsZOx50z4=
+ gonum.org/v1/gonum v0.17.0/go.mod h1:El3tOrEuMpv2UdMrbNlKEh9vd86bmQ6vqIcDwxEOc1E=
+-google.golang.org/genproto/googleapis/rpc v0.0.0-20260406210006-6f92a3bedf2d h1:wT2n40TBqFY6wiwazVK9/iTWbsQrgk5ZfCSVFLO9LQA=
+-google.golang.org/genproto/googleapis/rpc v0.0.0-20260406210006-6f92a3bedf2d/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
+-google.golang.org/grpc v1.81.0 h1:W3G9N3KQf3BU+YuCtGKJk0CmxQNbAISICD/9AORxLIw=
+-google.golang.org/grpc v1.81.0/go.mod h1:xGH9GfzOyMTGIOXBJmXt+BX/V0kcdQbdcuwQ/zNw42I=
++google.golang.org/genproto/googleapis/rpc v0.0.0-20260414002931-afd174a4e478 h1:RmoJA1ujG+/lRGNfUnOMfhCy5EipVMyvUE+KNbPbTlw=
++google.golang.org/genproto/googleapis/rpc v0.0.0-20260414002931-afd174a4e478/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
++google.golang.org/grpc v1.82.1 h1:NnAxzGRA0677vCa4BUkOAnO5+FfQqVl9iUXeD0IqcGE=
++google.golang.org/grpc v1.82.1/go.mod h1:yzTZ1TB1Z3SG+LIYaI+WiE8D5+PZ3ArnrSp8zF3+/ZA=
+ google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=
+ google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
+ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
Refreshes the node-driver-registrar dependency patch on release-v3.31 to clear CVEs flagged in the latest security scan.

## Changes
- `pod2daemon/node-driver-registrar-patches/0001-CVE-dependency-fixes.patch`: advance
  - google.golang.org/grpc v1.81.0 -> v1.82.1 (GO-2026-6061)
  - golang.org/x/net v0.54.0 -> v0.56.0 (GO-2026-5942)
  - golang.org/x/text v0.37.0 -> v0.39.0 (CVE-2026-56852)
  - golang.org/x/sys v0.44.0 -> v0.46.0

## Notes
- The registrar's `go` directive stays 1.25.0, so no GOTOOLCHAIN override is needed (builds with the branch Go toolchain).
- Patch applies cleanly against the pinned UPSTREAM_REGISTRAR_TAG commit.
- Build-verified: node-driver-registrar compiles with grpc v1.82.1.

```release-note
Refresh the node-driver-registrar dependency patch to remediate CVEs (grpc v1.82.1, x/net, x/text).
```
