### PR TITLE
Prefer elevated local workload routes in BIRD kernel import filter

### DIFF
--- a/confd/tests/compiled_templates/bgpfilter/as_path_and_priority/bird.cfg
+++ b/confd/tests/compiled_templates/bgpfilter/as_path_and_priority/bird.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/bgpfilter/as_path_and_priority/bird6.cfg
+++ b/confd/tests/compiled_templates/bgpfilter/as_path_and_priority/bird6.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/bgpfilter/communities_and_operations/bird.cfg
+++ b/confd/tests/compiled_templates/bgpfilter/communities_and_operations/bird.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/bgpfilter/communities_and_operations/bird6.cfg
+++ b/confd/tests/compiled_templates/bgpfilter/communities_and_operations/bird6.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/bgpfilter/export_only/explicit_peer/bird.cfg
+++ b/confd/tests/compiled_templates/bgpfilter/export_only/explicit_peer/bird.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/bgpfilter/export_only/explicit_peer/bird6.cfg
+++ b/confd/tests/compiled_templates/bgpfilter/export_only/explicit_peer/bird6.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/bgpfilter/export_only/global_peer/bird.cfg
+++ b/confd/tests/compiled_templates/bgpfilter/export_only/global_peer/bird.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/bgpfilter/export_only/global_peer/bird6.cfg
+++ b/confd/tests/compiled_templates/bgpfilter/export_only/global_peer/bird6.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/bgpfilter/filter_deletion/step1/bird.cfg
+++ b/confd/tests/compiled_templates/bgpfilter/filter_deletion/step1/bird.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/bgpfilter/filter_deletion/step1/bird6.cfg
+++ b/confd/tests/compiled_templates/bgpfilter/filter_deletion/step1/bird6.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/bgpfilter/filter_deletion/step2/bird.cfg
+++ b/confd/tests/compiled_templates/bgpfilter/filter_deletion/step2/bird.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/bgpfilter/filter_deletion/step2/bird6.cfg
+++ b/confd/tests/compiled_templates/bgpfilter/filter_deletion/step2/bird6.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/bgpfilter/filter_names/bird.cfg
+++ b/confd/tests/compiled_templates/bgpfilter/filter_names/bird.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/bgpfilter/filter_names/bird6.cfg
+++ b/confd/tests/compiled_templates/bgpfilter/filter_names/bird6.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/bgpfilter/import_only/explicit_peer/bird.cfg
+++ b/confd/tests/compiled_templates/bgpfilter/import_only/explicit_peer/bird.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/bgpfilter/import_only/explicit_peer/bird6.cfg
+++ b/confd/tests/compiled_templates/bgpfilter/import_only/explicit_peer/bird6.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/bgpfilter/import_only/global_peer/bird.cfg
+++ b/confd/tests/compiled_templates/bgpfilter/import_only/global_peer/bird.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/bgpfilter/import_only/global_peer/bird6.cfg
+++ b/confd/tests/compiled_templates/bgpfilter/import_only/global_peer/bird6.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/bgpfilter/kubevirt_live_migration/bird.cfg
+++ b/confd/tests/compiled_templates/bgpfilter/kubevirt_live_migration/bird.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/bgpfilter/kubevirt_live_migration/bird6.cfg
+++ b/confd/tests/compiled_templates/bgpfilter/kubevirt_live_migration/bird6.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/bgpfilter/large_community/bird.cfg
+++ b/confd/tests/compiled_templates/bgpfilter/large_community/bird.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/bgpfilter/large_community/bird6.cfg
+++ b/confd/tests/compiled_templates/bgpfilter/large_community/bird6.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/bgpfilter/match_interface/bird.cfg
+++ b/confd/tests/compiled_templates/bgpfilter/match_interface/bird.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/bgpfilter/match_interface/bird6.cfg
+++ b/confd/tests/compiled_templates/bgpfilter/match_interface/bird6.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/bgpfilter/match_operators/bird.cfg
+++ b/confd/tests/compiled_templates/bgpfilter/match_operators/bird.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/bgpfilter/match_operators/bird6.cfg
+++ b/confd/tests/compiled_templates/bgpfilter/match_operators/bird6.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/bgpfilter/match_source/bird.cfg
+++ b/confd/tests/compiled_templates/bgpfilter/match_source/bird.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/bgpfilter/match_source/bird6.cfg
+++ b/confd/tests/compiled_templates/bgpfilter/match_source/bird6.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/bgpfilter/multi_filter/explicit_peer/bird.cfg
+++ b/confd/tests/compiled_templates/bgpfilter/multi_filter/explicit_peer/bird.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/bgpfilter/multi_filter/explicit_peer/bird6.cfg
+++ b/confd/tests/compiled_templates/bgpfilter/multi_filter/explicit_peer/bird6.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/bgpfilter/multi_filter/global_peer/bird.cfg
+++ b/confd/tests/compiled_templates/bgpfilter/multi_filter/global_peer/bird.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/bgpfilter/multi_filter/global_peer/bird6.cfg
+++ b/confd/tests/compiled_templates/bgpfilter/multi_filter/global_peer/bird6.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/bgpfilter/node_mesh/bird.cfg
+++ b/confd/tests/compiled_templates/bgpfilter/node_mesh/bird.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/bgpfilter/node_mesh/bird6.cfg
+++ b/confd/tests/compiled_templates/bgpfilter/node_mesh/bird6.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/bgpfilter/node_mesh/priority1/bird.cfg
+++ b/confd/tests/compiled_templates/bgpfilter/node_mesh/priority1/bird.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/bgpfilter/node_mesh/priority1/bird6.cfg
+++ b/confd/tests/compiled_templates/bgpfilter/node_mesh/priority1/bird6.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/bgpfilter/node_mesh/priority2/bird.cfg
+++ b/confd/tests/compiled_templates/bgpfilter/node_mesh/priority2/bird.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 5000 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/bgpfilter/node_mesh/priority2/bird6.cfg
+++ b/confd/tests/compiled_templates/bgpfilter/node_mesh/priority2/bird6.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/bgpfilter/node_mesh/priority3/bird.cfg
+++ b/confd/tests/compiled_templates/bgpfilter/node_mesh/priority3/bird.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 5000 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/bgpfilter/node_mesh/priority3/bird6.cfg
+++ b/confd/tests/compiled_templates/bgpfilter/node_mesh/priority3/bird6.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 80 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/bgpfilter/peer_type/bird.cfg
+++ b/confd/tests/compiled_templates/bgpfilter/peer_type/bird.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/bgpfilter/peer_type/bird6.cfg
+++ b/confd/tests/compiled_templates/bgpfilter/peer_type/bird6.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/bgpfilter/single_filter/explicit_peer/bird.cfg
+++ b/confd/tests/compiled_templates/bgpfilter/single_filter/explicit_peer/bird.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/bgpfilter/single_filter/explicit_peer/bird6.cfg
+++ b/confd/tests/compiled_templates/bgpfilter/single_filter/explicit_peer/bird6.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/bgpfilter/single_filter/global_peer/bird.cfg
+++ b/confd/tests/compiled_templates/bgpfilter/single_filter/global_peer/bird.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/bgpfilter/single_filter/global_peer/bird6.cfg
+++ b/confd/tests/compiled_templates/bgpfilter/single_filter/global_peer/bird6.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/bgpfilter/v4_only/explicit_peer/bird.cfg
+++ b/confd/tests/compiled_templates/bgpfilter/v4_only/explicit_peer/bird.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/bgpfilter/v4_only/explicit_peer/bird6.cfg
+++ b/confd/tests/compiled_templates/bgpfilter/v4_only/explicit_peer/bird6.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/bgpfilter/v4_only/global_peer/bird.cfg
+++ b/confd/tests/compiled_templates/bgpfilter/v4_only/global_peer/bird.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/bgpfilter/v4_only/global_peer/bird6.cfg
+++ b/confd/tests/compiled_templates/bgpfilter/v4_only/global_peer/bird6.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/bgpfilter/v6_only/explicit_peer/bird.cfg
+++ b/confd/tests/compiled_templates/bgpfilter/v6_only/explicit_peer/bird.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/bgpfilter/v6_only/explicit_peer/bird6.cfg
+++ b/confd/tests/compiled_templates/bgpfilter/v6_only/explicit_peer/bird6.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/bgpfilter/v6_only/global_peer/bird.cfg
+++ b/confd/tests/compiled_templates/bgpfilter/v6_only/global_peer/bird.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/bgpfilter/v6_only/global_peer/bird6.cfg
+++ b/confd/tests/compiled_templates/bgpfilter/v6_only/global_peer/bird6.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/cluster_routes/default/bird.cfg
+++ b/confd/tests/compiled_templates/cluster_routes/default/bird.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/cluster_routes/default/bird6.cfg
+++ b/confd/tests/compiled_templates/cluster_routes/default/bird6.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/cluster_routes/enabled/bird.cfg
+++ b/confd/tests/compiled_templates/cluster_routes/enabled/bird.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/cluster_routes/enabled/bird6.cfg
+++ b/confd/tests/compiled_templates/cluster_routes/enabled/bird6.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/cluster_routes/ipip-only/bird.cfg
+++ b/confd/tests/compiled_templates/cluster_routes/ipip-only/bird.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/cluster_routes/ipip-only/bird6.cfg
+++ b/confd/tests/compiled_templates/cluster_routes/ipip-only/bird6.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/cluster_routes/noencap-only/bird.cfg
+++ b/confd/tests/compiled_templates/cluster_routes/noencap-only/bird.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/cluster_routes/noencap-only/bird6.cfg
+++ b/confd/tests/compiled_templates/cluster_routes/noencap-only/bird6.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/explicit_peering/global-external/bird.cfg
+++ b/confd/tests/compiled_templates/explicit_peering/global-external/bird.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug all;

--- a/confd/tests/compiled_templates/explicit_peering/global-external/bird6.cfg
+++ b/confd/tests/compiled_templates/explicit_peering/global-external/bird6.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug all;

--- a/confd/tests/compiled_templates/explicit_peering/global-ipv6/bird.cfg
+++ b/confd/tests/compiled_templates/explicit_peering/global-ipv6/bird.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug all;

--- a/confd/tests/compiled_templates/explicit_peering/global-ipv6/bird6.cfg
+++ b/confd/tests/compiled_templates/explicit_peering/global-ipv6/bird6.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug all;

--- a/confd/tests/compiled_templates/explicit_peering/global/bird.cfg
+++ b/confd/tests/compiled_templates/explicit_peering/global/bird.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug all;

--- a/confd/tests/compiled_templates/explicit_peering/global/bird6.cfg
+++ b/confd/tests/compiled_templates/explicit_peering/global/bird6.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug all;

--- a/confd/tests/compiled_templates/explicit_peering/keepnexthop-global/bird.cfg
+++ b/confd/tests/compiled_templates/explicit_peering/keepnexthop-global/bird.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/explicit_peering/keepnexthop-global/bird6.cfg
+++ b/confd/tests/compiled_templates/explicit_peering/keepnexthop-global/bird6.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/explicit_peering/keepnexthop/bird.cfg
+++ b/confd/tests/compiled_templates/explicit_peering/keepnexthop/bird.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/explicit_peering/keepnexthop/bird6.cfg
+++ b/confd/tests/compiled_templates/explicit_peering/keepnexthop/bird6.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/explicit_peering/local-as-global-ipv6/bird.cfg
+++ b/confd/tests/compiled_templates/explicit_peering/local-as-global-ipv6/bird.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug all;

--- a/confd/tests/compiled_templates/explicit_peering/local-as-global-ipv6/bird6.cfg
+++ b/confd/tests/compiled_templates/explicit_peering/local-as-global-ipv6/bird6.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug all;

--- a/confd/tests/compiled_templates/explicit_peering/local-as-global/bird.cfg
+++ b/confd/tests/compiled_templates/explicit_peering/local-as-global/bird.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug all;

--- a/confd/tests/compiled_templates/explicit_peering/local-as-global/bird6.cfg
+++ b/confd/tests/compiled_templates/explicit_peering/local-as-global/bird6.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug all;

--- a/confd/tests/compiled_templates/explicit_peering/local-as-ipv6/bird.cfg
+++ b/confd/tests/compiled_templates/explicit_peering/local-as-ipv6/bird.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/explicit_peering/local-as-ipv6/bird6.cfg
+++ b/confd/tests/compiled_templates/explicit_peering/local-as-ipv6/bird6.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/explicit_peering/local-as/bird.cfg
+++ b/confd/tests/compiled_templates/explicit_peering/local-as/bird.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/explicit_peering/local-as/bird6.cfg
+++ b/confd/tests/compiled_templates/explicit_peering/local-as/bird6.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/explicit_peering/local_bgp_peer/bird.cfg
+++ b/confd/tests/compiled_templates/explicit_peering/local_bgp_peer/bird.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/explicit_peering/local_bgp_peer/bird6.cfg
+++ b/confd/tests/compiled_templates/explicit_peering/local_bgp_peer/bird6.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/explicit_peering/route_reflector/bird.cfg
+++ b/confd/tests/compiled_templates/explicit_peering/route_reflector/bird.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/explicit_peering/route_reflector/bird6.cfg
+++ b/confd/tests/compiled_templates/explicit_peering/route_reflector/bird6.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/explicit_peering/route_reflector_v6_by_ip/bird.cfg
+++ b/confd/tests/compiled_templates/explicit_peering/route_reflector_v6_by_ip/bird.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/explicit_peering/route_reflector_v6_by_ip/bird6.cfg
+++ b/confd/tests/compiled_templates/explicit_peering/route_reflector_v6_by_ip/bird6.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/explicit_peering/selectors/bird.cfg
+++ b/confd/tests/compiled_templates/explicit_peering/selectors/bird.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/explicit_peering/selectors/bird6.cfg
+++ b/confd/tests/compiled_templates/explicit_peering/selectors/bird6.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/explicit_peering/selectors/step2/bird.cfg
+++ b/confd/tests/compiled_templates/explicit_peering/selectors/step2/bird.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/explicit_peering/selectors/step2/bird6.cfg
+++ b/confd/tests/compiled_templates/explicit_peering/selectors/step2/bird6.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/explicit_peering/specific_node/bird.cfg
+++ b/confd/tests/compiled_templates/explicit_peering/specific_node/bird.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/explicit_peering/specific_node/bird6.cfg
+++ b/confd/tests/compiled_templates/explicit_peering/specific_node/bird6.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/felix_cluster_routing/bird.cfg
+++ b/confd/tests/compiled_templates/felix_cluster_routing/bird.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/felix_cluster_routing/bird6.cfg
+++ b/confd/tests/compiled_templates/felix_cluster_routing/bird6.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/ignored_interfaces/bird.cfg
+++ b/confd/tests/compiled_templates/ignored_interfaces/bird.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/ignored_interfaces/bird6.cfg
+++ b/confd/tests/compiled_templates/ignored_interfaces/bird6.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/mesh/bgp-export/bird.cfg
+++ b/confd/tests/compiled_templates/mesh/bgp-export/bird.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/mesh/bgp-export/bird6.cfg
+++ b/confd/tests/compiled_templates/mesh/bgp-export/bird6.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/mesh/communities/bird.cfg
+++ b/confd/tests/compiled_templates/mesh/communities/bird.cfg
@@ -10,7 +10,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/mesh/communities/bird6.cfg
+++ b/confd/tests/compiled_templates/mesh/communities/bird6.cfg
@@ -8,7 +8,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/mesh/communities/step2/bird.cfg
+++ b/confd/tests/compiled_templates/mesh/communities/step2/bird.cfg
@@ -9,7 +9,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/mesh/communities/step2/bird6.cfg
+++ b/confd/tests/compiled_templates/mesh/communities/step2/bird6.cfg
@@ -8,7 +8,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/mesh/hash/bird.cfg
+++ b/confd/tests/compiled_templates/mesh/hash/bird.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/mesh/hash/bird6.cfg
+++ b/confd/tests/compiled_templates/mesh/hash/bird6.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/mesh/ipip-always/bird.cfg
+++ b/confd/tests/compiled_templates/mesh/ipip-always/bird.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/mesh/ipip-always/bird6.cfg
+++ b/confd/tests/compiled_templates/mesh/ipip-always/bird6.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/mesh/ipip-cross-subnet/bird.cfg
+++ b/confd/tests/compiled_templates/mesh/ipip-cross-subnet/bird.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/mesh/ipip-cross-subnet/bird6.cfg
+++ b/confd/tests/compiled_templates/mesh/ipip-cross-subnet/bird6.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/mesh/ipip-off/bird.cfg
+++ b/confd/tests/compiled_templates/mesh/ipip-off/bird.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/mesh/ipip-off/bird6.cfg
+++ b/confd/tests/compiled_templates/mesh/ipip-off/bird6.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/mesh/password/step1/bird.cfg
+++ b/confd/tests/compiled_templates/mesh/password/step1/bird.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/mesh/password/step1/bird6.cfg
+++ b/confd/tests/compiled_templates/mesh/password/step1/bird6.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/mesh/password/step2/bird.cfg
+++ b/confd/tests/compiled_templates/mesh/password/step2/bird.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/mesh/password/step2/bird6.cfg
+++ b/confd/tests/compiled_templates/mesh/password/step2/bird6.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/mesh/password/step3/bird.cfg
+++ b/confd/tests/compiled_templates/mesh/password/step3/bird.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/mesh/password/step3/bird6.cfg
+++ b/confd/tests/compiled_templates/mesh/password/step3/bird6.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/mesh/restart-time/bird.cfg
+++ b/confd/tests/compiled_templates/mesh/restart-time/bird.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/mesh/restart-time/bird6.cfg
+++ b/confd/tests/compiled_templates/mesh/restart-time/bird6.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/mesh/restart-time/pcr-disabled/bird.cfg
+++ b/confd/tests/compiled_templates/mesh/restart-time/pcr-disabled/bird.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/mesh/restart-time/pcr-disabled/bird6.cfg
+++ b/confd/tests/compiled_templates/mesh/restart-time/pcr-disabled/bird6.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/mesh/restart-time/pcr-enabled/bird.cfg
+++ b/confd/tests/compiled_templates/mesh/restart-time/pcr-enabled/bird.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/mesh/restart-time/pcr-enabled/bird6.cfg
+++ b/confd/tests/compiled_templates/mesh/restart-time/pcr-enabled/bird6.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/mesh/restart-time/pcr-ipip-only/bird.cfg
+++ b/confd/tests/compiled_templates/mesh/restart-time/pcr-ipip-only/bird.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/mesh/restart-time/pcr-ipip-only/bird6.cfg
+++ b/confd/tests/compiled_templates/mesh/restart-time/pcr-ipip-only/bird6.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/mesh/route-reflector-mesh-enabled/bird.cfg
+++ b/confd/tests/compiled_templates/mesh/route-reflector-mesh-enabled/bird.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/mesh/route-reflector-mesh-enabled/bird6.cfg
+++ b/confd/tests/compiled_templates/mesh/route-reflector-mesh-enabled/bird6.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/mesh/static-routes-exclude-node/bird.cfg
+++ b/confd/tests/compiled_templates/mesh/static-routes-exclude-node/bird.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/mesh/static-routes-exclude-node/bird6.cfg
+++ b/confd/tests/compiled_templates/mesh/static-routes-exclude-node/bird6.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/mesh/static-routes-exclude-node/step2/bird.cfg
+++ b/confd/tests/compiled_templates/mesh/static-routes-exclude-node/step2/bird.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/mesh/static-routes-exclude-node/step2/bird6.cfg
+++ b/confd/tests/compiled_templates/mesh/static-routes-exclude-node/step2/bird6.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/mesh/static-routes-no-ipv4-address/bird.cfg
+++ b/confd/tests/compiled_templates/mesh/static-routes-no-ipv4-address/bird.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/mesh/static-routes-no-ipv4-address/bird6.cfg
+++ b/confd/tests/compiled_templates/mesh/static-routes-no-ipv4-address/bird6.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/mesh/static-routes/bird.cfg
+++ b/confd/tests/compiled_templates/mesh/static-routes/bird.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/mesh/static-routes/bird6.cfg
+++ b/confd/tests/compiled_templates/mesh/static-routes/bird6.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/mesh/static-routes/step2/bird.cfg
+++ b/confd/tests/compiled_templates/mesh/static-routes/step2/bird.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/mesh/static-routes/step2/bird6.cfg
+++ b/confd/tests/compiled_templates/mesh/static-routes/step2/bird6.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/mesh/vxlan-always/bird.cfg
+++ b/confd/tests/compiled_templates/mesh/vxlan-always/bird.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/mesh/vxlan-always/bird6.cfg
+++ b/confd/tests/compiled_templates/mesh/vxlan-always/bird6.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/next_hop_mode/global_peers/bird.cfg
+++ b/confd/tests/compiled_templates/next_hop_mode/global_peers/bird.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/next_hop_mode/global_peers/bird6.cfg
+++ b/confd/tests/compiled_templates/next_hop_mode/global_peers/bird6.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/next_hop_mode/route_reflectors/bird.cfg
+++ b/confd/tests/compiled_templates/next_hop_mode/route_reflectors/bird.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/next_hop_mode/route_reflectors/bird6.cfg
+++ b/confd/tests/compiled_templates/next_hop_mode/route_reflectors/bird6.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/password-deadlock/bird.cfg
+++ b/confd/tests/compiled_templates/password-deadlock/bird.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/password-deadlock/bird6.cfg
+++ b/confd/tests/compiled_templates/password-deadlock/bird6.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/password/step1/bird.cfg
+++ b/confd/tests/compiled_templates/password/step1/bird.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/password/step1/bird6.cfg
+++ b/confd/tests/compiled_templates/password/step1/bird6.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/password/step2/bird.cfg
+++ b/confd/tests/compiled_templates/password/step2/bird.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/password/step2/bird6.cfg
+++ b/confd/tests/compiled_templates/password/step2/bird6.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/password/step3/bird.cfg
+++ b/confd/tests/compiled_templates/password/step3/bird.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/password/step3/bird6.cfg
+++ b/confd/tests/compiled_templates/password/step3/bird6.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/password/step4/bird.cfg
+++ b/confd/tests/compiled_templates/password/step4/bird.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/password/step4/bird6.cfg
+++ b/confd/tests/compiled_templates/password/step4/bird6.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/password/step5/bird.cfg
+++ b/confd/tests/compiled_templates/password/step5/bird.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/password/step5/bird6.cfg
+++ b/confd/tests/compiled_templates/password/step5/bird6.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/password/step6/bird.cfg
+++ b/confd/tests/compiled_templates/password/step6/bird.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/password/step6/bird6.cfg
+++ b/confd/tests/compiled_templates/password/step6/bird6.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/reachable_by/global_peers/bird.cfg
+++ b/confd/tests/compiled_templates/reachable_by/global_peers/bird.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/reachable_by/global_peers/bird6.cfg
+++ b/confd/tests/compiled_templates/reachable_by/global_peers/bird6.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/reachable_by/route_reflectors/bird.cfg
+++ b/confd/tests/compiled_templates/reachable_by/route_reflectors/bird.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/reachable_by/route_reflectors/bird6.cfg
+++ b/confd/tests/compiled_templates/reachable_by/route_reflectors/bird6.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/reverse_peering/auto/bird.cfg
+++ b/confd/tests/compiled_templates/reverse_peering/auto/bird.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/reverse_peering/auto/bird6.cfg
+++ b/confd/tests/compiled_templates/reverse_peering/auto/bird6.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/reverse_peering/manual/bird.cfg
+++ b/confd/tests/compiled_templates/reverse_peering/manual/bird.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/reverse_peering/manual/bird6.cfg
+++ b/confd/tests/compiled_templates/reverse_peering/manual/bird6.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/sourceaddr_gracefulrestart/step1/bird.cfg
+++ b/confd/tests/compiled_templates/sourceaddr_gracefulrestart/step1/bird.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/sourceaddr_gracefulrestart/step1/bird6.cfg
+++ b/confd/tests/compiled_templates/sourceaddr_gracefulrestart/step1/bird6.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/sourceaddr_gracefulrestart/step2/bird.cfg
+++ b/confd/tests/compiled_templates/sourceaddr_gracefulrestart/step2/bird.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/sourceaddr_gracefulrestart/step2/bird6.cfg
+++ b/confd/tests/compiled_templates/sourceaddr_gracefulrestart/step2/bird6.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/sourceaddr_gracefulrestart/step3/bird.cfg
+++ b/confd/tests/compiled_templates/sourceaddr_gracefulrestart/step3/bird.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/sourceaddr_gracefulrestart/step3/bird6.cfg
+++ b/confd/tests/compiled_templates/sourceaddr_gracefulrestart/step3/bird6.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/ttl_security/explicit_node/bird.cfg
+++ b/confd/tests/compiled_templates/ttl_security/explicit_node/bird.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/ttl_security/explicit_node/bird6.cfg
+++ b/confd/tests/compiled_templates/ttl_security/explicit_node/bird6.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/ttl_security/global/bird.cfg
+++ b/confd/tests/compiled_templates/ttl_security/global/bird.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/ttl_security/global/bird6.cfg
+++ b/confd/tests/compiled_templates/ttl_security/global/bird6.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/ttl_security/peer_selector/bird.cfg
+++ b/confd/tests/compiled_templates/ttl_security/peer_selector/bird.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/confd/tests/compiled_templates/ttl_security/peer_selector/bird6.cfg
+++ b/confd/tests/compiled_templates/ttl_security/peer_selector/bird6.cfg
@@ -5,7 +5,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < 1024 ) then
+      preference = 150;
+    accept;
+  };
 }
 template direct direct_template {
   debug { states };

--- a/e2e/pkg/tests/kubevirt/live_migration.go
+++ b/e2e/pkg/tests/kubevirt/live_migration.go
@@ -40,8 +40,9 @@ import (
 
 // KubeVirt live migration e2e tests validate Calico's seamless migration support for
 // KubeVirt VMs. The tests cover:
-//   - Zero-downtime TCP connectivity through iBGP and eBGP during migration (Tests 1-2)
-//   - Kubernetes NetworkPolicy enforcement survives migration (Test 3)
+//   - Zero-downtime TCP connectivity through iBGP during migration (Test 1)
+//   - Target-node BIRD route preference during migration (Test 2)
+//   - Zero-downtime TCP connectivity from an eBGP external client (Test 3)
 //
 // Prerequisites:
 //   - KubeVirt installed with live migration support
@@ -168,6 +169,44 @@ var _ = describe.CalicoDescribe(
 			logrus.Infof("Sequence: %d gaps, %d data points across 2 migrations", seqGaps, lastSeq)
 			Expect(seqGaps).To(BeNumerically("==", 0),
 				"seamless live migration must not drop any TCP segments")
+		})
+
+		// Test 2: target-node route preference. On the node receiving a
+		// migrated VM, BIRD must prefer the VM's local veth route (raised to
+		// preference 150 while Felix's route elevation is active) over the
+		// stale /32 still advertised by the migration source, and clients
+		// must see only a brief cutover disruption — not the ~9s black-hole
+		// that lasts until the source's veth teardown. Shared choreography in
+		// live_migration_target_route.go; MockVirt runs an ICMP variant.
+		It("should prefer the local workload route on the migration target node", func() {
+			if isMockVirtDeployed(f) {
+				Fail("This test requires real KubeVirt with QEMU-backed VMs for TCP connectivity; MockVirt does not run a guest OS")
+			}
+			utils.RequireNodeCount(f, 3)
+			ctx, cancel := context.WithTimeout(context.Background(), targetRouteMigrationTimeout)
+			defer cancel()
+
+			runTargetRouteMigrationTest(ctx, f, cli, targetRouteTestParams{
+				vmName:    "e2e-target-route",
+				cloudInit: tcpServerCloudInit,
+				preflight: func(ctx context.Context, client conncheck.Client, tester conncheck.ConnectionTester, vmIP string) {
+					tester.WithTimeout(2 * time.Minute)
+					tester.ExpectSuccess(client, conncheck.NewTCPConnectTarget(vmIP, 9999))
+					tester.Execute()
+					tester.ResetExpectations()
+				},
+				startProbe: func(ctx context.Context, client conncheck.Client, vmIP string) continuityProbe {
+					name := "tcp-stream-" + client.Name()
+					cp := conncheck.StartStream(ctx, name,
+						conncheck.NewPodSource(f, client),
+						conncheck.WithStreamCommand("nc", vmIP, "9999"))
+					return continuityProbe{name: name, cp: cp, filter: func(l string) bool {
+						return strings.HasPrefix(l, "seq=")
+					}}
+				},
+				contestGuardHard:   true,
+				requireZeroSeqGaps: true,
+			})
 		})
 
 		// Test 3: same as Test 2 but the client runs on an external TOR over eBGP.

--- a/e2e/pkg/tests/kubevirt/live_migration_mockvirt.go
+++ b/e2e/pkg/tests/kubevirt/live_migration_mockvirt.go
@@ -17,6 +17,7 @@ package kubevirt
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	//nolint:staticcheck // Ignore ST1001: should not use dot imports
@@ -155,6 +156,32 @@ var _ = describe.CalicoDescribe(
 				g.Expect(m).To(Equal(normalRouteMetric),
 					"target node kernel route metric should revert to 1024 after second migration convergence")
 			}, metricRevertTimeout, 2*time.Second).Should(Succeed())
+		})
+
+		// MockVirt variant of the target-node route preference test (shared
+		// choreography in live_migration_target_route.go): all route-level
+		// assertions of the real-KubeVirt variant, with ICMP cadence probes —
+		// mock virt-launcher pods answer ping but run no guest TCP server.
+		// The stale-/32 contest observation is opportunistic here because
+		// MockVirt does not model the source pod's ~9s teardown delay.
+		It("should prefer the local workload route on the migration target node", func() {
+			ctx, cancel := context.WithTimeout(context.Background(), targetRouteMigrationTimeout)
+			defer cancel()
+
+			runTargetRouteMigrationTest(ctx, f, cli, targetRouteTestParams{
+				vmName: "e2e-mockvirt-target-route",
+				startProbe: func(ctx context.Context, client conncheck.Client, vmIP string) continuityProbe {
+					name := "ping-stream-" + client.Name()
+					cp := conncheck.StartStream(ctx, name,
+						conncheck.NewPodSource(f, client),
+						conncheck.WithStreamCommand("ping", "-i", "0.5", vmIP))
+					return continuityProbe{name: name, cp: cp, filter: func(l string) bool {
+						return strings.Contains(l, "bytes from")
+					}}
+				},
+				contestGuardHard:   false,
+				requireZeroSeqGaps: false,
+			})
 		})
 
 		It("should not have /32 host route on target node after a migration timeout", func() {

--- a/e2e/pkg/tests/kubevirt/live_migration_mockvirt.go
+++ b/e2e/pkg/tests/kubevirt/live_migration_mockvirt.go
@@ -164,12 +164,21 @@ var _ = describe.CalicoDescribe(
 		// mock virt-launcher pods answer ping but run no guest TCP server.
 		// The stale-/32 contest observation is opportunistic here because
 		// MockVirt does not model the source pod's ~9s teardown delay.
-		It("should prefer the local workload route on the migration target node", func() {
+		//
+		// This is also the variant that carries the recursive-next-hop check, since it is the one
+		// with a BIRD container available to play the nested cluster's upstream. Serial because
+		// it reconfigures that shared container.
+		It("should prefer the local workload route on the migration target node", Serial, func() {
 			ctx, cancel := context.WithTimeout(context.Background(), targetRouteMigrationTimeout)
 			defer cancel()
 
+			bird := bgp.NewContainerBIRDPeer()
+
 			runTargetRouteMigrationTest(ctx, f, cli, targetRouteTestParams{
 				vmName: "e2e-mockvirt-target-route",
+				setupRecursiveRoute: func(_ context.Context, vmIP string) string {
+					return setupRecursiveRoutePeering(f, bird, vmIP)
+				},
 				startProbe: func(ctx context.Context, client conncheck.Client, vmIP string) continuityProbe {
 					name := "ping-stream-" + client.Name()
 					cp := conncheck.StartStream(ctx, name,

--- a/e2e/pkg/tests/kubevirt/live_migration_target_route.go
+++ b/e2e/pkg/tests/kubevirt/live_migration_target_route.go
@@ -1,0 +1,398 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubevirt
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	//nolint:staticcheck // Ignore ST1001: should not use dot imports
+	. "github.com/onsi/ginkgo/v2"
+	//nolint:staticcheck // Ignore ST1001: should not use dot imports
+	. "github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/kubernetes/test/e2e/framework"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/projectcalico/calico/e2e/pkg/utils"
+	"github.com/projectcalico/calico/e2e/pkg/utils/bgp"
+	"github.com/projectcalico/calico/e2e/pkg/utils/conncheck"
+)
+
+// This file holds the shared choreography for the "target node prefers its
+// local workload route" live-migration regression test. Two thin Its invoke
+// it: the real-KubeVirt variant in live_migration.go (nc TCP streams to the
+// guest's tcp-server) and the MockVirt variant in live_migration_mockvirt.go
+// (ICMP cadence probes; mock pods answer ping but run no guest OS).
+//
+// The bug (fixed in confd's BIRD kernel-protocol import filter): on the node
+// receiving a live-migrated workload, the kernel-learned local veth route
+// (BIRD preference 10) loses to the stale /32 still advertised over BGP by
+// the migration source (preference 100) until the source's veth is torn down
+// (~9s). Remote nodes still converge onto the target (ADD-PATH exports the
+// non-best local route with elevated local_pref), but the target's own RIB
+// resolves recursive next-hops through the workload (e.g. a nested-cluster
+// Service VIP) via the stale BGP route, refuses BGP-through-BGP recursion,
+// and programs those routes as unreachable — dropping the very traffic the
+// rest of the network correctly delivers to it. The fix raises the local
+// route to preference 150 while Felix's route elevation (metric 512 <
+// NormalRoutePriority) is active.
+
+// Route-preference constants for the target-route test.
+const (
+	// localWorkloadRoutePreference is the preference confd's kernel-protocol
+	// import filter assigns to an elevated local workload route: above a
+	// normal remote BGP route (100), deliberately below an elevated remote
+	// route (200).
+	localWorkloadRoutePreference = 150
+	// kernelDefaultRoutePreference is BIRD's default kernel-protocol
+	// preference, in effect at rest when the filter's metric gate is false.
+	kernelDefaultRoutePreference = 10
+
+	// continuityMaxGap bounds the worst inter-arrival gap between genuine
+	// delivery lines on a continuity probe. Sized to catch the ~9-13s
+	// black-hole (stale /32 until source teardown) while tolerating the
+	// ~1-3s cutover disruption plus scheduling jitter.
+	continuityMaxGap = 6 * time.Second
+
+	// contestPollInterval paces the target-node RIB polling: fast enough to
+	// observe the stale-/32 overlap before the source's veth teardown ends it.
+	contestPollInterval = 500 * time.Millisecond
+	// contestSettleWindow is how long the winning state must then hold; kept
+	// short so elevation-window polling (elevatedMetricTimeout) plus this
+	// stays inside LiveMigrationRouteConvergenceTime (~30s from cutover).
+	contestSettleWindow = 3 * time.Second
+
+	targetRouteMigrationTimeout = 10 * time.Minute
+)
+
+// continuityProbe couples a stream checkpointer with a filter selecting
+// genuine delivery lines ("seq=" data from the VM's TCP server, "bytes from"
+// ping replies). The filter matters: during a black-hole, ping keeps printing
+// "Destination Net Unreachable" lines at full cadence, so raw line counts
+// would mask exactly the disruption this test exists to catch.
+type continuityProbe struct {
+	name   string
+	cp     conncheck.StreamCheckpointer
+	filter func(string) bool
+}
+
+// targetRouteTestParams parameterizes runTargetRouteMigrationTest per KubeVirt
+// flavor (real QEMU vs MockVirt).
+type targetRouteTestParams struct {
+	vmName    string
+	cloudInit string
+	// preflight optionally blocks until vmIP is reachable from client. The nc
+	// probe needs this: nc exits rc=1 on a refused connect while the VM's TCP
+	// server is still booting, and that sticky error kills the stream.
+	preflight func(ctx context.Context, client conncheck.Client, tester conncheck.ConnectionTester, vmIP string)
+	// startProbe launches the continuity stream from client toward vmIP.
+	startProbe func(ctx context.Context, client conncheck.Client, vmIP string) continuityProbe
+	// contestGuardHard fails the test if the contested two-route state (stale
+	// remote /32 present alongside the local route) was never observed. Real
+	// KubeVirt holds the stale route for the ~9s virt-launcher teardown so
+	// the window is reliably observable; MockVirt does not model that delay,
+	// so its variant only logs.
+	contestGuardHard bool
+	// requireZeroSeqGaps additionally asserts countSequenceGaps == 0 over the
+	// raw stream. Only for tcp-server "seq=N" streams: TCP retransmits
+	// through a stall so gaps indicate real segment loss, whereas ping
+	// sequence numbers legitimately skip on drops.
+	requireZeroSeqGaps bool
+}
+
+// runTargetRouteMigrationTest runs the shared choreography. The stale /32
+// only exists when the migration *source* is a non-owner of the IP's IPAM
+// block, so migration 1 merely arms the condition (moves the VM off the block
+// owner) and migration 2 — pinned to a third node that also hosts one of the
+// client pods — is the observed one.
+func runTargetRouteMigrationTest(ctx context.Context, f *framework.Framework, cli ctrlclient.Client, p targetRouteTestParams) {
+	GinkgoHelper()
+	ns := f.Namespace.Name
+
+	By("Creating the VM")
+	vm := &kubeVirtVM{name: p.vmName, namespace: ns, cloudInit: p.cloudInit}
+	vm.Create(ctx, cli)
+	DeferCleanup(func() { vm.Delete(cli) })
+	vmIP, node1 := vm.WaitForRunningWithIP(ctx, cli)
+	logrus.Infof("VM %s on %s with IP %s", p.vmName, node1, vmIP)
+
+	// The VMI is Running with an IP, but the guest OS is still booting cloud-init
+	// — which is what starts the TCP server. Migrating now would move a VM whose
+	// server isn't up yet, so nothing answers after cutover (WaitForRunningWithIP
+	// returns at phase=Running, well before the guest finishes booting). Gate on
+	// reachability first, mirroring the iBGP test's pre-migration gate. The remote
+	// client is pinned to node1 (the VM's current node), so create it here and
+	// reuse it below as the mesh-crossing probe.
+	remoteClient, remoteTester := setupNodePinnedPod(ctx, f, "remote-client", node1)
+	if p.preflight != nil {
+		By("Waiting for the VM's TCP server to be reachable before migration 1")
+		p.preflight(ctx, remoteClient, remoteTester, vmIP)
+	}
+
+	By("Migrating the VM off the block owner (arms the stale-/32 condition)")
+	vmim1 := newVMIMigration(p.vmName+"-migration1", ns, p.vmName)
+	Expect(cli.Create(ctx, vmim1)).To(Succeed())
+	DeferCleanup(func() { deleteVMIMigration(cli, vmim1) })
+	expectMigrationSuccess(ctx, cli, vmim1)
+	vmi := expectMigrationStatePopulated(ctx, cli, ns, p.vmName)
+	node2 := vmi.Status.MigrationState.TargetNode
+	Expect(node2).NotTo(Equal(node1), "VM didn't migrate off node 1")
+
+	// Wait out migration 1's route elevation. If node2's veth were still at
+	// the elevated metric when migration 2 cuts over, node2 would advertise
+	// the stale /32 with elevated local_pref, the BGP import filter on the
+	// new target would raise it to preference 200, and it would legitimately
+	// beat the local route's 150 — invalidating the assertions below.
+	By("Waiting for migration 1's route elevation to revert on node 2")
+	Eventually(func() (int, error) {
+		return queryWorkerMetric(f, node2, vmIP)
+	}, metricRevertTimeout, 2*time.Second).Should(Equal(normalRouteMetric),
+		"node2's kernel route metric should revert before the observed migration")
+
+	node3 := pickThirdWorkerNode(ctx, f, node1, node2)
+
+	// Remote client (pinned to node1, created before migration 1 above): its path
+	// to the VM crosses the mesh, exercising the cutover re-convergence remote
+	// nodes perform. Target client: pinned to migration 2's destination,
+	// validating that a client colocated with the arriving VM keeps working via
+	// the local veth. Note the primary regression signal is the RIB assertions
+	// below, not these probes: plain /32 forwarding largely survives the
+	// stale-best window (the target's FIB stays correct and ADD-PATH keeps remote
+	// nodes converging), whereas the recursive-next-hop black-hole needs a
+	// nested-BGP VIP to observe directly.
+	targetClient, targetTester := setupNodePinnedPod(ctx, f, "target-client", node3)
+	if p.preflight != nil {
+		By("Waiting for the VM to be reachable from the target-node client pod")
+		p.preflight(ctx, targetClient, targetTester, vmIP)
+	}
+
+	By("Starting continuity probes from both client pods")
+	remoteProbe := p.startProbe(ctx, remoteClient, vmIP)
+	DeferCleanup(func() { _ = remoteProbe.cp.Stop() })
+	targetProbe := p.startProbe(ctx, targetClient, vmIP)
+	DeferCleanup(func() { _ = targetProbe.cp.Stop() })
+	probes := []continuityProbe{remoteProbe, targetProbe}
+	for _, probe := range probes {
+		waitForDeliveryLines(probe, 5, 2*time.Minute)
+	}
+
+	By(fmt.Sprintf("Migrating the VM a second time, pinned to node %s", node3))
+	vmim2 := newVMIMigration(p.vmName+"-migration2", ns, p.vmName)
+	vmim2.Spec.AddedNodeSelector = map[string]string{"kubernetes.io/hostname": node3}
+	Expect(cli.Create(ctx, vmim2)).To(Succeed())
+	DeferCleanup(func() { deleteVMIMigration(cli, vmim2) })
+	expectMigrationSuccess(ctx, cli, vmim2)
+
+	// The elevated state lasts LiveMigrationRouteConvergenceTime (~30s) from
+	// cutover and the stale /32 lasts only until the source veth teardown, so
+	// this is a single combined fast poll rather than sequential Eventually
+	// blocks whose budgets would add up past the windows.
+	By("Verifying the target node's BIRD RIB prefers the local workload route")
+	contestSeen := false
+	checkTargetRIB := func(g Gomega) {
+		metric, err := queryWorkerMetric(f, node3, vmIP)
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(metric).To(Equal(elevatedRouteMetric),
+			"target kernel route metric should be elevated after migration")
+
+		routes, err := queryWorkerBIRDRoute(f, node3, vmIP)
+		g.Expect(err).NotTo(HaveOccurred())
+		var local *bgp.BIRDRoute
+		remotePresent := false
+		for i := range routes {
+			r := &routes[i]
+			if r.Device {
+				local = r
+			} else {
+				remotePresent = true
+				g.Expect(r.Best).To(BeFalse(),
+					"a remote route for the VM IP must not beat the local workload route (route: %+v)", *r)
+			}
+		}
+		g.Expect(local).NotTo(BeNil(),
+			"no local device route for the VM in the target's BIRD RIB (routes: %+v)", routes)
+		if remotePresent {
+			contestSeen = true // stale /32 observed alongside the local route
+		}
+		g.Expect(local.Best).To(BeTrue(), "local workload route should be selected best")
+		g.Expect(local.Preference).To(Equal(localWorkloadRoutePreference),
+			"local workload route should be raised to the elevated preference")
+	}
+	Eventually(checkTargetRIB, elevatedMetricTimeout, contestPollInterval).Should(Succeed())
+	// The winning state must then hold for the rest of the overlap, not just once.
+	Consistently(checkTargetRIB, contestSettleWindow, contestPollInterval).Should(Succeed())
+
+	By("Verifying the target node's kernel FIB resolves the VM locally")
+	pod3 := utils.GetCalicoNodePodOnNode(f.ClientSet, node3)
+	Expect(pod3).NotTo(BeNil(), "no calico-node pod on %s", node3)
+	out, err := utils.ExecInCalicoNode(pod3, fmt.Sprintf("ip route get %s", strings.Split(vmIP, "/")[0]))
+	Expect(err).NotTo(HaveOccurred())
+	Expect(out).To(ContainSubstring(" dev cali"),
+		"kernel FIB on the target should resolve the VM via its local veth, got: %s", out)
+
+	if p.contestGuardHard {
+		Expect(contestSeen).To(BeTrue(),
+			"never observed the stale remote /32 contesting the local route; the regression surface was not exercised (source teardown faster than polling?)")
+	} else if !contestSeen {
+		logrus.Warn("target-route test: stale remote /32 never observed in the target RIB; preference assertions passed but the contested state was not exercised")
+	}
+
+	By("Waiting for the route elevation to revert on the target node")
+	Eventually(func() (int, error) {
+		return queryWorkerMetric(f, node3, vmIP)
+	}, metricRevertTimeout, 2*time.Second).Should(Equal(normalRouteMetric))
+
+	By("Verifying the local route drops back to the kernel-default preference at rest")
+	Eventually(func(g Gomega) {
+		routes, err := queryWorkerBIRDRoute(f, node3, vmIP)
+		g.Expect(err).NotTo(HaveOccurred())
+		var local *bgp.BIRDRoute
+		for i := range routes {
+			if routes[i].Device {
+				local = &routes[i]
+			}
+		}
+		g.Expect(local).NotTo(BeNil())
+		g.Expect(local.Best).To(BeTrue(), "local route should remain best at rest")
+		g.Expect(local.Preference).To(Equal(kernelDefaultRoutePreference),
+			"the preference raise must be a no-op once the metric reverts")
+	}, 15*time.Second, 1*time.Second).Should(Succeed())
+
+	By("Verifying both probes kept delivering and recovered quickly")
+	for _, probe := range probes {
+		base := probe.filteredCount()
+		Eventually(probe.filteredCount, 15*time.Second, 500*time.Millisecond).Should(BeNumerically(">", base),
+			"stream %s stopped delivering after convergence", probe.name)
+
+		_ = probe.cp.Stop()
+		Expect(probe.cp.Err()).NotTo(HaveOccurred(), "stream %s errored", probe.name)
+		worst, n := probe.worstDeliveryGap()
+		logrus.Infof("stream %s: %d delivery lines, worst inter-arrival gap %v", probe.name, n, worst)
+		Expect(n).To(BeNumerically(">=", 10),
+			"stream %s captured too few delivery lines for gap analysis", probe.name)
+		Expect(worst).To(BeNumerically("<=", continuityMaxGap),
+			"stream %s stalled for %v (bound %v) — the migration window black-holed traffic", probe.name, worst, continuityMaxGap)
+		if p.requireZeroSeqGaps {
+			gaps, lastSeq := countSequenceGaps(probe.cp.Lines())
+			logrus.Infof("stream %s: %d sequence gaps, last seq=%d", probe.name, gaps, lastSeq)
+			Expect(gaps).To(BeZero(), "stream %s dropped TCP segments across the migration", probe.name)
+		}
+	}
+}
+
+// filteredCount returns how many delivery lines the probe has captured.
+func (p continuityProbe) filteredCount() int {
+	n := 0
+	for _, l := range p.cp.Lines() {
+		if p.filter(l) {
+			n++
+		}
+	}
+	return n
+}
+
+// worstDeliveryGap returns the maximum inter-arrival gap between consecutive
+// delivery lines and how many there were. It uses the stream's arrival
+// timestamps, so a black-hole shows up as one large gap even though the
+// retransmitted backlog arrives as a burst afterwards.
+func (p continuityProbe) worstDeliveryGap() (time.Duration, int) {
+	lines := p.cp.Lines()
+	events := p.cp.Events()
+	// Lines() and Events() are separate snapshots; trim to the shorter.
+	m := len(lines)
+	if len(events) < m {
+		m = len(events)
+	}
+	var worst time.Duration
+	var prev time.Time
+	n := 0
+	for i := 0; i < m; i++ {
+		if !p.filter(lines[i]) {
+			continue
+		}
+		if n > 0 {
+			if gap := events[i].Sub(prev); gap > worst {
+				worst = gap
+			}
+		}
+		prev = events[i]
+		n++
+	}
+	return worst, n
+}
+
+// waitForDeliveryLines blocks until the probe has captured at least n
+// delivery lines, failing on stream error or timeout. The filtered analog of
+// conncheck.WaitForCadence.
+func waitForDeliveryLines(p continuityProbe, n int, within time.Duration) {
+	GinkgoHelper()
+	Eventually(func(g Gomega) {
+		g.Expect(p.cp.Err()).NotTo(HaveOccurred(), "stream %s errored", p.name)
+		g.Expect(p.filteredCount()).To(BeNumerically(">=", n))
+	}, within, 500*time.Millisecond).Should(Succeed(),
+		"stream %s did not reach %d delivery lines", p.name, n)
+}
+
+// setupNodePinnedPod deploys a client pod pinned to a specific node — the
+// affinity dual of setupAntiAffinityPod. name must be unique per test since
+// several pinned clients can coexist in one namespace.
+func setupNodePinnedPod(ctx context.Context, f *framework.Framework, name, node string) (conncheck.Client, conncheck.ConnectionTester) {
+	By(fmt.Sprintf("Creating client pod %s pinned to node %s", name, node))
+	tester := conncheck.NewConnectionTester(f)
+	DeferCleanup(tester.Stop)
+	client := conncheck.NewClient(name, f.Namespace,
+		conncheck.WithClientCustomizer(func(pod *corev1.Pod) {
+			if pod.Spec.Affinity == nil {
+				pod.Spec.Affinity = &corev1.Affinity{}
+			}
+			pod.Spec.Affinity.NodeAffinity = &corev1.NodeAffinity{
+				RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+					NodeSelectorTerms: []corev1.NodeSelectorTerm{{
+						MatchExpressions: []corev1.NodeSelectorRequirement{{
+							Key:      "kubernetes.io/hostname",
+							Operator: corev1.NodeSelectorOpIn,
+							Values:   []string{node},
+						}},
+					}},
+				},
+			}
+		}),
+	)
+	tester.AddClient(client)
+	tester.Deploy()
+	pod := client.Pod()
+	Expect(pod.Spec.NodeName).To(Equal(node), "client pod %s should be pinned to %s", name, node)
+	return client, tester
+}
+
+// queryWorkerBIRDRoute returns the parsed BIRD RIB entries for the VM's /32
+// on a worker node, from "birdcl show route for <ip> all" inside the node's
+// calico-node pod.
+func queryWorkerBIRDRoute(f *framework.Framework, nodeName, vmIP string) ([]bgp.BIRDRoute, error) {
+	ip := strings.Split(vmIP, "/")[0]
+	pod := utils.GetCalicoNodePodOnNode(f.ClientSet, nodeName)
+	if pod == nil {
+		return nil, fmt.Errorf("no calico-node pod on %s", nodeName)
+	}
+	out, err := utils.ExecInCalicoNode(pod, fmt.Sprintf("birdcl show route for %s all", ip))
+	if err != nil {
+		return nil, fmt.Errorf("birdcl show route failed on %s: %w", nodeName, err)
+	}
+	return bgp.ParseBIRDRouteOutput(out), nil
+}

--- a/e2e/pkg/tests/kubevirt/live_migration_target_route.go
+++ b/e2e/pkg/tests/kubevirt/live_migration_target_route.go
@@ -114,6 +114,15 @@ type targetRouteTestParams struct {
 	// through a stall so gaps indicate real segment loss, whereas ping
 	// sequence numbers legitimately skip on drops.
 	requireZeroSeqGaps bool
+	// setupRecursiveRoute, when non-nil, is called once the VM's IP is known and must arrange for
+	// an external BGP speaker to advertise some prefix to the cluster with vmIP as its NEXT_HOP,
+	// returning that prefix.  It stands in for a nested cluster inside the VM advertising a
+	// Service VIP or pod CIDR over BGP, and turns this test from an assertion about BIRD
+	// preference numbers into one about whether such a route still forwards.
+	//
+	// Left nil where no external BIRD peer exists in the environment, in which case the
+	// recursive-next-hop assertions are skipped.
+	setupRecursiveRoute func(ctx context.Context, vmIP string) string
 }
 
 // runTargetRouteMigrationTest runs the shared choreography. The stale /32
@@ -143,6 +152,20 @@ func runTargetRouteMigrationTest(ctx context.Context, f *framework.Framework, cl
 	if p.preflight != nil {
 		By("Waiting for the VM's TCP server to be reachable before migration 1")
 		p.preflight(ctx, remoteClient, remoteTester, vmIP)
+	}
+
+	// Stand up the nested-cluster prefix now, while the VM is still on its original node and
+	// uncontested, and confirm it resolves there.  That establishes the harness works — the peer
+	// really is imposing the VM's IP as NEXT_HOP and the nodes really are importing it — before
+	// the post-migration assertions start treating it as a regression signal.  Without this
+	// gate, a broken advertisement would look identical to a passing test.
+	var recursivePrefix string
+	if p.setupRecursiveRoute != nil {
+		recursivePrefix = p.setupRecursiveRoute(ctx, vmIP)
+		By(fmt.Sprintf("Verifying %s resolves via the VM on its original node %s", recursivePrefix, node1))
+		Eventually(func(g Gomega) {
+			expectRecursivePrefixResolved(g, f, node1, recursivePrefix, vmIP)
+		}, 2*time.Minute, 2*time.Second).Should(Succeed())
 	}
 
 	By("Migrating the VM off the block owner (arms the stale-/32 condition)")
@@ -233,6 +256,13 @@ func runTargetRouteMigrationTest(ctx context.Context, f *framework.Framework, cl
 		g.Expect(local.Best).To(BeTrue(), "local workload route should be selected best")
 		g.Expect(local.Preference).To(Equal(localWorkloadRoutePreference),
 			"local workload route should be raised to the elevated preference")
+
+		// The consequence that actually matters: with the local route best, a route whose next
+		// hop is the VM still resolves.  Checked in the same poll as the preference above so it
+		// is asserted throughout the contested window rather than after it has passed.
+		if recursivePrefix != "" {
+			expectRecursivePrefixResolved(g, f, node3, recursivePrefix, vmIP)
+		}
 	}
 	Eventually(checkTargetRIB, elevatedMetricTimeout, contestPollInterval).Should(Succeed())
 	// The winning state must then hold for the rest of the overlap, not just once.
@@ -245,6 +275,23 @@ func runTargetRouteMigrationTest(ctx context.Context, f *framework.Framework, cl
 	Expect(err).NotTo(HaveOccurred())
 	Expect(out).To(ContainSubstring(" dev cali"),
 		"kernel FIB on the target should resolve the VM via its local veth, got: %s", out)
+
+	if recursivePrefix != "" {
+		// The end of the chain: BIRD's RIB decision has to reach the FIB, because that is what
+		// actually forwards.  Pre-fix this returns "RTNETLINK answers: Host is unreachable" —
+		// packets from pods and host processes on this node are dropped locally even though the
+		// VM is one veth away.
+		By(fmt.Sprintf("Verifying the target node's kernel FIB forwards %s via the VM", recursivePrefix))
+		recursiveIP := strings.Split(recursivePrefix, "/")[0]
+		Eventually(func(g Gomega) {
+			out, err := utils.ExecInCalicoNode(pod3, fmt.Sprintf("ip route get %s", recursiveIP))
+			g.Expect(err).NotTo(HaveOccurred(), "ip route get %s failed: %s", recursiveIP, out)
+			g.Expect(out).To(ContainSubstring("via "+strings.Split(vmIP, "/")[0]),
+				"kernel FIB on the target should forward %s via the VM, got: %s", recursivePrefix, out)
+			g.Expect(out).To(ContainSubstring(" dev cali"),
+				"kernel FIB on the target should forward %s out the VM's veth, got: %s", recursivePrefix, out)
+		}, 15*time.Second, 1*time.Second).Should(Succeed())
+	}
 
 	if p.contestGuardHard {
 		Expect(contestSeen).To(BeTrue(),
@@ -382,17 +429,63 @@ func setupNodePinnedPod(ctx context.Context, f *framework.Framework, name, node 
 }
 
 // queryWorkerBIRDRoute returns the parsed BIRD RIB entries for the VM's /32
-// on a worker node, from "birdcl show route for <ip> all" inside the node's
-// calico-node pod.
+// on a worker node.
 func queryWorkerBIRDRoute(f *framework.Framework, nodeName, vmIP string) ([]bgp.BIRDRoute, error) {
-	ip := strings.Split(vmIP, "/")[0]
+	return queryWorkerBIRDPrefix(f, nodeName, strings.Split(vmIP, "/")[0]+"/32")
+}
+
+// queryWorkerBIRDPrefix returns the parsed BIRD RIB entries for an exact prefix on a worker node,
+// from "birdcl show route <prefix> all" inside the node's calico-node pod.
+//
+// The prefix is queried exactly rather than by longest-prefix lookup ("show route for <ip>"),
+// because "for" silently falls back to a less specific net when the prefix itself is absent — on
+// a node with no /32 for the VM it returns the default route — leaving the caller asserting on a
+// different network than it asked about.
+func queryWorkerBIRDPrefix(f *framework.Framework, nodeName, prefix string) ([]bgp.BIRDRoute, error) {
 	pod := utils.GetCalicoNodePodOnNode(f.ClientSet, nodeName)
 	if pod == nil {
 		return nil, fmt.Errorf("no calico-node pod on %s", nodeName)
 	}
-	out, err := utils.ExecInCalicoNode(pod, fmt.Sprintf("birdcl show route for %s all", ip))
+	out, err := utils.ExecInCalicoNode(pod, fmt.Sprintf("birdcl show route %s all", prefix))
 	if err != nil {
 		return nil, fmt.Errorf("birdcl show route failed on %s: %w", nodeName, err)
 	}
 	return bgp.ParseBIRDRouteOutput(out), nil
+}
+
+// expectRecursivePrefixResolved asserts that prefix is in nodeName's BIRD RIB and resolves
+// through the VM's local veth rather than being programmed unreachable.
+//
+// This is the direct regression signal for the bug the kernel-protocol import filter fixes.  The
+// prefix is advertised with vmIP as its NEXT_HOP, so BIRD has to resolve it recursively against
+// this node's RIB, and BIRD refuses to resolve a recursive next hop through another recursive
+// (BGP) route.  While the stale /32 from the migration source is the best route for vmIP the
+// prefix is therefore unreachable — black-holed on the very node now hosting the VM — and once
+// the local veth route wins it resolves via cali*.
+func expectRecursivePrefixResolved(g Gomega, f *framework.Framework, nodeName, prefix, vmIP string) {
+	// Callers pass the VM address in either form; BIRD reports next hops as bare IPs.
+	vmIP = strings.Split(vmIP, "/")[0]
+
+	routes, err := queryWorkerBIRDPrefix(f, nodeName, prefix)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(routes).NotTo(BeEmpty(),
+		"%s is not in %s's BIRD RIB at all; the external peer is not advertising it (or the node "+
+			"is not importing it), so this test is not exercising recursive next-hop resolution",
+		prefix, nodeName)
+
+	var best *bgp.BIRDRoute
+	for i := range routes {
+		if routes[i].Best {
+			best = &routes[i]
+		}
+	}
+	g.Expect(best).NotTo(BeNil(), "no best route for %s on %s (routes: %+v)", prefix, nodeName, routes)
+	g.Expect(best.BGPNextHop).To(Equal(vmIP),
+		"%s should be advertised with the VM's IP as NEXT_HOP; got %q. Without a third-party "+
+			"next hop there is no recursive resolution to test", prefix, best.BGPNextHop)
+	g.Expect(best.Unreachable).To(BeFalse(),
+		"%s is programmed unreachable on %s: BIRD could not resolve next hop %s, which is the "+
+			"black-hole this test guards against (route: %+v)", prefix, nodeName, vmIP, *best)
+	g.Expect(best.NextHop).To(Equal(vmIP),
+		"%s should resolve via the VM's IP on %s (route: %+v)", prefix, nodeName, *best)
 }

--- a/e2e/pkg/tests/kubevirt/utils.go
+++ b/e2e/pkg/tests/kubevirt/utils.go
@@ -874,6 +874,117 @@ func setupMockVirtEBGPPeering(f *framework.Framework, bird *bgp.ContainerBIRDPee
 	setupEBGPPeeringCommon(f, bird, "kubevirt-mockvirt-lm-", "mockvirt-ebgp-peer-")
 }
 
+// recursiveRoutePrefix is the prefix an external peer advertises with a VM's IP as NEXT_HOP, to
+// stand in for a Service VIP or pod CIDR inside a nested cluster running in that VM.
+//
+// It only has to be routable in BIRD's tables, never actually reached, so nothing needs to answer
+// at it.  It must sit outside every IPPool in the cluster (checked at setup) so it cannot collide
+// with an IPAM allocation, and outside the node subnet so it cannot shadow real infrastructure.
+const recursiveRoutePrefix = "10.99.0.1/32"
+
+// setupRecursiveRoutePeering peers an external BIRD speaker with every node in the cluster and
+// has it advertise recursiveRoutePrefix with vmIP as the NEXT_HOP.  Returns the prefix.
+//
+// Unlike setupEBGPPeeringCommon this peers all nodes rather than just the control plane, because
+// the route has to reach the migration target with its third-party next hop intact.  Going via
+// the control plane instead would mean relying on it to re-export a prefix it cannot itself
+// resolve, through Calico's export filters — a lot of incidental machinery for the assertion at
+// hand.
+func setupRecursiveRoutePeering(f *framework.Framework, peer bgp.BIRDPeer, vmIP string) string {
+	GinkgoHelper()
+	By("Setting up eBGP peering for the nested-cluster prefix")
+
+	lcgc := newLibcalicoClient(f)
+	ctx := context.Background()
+
+	// The prefix must not overlap any IPPool, or Calico's own route programming for the pool
+	// would race with the advertisement.
+	pools, err := lcgc.IPPools().List(ctx, options.ListOptions{})
+	Expect(err).NotTo(HaveOccurred(), "failed to list IPPools")
+	recursiveIP, _, err := net.ParseCIDR(recursiveRoutePrefix)
+	Expect(err).NotTo(HaveOccurred(), "failed to parse %s", recursiveRoutePrefix)
+	for _, p := range pools.Items {
+		_, poolNet, err := net.ParseCIDR(p.Spec.CIDR)
+		if err != nil {
+			continue
+		}
+		Expect(poolNet.Contains(recursiveIP)).To(BeFalse(),
+			"recursiveRoutePrefix %s overlaps IPPool %s (%s); pick a prefix outside every pool",
+			recursiveRoutePrefix, p.Name, p.Spec.CIDR)
+	}
+
+	nodeList, err := f.ClientSet.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+	Expect(err).NotTo(HaveOccurred(), "failed to list nodes")
+	var nodeIPs []string
+	for _, node := range nodeList.Items {
+		addr := node.Annotations["projectcalico.org/IPv4Address"]
+		if addr == "" {
+			continue
+		}
+		ip, _, err := net.ParseCIDR(addr)
+		Expect(err).NotTo(HaveOccurred(), "failed to parse BGP address %q of node %s", addr, node.Name)
+		nodeIPs = append(nodeIPs, ip.String())
+	}
+	Expect(nodeIPs).NotTo(BeEmpty(), "no node found with a projectcalico.org/IPv4Address annotation")
+	logrus.Infof("Peering external BIRD with %d nodes, advertising %s via %s",
+		len(nodeIPs), recursiveRoutePrefix, vmIP)
+
+	podCIDR := discoverPodCIDR(ctx, lcgc)
+	peersConf := bgp.GenerateBIRDPeersConfWithRecursiveRoute(podCIDR, nodeIPs,
+		bgp.RecursiveRoute{Prefix: recursiveRoutePrefix, NextHop: strings.Split(vmIP, "/")[0]})
+	logrus.Infof("Generated BIRD peers config:\n%s", peersConf)
+	peer.ConfigureBIRD(peersConf)
+
+	// Sweep leftovers from runs whose DeferCleanup didn't fire; a BGPPeer pointing at a stale
+	// container IP would otherwise linger on a shared cluster forever. Only old ones, so a
+	// concurrent run of this suite isn't nuked mid-flight (same rule as setupEBGPPeeringCommon).
+	const peerPrefix = "mockvirt-recursive-peer-"
+	staleBefore := time.Now().Add(-30 * time.Minute)
+	if peers, err := lcgc.BGPPeers().List(ctx, options.ListOptions{}); err == nil {
+		for _, bp := range peers.Items {
+			if strings.HasPrefix(bp.Name, peerPrefix) && bp.CreationTimestamp.Time.Before(staleBefore) {
+				_, _ = lcgc.BGPPeers().Delete(ctx, bp.Name, options.DeleteOptions{})
+			}
+		}
+	}
+
+	// No BGPFilter: the peer needs no route from the cluster, and with no import rules confd
+	// renders "import all" so the nodes accept the advertised prefix.
+	peerName := utils.GenerateRandomName(peerPrefix)
+	By("Creating BGPPeer " + peerName + " (all nodes)")
+	bgpPeer := &v3.BGPPeer{
+		ObjectMeta: metav1.ObjectMeta{Name: peerName},
+		Spec: v3.BGPPeerSpec{
+			NodeSelector: "all()",
+			PeerIP:       peer.PeerIP(),
+			ASNumber:     numorstring.ASNumber(65001),
+		},
+	}
+	_, err = lcgc.BGPPeers().Create(ctx, bgpPeer, options.SetOptions{})
+	Expect(err).NotTo(HaveOccurred(), "failed to create BGPPeer")
+	DeferCleanup(func() {
+		By("Deleting BGPPeer " + peerName)
+		if _, err := lcgc.BGPPeers().Delete(context.Background(), peerName, options.DeleteOptions{}); err != nil {
+			logrus.WithError(err).Warnf("Failed to delete BGPPeer %s", peerName)
+		}
+	})
+
+	By("Waiting for the eBGP sessions to establish")
+	Eventually(func() error {
+		out, err := peer.CheckBGPSession()
+		if err != nil {
+			return fmt.Errorf("birdcl show protocols: %w", err)
+		}
+		if got := strings.Count(out, "Established"); got < len(nodeIPs) {
+			return fmt.Errorf("%d/%d sessions established:\n%s", got, len(nodeIPs), out)
+		}
+		return nil
+	}, 2*time.Minute, 5*time.Second).Should(Succeed(), "eBGP sessions not established")
+	logrus.Info("eBGP peering established for the nested-cluster prefix")
+
+	return recursiveRoutePrefix
+}
+
 // expectMigrationFailed polls the VMIM until it reaches MigrationFailed
 // phase. Immediately stops polling with a fatal error if MigrationSucceeded is
 // observed (the migration was expected to fail).

--- a/e2e/pkg/utils/bgp/bird_external_peer.go
+++ b/e2e/pkg/utils/bgp/bird_external_peer.go
@@ -23,6 +23,7 @@ import (
 	"net"
 	"os"
 	"os/exec"
+	"regexp"
 	"strings"
 	"time"
 
@@ -84,10 +85,19 @@ const birdPeerTemplate = `protocol bgp node_%d from bgp_template {
 
 // BIRDRoute represents a single BIRD route entry for a /32 prefix.
 type BIRDRoute struct {
-	NextHop   string `json:"nextHop"`
-	LocalPref int    `json:"localPref"`
-	Community string `json:"community"`
-	Best      bool   `json:"best"`
+	NextHop string `json:"nextHop"`
+	// Iface is the interface of a directly-connected device route ("dev caliX"
+	// lines); empty for via-gateway routes.
+	Iface string `json:"iface"`
+	// Device is true for directly-connected device routes (no "via" gateway),
+	// e.g. a local workload veth route learned by BIRD's kernel protocol.
+	Device bool `json:"device"`
+	// Preference is BIRD's protocol preference for the route, parsed from the
+	// trailing "(pref)" or "(pref/metric)" on the route line. Zero if absent.
+	Preference int    `json:"preference"`
+	LocalPref  int    `json:"localPref"`
+	Community  string `json:"community"`
+	Best       bool   `json:"best"`
 }
 
 // PrefixState captures whether a prefix is present in BIRD and its routes.
@@ -134,9 +144,16 @@ type BIRDPeer interface {
 	QuerySnapshot(vmIP string) RouteSnapshot
 }
 
+// birdRoutePrefRe matches the trailing preference on a BIRD route line:
+// "(150)" for kernel/device routes, "(100/0)" for BGP routes. Note that
+// ParseBIRDRouteOutput only recognises "via" and "dev" route lines, so
+// "unreachable" route lines (e.g. "(100/-)") are never parsed.
+var birdRoutePrefRe = regexp.MustCompile(`\((\d+)(?:/[^)]*)?\)`)
+
 // ParseBIRDRouteOutput parses the output of "birdcl show route <prefix> all"
-// and returns the list of routes. Returns nil if the output contains
-// "Network not in table" or is empty.
+// and returns the list of routes. Handles both via-gateway routes ("via <ip>
+// on <iface>") and directly-connected device routes ("dev <iface>"). Returns
+// nil if the output contains "Network not in table" or is empty.
 func ParseBIRDRouteOutput(output string) []BIRDRoute {
 	if strings.Contains(output, "Network not in table") {
 		return nil
@@ -152,13 +169,33 @@ func ParseBIRDRouteOutput(output string) []BIRDRoute {
 			continue
 		}
 
-		// Route line: contains "via" but is not a BGP attribute.
-		if strings.Contains(line, " via ") && !strings.HasPrefix(trimmed, "BGP.") {
+		// Route line: contains "via" or "dev" but is not a BGP attribute.
+		// (Attribute lines like "Type: device unicast univ" contain neither
+		// " via " nor " dev " as standalone tokens with surrounding spaces.)
+		isVia := strings.Contains(line, " via ")
+		isDev := !isVia && (strings.Contains(line, " dev ") || strings.HasPrefix(trimmed, "dev "))
+		if (isVia || isDev) && !strings.HasPrefix(trimmed, "BGP.") {
 			r := BIRDRoute{}
-			if idx := strings.Index(line, " via "); idx >= 0 {
-				fields := strings.Fields(line[idx+5:])
-				if len(fields) > 0 {
-					r.NextHop = fields[0]
+			if isVia {
+				if idx := strings.Index(line, " via "); idx >= 0 {
+					fields := strings.Fields(line[idx+5:])
+					if len(fields) > 0 {
+						r.NextHop = fields[0]
+					}
+				}
+			} else {
+				r.Device = true
+				if idx := strings.Index(line, "dev "); idx >= 0 {
+					fields := strings.Fields(line[idx+4:])
+					if len(fields) > 0 {
+						r.Iface = fields[0]
+					}
+				}
+			}
+			// Protocol preference: the last "(pref[/metric])" group on the line.
+			if ms := birdRoutePrefRe.FindAllStringSubmatch(line, -1); len(ms) > 0 {
+				if _, err := fmt.Sscanf(ms[len(ms)-1][1], "%d", &r.Preference); err != nil {
+					logrus.Warnf("ParseBIRDRouteOutput: failed to parse preference from %q: %v", line, err)
 				}
 			}
 			// BIRD marks the active/best route with " * " (space-asterisk-space)

--- a/e2e/pkg/utils/bgp/bird_external_peer.go
+++ b/e2e/pkg/utils/bgp/bird_external_peer.go
@@ -83,6 +83,41 @@ const birdPeerTemplate = `protocol bgp node_%d from bgp_template {
 
 `
 
+// birdRecursiveStaticTemplate declares the prefix the peer advertises on behalf of a "nested
+// cluster" behind a workload.  Args: prefix, the peer's own next hop for it.
+//
+// The peer never forwards anything to this prefix, so its own next hop only has to be resolvable
+// (otherwise BIRD holds the static route inactive and never exports it); the first cluster node
+// is used because it is directly connected on the BGP subnet.  The NEXT_HOP that actually matters
+// is the one imposed per-peer by birdRecursivePeerTemplate below.
+const birdRecursiveStaticTemplate = `protocol static static_recursive {
+  route %s via %s;
+}
+
+`
+
+// birdRecursivePeerTemplate is the per-peer block used when the peer advertises a recursive
+// route.  Args: index, peer IP, prefix, NEXT_HOP.
+//
+// Assigning bgp_next_hop in the export filter is what makes the node receive the prefix with a
+// third-party NEXT_HOP — the workload's IP rather than the peer's own address — which is the
+// whole point: it forces the receiving node to resolve the next hop recursively against its own
+// RIB.  Verified against calico/bird v0.3.3+birdv1.6.8: the assignment alone is sufficient and
+// "next hop keep" is not required, despite this being an eBGP session.
+const birdRecursivePeerTemplate = `protocol bgp node_%d from bgp_template {
+  neighbor %s as 64512;
+  passive on;
+  export filter {
+    if net = %s then {
+      bgp_next_hop = %s;
+      accept;
+    }
+    reject;
+  };
+}
+
+`
+
 // BIRDRoute represents a single BIRD route entry for a /32 prefix.
 type BIRDRoute struct {
 	NextHop string `json:"nextHop"`
@@ -92,9 +127,24 @@ type BIRDRoute struct {
 	// Device is true for directly-connected device routes (no "via" gateway),
 	// e.g. a local workload veth route learned by BIRD's kernel protocol.
 	Device bool `json:"device"`
+	// Unreachable is true for a route BIRD accepted into its RIB but could not resolve to a next
+	// hop, and has therefore programmed into the FIB as unreachable.  BIRD prints these with
+	// "unreachable" in place of the "via <ip> on <iface>" clause and an empty metric field:
+	//
+	//	10.99.0.1/32       unreachable [tor 15:24:05 from 10.55.0.2] * (100/-) [AS65001i]
+	//
+	// The case this exists for is a recursive next hop that resolves only through another
+	// recursive (BGP) route: BIRD refuses BGP-through-BGP recursion, so the route lands here
+	// rather than being dropped.  Distinguishing this from "prefix absent" is the whole point of
+	// parsing it — a black-holed prefix and an unadvertised one are otherwise identical.
+	Unreachable bool `json:"unreachable"`
 	// Preference is BIRD's protocol preference for the route, parsed from the
 	// trailing "(pref)" or "(pref/metric)" on the route line. Zero if absent.
-	Preference int    `json:"preference"`
+	Preference int `json:"preference"`
+	// BGPNextHop is the BGP.next_hop attribute, when the output included attributes ("... all").
+	// For an Unreachable route this is the only place the intended next hop appears, since the
+	// route line itself carries none.
+	BGPNextHop string `json:"bgpNextHop"`
 	LocalPref  int    `json:"localPref"`
 	Community  string `json:"community"`
 	Best       bool   `json:"best"`
@@ -144,16 +194,16 @@ type BIRDPeer interface {
 	QuerySnapshot(vmIP string) RouteSnapshot
 }
 
-// birdRoutePrefRe matches the trailing preference on a BIRD route line:
-// "(150)" for kernel/device routes, "(100/0)" for BGP routes. Note that
-// ParseBIRDRouteOutput only recognises "via" and "dev" route lines, so
-// "unreachable" route lines (e.g. "(100/-)") are never parsed.
+// birdRoutePrefRe matches the trailing preference on a BIRD route line: "(150)" for
+// kernel/device routes, "(100/0)" for BGP routes, "(100/-)" for unreachable ones (the metric
+// field is empty because there is no resolved next hop to take a metric from).
 var birdRoutePrefRe = regexp.MustCompile(`\((\d+)(?:/[^)]*)?\)`)
 
 // ParseBIRDRouteOutput parses the output of "birdcl show route <prefix> all"
-// and returns the list of routes. Handles both via-gateway routes ("via <ip>
-// on <iface>") and directly-connected device routes ("dev <iface>"). Returns
-// nil if the output contains "Network not in table" or is empty.
+// and returns the list of routes. Handles via-gateway routes ("via <ip> on
+// <iface>"), directly-connected device routes ("dev <iface>") and unresolved
+// routes ("unreachable"). Returns nil if the output contains "Network not in
+// table" or is empty.
 func ParseBIRDRouteOutput(output string) []BIRDRoute {
 	if strings.Contains(output, "Network not in table") {
 		return nil
@@ -169,21 +219,24 @@ func ParseBIRDRouteOutput(output string) []BIRDRoute {
 			continue
 		}
 
-		// Route line: contains "via" or "dev" but is not a BGP attribute.
-		// (Attribute lines like "Type: device unicast univ" contain neither
-		// " via " nor " dev " as standalone tokens with surrounding spaces.)
+		// Route line: contains "via", "dev" or "unreachable" but is not a BGP
+		// attribute. (Attribute lines like "Type: device unicast univ" contain
+		// neither " via " nor " dev " as standalone tokens with surrounding
+		// spaces, and none of them carry an "unreachable" token.)
 		isVia := strings.Contains(line, " via ")
 		isDev := !isVia && (strings.Contains(line, " dev ") || strings.HasPrefix(trimmed, "dev "))
-		if (isVia || isDev) && !strings.HasPrefix(trimmed, "BGP.") {
+		isUnreach := !isVia && !isDev && hasToken(line, "unreachable")
+		if (isVia || isDev || isUnreach) && !strings.HasPrefix(trimmed, "BGP.") {
 			r := BIRDRoute{}
-			if isVia {
+			switch {
+			case isVia:
 				if idx := strings.Index(line, " via "); idx >= 0 {
 					fields := strings.Fields(line[idx+5:])
 					if len(fields) > 0 {
 						r.NextHop = fields[0]
 					}
 				}
-			} else {
+			case isDev:
 				r.Device = true
 				if idx := strings.Index(line, "dev "); idx >= 0 {
 					fields := strings.Fields(line[idx+4:])
@@ -191,6 +244,10 @@ func ParseBIRDRouteOutput(output string) []BIRDRoute {
 						r.Iface = fields[0]
 					}
 				}
+			default:
+				// An unreachable route has no next hop or interface on the route line at all;
+				// BGPNextHop below is the only record of what BIRD failed to resolve.
+				r.Unreachable = true
 			}
 			// Protocol preference: the last "(pref[/metric])" group on the line.
 			if ms := birdRoutePrefRe.FindAllStringSubmatch(line, -1); len(ms) > 0 {
@@ -205,13 +262,7 @@ func ParseBIRDRouteOutput(output string) []BIRDRoute {
 			// Match the standalone token rather than substring " * " elsewhere
 			// in the line (e.g. interface names containing "*" or AS-path
 			// expressions) so we never wrongly mark a non-best route as best.
-			r.Best = false
-			for _, tok := range strings.Fields(line) {
-				if tok == "*" {
-					r.Best = true
-					break
-				}
-			}
+			r.Best = hasToken(line, "*")
 			routes = append(routes, r)
 			current = &routes[len(routes)-1]
 			continue
@@ -226,18 +277,68 @@ func ParseBIRDRouteOutput(output string) []BIRDRoute {
 				}
 			} else if strings.HasPrefix(trimmed, "BGP.community:") {
 				current.Community = strings.TrimSpace(strings.TrimPrefix(trimmed, "BGP.community:"))
+			} else if strings.HasPrefix(trimmed, "BGP.next_hop:") {
+				current.BGPNextHop = strings.TrimSpace(strings.TrimPrefix(trimmed, "BGP.next_hop:"))
 			}
 		}
 	}
 	return routes
 }
 
+// hasToken reports whether line contains tok as a whitespace-delimited token.  Used instead of a
+// substring test so that, say, " * " appearing inside an AS-path expression or an interface name
+// cannot be mistaken for BIRD's best-route marker.
+func hasToken(line, tok string) bool {
+	for _, f := range strings.Fields(line) {
+		if f == tok {
+			return true
+		}
+	}
+	return false
+}
+
+// RecursiveRoute describes a prefix the external peer advertises with a third-party NEXT_HOP, to
+// stand in for a nested cluster reached through a workload — e.g. a Service VIP inside a child
+// cluster running in a KubeVirt VM.
+//
+// The receiving node has to resolve NextHop against its own RIB, and BIRD refuses to resolve a
+// recursive next hop through another recursive (BGP) route.  So whether Prefix ends up usable or
+// programmed as unreachable is decided entirely by which route wins for NextHop in that node's
+// RIB — which is exactly what confd's kernel-protocol import filter controls.
+type RecursiveRoute struct {
+	// Prefix is the advertised prefix, e.g. "10.99.0.1/32".  Keep it outside every IPPool CIDR
+	// in the cluster so it can never collide with an IPAM allocation, and outside the peer's own
+	// import filter range so the advertisement cannot loop back.
+	Prefix string
+	// NextHop is the NEXT_HOP to advertise Prefix with: the IP of the workload the nested cluster
+	// is deemed to sit behind.
+	NextHop string
+}
+
 // GenerateBIRDPeersConf renders a BIRD 1.x peers config. podCIDR gates the
 // import filter; pass the cluster's IPv4 IPPool CIDR.
 func GenerateBIRDPeersConf(podCIDR string, nodeIPs []string) string {
+	return generateBIRDPeersConf(podCIDR, nodeIPs, nil)
+}
+
+// GenerateBIRDPeersConfWithRecursiveRoute renders a BIRD 1.x peers config that, in addition to
+// peering with nodeIPs, advertises rr.Prefix to every one of them with rr.NextHop as the
+// NEXT_HOP.  See RecursiveRoute for what that buys.
+func GenerateBIRDPeersConfWithRecursiveRoute(podCIDR string, nodeIPs []string, rr RecursiveRoute) string {
+	return generateBIRDPeersConf(podCIDR, nodeIPs, &rr)
+}
+
+func generateBIRDPeersConf(podCIDR string, nodeIPs []string, rr *RecursiveRoute) string {
 	var sb strings.Builder
 	fmt.Fprintf(&sb, birdHeaderTemplate, podCIDR)
+	if rr != nil && len(nodeIPs) > 0 {
+		fmt.Fprintf(&sb, birdRecursiveStaticTemplate, rr.Prefix, nodeIPs[0])
+	}
 	for i, nodeIP := range nodeIPs {
+		if rr != nil {
+			sb.WriteString(fmt.Sprintf(birdRecursivePeerTemplate, i, nodeIP, rr.Prefix, rr.NextHop))
+			continue
+		}
 		sb.WriteString(fmt.Sprintf(birdPeerTemplate, i, nodeIP))
 	}
 	return sb.String()
@@ -297,8 +398,12 @@ func (p *ContainerBIRDPeer) CheckBGPSession() (string, error) {
 func (p *ContainerBIRDPeer) ConfigureBIRD(peersConf string) {
 	GinkgoHelper()
 
-	// Enable merge paths in the kernel protocol for ECMP support.
-	out, err := p.exec("sed", "-i", "/protocol kernel {/a merge paths on;", "/etc/bird.conf")
+	// Enable merge paths in the kernel protocol for ECMP support.  The container outlives a
+	// single spec, so guard against inserting the option twice: BIRD rejects the duplicate, and
+	// "birdcl configure" reports a parse error while still exiting 0, which would silently leave
+	// the previous config in place.
+	out, err := p.exec("sh", "-c",
+		"grep -q 'merge paths on;' /etc/bird.conf || sed -i '/protocol kernel {/a merge paths on;' /etc/bird.conf")
 	Expect(err).NotTo(HaveOccurred(),
 		"failed to enable merge paths in BIRD: %s", out)
 

--- a/e2e/pkg/utils/bgp/bird_external_peer_test.go
+++ b/e2e/pkg/utils/bgp/bird_external_peer_test.go
@@ -16,6 +16,7 @@ package bgp
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -58,6 +59,58 @@ func TestParseBIRDRouteOutput(t *testing.T) {
 				{NextHop: "172.16.8.3", Preference: 100, LocalPref: 2147482623, Best: false},
 			},
 		},
+		// The next three fixtures are literal captures from a three-container BIRD lab
+		// (calico/bird v0.3.3+birdv1.6.8) reproducing the live-migration black-hole: a peer
+		// advertising 10.99.0.1/32 with the workload IP 192.168.99.7 as NEXT_HOP, against a
+		// node holding both a local "cali99" device route for the workload and a stale BGP
+		// route for it from the migration source.
+		{
+			name: "recursive route black-holed: next hop resolves only via another BGP route",
+			output: `BIRD v0.3.3+birdv1.6.8 ready.
+10.99.0.1/32       unreachable [tor 15:24:05 from 10.55.0.2] * (100/-) [AS65001i]
+	Type: BGP unicast univ
+	BGP.origin: IGP
+	BGP.as_path: 65001
+	BGP.next_hop: 192.168.99.7
+	BGP.local_pref: 100
+`,
+			want: []BIRDRoute{
+				{Unreachable: true, Preference: 100, BGPNextHop: "192.168.99.7", LocalPref: 100, Best: true},
+			},
+		},
+		{
+			name: "recursive route resolved through the local workload veth",
+			output: `BIRD v0.3.3+birdv1.6.8 ready.
+10.99.0.1/32       via 192.168.99.7 on cali99 [tor 15:25:07 from 10.55.0.2] * (100/0) [AS65001i]
+	Type: BGP unicast univ
+	BGP.origin: IGP
+	BGP.as_path: 65001
+	BGP.next_hop: 192.168.99.7
+	BGP.local_pref: 100
+`,
+			want: []BIRDRoute{
+				{NextHop: "192.168.99.7", Preference: 100, BGPNextHop: "192.168.99.7", LocalPref: 100, Best: true},
+			},
+		},
+		{
+			name: "stale BGP route beats the local device route (pre-fix contest)",
+			output: `BIRD v0.3.3+birdv1.6.8 ready.
+192.168.99.7/32    via 10.55.0.4 on eth0 [src 15:24:05] * (100/0) [i]
+	Type: BGP unicast univ
+	BGP.origin: IGP
+	BGP.as_path:
+	BGP.next_hop: 10.55.0.4
+	BGP.local_pref: 100
+                   dev cali99 [kernel1 15:24:03] (10)
+	Type: inherit unicast univ
+	Kernel.source: 3
+	Kernel.metric: 512
+`,
+			want: []BIRDRoute{
+				{NextHop: "10.55.0.4", Preference: 100, BGPNextHop: "10.55.0.4", LocalPref: 100, Best: true},
+				{Iface: "cali99", Device: true, Preference: 10},
+			},
+		},
 		{
 			name: "device route at kernel default preference",
 			output: `BIRD v0.3.3+birdv1.6.8 ready.
@@ -92,5 +145,41 @@ func TestParseBIRDRouteOutput(t *testing.T) {
 				t.Errorf("ParseBIRDRouteOutput() =\n%+v\nwant\n%+v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestGenerateBIRDPeersConfWithRecursiveRoute(t *testing.T) {
+	conf := GenerateBIRDPeersConfWithRecursiveRoute(
+		"192.168.0.0/16",
+		[]string{"172.18.0.3", "172.18.0.4"},
+		RecursiveRoute{Prefix: "10.99.0.1/32", NextHop: "192.168.130.67"},
+	)
+
+	// One static declaration, resolvable via the first node.
+	if want := "route 10.99.0.1/32 via 172.18.0.3;"; !strings.Contains(conf, want) {
+		t.Errorf("config missing %q:\n%s", want, conf)
+	}
+	// Every peer must impose the workload IP as NEXT_HOP, or the receiving node has nothing to
+	// resolve recursively and the test the config exists for silently passes for the wrong
+	// reason.
+	if got := strings.Count(conf, "bgp_next_hop = 192.168.130.67;"); got != 2 {
+		t.Errorf("bgp_next_hop assignments = %d, want one per peer (2):\n%s", got, conf)
+	}
+	for _, ip := range []string{"172.18.0.3", "172.18.0.4"} {
+		if want := "neighbor " + ip + " as 64512;"; !strings.Contains(conf, want) {
+			t.Errorf("config missing %q:\n%s", want, conf)
+		}
+	}
+	// The per-peer export filter must override the template's "export none", not sit alongside
+	// it: BIRD takes the protocol's own option, but a stray template-level export would mean the
+	// prefix is never advertised at all.
+	if strings.Count(conf, "export none;") != 1 {
+		t.Errorf("expected exactly one template-level 'export none;':\n%s", conf)
+	}
+
+	// Without a recursive route the output must be unchanged from the plain generator.
+	plain := GenerateBIRDPeersConf("192.168.0.0/16", []string{"172.18.0.3"})
+	if strings.Contains(plain, "bgp_next_hop") || strings.Contains(plain, "static_recursive") {
+		t.Errorf("plain config should not contain recursive-route config:\n%s", plain)
 	}
 }

--- a/e2e/pkg/utils/bgp/bird_external_peer_test.go
+++ b/e2e/pkg/utils/bgp/bird_external_peer_test.go
@@ -1,0 +1,96 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bgp
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseBIRDRouteOutput(t *testing.T) {
+	tests := []struct {
+		name   string
+		output string
+		want   []BIRDRoute
+	}{
+		{
+			name:   "network not in table",
+			output: "BIRD 1.6.8 ready.\nNetwork not in table\n",
+			want:   nil,
+		},
+		{
+			name: "single BGP via route, best",
+			output: `BIRD 1.6.8 ready.
+10.244.0.64/32     via 172.16.8.2 on eth0 [bgp_node0 16:22:38] * (100/0) [AS65000i]
+	Type: BGP unicast univ
+	BGP.origin: IGP
+	BGP.local_pref: 100
+	BGP.community: (65000,100)
+`,
+			want: []BIRDRoute{
+				{NextHop: "172.16.8.2", Preference: 100, LocalPref: 100, Community: "(65000,100)", Best: true},
+			},
+		},
+		{
+			name: "local device route contested with stale BGP route",
+			output: `BIRD v0.3.3+birdv1.6.8 ready.
+192.168.130.67/32  dev cali3cab184f37f [kernel1 22:35:57] * (150)
+	Type: device unicast univ
+                   via 172.16.8.3 on l2tpeth0 [Mesh_172_16_8_3 22:35:20] (100/0) [AS64512i]
+	Type: BGP unicast univ
+	BGP.origin: IGP
+	BGP.local_pref: 2147482623
+`,
+			want: []BIRDRoute{
+				{Iface: "cali3cab184f37f", Device: true, Preference: 150, Best: true},
+				{NextHop: "172.16.8.3", Preference: 100, LocalPref: 2147482623, Best: false},
+			},
+		},
+		{
+			name: "device route at kernel default preference",
+			output: `BIRD v0.3.3+birdv1.6.8 ready.
+192.168.130.67/32  dev cali3cab184f37f [kernel1 22:35:57] * (10)
+	Type: device unicast univ
+`,
+			want: []BIRDRoute{
+				{Iface: "cali3cab184f37f", Device: true, Preference: 10, Best: true},
+			},
+		},
+		{
+			name: "two via routes, non-best second",
+			output: `BIRD 1.6.8 ready.
+10.244.0.64/32     via 172.16.8.2 on eth0 [bgp_node0 16:22:38] * (100/0) [AS65000i]
+	Type: BGP unicast univ
+	BGP.local_pref: 2147483135
+	BGP.community: (65000,100)
+                   via 172.16.8.4 on eth0 [bgp_node2 16:21:49] (100/0) [AS65000i]
+	Type: BGP unicast univ
+	BGP.local_pref: 100
+`,
+			want: []BIRDRoute{
+				{NextHop: "172.16.8.2", Preference: 100, LocalPref: 2147483135, Community: "(65000,100)", Best: true},
+				{NextHop: "172.16.8.4", Preference: 100, LocalPref: 100, Best: false},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ParseBIRDRouteOutput(tt.output)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ParseBIRDRouteOutput() =\n%+v\nwant\n%+v", got, tt.want)
+			}
+		})
+	}
+}

--- a/e2e/testsets/index.txt
+++ b/e2e/testsets/index.txt
@@ -29,7 +29,7 @@
 .argoci/cron/e2e-bpf.yaml | bpf-run-matrix-kops-w-calico-cni-ipv4 [calicoiptables-ipv4] | bpf/kops-xtables-encap-nobgp-extnode-aws | 208
 .argoci/cron/e2e-bpf.yaml | bpf-run-matrix-kops-w-calico-cni-ipv6 [calicobpf-ipv6] | bpf/kops-bpf-encap-nobgp-extnode-aws | 204
 .argoci/cron/e2e-bpf.yaml | bpf-run-matrix-kops-w-calico-cni-ipv6 [calicoiptables-ipv6] | bpf/kops-xtables-encap-nobgp-extnode-aws | 208
-.argoci/cron/e2e-bpf.yaml | kubevirt-e2e-tests | gcp/kubevirt | 8
+.argoci/cron/e2e-bpf.yaml | kubevirt-e2e-tests | gcp/kubevirt | 9
 .argoci/cron/e2e-bpf.yaml | usage-reporting-with-bpf | (usage-reporting) | -
 .argoci/cron/e2e-bpf.yaml | wireguard | bpf/aks-bpf-encap-nobgp | 206
 .argoci/cron/e2e-certification.yaml | hcp-hosted-setup-and-tests | (ocp-cert) | -
@@ -56,7 +56,7 @@
 .argoci/cron/e2e-iptables.yaml | ipvs | iptables/xtables-v3crd | 216
 .argoci/cron/e2e-iptables.yaml | k8s-beta-runs | iptables/xtables-manifest | 211
 .argoci/cron/e2e-iptables.yaml | k8s-distros | iptables/xtables | 220
-.argoci/cron/e2e-iptables.yaml | kubevirt-e2e-tests | gcp/kubevirt | 8
+.argoci/cron/e2e-iptables.yaml | kubevirt-e2e-tests | gcp/kubevirt | 9
 .argoci/cron/e2e-iptables.yaml | migration | iptables/xtables-manifest | 211
 .argoci/cron/e2e-iptables.yaml | migration [pre-migration] | pre-migration-smoke | 1
 .argoci/cron/e2e-iptables.yaml | native-v3-crds-aks | iptables/aks-xtables-nobgp-v3crd | 192
@@ -70,7 +70,7 @@
 .argoci/cron/e2e-iptables.yaml | wireguard-regression-k8s-e2e-kdd-new | iptables/xtables-aws | 221
 .argoci/cron/e2e-iptables.yaml | wireguard-regression-k8s-e2e-kdd-old | iptables/xtables-v3crd-aws | 217
 .argoci/cron/e2e-iptables.yaml | wireguard-vxlan-k8s-e2e | iptables/xtables-wireguard | 217
-.argoci/cron/e2e-nftables.yaml | kubevirt-e2e-tests | gcp/kubevirt | 8
+.argoci/cron/e2e-nftables.yaml | kubevirt-e2e-tests | gcp/kubevirt | 9
 .argoci/cron/e2e-nftables.yaml | nftables-mode-arm64-wg | nftables/xtables-autohep | 223
 .argoci/cron/e2e-nftables.yaml | nftables-mode-eks-eks-w-aws-cni | nftables/eks-xtables-nobgp-aws-autohep | 206
 .argoci/cron/e2e-nftables.yaml | nftables-mode-eks-eks-w-calico-cni | nftables/eks-xtables-aws-autohep | 213
@@ -82,7 +82,7 @@
 .argoci/cron/e2e-openstack.yaml | full-fv | (openstack-e2e) | -
 .argoci/cron/e2e-openstack.yaml | multi-region | (openstack-e2e) | -
 .argoci/cron/e2e-patch-verification.yaml | kind-tests | patch-verification/xtables | 83
-.argoci/cron/e2e-patch-verification.yaml | kubevirt-e2e-tests | gcp/kubevirt | 8
+.argoci/cron/e2e-patch-verification.yaml | kubevirt-e2e-tests | gcp/kubevirt | 9
 .argoci/cron/e2e-patch-verification.yaml | manifests-calico-etcd | patch-verification/xtables-encap-manifest | 80
 .argoci/cron/e2e-patch-verification.yaml | manifests-canal | patch-verification/xtables-manifest | 80
 .argoci/cron/e2e-patch-verification.yaml | manifests-canal-migration | patch-verification/xtables-manifest | 80
@@ -147,7 +147,7 @@
 .semaphore/end-to-end/pipelines/bpf.yml | BPF run matrix / aws-kubeadm dual stack, iptables | bpf/xtables-encap-extnode-aws | 220
 .semaphore/end-to-end/pipelines/bpf.yml | BPF run matrix / aws-lb-bpf | bpf/eks-bpf-encap-extnode-aws | 206
 .semaphore/end-to-end/pipelines/bpf.yml | BPF run matrix / aws-lb-iptables | bpf/eks-xtables-encap-extnode-aws | 210
-.semaphore/end-to-end/pipelines/bpf.yml | KubeVirt e2e tests / KubeVirt IP persistence and live migration | gcp/kubevirt | 8
+.semaphore/end-to-end/pipelines/bpf.yml | KubeVirt e2e tests / KubeVirt IP persistence and live migration | gcp/kubevirt | 9
 .semaphore/end-to-end/pipelines/bpf.yml | Wireguard / BPF + AKS w AKS CNI + Overlay | bpf/aks-bpf-encap-nobgp | 206
 .semaphore/end-to-end/pipelines/bpf.yml | usage reporting with bpf / mainline | (usage-reporting) | -
 .semaphore/end-to-end/pipelines/certification.yml | HCP hosted setup and tests / HCP tests - hosted (cert) | (ocp-cert) | -
@@ -168,7 +168,7 @@
 .semaphore/end-to-end/pipelines/iptables.yml | Focused WireGuard E2E (EKS) / kdd (AWS CNI) | wireguard | 1
 .semaphore/end-to-end/pipelines/iptables.yml | Focused WireGuard E2E (EKS) / kdd (Calico CNI) | wireguard | 1
 .semaphore/end-to-end/pipelines/iptables.yml | IPVS / ipvs | iptables/xtables-v3crd | 216
-.semaphore/end-to-end/pipelines/iptables.yml | KubeVirt e2e tests / KubeVirt IP persistence and live migration | gcp/kubevirt | 8
+.semaphore/end-to-end/pipelines/iptables.yml | KubeVirt e2e tests / KubeVirt IP persistence and live migration | gcp/kubevirt | 9
 .semaphore/end-to-end/pipelines/iptables.yml | Migration / Flannel migration | iptables/xtables-manifest | 211
 .semaphore/end-to-end/pipelines/iptables.yml | Migration / Flannel migration [pre-migration] | pre-migration-smoke | 1
 .semaphore/end-to-end/pipelines/iptables.yml | Openshift OCP / hashrelease | iptables/openshift-xtables-encap-aws | 216
@@ -187,7 +187,7 @@
 .semaphore/end-to-end/pipelines/iptables.yml | k8s beta runs / k8s beta | iptables/xtables-manifest | 211
 .semaphore/end-to-end/pipelines/iptables.yml | k8s distros / install required | iptables/xtables | 220
 .semaphore/end-to-end/pipelines/iptables.yml | usage reporting / mainline | (usage-reporting) | -
-.semaphore/end-to-end/pipelines/nftables.yml | KubeVirt e2e tests / KubeVirt IP persistence and live migration | gcp/kubevirt | 8
+.semaphore/end-to-end/pipelines/nftables.yml | KubeVirt e2e tests / KubeVirt IP persistence and live migration | gcp/kubevirt | 9
 .semaphore/end-to-end/pipelines/nftables.yml | Nftables mode, EKS / EKS w/ Calico CNI | nftables/eks-xtables-aws-autohep | 213
 .semaphore/end-to-end/pipelines/nftables.yml | Nftables mode, EKS / EKS w/ aws CNI | nftables/eks-xtables-nobgp-aws-autohep | 206
 .semaphore/end-to-end/pipelines/nftables.yml | Nftables mode, KinD / Nftables mode, ipv6-only | nftables/xtables-autohep | 223
@@ -197,7 +197,7 @@
 .semaphore/end-to-end/pipelines/nftables.yml | Nftables, Talos / Native v3 CRDs (GCP) | nftables/xtables-encap-nobgp-v3crd-autohep | 214
 .semaphore/end-to-end/pipelines/nftables.yml | Nftables, Talos / Nftables, Talos | nftables/xtables-encap-aws-autohep | 219
 .semaphore/end-to-end/pipelines/patch-verification.yml | KinD tests / IPv6 | patch-verification/xtables | 83
-.semaphore/end-to-end/pipelines/patch-verification.yml | KubeVirt e2e tests / KubeVirt IP persistence and live migration | gcp/kubevirt | 8
+.semaphore/end-to-end/pipelines/patch-verification.yml | KubeVirt e2e tests / KubeVirt IP persistence and live migration | gcp/kubevirt | 9
 .semaphore/end-to-end/pipelines/patch-verification.yml | Manifests / Calico etcd | patch-verification/xtables-encap-manifest | 80
 .semaphore/end-to-end/pipelines/patch-verification.yml | Manifests / Canal | patch-verification/xtables-manifest | 80
 .semaphore/end-to-end/pipelines/patch-verification.yml | Manifests / Canal migration | patch-verification/xtables-manifest | 80

--- a/e2e/testsets/sets/gcp/kubevirt.txt
+++ b/e2e/testsets/sets/gcp/kubevirt.txt
@@ -6,3 +6,4 @@
 [sig-calico] [Team:CORE] [Feature:KubeVirt] [Category:Networking] KubeVirt IP persistence should release IPAM handle when VM is deleted
 [sig-calico] [Team:CORE] [Feature:KubeVirt] [RequiresRealKubeVirt] [Category:Networking] KubeVirt live migration eBGP external client [ExternalNode] should maintain TCP connection from eBGP external client across two consecutive migrations
 [sig-calico] [Team:CORE] [Feature:KubeVirt] [RequiresRealKubeVirt] [Category:Networking] KubeVirt live migration should maintain TCP connection over iBGP across two consecutive live migrations
+[sig-calico] [Team:CORE] [Feature:KubeVirt] [RequiresRealKubeVirt] [Category:Networking] KubeVirt live migration should prefer the local workload route on the migration target node

--- a/node/filesystem/etc/calico/confd/templates/bird.cfg.template
+++ b/node/filesystem/etc/calico/confd/templates/bird.cfg.template
@@ -15,7 +15,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < {{$config.NormalRoutePriority}} ) then
+      preference = 150;
+    accept;
+  };
 }
 
 template direct direct_template {

--- a/node/filesystem/etc/calico/confd/templates/bird6.cfg.template
+++ b/node/filesystem/etc/calico/confd/templates/bird6.cfg.template
@@ -15,7 +15,20 @@ template kernel kernel_template {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
-  import all;
+  import filter {
+    # Raise the preference of a local workload route that Felix has programmed
+    # at an elevated FIB priority (metric below NormalRoutePriority), e.g. on
+    # the target node of a live migration, so that it beats a stale route for
+    # the same address still advertised over BGP by the previous host
+    # (preference 100).  150 deliberately stays below the preference given to
+    # elevated remote routes (200) in the BGP import filter.  Restricted to
+    # workload interfaces so infrastructure routes (default/gateway) are
+    # untouched, and gated on the elevated metric so a departing workload's
+    # lingering veth route is never raised.
+    if ( defined(ifname) && ifname ~ "cali*" && krt_metric < {{$config.NormalRoutePriority}} ) then
+      preference = 150;
+    accept;
+  };
 }
 
 template direct direct_template {


### PR DESCRIPTION
## Description

**Bug fix.** On the node receiving a live-migrated workload (e.g. a KubeVirt VM), the kernel-learned local veth route enters BIRD at the kernel protocol's default preference (10) and loses to the stale /32 still advertised over BGP by the migration source (preference 100) until the source's virt-launcher/veth teardown (~9s).

Direct traffic to the VM's /32 survives this window, on two counts:

- **The target's kernel FIB stays correct.** Felix programs the local veth route at elevated metric 512, while BIRD programs the stale BGP route at metric 1024 (`krt_metric = 2147483647 − bgp_local_pref`, and the stale advertisement carries normal local_pref). The kernel picks the lowest metric, so clients on the target node keep reaching the VM via the local veth.
- **Remote nodes converge onto the target promptly.** Calico configures `add paths on`, so BGP exports all routes for the prefix, and the target's local kernel route is always advertised — with elevated local_pref during the migration window, so remote nodes import it at preference 200 and switch away from the stale route.

The damage is in BIRD's RIB, where the stale route is best — and BIRD resolves recursive next-hops against its RIB, not the FIB. BIRD refuses to resolve a recursive next-hop through another recursive (BGP) route, so **every route whose next hop is the VM's IP — e.g. a Service LB VIP or pod CIDR advertised over BGP from a nested cluster running inside the VM — is programmed into the target's FIB as `unreachable`**. That black-holes two kinds of traffic on the very node that now hosts the VM:

- **Clients on the target node itself** — host processes and pods colocated with the arriving VM — can no longer reach the VIP or the nested pod CIDR: their packets hit the `unreachable` route and are dropped locally, even though the VM is one veth away.
- **Traffic from the rest of the network**, which converges onto the target promptly (see above), is likewise dropped at the `unreachable` route on arrival.

The black-hole lasts ~9–13s after every migration whose source is a non-owner of the IP's IPAM block — on a long-running cluster, that is most migrations.

### The fix

Replace `import all` in confd's BIRD kernel protocol with an import filter that raises a local workload route to **preference 150** while Felix has it programmed at an elevated FIB metric (below `NormalRoutePriority`), i.e. only on the current migration target:

```
if ( defined(ifname) && ifname ~ "cali*" && krt_metric < {{$config.NormalRoutePriority}} ) then
  preference = 150;
accept;
```

This gives one coherent preference ladder: normal remote BGP route (100) < elevated local workload route (150) < elevated remote route (200). The `krt_metric` gate keys off Felix's authoritative "this is the migration target" signal, so the departing source's lingering veth is never raised and the source-side hand-off (remote elevated 200 beats local) is preserved. At rest the gate is false and the clause is a no-op.

With the local route best on the target, recursive next-hops through the VM resolve correctly. Follow-ups (plumbing the configurable interface prefix into confd; always-on vs migration-gated scope) are tracked in CORE-13344.

### Testing

- confd FV golden files regenerated (the kernel filter now renders per-IP-version `NormalRoutePriority`, exercised by `TestNormalRoutePriorityChange` with non-default values); rendered configs parse-validated with the calico BIRD 1.6 binaries.
- New e2e regression test in both KubeVirt flavors (shared choreography): two consecutive migrations, the second pinned to a node hosting a client pod. Asserts on the target node's BIRD RIB (local veth route best at 150 **while the stale remote /32 is present**), the kernel FIB, reversion to preference 10 at rest, and bounds the worst inter-arrival gap of TCP/ICMP continuity probes. The RIB assertions are the primary regression signal: plain /32 forwarding largely survives the stale-best window in a node mesh (ADD-PATH keeps remote nodes converging), whereas observing the recursive-next-hop black-hole directly would need a nested cluster advertising a VIP over BGP through the VM.
- MockVirt variant verified green on a KIND cluster, with the contested two-route state captured: `dev caliX [kernel1] * (150)` beating `via <source> (100/0)`.

**Release note:**
```release-note
Fixed a routing black-hole of up to ~10s on the node receiving a live-migrated KubeVirt VM: BIRD now prefers the VM's local route over a stale route still advertised by the migration source, so routes resolved via the VM (e.g. BGP routes advertised from a nested cluster) no longer become unreachable.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
