### PR TITLE
ci: make nftables-rpms registry cache push best-effort (release-v3.31)

### DIFF
--- a/.semaphore/semaphore-scheduled-builds.yml
+++ b/.semaphore/semaphore-scheduled-builds.yml
@@ -392,7 +392,9 @@ blocks:
                 # branch — gate on SEMAPHORE_GIT_PR_NUMBER being empty to detect
                 # an actual branch build before pushing.
                 if [[ -z "${SEMAPHORE_GIT_PR_NUMBER}" && ( "$SEMAPHORE_GIT_BRANCH" == "master" || "$SEMAPHORE_GIT_BRANCH" == release-* ) ]]; then
-                  docker push "$NFT_RPMS_IMAGE"
+                  # Best-effort registry cache push; the GCS tarball below is the
+                  # authoritative cache, so a push failure must not fail the block.
+                  docker push "$NFT_RPMS_IMAGE" || echo "WARNING: push of $NFT_RPMS_IMAGE failed (non-fatal); relying on GCS cache"
                 fi
               fi
             - docker save "$NFT_RPMS_IMAGE" -o /tmp/nft-rpms.tar

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -392,7 +392,9 @@ blocks:
                 # branch — gate on SEMAPHORE_GIT_PR_NUMBER being empty to detect
                 # an actual branch build before pushing.
                 if [[ -z "${SEMAPHORE_GIT_PR_NUMBER}" && ( "$SEMAPHORE_GIT_BRANCH" == "master" || "$SEMAPHORE_GIT_BRANCH" == release-* ) ]]; then
-                  docker push "$NFT_RPMS_IMAGE"
+                  # Best-effort registry cache push; the GCS tarball below is the
+                  # authoritative cache, so a push failure must not fail the block.
+                  docker push "$NFT_RPMS_IMAGE" || echo "WARNING: push of $NFT_RPMS_IMAGE failed (non-fatal); relying on GCS cache"
                 fi
               fi
             - docker save "$NFT_RPMS_IMAGE" -o /tmp/nft-rpms.tar

--- a/.semaphore/semaphore.yml.d/blocks/10-prerequisites.yml
+++ b/.semaphore/semaphore.yml.d/blocks/10-prerequisites.yml
@@ -166,7 +166,9 @@
               # branch — gate on SEMAPHORE_GIT_PR_NUMBER being empty to detect
               # an actual branch build before pushing.
               if [[ -z "${SEMAPHORE_GIT_PR_NUMBER}" && ( "$SEMAPHORE_GIT_BRANCH" == "master" || "$SEMAPHORE_GIT_BRANCH" == release-* ) ]]; then
-                docker push "$NFT_RPMS_IMAGE"
+                # Best-effort registry cache push; the GCS tarball below is the
+                # authoritative cache, so a push failure must not fail the block.
+                docker push "$NFT_RPMS_IMAGE" || echo "WARNING: push of $NFT_RPMS_IMAGE failed (non-fatal); relying on GCS cache"
               fi
             fi
           - docker save "$NFT_RPMS_IMAGE" -o /tmp/nft-rpms.tar


### PR DESCRIPTION
## Problem

The `Build: nftables RPMs` prerequisites block does an inline `docker push` of the `nftables-rpms` cache image on master/release-branch builds. On `release-v3.31` that push returns `denied: requested access to the resource is denied` (the job runs without the Docker Hub push credential), which fails the block and reddens every branch CI run.

This reproduces on every recent `release-v3.31` branch build, always on the same content-addressed tag (`calico/nftables-rpms:7a849b41ef14-<arch>`) with the same `denied` error: the image was never successfully pushed, so every build misses the registry cache and dies on the push. Because the block is content-addressed and the nftables inputs have not changed, it fails identically until the push is made non-fatal.

## Root cause

The push targets `calico/nftables-rpms` from a job that lacks the push credential, so it is denied. The `gcloud storage cp` of the image tarball to GCS immediately after is the authoritative cross-block cache; the registry push is only a best-effort cross-workflow cache optimization.

## Fix

Guard the push so a failure is logged but does not fail the block. This restores green branch CI without changing which credentials the block receives.

master resolved this differently via a separate credentialed push promotion (#12725), but that change removes per-image push secrets across many files and does not cherry-pick cleanly onto `release-v3.31`; this is the minimal equivalent.

## Testing

- `make gen-semaphore-yaml` regenerated `semaphore.yml` and `semaphore-scheduled-builds.yml` from the template; a re-run is idempotent, so the `Check SemaphoreCI files` gate passes.
