### PR TITLE
PMREQ-821: Grant the operator Gateway API access for Whisker CIG 

### DIFF
--- a/charts/tigera-operator/templates/tigera-operator/02-role-tigera-operator.yaml
+++ b/charts/tigera-operator/templates/tigera-operator/02-role-tigera-operator.yaml
@@ -698,15 +698,26 @@ rules:
       - update
     resourceNames:
       - tigera-gateway-api-gateway-helm-certgen
-  # 4. The operator needs to be able to read Gateway resources to determine namespaces to apply
-  # CIG resources to.
+  # 4. Gateway API resources for Whisker UI access through Calico Ingress Gateway.
+  # Reads are cluster-wide for the operator's cache; writes are self-granted per
+  # namespace at runtime.
   - apiGroups:
       - gateway.networking.k8s.io
     resources:
       - gateways
+      - httproutes
+      - referencegrants
     verbs:
-      - list
       - get
+      - list
+      - watch
+  - apiGroups:
+      - gateway.envoyproxy.io
+    resources:
+      - backends
+    verbs:
+      - get
+      - list
       - watch
   # For monitoring KubeVirt live migration.  The operator does not do this itself, but needs to
   # be able to assign this RBAC to Typha and calico-node.

--- a/manifests/ocp/02-role-tigera-operator.yaml
+++ b/manifests/ocp/02-role-tigera-operator.yaml
@@ -675,15 +675,26 @@ rules:
       - update
     resourceNames:
       - tigera-gateway-api-gateway-helm-certgen
-  # 4. The operator needs to be able to read Gateway resources to determine namespaces to apply
-  # CIG resources to.
+  # 4. Gateway API resources for Whisker UI access through Calico Ingress Gateway.
+  # Reads are cluster-wide for the operator's cache; writes are self-granted per
+  # namespace at runtime.
   - apiGroups:
       - gateway.networking.k8s.io
     resources:
       - gateways
+      - httproutes
+      - referencegrants
     verbs:
-      - list
       - get
+      - list
+      - watch
+  - apiGroups:
+      - gateway.envoyproxy.io
+    resources:
+      - backends
+    verbs:
+      - get
+      - list
       - watch
   # For monitoring KubeVirt live migration.  The operator does not do this itself, but needs to
   # be able to assign this RBAC to Typha and calico-node.

--- a/manifests/tigera-operator-ocp-upgrade.yaml
+++ b/manifests/tigera-operator-ocp-upgrade.yaml
@@ -715,15 +715,26 @@ rules:
       - update
     resourceNames:
       - tigera-gateway-api-gateway-helm-certgen
-  # 4. The operator needs to be able to read Gateway resources to determine namespaces to apply
-  # CIG resources to.
+  # 4. Gateway API resources for Whisker UI access through Calico Ingress Gateway.
+  # Reads are cluster-wide for the operator's cache; writes are self-granted per
+  # namespace at runtime.
   - apiGroups:
       - gateway.networking.k8s.io
     resources:
       - gateways
+      - httproutes
+      - referencegrants
     verbs:
-      - list
       - get
+      - list
+      - watch
+  - apiGroups:
+      - gateway.envoyproxy.io
+    resources:
+      - backends
+    verbs:
+      - get
+      - list
       - watch
   # For monitoring KubeVirt live migration.  The operator does not do this itself, but needs to
   # be able to assign this RBAC to Typha and calico-node.

--- a/manifests/tigera-operator.yaml
+++ b/manifests/tigera-operator.yaml
@@ -654,15 +654,26 @@ rules:
       - update
     resourceNames:
       - tigera-gateway-api-gateway-helm-certgen
-  # 4. The operator needs to be able to read Gateway resources to determine namespaces to apply
-  # CIG resources to.
+  # 4. Gateway API resources for Whisker UI access through Calico Ingress Gateway.
+  # Reads are cluster-wide for the operator's cache; writes are self-granted per
+  # namespace at runtime.
   - apiGroups:
       - gateway.networking.k8s.io
     resources:
       - gateways
+      - httproutes
+      - referencegrants
     verbs:
-      - list
       - get
+      - list
+      - watch
+  - apiGroups:
+      - gateway.envoyproxy.io
+    resources:
+      - backends
+    verbs:
+      - get
+      - list
       - watch
   # For monitoring KubeVirt live migration.  The operator does not do this itself, but needs to
   # be able to assign this RBAC to Typha and calico-node.


### PR DESCRIPTION
## Description

Grants the operator the Gateway API access the Whisker controller needs when
`spec.ingressGateway` is set on the Whisker CR, which renders a Gateway,
HTTPRoute, ReferenceGrant and an Envoy Gateway Backend. The ClusterRole
previously allowed only reading Gateways, so every render failed with Forbidden.

Reads are cluster-wide: the operator's controller-runtime cache lists and
watches these kinds in every namespace, and cleanup finds leftovers by listing
Gateways cluster-wide.

Writes are **not** cluster-wide. `create/update/delete` are deliberately
withheld here — the operator self-grants them through a namespace-scoped Role
and RoleBinding rendered alongside the gateway resources, confining its
mutations to the namespaces `spec.ingressGateway` names. Those Roles are
rendered operator-side rather than in this chart because a user-chosen gateway
namespace does not exist at chart-install time. This is the same shape the
waypoint EnvoyFilter rule a few rules up already uses.

Manifests regenerated from the chart with `make gen-manifests`.

**Merge order:** tigera/operator#5146 must merge first (or together with this).
Without the operator change the namespace-scoped Roles do not exist, so gateway
renders fail with Forbidden.

Verified on an OSS EKS cluster with this ClusterRole applied, using SubjectAccessReview
to confirm `create` on `gateways`, `httproutes`, `referencegrants` and `backends` is
denied cluster-wide but allowed in the configured namespace. The operator self-granted
`calico-whisker-ingressgateway-access` on the first reconcile, rendered the gateway
resources, and served the Whisker UI and flow logs through the gateway load balancer,
including the server-sent-event stream. Moving `gatewayNamespace` to a user-chosen
namespace carried the grant and the gateway resources across, leaving the backend
namespace's own grant in place. Cleanup on spec removal is covered by the render tests
in the operator PR.

## Related

- tigera/operator#5146 — the operator change that renders the namespace-scoped Roles

## Release Note

```release-note
The Whisker UI can be exposed through Calico Ingress Gateway by setting spec.ingressGateway on the Whisker resource.
```

