### PR TITLE
confd: don't re-advertise Felix's unencapsulated cluster routes

### DIFF
--- a/confd/pkg/backends/calico/bgp_processor.go
+++ b/confd/pkg/backends/calico/bgp_processor.go
@@ -920,25 +920,11 @@ func (c *client) processIPPools(pc *processorContext, config *types.BirdBGPConfi
 		"noEncap": policy.noEncap,
 	}).Debug("BIRD's responsibility for programming cluster routes.")
 
-	// Don't export Felix-programmed tunnel routes to other nodes over iBGP.  This always
-	// includes VXLAN and Wireguard routes.  When Felix is responsible for programming remote
-	// IPIP routes it also includes those.
-	felixTunnelIntfPatterns := []string{"*.cali", "*.calico"}
-	if !policy.ipip {
-		// Felix is programming remote IPIP routes.
-		felixTunnelIntfPatterns = append(felixTunnelIntfPatterns, "tunl0")
-	}
-	conditions := make([]string, len(felixTunnelIntfPatterns))
-	for i := range felixTunnelIntfPatterns {
-		conditions[i] = "(ifname ~ \"" + felixTunnelIntfPatterns[i] + "\")"
-	}
-	config.IBGPExportFilterForTunnelRoutes = []string{
-		"if (defined(ifname)) then {",
-		"  if (" + strings.Join(conditions, " || ") + ") then {",
-		"    reject;",
-		"  }",
-		"}",
-	}
+	// Don't export the cluster routes that Felix programmed to other nodes over iBGP.  The
+	// interface test below catches the ones that leave via a Calico tunnel device; the pool CIDRs
+	// collected in the loop below catch the rest.  See rejectForFelixTunnelRoutes and
+	// rejectForFelixOwnedPools.
+	config.IBGPExportFilterForFelixClusterRoutes = rejectForFelixTunnelRoutes(policy)
 
 	kvPairs, err := c.GetValues([]string{poolKey})
 	if err != nil {
@@ -958,6 +944,7 @@ func (c *client) processIPPools(pc *processorContext, config *types.BirdBGPConfi
 	}
 
 	birdIPIPInUse := false
+	var felixOwnedPoolCIDRs []string
 	for key, value := range kvPairs {
 		var ippool model.IPPool
 		if err := json.Unmarshal([]byte(value), &ippool); err != nil {
@@ -967,6 +954,13 @@ func (c *client) processIPPools(pc *processorContext, config *types.BirdBGPConfi
 
 		if policy.programsPool(&ippool) && poolUsesIPIP(&ippool) {
 			birdIPIPInUse = true
+		}
+
+		// Collect the pools whose cluster routes Felix programs, for the iBGP reject.  Pools with
+		// BGP export disabled are left out: they are rejected outright, for every peer, by
+		// BGPExportFilterForDisabledIPPools, which the templates render ahead of this filter.
+		if !policy.programsPool(&ippool) && !ippool.DisableBGPExport {
+			felixOwnedPoolCIDRs = append(felixOwnedPoolCIDRs, ippool.CIDR.String())
 		}
 
 		// Generate statements for rejecting disabled ippools in the filter for exporting routes to other peers.
@@ -1003,7 +997,76 @@ func (c *client) processIPPools(pc *processorContext, config *types.BirdBGPConfi
 	slices.Sort(config.BGPExportFilterForDisabledIPPools)
 	slices.Sort(config.BGPExportFilterForEnabledIPPools)
 
+	slices.Sort(felixOwnedPoolCIDRs)
+	config.IBGPExportFilterForFelixClusterRoutes = append(
+		config.IBGPExportFilterForFelixClusterRoutes,
+		rejectForFelixOwnedPools(felixOwnedPoolCIDRs)...,
+	)
+
 	return nil
+}
+
+// rejectForFelixTunnelRoutes builds the arm of the iBGP export reject that matches on the outgoing
+// interface.  It catches the cluster routes Felix programs through a Calico tunnel device: VXLAN
+// and WireGuard routes always, since Felix always owns those, and IPIP routes when Felix owns them
+// too.
+//
+// This arm cannot catch every Felix-programmed cluster route, because not all of them leave via a
+// tunnel device — see rejectForFelixOwnedPools.  It is kept alongside the CIDR test because it
+// holds for a route whose destination is not in any IP Pool that confd currently knows about, for
+// instance while a pool is being deleted.
+func rejectForFelixTunnelRoutes(policy clusterRoutePolicy) []string {
+	felixTunnelIntfPatterns := []string{"*.cali", "*.calico"}
+	if !policy.ipip {
+		// Felix is programming remote IPIP routes.
+		felixTunnelIntfPatterns = append(felixTunnelIntfPatterns, "tunl0")
+	}
+	conditions := make([]string, len(felixTunnelIntfPatterns))
+	for i := range felixTunnelIntfPatterns {
+		conditions[i] = "(ifname ~ \"" + felixTunnelIntfPatterns[i] + "\")"
+	}
+	return []string{
+		"if (defined(ifname)) then {",
+		"  if (" + strings.Join(conditions, " || ") + ") then {",
+		"    reject;",
+		"  }",
+		"}",
+	}
+}
+
+// rejectForFelixOwnedPools builds the arm of the iBGP export reject that matches on the IP Pool
+// CIDR, for the pools whose cluster routes Felix programs.
+//
+// The interface test in rejectForFelixTunnelRoutes only catches an encapsulated route.  Felix does
+// not encapsulate a cluster route to a node in this node's own subnet when the pool is in
+// CrossSubnet mode, and does not encapsulate at all in an unencapsulated pool that it owns: those
+// routes leave via the host NIC, so the interface test lets them through and the node re-advertises
+// another node's block.  Matching the pool's CIDR is what catches them.
+//
+// The CIDR on its own would be too broad — this node's own routes into the pool are in it too — so
+// the match is narrowed to the routes that Felix programmed to somewhere else:
+//
+//   - source = RTS_INHERIT selects the routes BIRD learned from the kernel, which is how Felix's
+//     routes get into BIRD's table (the kernel protocol runs with `learn`).  It excludes the
+//     blocks this node advertises from its own affinities, which come from BIRD's own static
+//     protocol, and it excludes anything learned over BGP, so a route reflector goes on reflecting
+//     its clients' routes.
+//   - dest selects the routes that have a next hop, i.e. that lead off this node.  It excludes the
+//     device routes to this node's own workloads, which must still be advertised — including a
+//     workload whose address was borrowed from another node's block, and the elevated-priority /32
+//     of a workload that has migrated here — and the blackhole routes for this node's own blocks.
+func rejectForFelixOwnedPools(cidrs []string) []string {
+	if len(cidrs) == 0 {
+		return nil
+	}
+	lines := []string{
+		"if (defined(source) && (source = RTS_INHERIT) && ((dest = RTD_ROUTER) || (dest = RTD_MULTIPATH))) then {",
+		"  # Cluster routes for these pools are Felix's to program, and the owning node's to advertise.",
+	}
+	for _, cidr := range cidrs {
+		lines = append(lines, emitFilterStatementForIPPools(cidr, "", "reject", "", ""))
+	}
+	return append(lines, "}")
 }
 
 // processWireguardPeerFilter generates BIRD kernel filter reject statements for peers

--- a/confd/pkg/backends/calico/ippools_test.go
+++ b/confd/pkg/backends/calico/ippools_test.go
@@ -105,6 +105,24 @@ var (
 		`  if (net ~ 10.19.0.0/16) then { reject; } # VXLAN routes are handled by Felix.`,
 	}
 
+	// The pool CIDRs that the iBGP export filter rejects, for the IPv4 pool table above, grouped by
+	// class of IP Pool.  A pool is in the list when Felix programs its cluster routes: this node
+	// learns those routes from the kernel, but they are the owning node's to advertise.  Both the
+	// CrossSubnet pools and the unencapsulated pool are here because their routes do not
+	// necessarily leave via a Calico tunnel device, so the interface test alone lets them through.
+	// Pools with BGP export disabled are absent: they are rejected outright, ahead of this filter.
+	ibgpRejectIPIPByFelixV4 = []string{
+		`  if (net ~ 10.10.0.0/16) then { reject; }`,
+		`  if (net ~ 10.12.0.0/16) then { reject; }`,
+	}
+	ibgpRejectNoEncapByFelixV4 = []string{
+		`  if (net ~ 10.14.0.0/16) then { reject; }`,
+	}
+	ibgpRejectVXLANV4 = []string{
+		`  if (net ~ 10.16.0.0/16) then { reject; }`,
+		`  if (net ~ 10.18.0.0/16) then { reject; }`,
+	}
+
 	// The filters for exporting to BGP peers only depend on DisableBGPExport, so they are the same
 	// whichever component programs the cluster routes.
 	exportStatementsV4 = []string{
@@ -152,6 +170,20 @@ var (
 		`  if (net ~ dead:beef:19::/64) then { reject; } # VXLAN routes are handled by Felix.`,
 	}
 
+	// The same, for the IPv6 pool table.  IPIP is IPv4-only in practice, but processIPPool keys off
+	// the pool's ipipMode rather than the IP version, so the IPv6 IPIP pools behave the same way.
+	ibgpRejectIPIPByFelixV6 = []string{
+		`  if (net ~ dead:beef:10::/64) then { reject; }`,
+		`  if (net ~ dead:beef:12::/64) then { reject; }`,
+	}
+	ibgpRejectNoEncapByFelixV6 = []string{
+		`  if (net ~ dead:beef:14::/64) then { reject; }`,
+	}
+	ibgpRejectVXLANV6 = []string{
+		`  if (net ~ dead:beef:16::/64) then { reject; }`,
+		`  if (net ~ dead:beef:18::/64) then { reject; }`,
+	}
+
 	exportStatementsV6 = []string{
 		`  if (net ~ dead:beef:10::/64) then { accept; }`,
 		`  if (net ~ dead:beef:11::/64) then { reject; } # BGP export is disabled.`,
@@ -175,58 +207,82 @@ func Test_processIPPools(t *testing.T) {
 		programClusterRoutes *string
 		ipVersion            int
 		wantKernel           []string
+		// wantIBGPRejectCIDRs is the pool-CIDR arm of the iBGP export reject: the pools whose
+		// cluster routes Felix programs.
+		wantIBGPRejectCIDRs []string
+		// felixOwnsIPIP selects the interface arm of the same reject: tunl0 is only in it when
+		// Felix programs the IPIP cluster routes.
+		felixOwnsIPIP bool
 	}{
 		{
-			name:       "IPv4, field unset: BIRD programs unencapsulated pools only",
-			ipVersion:  4,
-			wantKernel: slices.Concat(kernelIPIPByFelixV4, kernelNoEncapByBIRDV4, kernelVXLANV4),
+			name:                "IPv4, field unset: BIRD programs unencapsulated pools only",
+			ipVersion:           4,
+			wantKernel:          slices.Concat(kernelIPIPByFelixV4, kernelNoEncapByBIRDV4, kernelVXLANV4),
+			wantIBGPRejectCIDRs: slices.Concat(ibgpRejectIPIPByFelixV4, ibgpRejectVXLANV4),
+			felixOwnsIPIP:       true,
 		},
 		{
 			name:                 "IPv4, EnabledNoEncapOnly: BIRD programs unencapsulated pools only",
 			programClusterRoutes: ptr.To(v3.EnabledNoEncapOnly),
 			ipVersion:            4,
 			wantKernel:           slices.Concat(kernelIPIPByFelixV4, kernelNoEncapByBIRDV4, kernelVXLANV4),
+			wantIBGPRejectCIDRs:  slices.Concat(ibgpRejectIPIPByFelixV4, ibgpRejectVXLANV4),
+			felixOwnsIPIP:        true,
 		},
 		{
 			name:                 "IPv4, Enabled: BIRD programs both IPIP and unencapsulated pools",
 			programClusterRoutes: ptr.To(v3.Enabled),
 			ipVersion:            4,
 			wantKernel:           slices.Concat(kernelIPIPByBIRDV4, kernelNoEncapByBIRDV4, kernelVXLANV4),
+			wantIBGPRejectCIDRs:  slices.Clone(ibgpRejectVXLANV4),
+			felixOwnsIPIP:        false,
 		},
 		{
 			name:                 "IPv4, EnabledIPIPOnly: BIRD programs IPIP pools only",
 			programClusterRoutes: ptr.To(v3.EnabledIPIPOnly),
 			ipVersion:            4,
 			wantKernel:           slices.Concat(kernelIPIPByBIRDV4, kernelNoEncapByFelixV4, kernelVXLANV4),
+			wantIBGPRejectCIDRs:  slices.Concat(ibgpRejectNoEncapByFelixV4, ibgpRejectVXLANV4),
+			felixOwnsIPIP:        false,
 		},
 		{
 			name:                 "IPv4, Disabled: Felix programs everything",
 			programClusterRoutes: ptr.To(v3.Disabled),
 			ipVersion:            4,
 			wantKernel:           slices.Concat(kernelIPIPByFelixV4, kernelNoEncapByFelixV4, kernelVXLANV4),
+			wantIBGPRejectCIDRs:  slices.Concat(ibgpRejectIPIPByFelixV4, ibgpRejectNoEncapByFelixV4, ibgpRejectVXLANV4),
+			felixOwnsIPIP:        true,
 		},
 		{
 			name:                 "IPv4, unrecognised value: falls back to the default",
 			programClusterRoutes: ptr.To("SomethingFromANewerAPI"),
 			ipVersion:            4,
 			wantKernel:           slices.Concat(kernelIPIPByFelixV4, kernelNoEncapByBIRDV4, kernelVXLANV4),
+			wantIBGPRejectCIDRs:  slices.Concat(ibgpRejectIPIPByFelixV4, ibgpRejectVXLANV4),
+			felixOwnsIPIP:        true,
 		},
 		{
-			name:       "IPv6, field unset: BIRD programs unencapsulated pools only",
-			ipVersion:  6,
-			wantKernel: slices.Concat(kernelIPIPByFelixV6, kernelNoEncapByBIRDV6, kernelVXLANV6),
+			name:                "IPv6, field unset: BIRD programs unencapsulated pools only",
+			ipVersion:           6,
+			wantKernel:          slices.Concat(kernelIPIPByFelixV6, kernelNoEncapByBIRDV6, kernelVXLANV6),
+			wantIBGPRejectCIDRs: slices.Concat(ibgpRejectIPIPByFelixV6, ibgpRejectVXLANV6),
+			felixOwnsIPIP:       true,
 		},
 		{
 			name:                 "IPv6, Enabled: BIRD programs both IPIP and unencapsulated pools",
 			programClusterRoutes: ptr.To(v3.Enabled),
 			ipVersion:            6,
 			wantKernel:           slices.Concat(kernelIPIPByBIRDV6, kernelNoEncapByBIRDV6, kernelVXLANV6),
+			wantIBGPRejectCIDRs:  slices.Clone(ibgpRejectVXLANV6),
+			felixOwnsIPIP:        false,
 		},
 		{
 			name:                 "IPv6, Disabled: Felix programs everything",
 			programClusterRoutes: ptr.To(v3.Disabled),
 			ipVersion:            6,
 			wantKernel:           slices.Concat(kernelIPIPByFelixV6, kernelNoEncapByFelixV6, kernelVXLANV6),
+			wantIBGPRejectCIDRs:  slices.Concat(ibgpRejectIPIPByFelixV6, ibgpRejectNoEncapByFelixV6, ibgpRejectVXLANV6),
+			felixOwnsIPIP:        true,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -271,8 +327,42 @@ func Test_processIPPools(t *testing.T) {
 			slices.Sort(wantExport)
 			require.Equal(t, filterExpectedStatements(wantExport, "reject"), config.BGPExportFilterForDisabledIPPools)
 			require.Equal(t, filterExpectedStatements(wantExport, "accept"), config.BGPExportFilterForEnabledIPPools)
+
+			require.Equal(t,
+				wantIBGPExportReject(tc.felixOwnsIPIP, tc.wantIBGPRejectCIDRs),
+				config.IBGPExportFilterForFelixClusterRoutes)
 		})
 	}
+}
+
+// wantIBGPExportReject spells out the whole reject that confd builds for internal peers: the
+// interface arm, whose tunl0 test is only present when Felix programs the IPIP cluster routes,
+// followed by the pool-CIDR arm for the pools Felix owns.  The text is written out here rather
+// than borrowed from the code under test, so that a change to what BIRD is asked to match has to
+// be made deliberately in both places.
+func wantIBGPExportReject(felixOwnsIPIP bool, rejectCIDRs []string) []string {
+	interfaces := `(ifname ~ "*.cali") || (ifname ~ "*.calico")`
+	if felixOwnsIPIP {
+		interfaces += ` || (ifname ~ "tunl0")`
+	}
+	lines := []string{
+		"if (defined(ifname)) then {",
+		"  if (" + interfaces + ") then {",
+		"    reject;",
+		"  }",
+		"}",
+	}
+	if len(rejectCIDRs) == 0 {
+		return lines
+	}
+	lines = append(lines,
+		"if (defined(source) && (source = RTS_INHERIT) && ((dest = RTD_ROUTER) || (dest = RTD_MULTIPATH))) then {",
+		"  # Cluster routes for these pools are Felix's to program, and the owning node's to advertise.",
+	)
+	sortedCIDRs := slices.Clone(rejectCIDRs)
+	slices.Sort(sortedCIDRs)
+	lines = append(lines, sortedCIDRs...)
+	return append(lines, "}")
 }
 
 func Test_processIPPoolsV4_NoLocalSubnet(t *testing.T) {

--- a/confd/pkg/backends/types/bird_bgp_config.go
+++ b/confd/pkg/backends/types/bird_bgp_config.go
@@ -34,12 +34,14 @@ type BirdBGPConfig struct {
 	ExternalIPs                       []string
 	LoadBalancerIPs                   []string
 	BGPExportFilterForDisabledIPPools []string
-	IBGPExportFilterForTunnelRoutes   []string
-	BGPExportFilterForEnabledIPPools  []string
-	KernelFilterForIPPools            []string
-	SetMetricForBGPRoutes             []string
-	WireguardPeerKernelFilter         []string
-	NormalRoutePriority               int // IPv4 or IPv6 normal route priority (default 1024)
+	// IBGPExportFilterForFelixClusterRoutes rejects the cluster routes that Felix programmed, which
+	// BIRD learns from the kernel but which are not this node's to advertise.  Internal peers only.
+	IBGPExportFilterForFelixClusterRoutes []string
+	BGPExportFilterForEnabledIPPools      []string
+	KernelFilterForIPPools                []string
+	SetMetricForBGPRoutes                 []string
+	WireguardPeerKernelFilter             []string
+	NormalRoutePriority                   int // IPv4 or IPv6 normal route priority (default 1024)
 }
 
 // BirdBGPPeer represents a processed BGP peer configuration

--- a/confd/tests/compiled_templates/cluster_routes/default/bird_ipam.cfg
+++ b/confd/tests/compiled_templates/cluster_routes/default/bird_ipam.cfg
@@ -15,6 +15,11 @@ function calico_export_to_bgp_peers(bool internal_peer) {
         reject;
       }
     }
+    if (defined(source) && (source = RTS_INHERIT) && ((dest = RTD_ROUTER) || (dest = RTD_MULTIPATH))) then {
+      # Cluster routes for these pools are Felix's to program, and the owning node's to advertise.
+      if (net ~ 172.16.0.0/16) then { reject; }
+      if (net ~ 192.168.0.0/16) then { reject; }
+    }
   }
   reject_local_routes();
   apply_communities();

--- a/confd/tests/compiled_templates/cluster_routes/ipip-only/bird6_ipam.cfg
+++ b/confd/tests/compiled_templates/cluster_routes/ipip-only/bird6_ipam.cfg
@@ -15,6 +15,11 @@ function calico_export_to_bgp_peers(bool internal_peer) {
         reject;
       }
     }
+    if (defined(source) && (source = RTS_INHERIT) && ((dest = RTD_ROUTER) || (dest = RTD_MULTIPATH))) then {
+      # Cluster routes for these pools are Felix's to program, and the owning node's to advertise.
+      if (net ~ 2002::/64) then { reject; }
+      if (net ~ 2010::/64) then { reject; }
+    }
   }
   reject_local_routes();
   apply_communities();

--- a/confd/tests/compiled_templates/cluster_routes/ipip-only/bird_ipam.cfg
+++ b/confd/tests/compiled_templates/cluster_routes/ipip-only/bird_ipam.cfg
@@ -15,6 +15,10 @@ function calico_export_to_bgp_peers(bool internal_peer) {
         reject;
       }
     }
+    if (defined(source) && (source = RTS_INHERIT) && ((dest = RTD_ROUTER) || (dest = RTD_MULTIPATH))) then {
+      # Cluster routes for these pools are Felix's to program, and the owning node's to advertise.
+      if (net ~ 172.17.0.0/16) then { reject; }
+    }
   }
   reject_local_routes();
   apply_communities();

--- a/confd/tests/compiled_templates/cluster_routes/noencap-only/bird_ipam.cfg
+++ b/confd/tests/compiled_templates/cluster_routes/noencap-only/bird_ipam.cfg
@@ -15,6 +15,11 @@ function calico_export_to_bgp_peers(bool internal_peer) {
         reject;
       }
     }
+    if (defined(source) && (source = RTS_INHERIT) && ((dest = RTD_ROUTER) || (dest = RTD_MULTIPATH))) then {
+      # Cluster routes for these pools are Felix's to program, and the owning node's to advertise.
+      if (net ~ 172.16.0.0/16) then { reject; }
+      if (net ~ 192.168.0.0/16) then { reject; }
+    }
   }
   reject_local_routes();
   apply_communities();

--- a/confd/tests/compiled_templates/explicit_peering/global-external/bird_ipam.cfg
+++ b/confd/tests/compiled_templates/explicit_peering/global-external/bird_ipam.cfg
@@ -15,6 +15,10 @@ function calico_export_to_bgp_peers(bool internal_peer) {
         reject;
       }
     }
+    if (defined(source) && (source = RTS_INHERIT) && ((dest = RTD_ROUTER) || (dest = RTD_MULTIPATH))) then {
+      # Cluster routes for these pools are Felix's to program, and the owning node's to advertise.
+      if (net ~ 192.168.0.0/16) then { reject; }
+    }
   }
   reject_local_routes();
   apply_communities();

--- a/confd/tests/compiled_templates/explicit_peering/global-ipv6/bird_ipam.cfg
+++ b/confd/tests/compiled_templates/explicit_peering/global-ipv6/bird_ipam.cfg
@@ -15,6 +15,10 @@ function calico_export_to_bgp_peers(bool internal_peer) {
         reject;
       }
     }
+    if (defined(source) && (source = RTS_INHERIT) && ((dest = RTD_ROUTER) || (dest = RTD_MULTIPATH))) then {
+      # Cluster routes for these pools are Felix's to program, and the owning node's to advertise.
+      if (net ~ 192.168.0.0/16) then { reject; }
+    }
   }
   reject_local_routes();
   apply_communities();

--- a/confd/tests/compiled_templates/explicit_peering/global/bird_ipam.cfg
+++ b/confd/tests/compiled_templates/explicit_peering/global/bird_ipam.cfg
@@ -15,6 +15,10 @@ function calico_export_to_bgp_peers(bool internal_peer) {
         reject;
       }
     }
+    if (defined(source) && (source = RTS_INHERIT) && ((dest = RTD_ROUTER) || (dest = RTD_MULTIPATH))) then {
+      # Cluster routes for these pools are Felix's to program, and the owning node's to advertise.
+      if (net ~ 192.168.0.0/16) then { reject; }
+    }
   }
   reject_local_routes();
   apply_communities();

--- a/confd/tests/compiled_templates/explicit_peering/keepnexthop-global/bird_ipam.cfg
+++ b/confd/tests/compiled_templates/explicit_peering/keepnexthop-global/bird_ipam.cfg
@@ -15,6 +15,10 @@ function calico_export_to_bgp_peers(bool internal_peer) {
         reject;
       }
     }
+    if (defined(source) && (source = RTS_INHERIT) && ((dest = RTD_ROUTER) || (dest = RTD_MULTIPATH))) then {
+      # Cluster routes for these pools are Felix's to program, and the owning node's to advertise.
+      if (net ~ 192.168.0.0/16) then { reject; }
+    }
   }
   reject_local_routes();
   apply_communities();

--- a/confd/tests/compiled_templates/explicit_peering/keepnexthop/bird_ipam.cfg
+++ b/confd/tests/compiled_templates/explicit_peering/keepnexthop/bird_ipam.cfg
@@ -15,6 +15,10 @@ function calico_export_to_bgp_peers(bool internal_peer) {
         reject;
       }
     }
+    if (defined(source) && (source = RTS_INHERIT) && ((dest = RTD_ROUTER) || (dest = RTD_MULTIPATH))) then {
+      # Cluster routes for these pools are Felix's to program, and the owning node's to advertise.
+      if (net ~ 192.168.0.0/16) then { reject; }
+    }
   }
   reject_local_routes();
   apply_communities();

--- a/confd/tests/compiled_templates/explicit_peering/local-as-global-ipv6/bird_ipam.cfg
+++ b/confd/tests/compiled_templates/explicit_peering/local-as-global-ipv6/bird_ipam.cfg
@@ -15,6 +15,10 @@ function calico_export_to_bgp_peers(bool internal_peer) {
         reject;
       }
     }
+    if (defined(source) && (source = RTS_INHERIT) && ((dest = RTD_ROUTER) || (dest = RTD_MULTIPATH))) then {
+      # Cluster routes for these pools are Felix's to program, and the owning node's to advertise.
+      if (net ~ 192.168.0.0/16) then { reject; }
+    }
   }
   reject_local_routes();
   apply_communities();

--- a/confd/tests/compiled_templates/explicit_peering/local-as-global/bird_ipam.cfg
+++ b/confd/tests/compiled_templates/explicit_peering/local-as-global/bird_ipam.cfg
@@ -15,6 +15,10 @@ function calico_export_to_bgp_peers(bool internal_peer) {
         reject;
       }
     }
+    if (defined(source) && (source = RTS_INHERIT) && ((dest = RTD_ROUTER) || (dest = RTD_MULTIPATH))) then {
+      # Cluster routes for these pools are Felix's to program, and the owning node's to advertise.
+      if (net ~ 192.168.0.0/16) then { reject; }
+    }
   }
   reject_local_routes();
   apply_communities();

--- a/confd/tests/compiled_templates/explicit_peering/local-as-ipv6/bird_ipam.cfg
+++ b/confd/tests/compiled_templates/explicit_peering/local-as-ipv6/bird_ipam.cfg
@@ -15,6 +15,10 @@ function calico_export_to_bgp_peers(bool internal_peer) {
         reject;
       }
     }
+    if (defined(source) && (source = RTS_INHERIT) && ((dest = RTD_ROUTER) || (dest = RTD_MULTIPATH))) then {
+      # Cluster routes for these pools are Felix's to program, and the owning node's to advertise.
+      if (net ~ 192.168.0.0/16) then { reject; }
+    }
   }
   reject_local_routes();
   apply_communities();

--- a/confd/tests/compiled_templates/explicit_peering/local-as/bird_ipam.cfg
+++ b/confd/tests/compiled_templates/explicit_peering/local-as/bird_ipam.cfg
@@ -15,6 +15,10 @@ function calico_export_to_bgp_peers(bool internal_peer) {
         reject;
       }
     }
+    if (defined(source) && (source = RTS_INHERIT) && ((dest = RTD_ROUTER) || (dest = RTD_MULTIPATH))) then {
+      # Cluster routes for these pools are Felix's to program, and the owning node's to advertise.
+      if (net ~ 192.168.0.0/16) then { reject; }
+    }
   }
   reject_local_routes();
   apply_communities();

--- a/confd/tests/compiled_templates/explicit_peering/route_reflector/bird_ipam.cfg
+++ b/confd/tests/compiled_templates/explicit_peering/route_reflector/bird_ipam.cfg
@@ -15,6 +15,10 @@ function calico_export_to_bgp_peers(bool internal_peer) {
         reject;
       }
     }
+    if (defined(source) && (source = RTS_INHERIT) && ((dest = RTD_ROUTER) || (dest = RTD_MULTIPATH))) then {
+      # Cluster routes for these pools are Felix's to program, and the owning node's to advertise.
+      if (net ~ 192.168.0.0/16) then { reject; }
+    }
   }
   reject_local_routes();
   apply_communities();

--- a/confd/tests/compiled_templates/explicit_peering/route_reflector_v6_by_ip/bird_ipam.cfg
+++ b/confd/tests/compiled_templates/explicit_peering/route_reflector_v6_by_ip/bird_ipam.cfg
@@ -15,6 +15,10 @@ function calico_export_to_bgp_peers(bool internal_peer) {
         reject;
       }
     }
+    if (defined(source) && (source = RTS_INHERIT) && ((dest = RTD_ROUTER) || (dest = RTD_MULTIPATH))) then {
+      # Cluster routes for these pools are Felix's to program, and the owning node's to advertise.
+      if (net ~ 192.168.0.0/16) then { reject; }
+    }
   }
   reject_local_routes();
   apply_communities();

--- a/confd/tests/compiled_templates/explicit_peering/selectors/bird_ipam.cfg
+++ b/confd/tests/compiled_templates/explicit_peering/selectors/bird_ipam.cfg
@@ -15,6 +15,10 @@ function calico_export_to_bgp_peers(bool internal_peer) {
         reject;
       }
     }
+    if (defined(source) && (source = RTS_INHERIT) && ((dest = RTD_ROUTER) || (dest = RTD_MULTIPATH))) then {
+      # Cluster routes for these pools are Felix's to program, and the owning node's to advertise.
+      if (net ~ 192.168.0.0/16) then { reject; }
+    }
   }
   reject_local_routes();
   apply_communities();

--- a/confd/tests/compiled_templates/explicit_peering/selectors/step2/bird_ipam.cfg
+++ b/confd/tests/compiled_templates/explicit_peering/selectors/step2/bird_ipam.cfg
@@ -15,6 +15,10 @@ function calico_export_to_bgp_peers(bool internal_peer) {
         reject;
       }
     }
+    if (defined(source) && (source = RTS_INHERIT) && ((dest = RTD_ROUTER) || (dest = RTD_MULTIPATH))) then {
+      # Cluster routes for these pools are Felix's to program, and the owning node's to advertise.
+      if (net ~ 192.168.0.0/16) then { reject; }
+    }
   }
   reject_local_routes();
   apply_communities();

--- a/confd/tests/compiled_templates/explicit_peering/specific_node/bird_ipam.cfg
+++ b/confd/tests/compiled_templates/explicit_peering/specific_node/bird_ipam.cfg
@@ -15,6 +15,10 @@ function calico_export_to_bgp_peers(bool internal_peer) {
         reject;
       }
     }
+    if (defined(source) && (source = RTS_INHERIT) && ((dest = RTD_ROUTER) || (dest = RTD_MULTIPATH))) then {
+      # Cluster routes for these pools are Felix's to program, and the owning node's to advertise.
+      if (net ~ 192.168.0.0/16) then { reject; }
+    }
   }
   reject_local_routes();
   apply_communities();

--- a/confd/tests/compiled_templates/felix_cluster_routing/bird6_ipam.cfg
+++ b/confd/tests/compiled_templates/felix_cluster_routing/bird6_ipam.cfg
@@ -15,6 +15,11 @@ function calico_export_to_bgp_peers(bool internal_peer) {
         reject;
       }
     }
+    if (defined(source) && (source = RTS_INHERIT) && ((dest = RTD_ROUTER) || (dest = RTD_MULTIPATH))) then {
+      # Cluster routes for these pools are Felix's to program, and the owning node's to advertise.
+      if (net ~ 2002::/64) then { reject; }
+      if (net ~ 2010::/64) then { reject; }
+    }
   }
   reject_local_routes();
   apply_communities();

--- a/confd/tests/compiled_templates/felix_cluster_routing/bird_ipam.cfg
+++ b/confd/tests/compiled_templates/felix_cluster_routing/bird_ipam.cfg
@@ -15,6 +15,12 @@ function calico_export_to_bgp_peers(bool internal_peer) {
         reject;
       }
     }
+    if (defined(source) && (source = RTS_INHERIT) && ((dest = RTD_ROUTER) || (dest = RTD_MULTIPATH))) then {
+      # Cluster routes for these pools are Felix's to program, and the owning node's to advertise.
+      if (net ~ 172.16.0.0/16) then { reject; }
+      if (net ~ 172.17.0.0/16) then { reject; }
+      if (net ~ 192.168.0.0/16) then { reject; }
+    }
   }
   reject_local_routes();
   apply_communities();

--- a/confd/tests/compiled_templates/mesh/ipip-always/bird_ipam.cfg
+++ b/confd/tests/compiled_templates/mesh/ipip-always/bird_ipam.cfg
@@ -15,6 +15,10 @@ function calico_export_to_bgp_peers(bool internal_peer) {
         reject;
       }
     }
+    if (defined(source) && (source = RTS_INHERIT) && ((dest = RTD_ROUTER) || (dest = RTD_MULTIPATH))) then {
+      # Cluster routes for these pools are Felix's to program, and the owning node's to advertise.
+      if (net ~ 192.168.0.0/16) then { reject; }
+    }
   }
   reject_local_routes();
   apply_communities();

--- a/confd/tests/compiled_templates/mesh/ipip-cross-subnet/bird_ipam.cfg
+++ b/confd/tests/compiled_templates/mesh/ipip-cross-subnet/bird_ipam.cfg
@@ -15,6 +15,10 @@ function calico_export_to_bgp_peers(bool internal_peer) {
         reject;
       }
     }
+    if (defined(source) && (source = RTS_INHERIT) && ((dest = RTD_ROUTER) || (dest = RTD_MULTIPATH))) then {
+      # Cluster routes for these pools are Felix's to program, and the owning node's to advertise.
+      if (net ~ 192.168.0.0/16) then { reject; }
+    }
   }
   reject_local_routes();
   apply_communities();

--- a/confd/tests/compiled_templates/mesh/restart-time/pcr-disabled/bird6_ipam.cfg
+++ b/confd/tests/compiled_templates/mesh/restart-time/pcr-disabled/bird6_ipam.cfg
@@ -15,6 +15,10 @@ function calico_export_to_bgp_peers(bool internal_peer) {
         reject;
       }
     }
+    if (defined(source) && (source = RTS_INHERIT) && ((dest = RTD_ROUTER) || (dest = RTD_MULTIPATH))) then {
+      # Cluster routes for these pools are Felix's to program, and the owning node's to advertise.
+      if (net ~ 2002::/64) then { reject; }
+    }
   }
   reject_local_routes();
   apply_communities();

--- a/confd/tests/compiled_templates/mesh/restart-time/pcr-disabled/bird_ipam.cfg
+++ b/confd/tests/compiled_templates/mesh/restart-time/pcr-disabled/bird_ipam.cfg
@@ -15,6 +15,10 @@ function calico_export_to_bgp_peers(bool internal_peer) {
         reject;
       }
     }
+    if (defined(source) && (source = RTS_INHERIT) && ((dest = RTD_ROUTER) || (dest = RTD_MULTIPATH))) then {
+      # Cluster routes for these pools are Felix's to program, and the owning node's to advertise.
+      if (net ~ 192.168.0.0/16) then { reject; }
+    }
   }
   reject_local_routes();
   apply_communities();

--- a/confd/tests/compiled_templates/mesh/restart-time/pcr-ipip-only/bird6_ipam.cfg
+++ b/confd/tests/compiled_templates/mesh/restart-time/pcr-ipip-only/bird6_ipam.cfg
@@ -15,6 +15,10 @@ function calico_export_to_bgp_peers(bool internal_peer) {
         reject;
       }
     }
+    if (defined(source) && (source = RTS_INHERIT) && ((dest = RTD_ROUTER) || (dest = RTD_MULTIPATH))) then {
+      # Cluster routes for these pools are Felix's to program, and the owning node's to advertise.
+      if (net ~ 2002::/64) then { reject; }
+    }
   }
   reject_local_routes();
   apply_communities();

--- a/confd/tests/compiled_templates/mesh/restart-time/pcr-ipip-only/bird_ipam.cfg
+++ b/confd/tests/compiled_templates/mesh/restart-time/pcr-ipip-only/bird_ipam.cfg
@@ -15,6 +15,10 @@ function calico_export_to_bgp_peers(bool internal_peer) {
         reject;
       }
     }
+    if (defined(source) && (source = RTS_INHERIT) && ((dest = RTD_ROUTER) || (dest = RTD_MULTIPATH))) then {
+      # Cluster routes for these pools are Felix's to program, and the owning node's to advertise.
+      if (net ~ 192.168.0.0/16) then { reject; }
+    }
   }
   reject_local_routes();
   apply_communities();

--- a/confd/tests/compiled_templates/mesh/route-reflector-mesh-enabled/bird_ipam.cfg
+++ b/confd/tests/compiled_templates/mesh/route-reflector-mesh-enabled/bird_ipam.cfg
@@ -15,6 +15,10 @@ function calico_export_to_bgp_peers(bool internal_peer) {
         reject;
       }
     }
+    if (defined(source) && (source = RTS_INHERIT) && ((dest = RTD_ROUTER) || (dest = RTD_MULTIPATH))) then {
+      # Cluster routes for these pools are Felix's to program, and the owning node's to advertise.
+      if (net ~ 192.168.0.0/16) then { reject; }
+    }
   }
   reject_local_routes();
   apply_communities();

--- a/confd/tests/compiled_templates/mesh/static-routes-exclude-node/bird_ipam.cfg
+++ b/confd/tests/compiled_templates/mesh/static-routes-exclude-node/bird_ipam.cfg
@@ -15,6 +15,10 @@ function calico_export_to_bgp_peers(bool internal_peer) {
         reject;
       }
     }
+    if (defined(source) && (source = RTS_INHERIT) && ((dest = RTD_ROUTER) || (dest = RTD_MULTIPATH))) then {
+      # Cluster routes for these pools are Felix's to program, and the owning node's to advertise.
+      if (net ~ 192.168.0.0/16) then { reject; }
+    }
   }
   reject_local_routes();
   apply_communities();

--- a/confd/tests/compiled_templates/mesh/static-routes-exclude-node/step2/bird_ipam.cfg
+++ b/confd/tests/compiled_templates/mesh/static-routes-exclude-node/step2/bird_ipam.cfg
@@ -15,6 +15,10 @@ function calico_export_to_bgp_peers(bool internal_peer) {
         reject;
       }
     }
+    if (defined(source) && (source = RTS_INHERIT) && ((dest = RTD_ROUTER) || (dest = RTD_MULTIPATH))) then {
+      # Cluster routes for these pools are Felix's to program, and the owning node's to advertise.
+      if (net ~ 192.168.0.0/16) then { reject; }
+    }
   }
   reject_local_routes();
   apply_communities();

--- a/confd/tests/compiled_templates/mesh/static-routes-no-ipv4-address/bird_ipam.cfg
+++ b/confd/tests/compiled_templates/mesh/static-routes-no-ipv4-address/bird_ipam.cfg
@@ -15,6 +15,10 @@ function calico_export_to_bgp_peers(bool internal_peer) {
         reject;
       }
     }
+    if (defined(source) && (source = RTS_INHERIT) && ((dest = RTD_ROUTER) || (dest = RTD_MULTIPATH))) then {
+      # Cluster routes for these pools are Felix's to program, and the owning node's to advertise.
+      if (net ~ 192.168.0.0/16) then { reject; }
+    }
   }
   reject_local_routes();
   apply_communities();

--- a/confd/tests/compiled_templates/mesh/static-routes/bird_ipam.cfg
+++ b/confd/tests/compiled_templates/mesh/static-routes/bird_ipam.cfg
@@ -15,6 +15,10 @@ function calico_export_to_bgp_peers(bool internal_peer) {
         reject;
       }
     }
+    if (defined(source) && (source = RTS_INHERIT) && ((dest = RTD_ROUTER) || (dest = RTD_MULTIPATH))) then {
+      # Cluster routes for these pools are Felix's to program, and the owning node's to advertise.
+      if (net ~ 192.168.0.0/16) then { reject; }
+    }
   }
   reject_local_routes();
   apply_communities();

--- a/confd/tests/compiled_templates/mesh/static-routes/step2/bird_ipam.cfg
+++ b/confd/tests/compiled_templates/mesh/static-routes/step2/bird_ipam.cfg
@@ -15,6 +15,10 @@ function calico_export_to_bgp_peers(bool internal_peer) {
         reject;
       }
     }
+    if (defined(source) && (source = RTS_INHERIT) && ((dest = RTD_ROUTER) || (dest = RTD_MULTIPATH))) then {
+      # Cluster routes for these pools are Felix's to program, and the owning node's to advertise.
+      if (net ~ 192.168.0.0/16) then { reject; }
+    }
   }
   reject_local_routes();
   apply_communities();

--- a/confd/tests/compiled_templates/mesh/vxlan-always/bird6_ipam.cfg
+++ b/confd/tests/compiled_templates/mesh/vxlan-always/bird6_ipam.cfg
@@ -15,6 +15,10 @@ function calico_export_to_bgp_peers(bool internal_peer) {
         reject;
       }
     }
+    if (defined(source) && (source = RTS_INHERIT) && ((dest = RTD_ROUTER) || (dest = RTD_MULTIPATH))) then {
+      # Cluster routes for these pools are Felix's to program, and the owning node's to advertise.
+      if (net ~ dead:beef::/64) then { reject; }
+    }
   }
   reject_local_routes();
   apply_communities();

--- a/confd/tests/compiled_templates/mesh/vxlan-always/bird_ipam.cfg
+++ b/confd/tests/compiled_templates/mesh/vxlan-always/bird_ipam.cfg
@@ -15,6 +15,10 @@ function calico_export_to_bgp_peers(bool internal_peer) {
         reject;
       }
     }
+    if (defined(source) && (source = RTS_INHERIT) && ((dest = RTD_ROUTER) || (dest = RTD_MULTIPATH))) then {
+      # Cluster routes for these pools are Felix's to program, and the owning node's to advertise.
+      if (net ~ 192.168.0.0/16) then { reject; }
+    }
   }
   reject_local_routes();
   apply_communities();

--- a/design/cluster-route-programming/DESIGN.md
+++ b/design/cluster-route-programming/DESIGN.md
@@ -139,19 +139,32 @@ programming internally.
 
 The kernel-programming filter is not the only one that varies with ownership.
 `calico_export_to_bgp_peers` varies too: BIRD's kernel protocol runs with
-`learn`, so once Felix owns the IPIP cluster routes BIRD picks them up as its
-own, and a kernel-learned route is not subject to the iBGP
-no-re-advertisement rule.  `processIPPools` therefore adds `tunl0` to the
-tunnel-route reject (`IBGPExportFilterForTunnelRoutes`) exactly when Felix is
-the owner.  The `*.cali` / `*.calico` arms of that reject are unconditional,
-because Felix always owns VXLAN and WireGuard routes.
+`learn`, so once Felix owns a class of cluster route BIRD picks those routes up
+as its own, and a kernel-learned route is not subject to the iBGP
+no-re-advertisement rule.  `processIPPools` therefore builds a reject for
+internal peers, `IBGPExportFilterForFelixClusterRoutes`, with two arms:
+
+- **By outgoing interface.**  `*.cali` / `*.calico` unconditionally, because
+  Felix always owns VXLAN and WireGuard routes, plus `tunl0` exactly when Felix
+  owns the IPIP cluster routes.
+- **By IP Pool CIDR**, for every pool whose cluster routes Felix owns.  The
+  interface arm only catches an *encapsulated* route, and not every
+  Felix-programmed cluster route is one: in a CrossSubnet pool the route to a
+  node in this node's own subnet leaves by the host NIC, as does every route in
+  an unencapsulated pool that Felix owns.  The CIDR on its own would be too
+  broad — this node's own routes into the pool are inside it too — so the match
+  is narrowed to `source = RTS_INHERIT` (kernel-learned, so not this node's own
+  static blocks and not anything learned over BGP, which keeps a route
+  reflector reflecting) and to a `dest` that has a next hop (so not the device
+  routes to this node's own workloads, nor the blackholes for its own blocks).
 
 What does *not* vary is the rest of the export path: whether this node should
 advertise a prefix it owns is a separate question from who writes the route to
 this node's kernel.  `TestFelixClusterRoutesNotReadvertised`
-(`node/tests/k8st/tests/cluster_routes_test.go`) is what holds the `tunl0` arm
-in place — it asserts that no node exports another node's block once Felix is
-programming the route to it.
+(`node/tests/k8st/tests/cluster_routes_test.go`) is what holds both arms in
+place — it asserts that no node exports another node's block once Felix is
+programming the route to it, with an `ipipMode: Always` pool for the interface
+arm and an `ipipMode: CrossSubnet` pool for the CIDR arm.
 
 For an IPIP pool that BIRD owns, the filter statement also sets BIRD's
 `krt_tunnel` variable, which tells the kernel protocol to send the route out
@@ -260,17 +273,14 @@ possible future improvement; it is not implemented.
 These are recorded so that a future change does not mistake them for solved
 problems.
 
-**Felix-programmed no-encap cluster routes and BGP re-advertisement.**  BIRD's
-kernel protocol is configured with `learn`, so it learns alien kernel routes —
-including the cluster routes Felix programs.  `calico_export_to_bgp_peers`
-rejects the ones that leave via a Calico tunnel device: `*.cali` / `*.calico`
-(VXLAN, WireGuard) and, since the IPIP default moved, `tunl0`.  Felix-programmed
-*no-encap* routes leave via an ordinary NIC, so they are still not caught, and a
-node can end up advertising other nodes' blocks to its iBGP peers.  Whether that
-actually misadvertises anything for no-encap is not established; it is tracked,
-with the history of this filter, in CORE-13346.
-
-The scope of the reject is deliberate on one axis and a proxy on the other:
+**Felix-programmed cluster routes and BGP re-advertisement.**  BIRD's kernel
+protocol is configured with `learn`, so it learns alien kernel routes —
+including the cluster routes Felix programs.  The reject described in §2 keeps
+those out of the export to internal peers; its CIDR arm was added because the
+interface arm let through everything Felix does not encapsulate, which is a
+CrossSubnet pool's routes to nodes in the local subnet and all of an
+unencapsulated pool's routes (CORE-13346, which also carries the history of this
+filter).  What remains open:
 
 - **External peers are out of scope by decision, not by omission.**  The reject
   is applied only to internal peers, so a node does go on advertising these
@@ -280,17 +290,18 @@ The scope of the reject is deliberate on one axis and a proxy on the other:
   route, and has to learn that workload's block from another node's remote
   route instead.  Suppressing the advertisement would break those deployments.
   An operator who does want it suppressed can express that with a BGPFilter
-  `interface` rule, which is what that field exists for.  Any remaining work
-  here is therefore about the iBGP case only.
-- Matching on interface name is a proxy for the property we actually want, which
-  is "a route this node owns" versus "a route this node learned or synthesised".
-  A route protocol test (`krt_source` against Felix's `DeviceRouteProtocol`)
-  combined with "has a next hop" would express that directly and cover every
-  encapsulation at once; doing it in the kernel protocol's *import* filter would
-  keep the routes out of BIRD's table entirely.  Note that BIRD learning Felix's
-  *local* workload routes is load-bearing — `calico_aggr()` reads their
-  `krt_metric` to advertise the elevated-priority /32 during live migration — so
-  any such filter must exclude only the remote ones.
+  `interface` rule, which is what that field exists for.
+- Both arms are proxies for the property we actually want, which is "a route
+  this node owns" versus "a route this node learned or synthesised".  The CIDR
+  arm's `source` and `dest` tests come close, but a route protocol test
+  (`krt_source` against Felix's `DeviceRouteProtocol`) would say it directly and
+  without depending on the set of pools; doing it in the kernel protocol's
+  *import* filter would keep the routes out of BIRD's table entirely.  Note that
+  BIRD learning Felix's *local* workload routes is load-bearing —
+  `calico_aggr()` reads their `krt_metric` to advertise the elevated-priority
+  /32 during live migration — so any such filter must exclude only the remote
+  ones.  The CIDR arm's `dest` test is what preserves them today, along with the
+  /32s of workloads whose address is borrowed from another node's block.
 
 **KubeVirt live migration.**  Route-priority propagation for live migration was
 designed and tested for confd/BIRD-programmed routes.  Whether the elevated

--- a/node/filesystem/etc/calico/confd/templates/bird6_ipam.cfg.template
+++ b/node/filesystem/etc/calico/confd/templates/bird6_ipam.cfg.template
@@ -17,7 +17,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
 {{ $line }}
 {{- end}}
   if (internal_peer) then {
-    {{ range $line := $config.IBGPExportFilterForTunnelRoutes }}
+    {{ range $line := $config.IBGPExportFilterForFelixClusterRoutes }}
     {{ $line }}
     {{ end }}
   }

--- a/node/filesystem/etc/calico/confd/templates/bird_ipam.cfg.template
+++ b/node/filesystem/etc/calico/confd/templates/bird_ipam.cfg.template
@@ -17,7 +17,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
 {{ $line }}
 {{- end}}
   if (internal_peer) then {
-    {{ range $line := $config.IBGPExportFilterForTunnelRoutes }}
+    {{ range $line := $config.IBGPExportFilterForFelixClusterRoutes }}
     {{ $line }}
     {{ end }}
   }

--- a/node/tests/k8st/tests/cluster_routes_test.go
+++ b/node/tests/k8st/tests/cluster_routes_test.go
@@ -67,6 +67,16 @@ const (
 	// routeExportPoolPrefix is the substring matcher for blocks carved out
 	// of routeExportPoolCIDR.
 	routeExportPoolPrefix = "192.0.2."
+
+	// routeExportXSubnetPoolCIDR is a third dedicated IPPool, in ipipMode
+	// CrossSubnet, which TestFelixClusterRoutesNotReadvertised checks
+	// alongside routeExportPoolCIDR.  Its own CIDR again, so that the two
+	// pools' exports can be told apart.
+	routeExportXSubnetPoolCIDR = "198.51.100.0/24"
+
+	// routeExportXSubnetPoolPrefix is the substring matcher for blocks
+	// carved out of routeExportXSubnetPoolCIDR.
+	routeExportXSubnetPoolPrefix = "198.51.100."
 )
 
 // TestClusterRouteOwnership stands up a server / client pair on different nodes
@@ -141,6 +151,19 @@ func TestClusterRouteOwnership(t *testing.T) {
 	utils.AssertRouteOwnership(t, clientNode, routeOwnerPoolPrefix, "tunl0", expectedIPIPClusterRouteProto(g, cli))
 }
 
+// exportTestPool is one of the IP Pools that TestFelixClusterRoutesNotReadvertised stands up.  The
+// two differ only in encapsulation mode, which is what decides the device Felix's route to another
+// node's block leaves by, and so which arm of the reject has to catch it.
+type exportTestPool struct {
+	name     string
+	cidr     string
+	prefix   string
+	ipipMode v3.IPIPMode
+	// expectedDev is the device Felix's route to another node's block must leave by, or "" when
+	// that depends on the cluster's topology rather than on the pool.
+	expectedDev string
+}
+
 // TestFelixClusterRoutesNotReadvertised checks that a node does not advertise another node's IPAM
 // block over BGP merely because Felix programmed a kernel route to it.
 //
@@ -149,10 +172,17 @@ func TestClusterRouteOwnership(t *testing.T) {
 // that property holds for free.  It does not hold for free once Felix owns the cluster routes:
 // Felix programs a route to every remote node's block, BIRD's kernel protocol is configured with
 // `learn` so it picks those up as its own, and a kernel-learned route is not subject to the iBGP
-// no-re-advertisement rule.  What stops it is the tunnel-route reject that confd builds in
-// IBGPExportFilterForTunnelRoutes (confd/pkg/backends/calico/bgp_processor.go) and the ipam
-// templates render into calico_export_to_bgp_peers.  That reject's tunl0 arm is only emitted when
-// Felix is the component programming the IPIP cluster routes.
+// no-re-advertisement rule.  What stops it is the reject that confd builds in
+// IBGPExportFilterForFelixClusterRoutes (confd/pkg/backends/calico/bgp_processor.go) and the ipam
+// templates render into calico_export_to_bgp_peers.
+//
+// That reject has two arms, and this test covers one with each pool:
+//
+//   - The ipipMode: Always pool exercises the arm that matches on the outgoing interface, whose
+//     tunl0 test is only emitted when Felix is the component programming the IPIP cluster routes.
+//   - The ipipMode: CrossSubnet pool exercises the arm that matches on the pool's CIDR.  Felix
+//     does not encapsulate the route to a node in this node's own subnet, so that route leaves by
+//     the host NIC and the interface test does not see it.
 func TestFelixClusterRoutesNotReadvertised(t *testing.T) {
 	defer utils.CollectDiagsOnFailure(t)()
 
@@ -176,51 +206,77 @@ func TestFelixClusterRoutesNotReadvertised(t *testing.T) {
 		"need a control-plane node and at least two workers")
 	nodeA, nodeB := nodes[1], nodes[2]
 
-	pool := &v3.IPPool{
-		ObjectMeta: metav1.ObjectMeta{Name: "route-export-pool"},
-		Spec: v3.IPPoolSpec{
-			CIDR:        routeExportPoolCIDR,
-			IPIPMode:    v3.IPIPModeAlways,
-			NATOutgoing: true,
-			BlockSize:   28,
-			// Explicit because this test reads BIRD's export tables: with export disabled
-			// there would be nothing in them and the assertion would pass vacuously.
-			DisableBGPExport: false,
+	pools := []exportTestPool{
+		{
+			name:        "route-export-pool",
+			cidr:        routeExportPoolCIDR,
+			prefix:      routeExportPoolPrefix,
+			ipipMode:    v3.IPIPModeAlways,
+			expectedDev: "tunl0",
+		},
+		{
+			name:     "route-export-xsubnet-pool",
+			cidr:     routeExportXSubnetPoolCIDR,
+			prefix:   routeExportXSubnetPoolPrefix,
+			ipipMode: v3.IPIPModeCrossSubnet,
+			// Whether this one is encapsulated is a property of the cluster, not of the pool: the
+			// route to a node in our own subnet leaves by the host NIC, and only a node in another
+			// subnet is reached through tunl0.
+			expectedDev: "",
 		},
 	}
-	g.Expect(cli.Create(ctx, pool)).To(Succeed(), "creating IPPool")
-	t.Cleanup(func() { deletePool(t, cli, pool.Name) })
+	for _, p := range pools {
+		pool := &v3.IPPool{
+			ObjectMeta: metav1.ObjectMeta{Name: p.name},
+			Spec: v3.IPPoolSpec{
+				CIDR:        p.cidr,
+				IPIPMode:    p.ipipMode,
+				NATOutgoing: true,
+				BlockSize:   28,
+				// Explicit because this test reads BIRD's export tables: with export disabled
+				// there would be nothing in them and the assertion would pass vacuously.
+				DisableBGPExport: false,
+			},
+		}
+		g.Expect(cli.Create(ctx, pool)).To(Succeed(), "creating IPPool %s", p.name)
+		t.Cleanup(func() { deletePool(t, cli, pool.Name) })
+	}
 
 	nsName := e2eutils.GenerateRandomName("route-exports")
 	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: nsName}}
 	g.Expect(cli.Create(ctx, ns)).To(Succeed(), "creating namespace")
 	t.Cleanup(func() { _ = cli.Delete(context.Background(), ns) })
 
-	// One pod per worker, pinned to the test pool, which is what makes each of those nodes take a
-	// block affinity out of it.  The pods only need to hold an address, so both are idle: crossing
-	// the tunnel is TestClusterRouteOwnership's job.
-	for i, node := range []string{nodeA, nodeB} {
-		pod := routeOwnerPod(nsName, fmt.Sprintf("blockholder-%d", i), node, pool.Name, false)
-		g.Expect(cli.Create(ctx, pod)).To(Succeed(), "creating pod on %s", node)
-		t.Cleanup(func() { _ = cli.Delete(context.Background(), pod) })
-		waitForPodIP(ctx, g, cli, pod, corev1.IPv4Protocol)
+	// One pod per worker per pool, pinned to that pool, which is what makes each of those nodes
+	// take a block affinity out of it.  The pods only need to hold an address, so all of them are
+	// idle: crossing the tunnel is TestClusterRouteOwnership's job.
+	for _, p := range pools {
+		for i, node := range []string{nodeA, nodeB} {
+			pod := routeOwnerPod(nsName, fmt.Sprintf("%s-%d", p.name, i), node, p.name, false)
+			g.Expect(cli.Create(ctx, pod)).To(Succeed(), "creating pod on %s", node)
+			t.Cleanup(func() { _ = cli.Delete(context.Background(), pod) })
+			waitForPodIP(ctx, g, cli, pod, corev1.IPv4Protocol)
+		}
 	}
 
-	// Guard against asserting nothing: each worker must have a Felix-programmed route into the
-	// pool out tunl0, which can only be a route to the other worker's block, since a node's own
-	// block is a blackhole with no device.  That is the route that could leak.
-	for _, node := range []string{nodeA, nodeB} {
-		utils.AssertRouteOwnership(t, node, routeExportPoolPrefix, "tunl0", utils.RouteProtoFelix)
+	// Guard against asserting nothing: each worker must have a Felix-programmed route into each
+	// pool, which can only be a route to the other worker's block, since a node's own block is a
+	// blackhole with no device.  Those are the routes that could leak.
+	for _, p := range pools {
+		for _, node := range []string{nodeA, nodeB} {
+			utils.AssertRouteOwnership(t, node, p.prefix, p.expectedDev, utils.RouteProtoFelix)
+		}
 	}
+	logUnencapsulatedClusterRoute(t, []string{nodeA, nodeB}, routeExportXSubnetPoolPrefix)
 
-	// Every node's BIRD, control plane included, must export blocks of this pool only as the
+	// Every node's BIRD, control plane included, must export blocks of these pools only as the
 	// blackhole route that confd derives from the node's own block affinity.  Anything else -- in
-	// practice a "via <node> on tunl0" -- is a route the node learned from the kernel because
-	// Felix programmed it, and is not the node's to advertise.
+	// practice a "via <node>", on tunl0 or on the host NIC -- is a route the node learned from the
+	// kernel because Felix programmed it, and is not the node's to advertise.
 	blockOwner := map[string]bool{nodeA: true, nodeB: true}
 	g.Eventually(func() error {
 		for _, node := range nodes {
-			// Nothing can leak to a peering that does not exist: the tunl0 reject sits inside
+			// Nothing can leak to a peering that does not exist: the reject sits inside
 			// `if (internal_peer)` in calico_export_to_bgp_peers, so a node with no established
 			// peering would satisfy the assertion below for the wrong reason.
 			protocols, err := establishedBGPProtocols(t, node)
@@ -232,25 +288,55 @@ func TestFelixClusterRoutesNotReadvertised(t *testing.T) {
 					node)
 			}
 
-			blackholes, others, err := poolExports(t, node, protocols)
-			if err != nil {
-				return err
-			}
-			if len(others) > 0 {
-				return fmt.Errorf("node %s is exporting %v over BGP; a node should advertise only its "+
-					"own blocks, and only as blackhole routes.  These are Felix's routes to other "+
-					"nodes' blocks, learned by BIRD from the kernel and re-advertised", node, others)
-			}
+			for _, p := range pools {
+				blackholes, others, err := poolExports(t, node, protocols, p.prefix)
+				if err != nil {
+					return err
+				}
+				if len(others) > 0 {
+					return fmt.Errorf("node %s is exporting %v from pool %s over BGP; a node should "+
+						"advertise only its own blocks, and only as blackhole routes.  These are "+
+						"Felix's routes to other nodes' blocks, learned by BIRD from the kernel and "+
+						"re-advertised", node, others, p.cidr)
+				}
 
-			// Positive control for the nodes that do own a block: without this, "no non-blackhole
-			// exports" would also be satisfied by a node exporting nothing at all.
-			if blockOwner[node] && len(blackholes) == 0 {
-				return fmt.Errorf("node %s owns a block of %s but is not exporting it as a blackhole",
-					node, routeExportPoolCIDR)
+				// Positive control for the nodes that do own a block: without this, "no
+				// non-blackhole exports" would also be satisfied by a node exporting nothing at all.
+				if blockOwner[node] && len(blackholes) == 0 {
+					return fmt.Errorf("node %s owns a block of %s but is not exporting it as a blackhole",
+						node, p.cidr)
+				}
 			}
 		}
 		return nil
 	}, 90*time.Second, 5*time.Second).Should(Succeed())
+}
+
+// logUnencapsulatedClusterRoute reports whether the CrossSubnet pool is actually exercising the
+// unencapsulated path, which is the one the interface test in calico_export_to_bgp_peers cannot
+// catch.  It only holds where the workers share a subnet, which is the case for the kind clusters
+// this suite runs on, but is a property of the cluster rather than something the test can impose —
+// so this is a log line and not an assertion.
+func logUnencapsulatedClusterRoute(t testing.TB, nodes []string, prefix string) {
+	t.Helper()
+	for _, node := range nodes {
+		routes, err := utils.GetNodeRoutes(t, node, prefix)
+		if err != nil {
+			t.Logf("Could not read routes matching %q on node %s: %v", prefix, node, err)
+			continue
+		}
+		for _, r := range routes {
+			// "lo" and no device at all are this node's own blackholed block, not a route to
+			// anywhere; tunl0 is the encapsulated case the interface test already covers.
+			if r.Proto == utils.RouteProtoFelix && r.Dev != "" && r.Dev != "lo" && r.Dev != "tunl0" {
+				t.Logf("Node %s reaches %q unencapsulated, on dev %s: exercising the pool-CIDR arm "+
+					"of the export reject", node, r.Dst, r.Dev)
+				return
+			}
+		}
+	}
+	t.Logf("No unencapsulated Felix route to %q on any worker: the workers of this cluster do not "+
+		"share a subnet, so the CrossSubnet pool only re-tests the encapsulated path", prefix)
 }
 
 // routeOwnerPod builds a pod pinned to nodeName and to the test IPPool. The
@@ -321,14 +407,14 @@ func establishedBGPProtocols(t testing.TB, nodeName string) ([]string, error) {
 	return names, nil
 }
 
-// poolExports splits the routes within routeExportPoolCIDR that nodeName's BIRD is exporting to the
-// given peerings into those it exports as a blackhole -- its own block, from its block affinity --
-// and everything else.  It asks BIRD directly rather than inferring the answer from connectivity.
+// poolExports splits the routes matching poolPrefix that nodeName's BIRD is exporting to the given
+// peerings into those it exports as a blackhole -- its own block, from its block affinity -- and
+// everything else.  It asks BIRD directly rather than inferring the answer from connectivity.
 //
 // Only lines that start with a CIDR are considered: BIRD prints additional paths for the same prefix
 // as continuation lines, and a node's own block legitimately has a second, kernel-sourced path
 // behind the static one.
-func poolExports(t testing.TB, nodeName string, protocols []string) (blackholes, others []string, err error) {
+func poolExports(t testing.TB, nodeName string, protocols []string, poolPrefix string) (blackholes, others []string, err error) {
 	t.Helper()
 
 	seen := map[string]bool{}
@@ -345,7 +431,7 @@ func poolExports(t testing.TB, nodeName string, protocols []string) (blackholes,
 			if len(fields) == 0 {
 				continue
 			}
-			if cidr := fields[0]; !strings.HasPrefix(cidr, routeExportPoolPrefix) ||
+			if cidr := fields[0]; !strings.HasPrefix(cidr, poolPrefix) ||
 				!strings.Contains(cidr, "/") {
 				continue
 			}


### PR DESCRIPTION
Bug fix.

### The problem

BIRD's kernel protocol runs with `learn`, so BIRD picks up the cluster routes Felix programs as if they were its own, and a kernel-learned route is not subject to the iBGP no-re-advertisement rule. What stops a node advertising another node's IPAM block is the reject that confd builds in `IBGPExportFilterForTunnelRoutes` and the ipam templates render into `calico_export_to_bgp_peers`. It matched on the outgoing interface — `*.cali`, `*.calico`, and `tunl0` once Felix owns the IPIP cluster routes.

Matching the interface only catches an *encapsulated* route. `routeManager.noEncapRoute` (`felix/dataplane/linux/route_mgr.go`) programs a **CrossSubnet** pool's route to a node in the local subnet on the host NIC, not on the tunnel device, so `ifname` is `eth0` and the reject never fires; the same is true of every route in an unencapsulated pool that Felix owns. The node then re-advertises other nodes' blocks to its iBGP peers. Since v3.33 Felix owns the IPIP cluster routes by default, so an `ipipMode: CrossSubnet` pool hits this out of the box.

This is the gap `design/cluster-route-programming/DESIGN.md` §5 already recorded for no-encap (CORE-13346). It is one defect, so this fixes both.

### The fix

A second arm on the reject, matching the CIDR of every pool whose cluster routes Felix owns:

```
if (defined(source) && (source = RTS_INHERIT) && ((dest = RTD_ROUTER) || (dest = RTD_MULTIPATH))) then {
  # Cluster routes for these pools are Felix's to program, and the owning node's to advertise.
  if (net ~ 172.16.0.0/16) then { reject; }
}
```

The CIDR alone would be too broad — this node's own routes into the pool are inside it too — so the match is narrowed to the routes Felix programmed to somewhere else:

* `source = RTS_INHERIT` selects only what BIRD learned from the kernel. It leaves out the blocks the node advertises from its own affinities, which come from BIRD's static protocol, and everything learned over BGP, so a route reflector goes on reflecting its clients' routes.
* The `dest` test selects the routes that have a next hop. It leaves out the device routes to local workloads — including a workload whose address is borrowed from another node's block, and the elevated-priority /32 of a workload that has migrated here — and the blackholes for the node's own blocks.

The interface arm is kept alongside it: it costs nothing and still holds for a route whose destination is not in any pool confd currently knows about, e.g. while a pool is being deleted. The field is renamed to `IBGPExportFilterForFelixClusterRoutes` to match what it now covers.

Out of scope, unchanged: the reject applies to internal peers only, so a node still advertises these routes to its eBGP peers. That is deliberate — see the design doc.

### Testing

* **Against the BIRD fork itself** (`calico/bird:v0.3.3-211-g9111ec3c`, BIRD 1.6.8), driving the real rendered `bird_ipam.cfg`/`bird_aggr.cfg` with simulated kernel routes and reading what survives the filter. Before, the export table held both `192.168.6.0/26 via <node> on eth0` (another node's block, CrossSubnet, same subnet) and `192.168.221.100/32 via <node> on eth0` (a migrated pod's elevated /32, which `calico_aggr()` lets escape aggregation — advertised with the wrong node as next hop). After, both are gone, while the own-block blackholes, the local workload route and the borrowed /32 are all still exported. Same result for IPv6 under `bird6`.
* **UT** — `Test_processIPPools` now asserts the whole reject across the `programClusterRoutes` enum, for v4 and v6. It fails without the fix, on the missing CrossSubnet pool.
* **FV** — `make -C confd fv`: 180/180. Golden files regenerated; `mesh/ipip-cross-subnet/bird_ipam.cfg` is the FV-level regression. Every regenerated config also parse-checks under real `bird -p` / `bird6 -p`.
* **k8st** — `TestFelixClusterRoutesNotReadvertised` now stands up an `ipipMode: CrossSubnet` pool alongside the `Always` one, so each arm of the reject has a system test. Not run locally (needs a cluster); relying on CI.
* `make golangci-lint` clean over `./confd/... ./node/tests/...`.

**Release note:**
```release-note
Fix a bug where a node could advertise other nodes' IPAM blocks to its iBGP peers when Felix programs the cluster routes for a CrossSubnet or unencapsulated IP pool.
```
