### PR TITLE
Retry truncated source-tarball downloads instead of piping into tar

### DIFF
--- a/istio/Makefile
+++ b/istio/Makefile
@@ -44,14 +44,18 @@ init-sources: $(ISTIO_DOWNLOADED) $(ZTUNNEL_DOWNLOADED)
 
 $(ISTIO_DOWNLOADED):
 	mkdir -p istio
-	curl -sfL https://github.com/istio/istio/archive/refs/tags/$(ISTIO_VERSION).tar.gz | tar xz --strip-components=1 -C istio
+	curl -sSfL --retry 5 --retry-all-errors -o /tmp/calico-istio.tar.gz https://github.com/istio/istio/archive/refs/tags/$(ISTIO_VERSION).tar.gz
+	tar xz --strip-components=1 -C istio -f /tmp/calico-istio.tar.gz
+	rm -f /tmp/calico-istio.tar.gz
 	patch -d istio -p1 < patches/0001-feat-cni-DSCP-magic-mark-support-for-transparent-net.patch
 	patch -d istio -p1 < patches/0003-Update-deps-for-CVE-fixes.patch
 	touch $@
 
 $(ZTUNNEL_DOWNLOADED):
 	mkdir -p ztunnel
-	curl -sfL https://github.com/istio/ztunnel/archive/refs/tags/$(ISTIO_VERSION).tar.gz | tar xz --strip-components=1 -C ztunnel
+	curl -sSfL --retry 5 --retry-all-errors -o /tmp/calico-ztunnel.tar.gz https://github.com/istio/ztunnel/archive/refs/tags/$(ISTIO_VERSION).tar.gz
+	tar xz --strip-components=1 -C ztunnel -f /tmp/calico-ztunnel.tar.gz
+	rm -f /tmp/calico-ztunnel.tar.gz
 	patch -d ztunnel -p1 < patches/0002-transparent-policies.patch
 	touch $@
 

--- a/lib.Makefile
+++ b/lib.Makefile
@@ -1532,7 +1532,9 @@ bin/crane: $(REPO_ROOT)/bin/crane
 $(REPO_ROOT)/bin/crane:
 	$(info ::: Downloading crane from $(CRANE_URL))
 	@mkdir -p $(REPO_ROOT)/bin
-	@curl -sSfL --retry 5 $(CRANE_URL) | tar xz -C $(REPO_ROOT)/bin crane
+	@curl -sSfL --retry 5 --retry-all-errors -o /tmp/calico-crane.tar.gz $(CRANE_URL)
+	@tar xz -C $(REPO_ROOT)/bin -f /tmp/calico-crane.tar.gz crane
+	@rm -f /tmp/calico-crane.tar.gz
 
 ###############################################################################
 # Common functions for launching a local Kubernetes control plane.


### PR DESCRIPTION
## Description

The istio and ztunnel source fetches, and the crane install, piped `curl` straight into `tar`. A pipe cannot be retried — curl has already handed part of the body downstream — so a transfer cut short takes the build down, and the only diagnostic left is tar complaining about its stdin:

```
gzip: stdin: unexpected end of file
tar: Child returned status 1
make[5]: *** [Makefile:47: .istio.downloaded] Error 2
```

That failure mode has reddened master: a GitHub codeload transfer cut short mid-body, twice in the same window on two different tarballs.

Download to a temporary file first, then extract it — the same shape `bin/yq` already uses.

### Why `--retry-all-errors` and not just `--retry`

This is the part that actually matters. A truncated body is `CURLE_PARTIAL_FILE` (curl error 18), which curl does **not** count as a transient error, so plain `--retry` does not retry it. Measured against a server that advertises a full `Content-Length` and then hangs up mid-body:

| form | attempts | wall time |
|---|---|---|
| `--retry 5` | 1 | 0.016s |
| `--retry 5 --retry-all-errors` | 6 | 31s |

That is why `bin/crane`, which already passed `--retry 5`, was exposed too — writing to a file is necessary but not sufficient on its own.

## Scope

Three call sites: `istio/Makefile` (istio, ztunnel) and `lib.Makefile` (crane). +9/−3.

- `bin/helm` and `bin/yq` already download to a file and are left alone.
- Each temporary file is named after its target rather than shared, because `init-sources` builds istio and ztunnel in parallel — the Makefile already notes that those sub-makes race.
- The crane recipe is reachable on Windows in principle (`CRANE_OS = Windows`), but its body was already POSIX-shaped — `curl | tar` plus `mkdir -p` — so this changes nothing about whether it works there.

## Testing

Against a local server that advertises a full `Content-Length` and then hangs up mid-body:

- **old form** reproduces the failure exactly — `gzip: stdin: unexpected end of file` / `tar: Child returned status 1`.
- **new form** retries six times, then fails as `curl: (18) end of response with N bytes missing` — no partial source tree.

Each recipe was also re-run against its real upstream, with the patch steps: `bin/crane` (0.21.6), and `make -C istio init-sources` building both istio (VERSION 1.29, both patches) and ztunnel (patch applies), with no temporary files left behind.

## Release Note

```release-note
None
```
