### PR TITLE
semaphore: rename a killed batch's log so its failure gets analysed

### DIFF
--- a/.semaphore/vms/run-tests-on-vms
+++ b/.semaphore/vms/run-tests-on-vms
@@ -407,9 +407,13 @@ for i in "${!batches[@]}"; do
       # Reaching here means the batch never ran its own failure handler, so the
       # log stops wherever the batch was killed.  Say so in the log itself: it
       # is now an input to fv-tests-guru, and a truncated transcript otherwise
-      # reads as a test that simply stopped emitting.
+      # reads as a test that simply stopped emitting.  Best-effort under the
+      # script's `set -e`: a full disk is one of the things that gets a batch
+      # killed in the first place, and losing the marker must not cost us the
+      # summary, the failure exit code, or the watchdog cleanup below.
       printf '\n===== Batch %s did not complete: killed before it could finish, so this log is truncated mid-run =====\n' \
-        "$batch" >> "$failed_summary_log"
+        "$batch" >> "$failed_summary_log" ||
+        echo "  Could not mark $failed_summary_log as truncated (rc=$?)"
     fi
     summary+=( "Test batch $batch FAILED; Log file will be uploaded as artifact $failed_summary_log" )
     final_result=1

--- a/.semaphore/vms/run-tests-on-vms
+++ b/.semaphore/vms/run-tests-on-vms
@@ -394,7 +394,22 @@ for i in "${!batches[@]}"; do
     batch_formatted="$(format_batch_for_log "$batch")"
     failed_summary_log="$artifacts_dir/test-$batch_formatted-FAILED.log"
     if [ ! -f "$failed_summary_log" ] && [ -f "$artifacts_dir/test-$batch_formatted.log" ]; then
-      failed_summary_log="$artifacts_dir/test-$batch_formatted.log"
+      # The batch failed without renaming its own log.  A batch the watchdog
+      # kills never reaches that rename, because the kill takes out the process
+      # group that would have done it.  Rename it here instead: the -FAILED
+      # suffix is how analyze-test-failures discovers which batches to analyse,
+      # so a log left under its running name gets no fv-tests-guru diagnosis and
+      # no DIAGS artifact, and the failure reaches CI reporting as nothing but
+      # the summary line below.  Safe at this point: we are past `wait`, so the
+      # batch is finished and nothing is still writing to the log.
+      mv "$artifacts_dir/test-$batch_formatted.log" "$failed_summary_log" ||
+        failed_summary_log="$artifacts_dir/test-$batch_formatted.log"
+      # Reaching here means the batch never ran its own failure handler, so the
+      # log stops wherever the batch was killed.  Say so in the log itself: it
+      # is now an input to fv-tests-guru, and a truncated transcript otherwise
+      # reads as a test that simply stopped emitting.
+      printf '\n===== Batch %s did not complete: killed before it could finish, so this log is truncated mid-run =====\n' \
+        "$batch" >> "$failed_summary_log"
     fi
     summary+=( "Test batch $batch FAILED; Log file will be uploaded as artifact $failed_summary_log" )
     final_result=1


### PR DESCRIPTION
A batch killed by the job-timeout watchdog currently produces **no failure analysis at all** — no fv-tests-guru diagnosis, no DIAGS artifact, no failure signature. One missing rename causes it.

## The gap

A failing batch renames its log to `test-NNN-FAILED.log` from its own failure handler (`run-tests-on-vms:231`). A batch the watchdog kills never reaches that line — `kill -TERM "-$pid"` takes out the process group that would have done it.

That name is load-bearing. `felix/.semaphore/analyze-test-failures:241-245` discovers what to analyse by globbing it:

```sh
# Discover failed batches from -FAILED.log files (the definitive signal
# that a batch failed). ...
for failed_log in "$ARTIFACTS_DIR"/test-*-FAILED.log; do
```

So a batch killed at the job timeout is skipped, and everything downstream that reads DIAGS — the JUnit injection, the failure-signature database, the CI triage and branch-monitor bots — sees a job that failed with nothing said about why.

Observed on calico-private (`Felix: BPF tests on Ubuntu 22.04 (nftables)`, batches 5 and 9 killed at 60m): the only thing that reached the PR comment was the runner's own summary line, `Test batch 5 and 9 FAILED; Log file will be uploaded as artifact`. The actual failure — `Timed out waiting for Felix to become ready`, with `BPFEndpointManager … Not yet synced` — sat unread in `test-005.log`, which *was* uploaded, just never analysed.

## The change

Do the rename in the end-of-job summary loop rather than in the watchdog. That block already worked out which of the two names existed; it now moves the file instead of just reporting it.

The summary loop is the right place for two reasons:

- it runs after `wait "$pid"`, so the batch is definitively finished and nothing is still writing to the log — renaming next to the watchdog's `kill` would race the batch's final writes;
- it is the single point that decides a batch failed, so it covers **any** path that ends without renaming, not just the watchdog kill.

Reaching that branch means the batch never ran its own failure handler, so the log stops wherever the batch was killed. That gets noted in the log itself — it is an input to fv-tests-guru now, and a truncated transcript otherwise reads as a test that simply stopped emitting.

The watchdog already synthesises a JUnit XML so the timeout shows up in Semaphore's test results; this gives the log-analysis half the same treatment.

## Testing

The changed block was lifted verbatim into a harness and exercised across every case it can meet:

| case | expected | result |
|---|---|---|
| batch failed normally (already renamed) | untouched, no stray log, no marker | pass |
| batch killed (log under running name) | renamed, content kept, marked truncated | pass |
| `analyze-test-failures` glob after the fix | now matches the killed batch | pass |
| neither log present | no crash, no file created | pass |
| rename impossible (read-only dir) | falls back to the real name, log not lost | pass |

`bash -n` clean. Artifact upload is glob-based (`.semaphore/publish-artifacts:29` iterates `*`), so nothing downstream is coupled to the old name.

No behaviour changes for a batch that fails normally — that path already renamed its own log and this branch is not entered.

**Release note:**
```release-note
None
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)