### PR TITLE
BPF: keep conntrack RST state on the tracking entry for NAT'd flows

### DIFF
--- a/felix/bpf-gpl/conntrack.h
+++ b/felix/bpf-gpl/conntrack.h
@@ -797,7 +797,14 @@ static CALI_BPF_INLINE struct calico_ct_result calico_ct_lookup(struct cali_tc_c
 
 	struct calico_ct_leg *src_to_dst, *dst_to_src;
 
-	struct calico_ct_value *tracking_v;
+	/* Connection-level state -- the RST timestamp and the connlimit flags --
+	 * lives on the tracking entry. For a NAT_FWD hit that is the reverse
+	 * entry, picked up by the secondary lookup below, same as the legs
+	 * src_to_dst/dst_to_src point into; for every other type the entry we
+	 * looked up is itself the tracking entry.
+	 */
+	struct calico_ct_value *tracking_v = v;
+
 	switch (v->type) {
 	case CALI_CT_TYPE_NAT_FWD:
 		// This is a forward NAT entry; since we do the bookkeeping on the
@@ -1079,15 +1086,15 @@ static CALI_BPF_INLINE struct calico_ct_result calico_ct_lookup(struct cali_tc_c
 		if (tcp_header->rst) {
 			CALI_CT_DEBUG("RST seen, marking CT entry.");
 			src_to_dst->rst_seen = 1;
-			v->rst_seen = now;
-		} else if (v->rst_seen) {
-			if (now - v->rst_seen > 2 * 60 * 1000000000ull || now - v->rst_seen > (1ull << 63)) {
+			tracking_v->rst_seen = now;
+		} else if (tracking_v->rst_seen) {
+			if (now - tracking_v->rst_seen > 2 * 60 * 1000000000ull || now - tracking_v->rst_seen > (1ull << 63)) {
 				/* It's been a looong time (2m) since we saw the RST, we still see
 				 * traffic, we must have seen traffic between now and rst_seen,
 				 * otherwise the entry would have been GCed, the connection is
 				 * likely established and the RST was spurious.
 				 */
-				v->rst_seen = 0;
+				tracking_v->rst_seen = 0;
 			}
 		}
 		ct_tcp_entry_update(ctx, tcp_header, src_to_dst, dst_to_src);
@@ -1097,7 +1104,7 @@ static CALI_BPF_INLINE struct calico_ct_result calico_ct_lookup(struct cali_tc_c
 		 * before decrementing so concurrent paths bail.
 		 */
 		if ((src_to_dst->fin_seen && dst_to_src->fin_seen) || tcp_header->rst) {
-			qos_connlimit_decrement_for_ct(v);
+			qos_connlimit_decrement_for_ct(tracking_v);
 		}
 	}
 
@@ -1214,7 +1221,7 @@ static CALI_BPF_INLINE struct calico_ct_result calico_ct_lookup(struct cali_tc_c
 		 * INGRESS on success, REJECTED on failure, never both
 		 */
 		if (CALI_F_TO_WEP && INGRESS_CONN_LIMIT_CONFIGURED) {
-			__u32 cl = ct_value_get_flags(v);
+			__u32 cl = ct_value_get_flags(tracking_v);
 			if (cl & CALI_CT_FLAG_CONNLIMIT_INGRESS) {
 				result.flags |= CALI_CT_FLAG_CONNLIMIT_INGRESS;
 			}

--- a/felix/bpf/ut/conntrack_nat_rst_test.go
+++ b/felix/bpf/ut/conntrack_nat_rst_test.go
@@ -1,0 +1,228 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ut_test
+
+import (
+	"encoding/binary"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/gopacket/gopacket/layers"
+	. "github.com/onsi/gomega"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/projectcalico/calico/felix/bpf"
+	"github.com/projectcalico/calico/felix/bpf/conntrack"
+	"github.com/projectcalico/calico/felix/bpf/conntrack/timeouts"
+	ctv4 "github.com/projectcalico/calico/felix/bpf/conntrack/v4"
+	"github.com/projectcalico/calico/felix/bpf/maps"
+	"github.com/projectcalico/calico/felix/bpf/routes"
+)
+
+// natRSTFixture stages the CT entry pair of a NAT'd flow: a connection opened
+// by a local workload (srcIP) to a service (svcIP:svcPort) backed by a remote
+// workload (dstIP:backendPort). All connection state lives on the reverse
+// "tracking" entry; the forward entry is a stub holding the reverse key.
+type natRSTFixture struct {
+	fwdKey, revKey ctv4.Key
+	ctMap          maps.Map
+}
+
+const (
+	// natRSTIfIndex must match the BPF UT's default skb ifindex so the
+	// workload RPF check (route iface vs skb iface) passes.
+	natRSTIfIndex            = 1
+	natRSTSrcPort     uint16 = 12377
+	natRSTSvcPort     uint16 = 8080
+	natRSTBackendPort uint16 = 8055
+)
+
+var natRSTSvcIP = net.IPv4(10, 101, 0, 10)
+
+func (f natRSTFixture) fwdEntry() ctv4.ValueInterface {
+	b, err := f.ctMap.Get(f.fwdKey.AsBytes())
+	Expect(err).NotTo(HaveOccurred())
+	return ctv4.ValueFromBytes(b)
+}
+
+func (f natRSTFixture) revEntry() ctv4.ValueInterface {
+	b, err := f.ctMap.Get(f.revKey.AsBytes())
+	Expect(err).NotTo(HaveOccurred())
+	return ctv4.ValueFromBytes(b)
+}
+
+// setupNATRSTFixture installs the routes and the CT entry pair. revRSTSeen seeds
+// the tracking entry's rst_seen timestamp (0 for a connection that has seen no
+// RST).
+func setupNATRSTFixture(t *testing.T, revRSTSeen uint64) natRSTFixture {
+	rtKey := routes.NewKey(srcV4CIDR).AsBytes()
+	rtVal := routes.NewValueWithIfIndex(routes.FlagsLocalWorkload|routes.FlagInIPAMPool, natRSTIfIndex).AsBytes()
+	Expect(rtMap.Update(rtKey, rtVal)).NotTo(HaveOccurred())
+	rtKey = routes.NewKey(dstV4CIDR).AsBytes()
+	rtVal = routes.NewValueWithIfIndex(routes.FlagsRemoteWorkload|routes.FlagInIPAMPool, natRSTIfIndex).AsBytes()
+	Expect(rtMap.Update(rtKey, rtVal)).NotTo(HaveOccurred())
+	t.Cleanup(func() { resetRTMap(rtMap) })
+
+	ctMap := conntrack.Map()
+	Expect(ctMap.EnsureExists()).NotTo(HaveOccurred())
+	resetCTMap(ctMap)
+	t.Cleanup(func() { resetCTMap(ctMap) })
+
+	f := natRSTFixture{
+		fwdKey: ctv4.NewKey(6, srcIP, natRSTSrcPort, natRSTSvcIP, natRSTSvcPort),
+		revKey: ctv4.NewKey(6, srcIP, natRSTSrcPort, dstIP, natRSTBackendPort),
+		ctMap:  ctMap,
+	}
+
+	// The pod is the opener and carries the pod ifindex on its leg. Approved
+	// must be set on both legs: from_wep is CALI_F_TO_HOST, so
+	// calico_ct_lookup checks src_to_dst->approved and would otherwise return
+	// CALI_CT_INVALID for these non-SYN packets and drop them before they
+	// demonstrate anything.
+	legA := ctv4.Leg{SynSeen: true, AckSeen: true, Approved: true, Opener: true, Ifindex: natRSTIfIndex}
+	legB := ctv4.Leg{SynSeen: true, AckSeen: true, Approved: true}
+
+	revVal := ctv4.NewValueNATReverse(time.Duration(0), 0, legA, legB,
+		nil /* tunnelIP */, natRSTSvcIP /* origIP */, natRSTSvcPort)
+	if revRSTSeen != 0 {
+		vb := revVal.AsBytes()
+		binary.LittleEndian.PutUint64(vb[ctv4.VoRSTSeen:ctv4.VoRSTSeen+8], revRSTSeen)
+		Expect(ctMap.Update(f.revKey.AsBytes(), vb[:])).NotTo(HaveOccurred())
+	} else {
+		Expect(ctMap.Update(f.revKey.AsBytes(), revVal.AsBytes()[:])).NotTo(HaveOccurred())
+	}
+
+	fwdVal := ctv4.NewValueNATForward(time.Duration(0), 0, f.revKey)
+	Expect(ctMap.Update(f.fwdKey.AsBytes(), fwdVal.AsBytes()[:])).NotTo(HaveOccurred())
+
+	return f
+}
+
+// natRSTPacket builds a packet on the pre-DNAT tuple, i.e. one that hits the
+// forward entry, with the given TCP flags.
+func natRSTPacket(rst bool) []byte {
+	ip := *ipv4Default
+	ip.DstIP = natRSTSvcIP
+	_, _, _, _, pkt, err := testPacketV4(nil, &ip, &layers.TCP{
+		RST:        rst,
+		ACK:        true,
+		SrcPort:    layers.TCPPort(natRSTSrcPort),
+		DstPort:    layers.TCPPort(natRSTSvcPort),
+		DataOffset: 5,
+	}, nil)
+	Expect(err).NotTo(HaveOccurred())
+	return pkt
+}
+
+// waitForKTime blocks until the clock the BPF programs read has passed d.
+//
+// bpf_ktime_get_ns() counts from boot, so any test that needs the dataplane to
+// see a given age has to wait for the host to have been up that long — no
+// choice of seeded timestamp avoids it. The wait is bounded by d and only ever
+// happens on a freshly booted host. bpf.KTimeNanos() reads the same
+// CLOCK_MONOTONIC base, which conntrack_scanner_test.go already relies on when
+// it seeds last_seen for the BPF side to compare against.
+func waitForKTime(d time.Duration) {
+	for {
+		remaining := d - time.Duration(bpf.KTimeNanos())
+		if remaining <= 0 {
+			return
+		}
+		// Logged, not t.Logf'd: a passing test's t.Log output is suppressed,
+		// and an unexplained multi-minute pause is worse than the wait.
+		log.Infof("Waiting %s for the BPF clock to reach %s; host booted recently.", remaining, d)
+		time.Sleep(remaining)
+	}
+}
+
+// TestCTNatRSTHandling exercises TCP RST handling for a NAT'd flow in the
+// client->service direction. That direction matches the forward entry, so the
+// reverse direction is no substitute: it hits the tracking entry directly and
+// behaves correctly regardless.
+func TestCTNatRSTHandling(t *testing.T) {
+	RegisterTestingT(t)
+
+	bpfIfaceName = "NATrst"
+	defer func() { bpfIfaceName = "" }()
+
+	// runPkt replays pkt through from_wep. The retval check keeps a dropped
+	// packet from making the assertions pass, or fail, for the wrong reason.
+	runPkt := func(t *testing.T, f natRSTFixture, pkt []byte) {
+		skbMark = 0
+		runBpfTest(t, "calico_from_workload_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+			res, err := bpfrun(pkt)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(res.Retval).NotTo(Equal(resTC_ACT_SHOT))
+		})
+	}
+
+	t.Run("an RST is recorded for the flow", func(t *testing.T) {
+		RegisterTestingT(t)
+		f := setupNATRSTFixture(t, 0)
+
+		runPkt(t, f, natRSTPacket(true /* rst */))
+
+		Expect(f.revEntry().RSTSeen()).NotTo(BeZero(),
+			"the flow has no record of the RST; it is kept on the tracking entry, "+
+				"which is where every reader looks")
+		Expect(f.fwdEntry().RSTSeen()).To(BeZero(),
+			"the forward entry is a stub — state written there is never read")
+	})
+
+	t.Run("a flow closed by an RST expires without waiting out the established timeout",
+		func(t *testing.T) {
+			RegisterTestingT(t)
+			f := setupNATRSTFixture(t, 0)
+
+			runPkt(t, f, natRSTPacket(true /* rst */))
+
+			rev := f.revEntry()
+			to := timeouts.DefaultTimeouts()
+
+			// Three minutes after the RST, with no traffic since.
+			reason, expired := conntrack.EntryExpired(to,
+				rev.LastSeen()+int64(3*time.Minute), 6 /* TCP */, rev)
+			Expect(expired).To(BeTrue(),
+				"flow survived to the established timeout (%s); reason=%q",
+				to.TCPEstablished, reason)
+
+			// One minute in it is still inside the spurious-RST window: the
+			// RST may yet turn out to have been bogus, so the flow has to stay.
+			reason, expired = conntrack.EntryExpired(to,
+				rev.LastSeen()+int64(time.Minute), 6, rev)
+			Expect(expired).To(BeFalse(),
+				"flow expired inside the 2-minute spurious-RST window; reason=%q", reason)
+		})
+
+	t.Run("a spurious RST is retracted once traffic continues", func(t *testing.T) {
+		RegisterTestingT(t)
+
+		// rst_seen = 1ns is the earliest timestamp there is, so the
+		// dataplane calls the RST spurious as soon as its clock passes the
+		// two-minute window.
+		waitForKTime(2*time.Minute + time.Second)
+
+		f := setupNATRSTFixture(t, 1)
+		Expect(f.revEntry().RSTSeen()).NotTo(BeZero())
+
+		runPkt(t, f, natRSTPacket(false /* data, not rst */))
+
+		Expect(f.revEntry().RSTSeen()).To(BeZero(),
+			"traffic past the two-minute mark should have retracted the RST; the "+
+				"verdict reads the tracking entry's timestamp, so a flow whose RST "+
+				"was recorded elsewhere never reaches it")
+	})
+}

--- a/felix/design/bpf-conntrack-flowstate.md
+++ b/felix/design/bpf-conntrack-flowstate.md
@@ -129,6 +129,16 @@ Creating a NAT'd flow means creating both. Destroying a NAT'd flow
 means destroying both — atomically enough that BPF never sees only
 one side. The cleanup pipeline is built around this requirement.
 
+The forward entry is a **stub**: `calico_ct_create_nat_fwd()` fills in
+only the type, the timestamp, the reverse key, and any source-port
+rewrite. All connection state — the TCP legs, the flags, the RST
+timestamp — lives on the reverse entry, which is why it is also called
+the **tracking** entry, and is the single source of truth for the flow.
+Readers and writers alike have to reach it: a `NAT_FWD` hit gives
+`calico_ct_lookup()` the stub, so it redirects
+`src_to_dst`/`dst_to_src` into the tracking entry's legs and uses
+`tracking_v` for the fields hanging off the value itself.
+
 ### Cleanup: three layers
 
 #### 1. Userspace scanners
@@ -219,6 +229,11 @@ and the Go-side reader must agree on units and reference clock.
   BPF cleaner path (insert into `cali_ct_cleanup`) or accept the
   race (and document why it is safe) — never delete a single side
   from userspace.
+- Connection state read or written through a conntrack **value** in
+  `calico_ct_lookup()` must go via `tracking_v`, not `v` — on a `NAT_FWD` hit
+  `v` is the forward stub, and state put there is silently never read.
+  Test such a change in the client→service direction; the reverse
+  direction hits the tracking entry directly and passes either way.
 - Do not rely on LRU eviction to keep the table healthy. A PR that
   produces more conntrack entries per second than the cleanup
   pipeline removes will silently lose active flows once the map


### PR DESCRIPTION
A NAT'd flow has two conntrack entries: a forward **stub** keyed on the pre-DNAT tuple, holding only the reverse key, and a reverse **tracking** entry holding all the connection state. `calico_ct_lookup()` runs with `v` pointing at whichever entry the packet's tuple matched, so on a `NAT_FWD` hit — every client→service packet — `v` is the stub. It already redirects `src_to_dst`/`dst_to_src` into the tracking entry's legs, but the fields hanging off the value itself were left on the stub:

```c
src_to_dst->rst_seen = 1;   /* tracking entry */
v->rst_seen = now;          /* forward stub   */
```

Nothing reads the stub's value fields. `LivenessScanner` follows the reverse key and decides a forward key's fate from the reverse entry, the BPF cleaner decrements connlimit off `rev_ct_value`, and `calico_ct_lookup()` itself re-reads `result.flags` from `tracking_v`. The RST timestamp was written where it could never be seen.

## Impact

**Expiry.** `entryDone()`'s per-leg RST arm cannot fire for an established connection — `ct_tcp_entry_update()` clears both legs' `rst_seen` on the RST packet's own pass — so the entry-level timestamp is what expires an RST-closed flow, at `rst_seen + 2m`. With the timestamp on the stub the tracking entry has none, falls through to `TCPEstablished`, and **a service connection reset by the client holds its conntrack entry for an hour instead of two minutes**. Reset by the backend it behaves correctly, because that direction hits the tracking entry directly — same close, two lifetimes, depending on which end sent the RST.

**Spurious-RST verdict.** The 2-minute branch tests `v->rst_seen`, which on a `NAT_FWD` hit is the stub's zero, so continued traffic never clears the flag it was written to guard.

**Connlimit.** `qos_connlimit_decrement_for_ct(v)` was inert on this path for the same reason — the stub carries no `CONNLIMIT_*` flags — making the fast-path slot release direction-dependent for service traffic.

## Fix

Add a `bk` pointer beside the already-redirected leg pointers, set to `tracking_v` for `NAT_FWD` and `v` otherwise, and use it for `rst_seen`, the connlimit close-time decrement, and the connlimit flag read on the SYN path.

## Tests

Three BPF UTs (`felix/bpf/ut/conntrack_nat_rst_test.go`) drive an RST and a follow-up data packet through `from_wep` against a staged NAT pair, asserting the timestamp lands on — and is cleared on — the tracking entry rather than the stub. One asserts the consequence through the production predicate, `conntrack.EntryExpired`, rather than restating it: expired 3 minutes after the RST, still live at 1 minute.

All three fail on master, the middle one reporting the `1h0m0s` established timeout. The client→service direction is the one that matters — the reverse direction passes either way, which is why this went unnoticed.

**Release note:**
```release-note
Fixed BPF conntrack entries for NAT'd (service) connections surviving up to an hour after a client-side TCP RST instead of expiring after two minutes.
```
