### PR TITLE
ci(branch-monitor): send the pipeline id, not just the workflow id

### DIFF
--- a/.semaphore/semaphore-scheduled-builds.yml
+++ b/.semaphore/semaphore-scheduled-builds.yml
@@ -2045,8 +2045,17 @@ after_pipeline:
               failed) result=fail ;;
               *) echo "pipeline result '${SEMAPHORE_PIPELINE_RESULT}' — not recorded"; exit 0 ;;
             esac
-            msg=$(printf 'repo: calico\nbranch: %s\nworkflow_id: %s\nresult: %s\npipeline: %s' \
-              "$SEMAPHORE_GIT_BRANCH" "$SEMAPHORE_WORKFLOW_ID" "$result" "${SEMAPHORE_PIPELINE_NAME:-calico}")
+            # pipeline_id, not just workflow_id: a partial re-run of failed
+            # blocks runs under the SAME workflow id, so the workflow alone
+            # cannot say which run this is. This task runs inside the pipeline
+            # that just finished — the re-run itself — so it is the one place
+            # that knows, and passing it on is what lets the monitor tell a
+            # re-run apart from a repeated delivery of the same run.
+            msg=$(printf 'repo: calico\nbranch: %s\nworkflow_id: %s\npipeline_id: %s\nresult: %s\npipeline: %s' \
+              "$SEMAPHORE_GIT_BRANCH" "$SEMAPHORE_WORKFLOW_ID" "$SEMAPHORE_PIPELINE_ID" "$result" "${SEMAPHORE_PIPELINE_NAME:-calico}")
+            # Echo the payload: it is the only record of what the agent was
+            # told, and it is where an unset variable shows up as an empty field.
+            echo "branch-monitor: sending"; echo "$msg"
             req=$(jq -n --arg t "$msg" '{jsonrpc:"2.0",id:"1",method:"message/stream",params:{message:{role:"user",kind:"message",messageId:"1",parts:[{kind:"text",text:$t}]}}}')
             # We only need the trigger to land: the agent records the run and posts
             # to Slack itself, and its task runs to completion server-side even if

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -6431,8 +6431,17 @@ after_pipeline:
               failed) result=fail ;;
               *) echo "pipeline result '${SEMAPHORE_PIPELINE_RESULT}' — not recorded"; exit 0 ;;
             esac
-            msg=$(printf 'repo: calico\nbranch: %s\nworkflow_id: %s\nresult: %s\npipeline: %s' \
-              "$SEMAPHORE_GIT_BRANCH" "$SEMAPHORE_WORKFLOW_ID" "$result" "${SEMAPHORE_PIPELINE_NAME:-calico}")
+            # pipeline_id, not just workflow_id: a partial re-run of failed
+            # blocks runs under the SAME workflow id, so the workflow alone
+            # cannot say which run this is. This task runs inside the pipeline
+            # that just finished — the re-run itself — so it is the one place
+            # that knows, and passing it on is what lets the monitor tell a
+            # re-run apart from a repeated delivery of the same run.
+            msg=$(printf 'repo: calico\nbranch: %s\nworkflow_id: %s\npipeline_id: %s\nresult: %s\npipeline: %s' \
+              "$SEMAPHORE_GIT_BRANCH" "$SEMAPHORE_WORKFLOW_ID" "$SEMAPHORE_PIPELINE_ID" "$result" "${SEMAPHORE_PIPELINE_NAME:-calico}")
+            # Echo the payload: it is the only record of what the agent was
+            # told, and it is where an unset variable shows up as an empty field.
+            echo "branch-monitor: sending"; echo "$msg"
             req=$(jq -n --arg t "$msg" '{jsonrpc:"2.0",id:"1",method:"message/stream",params:{message:{role:"user",kind:"message",messageId:"1",parts:[{kind:"text",text:$t}]}}}')
             # We only need the trigger to land: the agent records the run and posts
             # to Slack itself, and its task runs to completion server-side even if

--- a/.semaphore/semaphore.yml.d/99-after_pipeline.yml
+++ b/.semaphore/semaphore.yml.d/99-after_pipeline.yml
@@ -32,8 +32,17 @@ after_pipeline:
               failed) result=fail ;;
               *) echo "pipeline result '${SEMAPHORE_PIPELINE_RESULT}' — not recorded"; exit 0 ;;
             esac
-            msg=$(printf 'repo: calico\nbranch: %s\nworkflow_id: %s\nresult: %s\npipeline: %s' \
-              "$SEMAPHORE_GIT_BRANCH" "$SEMAPHORE_WORKFLOW_ID" "$result" "${SEMAPHORE_PIPELINE_NAME:-calico}")
+            # pipeline_id, not just workflow_id: a partial re-run of failed
+            # blocks runs under the SAME workflow id, so the workflow alone
+            # cannot say which run this is. This task runs inside the pipeline
+            # that just finished — the re-run itself — so it is the one place
+            # that knows, and passing it on is what lets the monitor tell a
+            # re-run apart from a repeated delivery of the same run.
+            msg=$(printf 'repo: calico\nbranch: %s\nworkflow_id: %s\npipeline_id: %s\nresult: %s\npipeline: %s' \
+              "$SEMAPHORE_GIT_BRANCH" "$SEMAPHORE_WORKFLOW_ID" "$SEMAPHORE_PIPELINE_ID" "$result" "${SEMAPHORE_PIPELINE_NAME:-calico}")
+            # Echo the payload: it is the only record of what the agent was
+            # told, and it is where an unset variable shows up as an empty field.
+            echo "branch-monitor: sending"; echo "$msg"
             req=$(jq -n --arg t "$msg" '{jsonrpc:"2.0",id:"1",method:"message/stream",params:{message:{role:"user",kind:"message",messageId:"1",parts:[{kind:"text",text:$t}]}}}')
             # We only need the trigger to land: the agent records the run and posts
             # to Slack itself, and its task runs to completion server-side even if


### PR DESCRIPTION
## Description

A partial re-run of failed blocks runs under the **same workflow id** as the run it re-runs, so a workflow id alone cannot say which run a trigger is for. The branch CI monitor keys both its alert dedup and its run history on it, so a re-run is taken as a fresh delivery of the original run. Two consequences:

- it re-reports the *first* pipeline's failures, which by the time of the re-run may already be fixed, and
- it counts the run twice in the flake window, pulling a check towards "intermittent" on evidence that does not exist.

This was observed on a master run whose failed blocks were re-run once the underlying fix had landed: the monitor posted the same red a second time, describing a problem that no longer existed, while the re-run's actual (different) failure went unreported.

This `after_pipeline` task runs inside the pipeline that just finished — for a re-run, the re-run itself — so it is the one place that knows which run this is. It simply wasn't passing it on.

## Changes

- Add `pipeline_id: $SEMAPHORE_PIPELINE_ID` to the trigger payload.
- Echo the payload. It is the only record of what the agent was told, and an unset variable shows up there as an empty field.

Generated files regenerated with `make gen-semaphore-yaml` (`.semaphore/semaphore.yml` and `.semaphore/semaphore-scheduled-builds.yml`).

## On `SEMAPHORE_PIPELINE_ID` inside `after_pipeline`

Semaphore documents the variable but lists it under regular jobs rather than in the after-pipeline section. Two reasons this is safe regardless:

1. This same task already uses `SEMAPHORE_PIPELINE_NAME`, another pipeline-scoped variable, and it does resolve there — the monitor's recorded runs carry the real pipeline name, not the fallback the script would have used had it been empty.
2. If it *is* empty, nothing breaks: the consumers fall back to their current behaviour, which is what happens today.

The added echo settles it either way on the first run on master.

## Testing

`make gen-semaphore-yaml` reproduces both generated files from the template; `make yaml-lint` passes; both files parse, and the `Branch CI monitor` job of the `after_pipeline` task carries `pipeline_id` in the payload.

The end-to-end effect is only observable once this is on master, which is what the echoed payload is for.

## Release Note

```release-note
None
```
