### PR TITLE
Felix: adopt BIRD's leftover IPIP cluster routes

### DIFF
--- a/design/cluster-route-programming/DESIGN.md
+++ b/design/cluster-route-programming/DESIGN.md
@@ -223,29 +223,71 @@ of no-encap.
 
 ## 4. Transitioning a running cluster
 
-On upgrade to v3.33, a cluster with IPIP pools and no explicit configuration
-moves from BIRD-programmed to Felix-programmed IPIP cluster routes.  The
-handover is:
+A cluster moves between BIRD-programmed and Felix-programmed IPIP cluster routes
+in one of two ways, and they do not behave the same.
 
-1. confd sees the new default and re-renders `bird_ipam.cfg` so that
-   `calico_kernel_programming` rejects the IPIP pools' CIDRs.
-2. BIRD reloads and withdraws those routes from the kernel, because they were
-   BIRD's own routes and BIRD is no longer exporting them.
-3. Felix, in the same window, starts programming the same CIDRs with its own
-   route protocol (`DeviceRouteProtocol`, default 80).
+**Upgrading the code.**  On upgrade to v3.33, a cluster with IPIP pools and no
+explicit configuration changes owner without anything in the datastore changing
+at all: both `programClusterRoutes` fields are unset before and after, and what
+moves is the *default* each component derives from unset.  The calico-node pod
+is replaced, so:
 
-Steps 2 and 3 are not synchronised, so a route may be briefly absent or briefly
-present twice.  Both components converge on the same next hop and device, so
-the window is a reordering rather than a blackhole in practice — but it is
-unmeasured, and a cluster that cannot tolerate any cross-node packet loss should
-be upgraded with the pre-v3.33 configuration pinned explicitly, then switched
-over deliberately.
+1. The old BIRD exits.  Its kernel protocol is configured with `persist`, so it
+   deliberately leaves its routes in the kernel instead of withdrawing them.
+2. The new pod's confd renders `bird_ipam.cfg` so that
+   `calico_kernel_programming` rejects the IPIP pools' CIDRs, and Felix starts
+   programming those CIDRs with its own route protocol (`DeviceRouteProtocol`,
+   default 80).
+3. If BGP is still enabled, the new BIRD starts with `-R`, holds the routes it
+   found through its graceful-restart recovery period, and then reconciles.  By
+   then Felix has taken over the destinations it wants, so to BIRD those are
+   alien routes that it learns rather than removes; what is left to reconcile is
+   whatever Felix did not want.
 
-If BIRD is stopped before it withdraws its routes (for example, if the node
-container is killed mid-upgrade), stale `proto bird` routes can be left behind.
-Felix's route-ownership heuristic does not claim them, so they persist until
-BIRD next runs.  Making Felix adopt and clean up BIRD's IPIP routes is a
-possible future improvement; it is not implemented.
+There is no window in which a destination Felix wants has no route.  When Felix
+wants a route to exist, it atomically replaces any previous route for the same
+prefix, regardless of whether that previous route was within its logical
+ownership — it programs with `RouteReplace` (`felix/routetable/route_table.go`).
+That is long-standing behaviour and does not depend on the ownership rule
+described below.
+
+**Changing the configuration on a running cluster.**  Setting either
+`programClusterRoutes` field explicitly is picked up live: confd re-renders and
+BIRD reconfigures in place.  That BIRD knows it exported those routes, so it
+withdraws them itself.  Felix restarts on the config change and starts
+programming the same CIDRs.
+
+The two paths differ in whether there is a gap, and not in the direction one
+might expect.  Replacing the pod has none, as above.  Changing the configuration
+on a running cluster does: BIRD withdraws promptly, while Felix *restarts*
+because its configuration changed, and only programs the destinations once it is
+back.  The gap is therefore about the length of a Felix restart, and it is
+unmeasured.  A cluster that cannot tolerate any cross-node packet loss should
+prefer the upgrade path, or make the change during a maintenance window.
+
+Once Felix has re-programmed a destination, BIRD can no longer withdraw it out
+from under Felix: the kernel matches on route protocol when the delete specifies
+one, so a delete carrying `RTPROT_BIRD` does not match a route that is now
+Felix's proto 80.  (Verified against the kernel; it assumes BIRD sets the
+protocol on its delete messages, which its kernel protocol does.)
+
+**Where BIRD does not come back.**  Step 3 is what removes BIRD's persisted
+routes in the ordinary upgrade, and it does not happen if BGP is disabled as
+part of the same migration, if BIRD is not run because the cluster has no BGP
+peers, or if BIRD never completes recovery.  Nothing else would remove them:
+they are not Felix's by protocol, and BIRD is not there to reconcile them.  So
+Felix's route-ownership policy claims routes via the IPIP device that carry
+BIRD's protocol, whenever Felix is the configured owner of the IPIP cluster
+routes (`OwnBIRDIPIPRoutes`, `felix/routetable/ownershippol`), so that
+reconciliation removes them.
+
+Note what this does and does not cover.  Destinations Felix *does* want were
+already handled, by the atomic replace above; the rule adds nothing there.  What
+it adds is the removal of BIRD's routes to destinations Felix does **not** want
+— a block released while the node was down, a node that has left the cluster, a
+pool that has been deleted.  Those have no desired route to overwrite them, so
+without the rule, and without a BIRD to reconcile them, they would stay in the
+kernel indefinitely.
 
 ### Review notes — §4
 
@@ -254,6 +296,15 @@ possible future improvement; it is not implemented.
   window is short is that confd and Felix are reacting to the same change at the
   same time; introducing a staged or operator-driven migration would need the
   intermediate state to be explicitly representable in the API, not implied.
+- The ownership rule is deliberately not time-bounded, and not conditional on
+  having recently upgraded.  Felix has no notion of "we just upgraded", and a
+  bounded window would fail precisely the cases the rule exists for: a node down
+  across the window, a rolling upgrade slower than it, or BGP being switched off
+  weeks after the version moved.
+- Do not widen the rule to every protocol on `tunl0`.  Felix's own routes there
+  are already claimed by protocol, whoever the configured owner is, so widening
+  it would only take in routes belonging to neither Felix nor BIRD.  It is also
+  deliberately not scoped by destination; see the field comment for why.
 
 ## 5. Known gaps
 

--- a/felix/dataplane/linux/int_dataplane.go
+++ b/felix/dataplane/linux/int_dataplane.go
@@ -686,6 +686,7 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 			config.DeviceRouteProtocol,
 			config.RulesConfig.WorkloadIfacePrefixes,
 			config.RemoveExternalRoutes,
+			config.ProgramIPIPClusterRoutes,
 		)
 		routeTableV4 = routetable.New(
 			mainTablePolV4,
@@ -707,6 +708,9 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 				config.DeviceRouteProtocol,
 				config.RulesConfig.WorkloadIfacePrefixes,
 				config.RemoveExternalRoutes,
+				// IPIP is IPv4-only, so there is no IPIP device in the v6 table
+				// for BIRD to program routes through.
+				false,
 			)
 			routeTableV6 = routetable.New(
 				mainTablePolV6,

--- a/felix/fv/ipip_bird_routes_test.go
+++ b/felix/fv/ipip_bird_routes_test.go
@@ -1,0 +1,227 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fv_test
+
+import (
+	"fmt"
+	"regexp"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	api "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
+
+	"github.com/projectcalico/calico/felix/dataplane/linux/dataplanedefs"
+	"github.com/projectcalico/calico/felix/fv/infrastructure"
+	"github.com/projectcalico/calico/felix/fv/workload"
+	"github.com/projectcalico/calico/libcalico-go/lib/apiconfig"
+)
+
+// When Felix, rather than confd and BIRD, programs the cluster routes for IPIP IP Pools, BIRD's
+// routes via the IPIP device are inside Felix's ownership boundary.  These tests inject the routes
+// BIRD would have left behind -- its kernel protocol runs with `persist`, so it deliberately
+// leaves them in the kernel when it exits -- and check what Felix does with them.
+//
+// There is no real BIRD in the FV topology, so the routes are injected directly.  That makes these
+// tests about the ownership rule itself; what an upgrade actually does is covered by the node ST.
+const (
+	// Destinations outside the cluster's IP pool, so Felix never wants a route to either.  They
+	// stand in for a block that BIRD had a route to and that has since been released.
+	birdStrayCIDR      = "10.99.99.0/26"
+	birdThirdPartyCIDR = "10.99.98.0/26"
+
+	// RTPROT_BIRD, which `ip route` renders as "bird".
+	birdRouteProto = "bird"
+)
+
+// ipipBIRDRouteTopology returns topology options for an IPIP-Always cluster, with either Felix or
+// BIRD as the configured owner of the IPIP cluster routes.
+//
+// Ownership is selected with SimulateBIRDRoutes rather than by setting FELIX_ProgramClusterRoutes
+// directly: StartNNodeTopology derives that environment variable from SimulateBIRDRoutes itself,
+// after the caller's options have been built, so setting it here would be silently overwritten.
+func ipipBIRDRouteTopology(birdOwnsClusterRoutes bool) infrastructure.TopologyOptions {
+	// WorkloadIPs rather than CalicoIPAM as the route source: with CalicoIPAM, Felix's remote
+	// routes come from IPAM blocks, and creating a workload endpoint does not allocate one.  The
+	// tests here only need Felix to have some route of its own via the IPIP device.
+	opts := createIPIPBaseTopologyOptions(api.IPIPModeAlways, false, "WorkloadIPs", false)
+	opts.SimulateBIRDRoutes = birdOwnsClusterRoutes
+	// Felix picks up routes that something else changed on its periodic resync: the interface
+	// monitor's netlink subscription only feeds address tracking.  The default of 90s would make
+	// these tests very slow.
+	opts.ExtraEnvVars["FELIX_ROUTEREFRESHINTERVAL"] = "1"
+	return opts
+}
+
+var _ = infrastructure.DatastoreDescribe(
+	"IPIP cluster routes: BIRD's routes via tunl0, with Felix as the configured owner",
+	// Skipping k8s: this is about kernel route ownership, not about the datastore.
+	[]apiconfig.DatastoreType{apiconfig.EtcdV3},
+	func(getInfra infrastructure.InfraFactory) {
+		var (
+			infra   infrastructure.DatastoreInfra
+			tc      infrastructure.TopologyContainers
+			felixes []*infrastructure.Felix
+			w       [2]*workload.Workload
+		)
+
+		// tunl0Routes returns felixes[0]'s routes via the IPIP device.
+		tunl0Routes := func() string {
+			out, err := felixes[0].ExecOutput("ip", "route", "show", "dev", dataplanedefs.IPIPIfaceName)
+			if err != nil {
+				return fmt.Sprintf("ERROR: %v", err)
+			}
+			return out
+		}
+
+		BeforeEach(func() {
+			infra = getInfra()
+			tc, _ = infrastructure.StartNNodeTopology(2, ipipBIRDRouteTopology(false), infra)
+			felixes = tc.Felixes
+
+			// A workload on each node, so that each node has a remote block to route to and
+			// Felix has an IPIP route of its own to defend.
+			for i := range w {
+				w[i] = workload.Run(
+					felixes[i],
+					fmt.Sprintf("w%d", i),
+					"default",
+					fmt.Sprintf("10.65.%d.2", i),
+					"8055",
+					"tcp",
+				)
+				w[i].ConfigureInInfra(infra)
+			}
+		})
+
+		AfterEach(func() {
+			if CurrentGinkgoTestDescription().Failed {
+				for _, felix := range felixes {
+					felix.Exec("ip", "route")
+					felix.Exec("ip", "link")
+				}
+			}
+			for _, wl := range w {
+				wl.Stop()
+			}
+			tc.Stop()
+			if CurrentGinkgoTestDescription().Failed {
+				infra.DumpErrorData()
+			}
+			infra.Stop()
+		})
+
+		// Note: this one passes with or without the ownership rule -- Felix ignores routes it does
+		// not own, so it reads the destination as unoccupied and replaces it either way.  It is
+		// here as a regression guard on that atomic takeover, not as coverage of the rule.
+		It("should take back a route to a destination it wants", func() {
+			// Find the route Felix has programmed to the other node's block.
+			felixRoute := regexp.MustCompile(`(?m)^(\S+) via (\S+) .*proto 80`)
+			var match []string
+			Eventually(func() []string {
+				match = felixRoute.FindStringSubmatch(tunl0Routes())
+				return match
+			}, "60s", "500ms").Should(HaveLen(3),
+				"Felix did not program an IPIP route to the remote block")
+			dest, gw := match[1], match[2]
+
+			// Stand in for the route the old BIRD left behind for the same destination: same
+			// next hop and device, but BIRD's protocol.
+			felixes[0].Exec("ip", "route", "replace", dest, "via", gw,
+				"dev", dataplanedefs.IPIPIfaceName, "onlink", "proto", birdRouteProto)
+			Expect(tunl0Routes()).To(ContainSubstring("proto "+birdRouteProto),
+				"test setup did not install a BIRD-protocol route")
+
+			// Felix owns it, so it takes it back.  It must end up replaced rather than simply
+			// removed: this is a destination the cluster needs a route to.
+			Eventually(tunl0Routes, "30s", "500ms").Should(MatchRegexp(
+				`(?m)^`+regexp.QuoteMeta(dest)+` via `+regexp.QuoteMeta(gw)+` .*proto 80`),
+				"Felix did not take its route back from BIRD's protocol")
+		})
+
+		// This is the one that exercises the ownership rule: it is the only case the rule changes.
+		It("should remove a route to a destination it does not want", func() {
+			// A block BIRD had a route to, since released, so Felix has no route of its own to
+			// replace it with.  Without the ownership rule nothing would ever clean this up.
+			felixes[0].Exec("ip", "route", "add", birdStrayCIDR, "via", felixes[1].IP,
+				"dev", dataplanedefs.IPIPIfaceName, "onlink", "proto", birdRouteProto)
+			Expect(tunl0Routes()).To(ContainSubstring(birdStrayCIDR),
+				"test setup did not install a BIRD-protocol route")
+
+			Eventually(tunl0Routes, "30s", "500ms").ShouldNot(ContainSubstring(birdStrayCIDR),
+				"Felix did not remove BIRD's stale route")
+		})
+
+		It("should leave a route belonging to neither component alone", func() {
+			// The rule claims BIRD's protocol only.  Felix owns the IPIP device itself, but a
+			// route through it from some other source is not Felix's to delete.
+			felixes[0].Exec("ip", "route", "add", birdThirdPartyCIDR, "via", felixes[1].IP,
+				"dev", dataplanedefs.IPIPIfaceName, "onlink", "proto", "static")
+
+			Consistently(tunl0Routes, "10s", "1s").Should(ContainSubstring(birdThirdPartyCIDR),
+				"Felix removed a route belonging to neither Felix nor BIRD")
+		})
+	},
+)
+
+var _ = infrastructure.DatastoreDescribe(
+	"IPIP cluster routes: BIRD's routes via tunl0, with BIRD as the configured owner",
+	[]apiconfig.DatastoreType{apiconfig.EtcdV3},
+	func(getInfra infrastructure.InfraFactory) {
+		var (
+			infra   infrastructure.DatastoreInfra
+			tc      infrastructure.TopologyContainers
+			felixes []*infrastructure.Felix
+		)
+
+		BeforeEach(func() {
+			infra = getInfra()
+			// Leaves the IPIP cluster routes to confd and BIRD.
+			tc, _ = infrastructure.StartNNodeTopology(2, ipipBIRDRouteTopology(true), infra)
+			felixes = tc.Felixes
+		})
+
+		AfterEach(func() {
+			if CurrentGinkgoTestDescription().Failed {
+				for _, felix := range felixes {
+					felix.Exec("ip", "route")
+				}
+			}
+			tc.Stop()
+			if CurrentGinkgoTestDescription().Failed {
+				infra.DumpErrorData()
+			}
+			infra.Stop()
+		})
+
+		It("should leave BIRD's routes alone", func() {
+			// The mirror image of the tests above, and the reason the rule is conditional: when
+			// BIRD is the configured owner, its routes are not Felix's to touch.  This also
+			// covers the wiring from the configuration parameter through to the policy, which
+			// the unit tests cannot reach.
+			felixes[0].Exec("ip", "route", "add", birdStrayCIDR, "via", felixes[1].IP,
+				"dev", dataplanedefs.IPIPIfaceName, "onlink", "proto", birdRouteProto)
+
+			routes := func() string {
+				out, err := felixes[0].ExecOutput("ip", "route", "show", "dev", dataplanedefs.IPIPIfaceName)
+				if err != nil {
+					return fmt.Sprintf("ERROR: %v", err)
+				}
+				return out
+			}
+			Consistently(routes, "10s", "1s").Should(ContainSubstring(birdStrayCIDR),
+				"Felix removed BIRD's route even though BIRD is the configured owner")
+		})
+	},
+)

--- a/felix/routetable/bench_test.go
+++ b/felix/routetable/bench_test.go
@@ -74,6 +74,7 @@ func benchResyncNumRoutes(b *testing.B, numRoutes int) {
 			88,
 			[]string{"testcali"},
 			false,
+			false,
 		),
 		4,
 		5*time.Second,

--- a/felix/routetable/ownershippol/main_route_table_policy.go
+++ b/felix/routetable/ownershippol/main_route_table_policy.go
@@ -32,6 +32,7 @@ func NewMainTable(
 	deviceRouteProto netlink.RouteProtocol,
 	workloadIfacePrefixes []string,
 	removeExternalRoutes bool,
+	programIPIPClusterRoutes bool,
 ) *MainTableOwnershipPolicy {
 	var allRouteProtos []netlink.RouteProtocol
 	var exclusiveRouteProtos []netlink.RouteProtocol
@@ -65,11 +66,15 @@ func NewMainTable(
 			dataplanedefs.BPFInDev,
 			// Not including routetable.InterfaceNone because MainTableOwnershipPolicy
 			// automatically handles it.
-			// Not including tunl0, it is managed by BIRD.
+			// Not including tunl0: unlike the devices above, BIRD may legitimately
+			// program routes there, so claiming every protocol on the device would
+			// make Felix delete BIRD's routes even when BIRD is the configured
+			// owner.  OwnBIRDIPIPRoutes below handles it instead.
 			// Not including Wireguard, it has its own routing table.
 		},
 		AllRouteProtocols:       allRouteProtos,
 		ExclusiveRouteProtocols: exclusiveRouteProtos,
+		OwnBIRDIPIPRoutes:       programIPIPClusterRoutes,
 	}
 	return ownershipPolicy
 }
@@ -95,6 +100,28 @@ type MainTableOwnershipPolicy struct {
 	// ExclusiveRouteProtocols is a list of protocols that should only be
 	// used by Calico.
 	ExclusiveRouteProtocols []netlink.RouteProtocol
+
+	// OwnBIRDIPIPRoutes is set when Felix, rather than confd and BIRD, is responsible for
+	// programming the cluster routes for IPIP IP Pools.  It brings BIRD's routes via the IPIP
+	// device inside Felix's ownership boundary, so that reconciliation removes them.
+	//
+	// This is needed because BIRD's kernel protocol is configured with `persist`, so BIRD
+	// deliberately leaves its routes in the kernel when it exits.  A BIRD that comes back
+	// reconciles them away itself, after its graceful-restart recovery period; but where BIRD does
+	// not come back -- BGP disabled as part of the same migration, say -- nothing else would
+	// remove them.
+	//
+	// It only matters for destinations Felix does *not* want a route to: a block released while
+	// the node was down, a node that has left the cluster.  A destination Felix does want is
+	// taken over regardless of this flag, because when Felix wants a route to exist it atomically
+	// replaces any previous route for the same prefix, whether or not that route was within its
+	// logical ownership.
+	//
+	// Deliberately not scoped to Calico IP pool CIDRs.  Felix already owns the IPIP device
+	// outright: it creates it, keeps its MTU in sync, assigns its address, and removes addresses it
+	// did not add.  Owning the routes through it as well is consistent with that, and a
+	// destination test would not reclaim a route whose pool has since been deleted.
+	OwnBIRDIPIPRoutes bool
 
 	// IsWorkloadBGPPeerIface, if non-nil, reports whether the named
 	// interface belongs to a workload that is acting as a local BGP peer.
@@ -169,6 +196,17 @@ func (d *MainTableOwnershipPolicy) RouteIsOurs(ifaceName string, route *netlink.
 		// this is one of our interfaces so the route is very likely to be
 		// ours.
 		return slices.Contains(d.AllRouteProtocols, route.Protocol)
+	}
+
+	// BIRD's routes via the IPIP device are ours to manage when Felix is the component
+	// responsible for programming the IPIP cluster routes.  Only BIRD's protocol is claimed, not
+	// every protocol on the device: Felix's own routes are already covered by the exclusive
+	// protocol check above, so widening this further would only take in routes belonging to
+	// neither component.
+	if d.OwnBIRDIPIPRoutes &&
+		ifaceName == dataplanedefs.IPIPIfaceName &&
+		route.Protocol == unix.RTPROT_BIRD {
+		return true
 	}
 
 	// Check if this route goes to one of our tunnel/special purpose

--- a/felix/routetable/ownershippol/main_route_table_policy_test.go
+++ b/felix/routetable/ownershippol/main_route_table_policy_test.go
@@ -19,6 +19,8 @@ import (
 
 	"github.com/vishvananda/netlink"
 	"golang.org/x/sys/unix"
+
+	"github.com/projectcalico/calico/felix/dataplane/linux/dataplanedefs"
 )
 
 func TestRouteIsOurs_BIRDRoutesOnBGPPeerIfaces(t *testing.T) {
@@ -106,6 +108,81 @@ func TestRouteIsOurs_BIRDRoutesOnBGPPeerIfaces(t *testing.T) {
 				AllRouteProtocols:             []netlink.RouteProtocol{unix.RTPROT_BOOT, exclusiveProto},
 				ExclusiveRouteProtocols:       []netlink.RouteProtocol{exclusiveProto},
 				IsWorkloadBGPPeerIface:        tt.peerCallback,
+			}
+
+			route := &netlink.Route{Protocol: tt.protocol}
+			got := pol.RouteIsOurs(tt.ifaceName, route)
+			if got != tt.expectedRouteIsOurs {
+				t.Errorf("RouteIsOurs(%q, proto=%d) = %v, want %v",
+					tt.ifaceName, tt.protocol, got, tt.expectedRouteIsOurs)
+			}
+		})
+	}
+}
+
+// TestRouteIsOurs_BIRDRoutesOnIPIPDevice covers OwnBIRDIPIPRoutes: when Felix programs the IPIP
+// cluster routes, BIRD's routes via the IPIP device come inside Felix's ownership boundary, so that
+// the ones BIRD left behind on exit (its kernel protocol runs with `persist`) are reconciled away.
+// Only BIRD's protocol is claimed, and only on the IPIP device.
+func TestRouteIsOurs_BIRDRoutesOnIPIPDevice(t *testing.T) {
+	exclusiveProto := netlink.RouteProtocol(80) // dataplanedefs.DefaultRouteProto
+
+	tests := []struct {
+		name                string
+		ownBIRDIPIPRoutes   bool
+		ifaceName           string
+		protocol            netlink.RouteProtocol
+		expectedRouteIsOurs bool
+	}{
+		{
+			name:                "IPIP device, RTPROT_BIRD, Felix owns IPIP routes => ours",
+			ownBIRDIPIPRoutes:   true,
+			ifaceName:           dataplanedefs.IPIPIfaceName,
+			protocol:            unix.RTPROT_BIRD,
+			expectedRouteIsOurs: true,
+		},
+		{
+			name:                "IPIP device, RTPROT_BIRD, BIRD owns IPIP routes => not ours",
+			ownBIRDIPIPRoutes:   false,
+			ifaceName:           dataplanedefs.IPIPIfaceName,
+			protocol:            unix.RTPROT_BIRD,
+			expectedRouteIsOurs: false,
+		},
+		{
+			// Felix's own routes are claimed by the exclusive protocol check, whether or not
+			// it is the configured owner, so they do not depend on this flag.
+			name:                "IPIP device, exclusive proto, BIRD owns IPIP routes => ours",
+			ownBIRDIPIPRoutes:   false,
+			ifaceName:           dataplanedefs.IPIPIfaceName,
+			protocol:            exclusiveProto,
+			expectedRouteIsOurs: true,
+		},
+		{
+			// A third party's routes through the device are left alone, even though Felix owns
+			// the device itself.
+			name:                "IPIP device, unrelated proto, Felix owns IPIP routes => not ours",
+			ownBIRDIPIPRoutes:   true,
+			ifaceName:           dataplanedefs.IPIPIfaceName,
+			protocol:            unix.RTPROT_STATIC,
+			expectedRouteIsOurs: false,
+		},
+		{
+			name:                "non-IPIP device, RTPROT_BIRD, Felix owns IPIP routes => not ours",
+			ownBIRDIPIPRoutes:   true,
+			ifaceName:           "eth0",
+			protocol:            unix.RTPROT_BIRD,
+			expectedRouteIsOurs: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pol := &MainTableOwnershipPolicy{
+				WorkloadInterfacePrefixes: []string{"cali"},
+				CalicoSpecialInterfaces:   []string{"vxlan.calico"},
+				AllRouteProtocols:         []netlink.RouteProtocol{unix.RTPROT_BOOT, exclusiveProto},
+				ExclusiveRouteProtocols:   []netlink.RouteProtocol{exclusiveProto},
+				OwnBIRDIPIPRoutes:         tt.ownBIRDIPIPRoutes,
 			}
 
 			route := &netlink.Route{Protocol: tt.protocol}

--- a/felix/routetable/ownershippol/main_route_table_policy_test.go
+++ b/felix/routetable/ownershippol/main_route_table_policy_test.go
@@ -28,7 +28,7 @@ func TestRouteIsOurs_BIRDRoutesOnBGPPeerIfaces(t *testing.T) {
 		wlIface    = "cali12345"
 		nonWlIface = "eth0"
 	)
-	exclusiveProto := netlink.RouteProtocol(80) // dataplanedefs.DefaultRouteProto
+	exclusiveProto := dataplanedefs.DefaultRouteProto
 
 	peerTrue := func(string) bool { return true }
 	peerFalse := func(string) bool { return false }
@@ -125,7 +125,7 @@ func TestRouteIsOurs_BIRDRoutesOnBGPPeerIfaces(t *testing.T) {
 // the ones BIRD left behind on exit (its kernel protocol runs with `persist`) are reconciled away.
 // Only BIRD's protocol is claimed, and only on the IPIP device.
 func TestRouteIsOurs_BIRDRoutesOnIPIPDevice(t *testing.T) {
-	exclusiveProto := netlink.RouteProtocol(80) // dataplanedefs.DefaultRouteProto
+	exclusiveProto := dataplanedefs.DefaultRouteProto
 
 	tests := []struct {
 		name                string

--- a/node/tests/k8st/tests/ipip_graceful_upgrade_test.go
+++ b/node/tests/k8st/tests/ipip_graceful_upgrade_test.go
@@ -243,23 +243,30 @@ func evictCalicoNodeFrom(
 		}
 	}
 
-	setNodeSelector := func(ctx context.Context, selector map[string]string) {
+	// Whatever override the cluster already had, so that restoring puts it back rather than
+	// clearing it: the STs run against clusters this test does not own.
+	inst := &operatorv1.Installation{}
+	g.Expect(cli.Get(ctx, ctrlclient.ObjectKey{Name: "default"}, inst)).
+		To(Succeed(), "reading Installation default")
+	previousDaemonSet := inst.Spec.CalicoNodeDaemonSet.DeepCopy()
+
+	setDaemonSetOverride := func(ctx context.Context, override *operatorv1.CalicoNodeDaemonSet) {
 		inst := &operatorv1.Installation{}
 		g.Expect(cli.Get(ctx, ctrlclient.ObjectKey{Name: "default"}, inst)).
 			To(Succeed(), "reading Installation default")
 		patch := ctrlclient.MergeFrom(inst.DeepCopy())
-		if selector == nil {
-			inst.Spec.CalicoNodeDaemonSet = nil
-		} else {
-			inst.Spec.CalicoNodeDaemonSet = &operatorv1.CalicoNodeDaemonSet{
-				Spec: &operatorv1.CalicoNodeDaemonSetSpec{
-					Template: &operatorv1.CalicoNodeDaemonSetPodTemplateSpec{
-						Spec: &operatorv1.CalicoNodeDaemonSetPodSpec{NodeSelector: selector},
-					},
-				},
-			}
-		}
+		inst.Spec.CalicoNodeDaemonSet = override
 		g.Expect(cli.Patch(ctx, inst, patch)).To(Succeed(), "patching Installation calicoNodeDaemonSet")
+	}
+
+	pinToLabel := func(ctx context.Context, selector map[string]string) {
+		setDaemonSetOverride(ctx, &operatorv1.CalicoNodeDaemonSet{
+			Spec: &operatorv1.CalicoNodeDaemonSetSpec{
+				Template: &operatorv1.CalicoNodeDaemonSetPodTemplateSpec{
+					Spec: &operatorv1.CalicoNodeDaemonSetPodSpec{NodeSelector: selector},
+				},
+			},
+		})
 	}
 
 	calicoNodePodsOn := func(ctx context.Context, nodeName string) int {
@@ -274,7 +281,7 @@ func evictCalicoNodeFrom(
 	}
 
 	t.Logf("Removing calico-node from %s", targetNode)
-	setNodeSelector(ctx, map[string]string{labelKey: "true"})
+	pinToLabel(ctx, map[string]string{labelKey: "true"})
 	g.Eventually(func() int { return calicoNodePodsOn(ctx, targetNode) }, "3m", "2s").
 		Should(BeZero(), "calico-node did not go away on %s", targetNode)
 
@@ -286,7 +293,7 @@ func evictCalicoNodeFrom(
 		restored = true
 		ctx := context.Background()
 		t.Logf("Restoring calico-node on %s", targetNode)
-		setNodeSelector(ctx, nil)
+		setDaemonSetOverride(ctx, previousDaemonSet)
 		for _, n := range nodeList.Items {
 			if n.Name != targetNode {
 				setLabel(ctx, n.Name, false)
@@ -392,7 +399,9 @@ func tigeraStatusDegradedMessage(t testing.TB, name string) string {
 			` -o jsonpath='{.status.conditions[?(@.type=="Degraded")].message}'`,
 		utils.RunOptions{AllowFail: true, SuppressErrLog: true})
 	if err != nil {
-		return ""
+		// Deliberately not "": the caller waits for this to become empty, so a TigeraStatus it
+		// could not read must not be mistaken for a healthy one.
+		return fmt.Sprintf("could not read tigerastatus %s: %v", name, err)
 	}
 	return strings.TrimSpace(strings.Trim(out, "'"))
 }

--- a/node/tests/k8st/tests/ipip_graceful_upgrade_test.go
+++ b/node/tests/k8st/tests/ipip_graceful_upgrade_test.go
@@ -431,16 +431,6 @@ func routesOnNodeViaDocker(t testing.TB, nodeName string) string {
 	return strings.TrimSpace(out)
 }
 
-// routesOnNode returns the node's whole main routing table, for substring assertions.
-func routesOnNode(t testing.TB, nodeName string) string {
-	t.Helper()
-	out, err := utils.ExecInCalicoNode(t, nodeName, "ip route show", utils.RunOptions{AllowFail: true})
-	if err != nil {
-		return fmt.Sprintf("ERROR: %v", err)
-	}
-	return strings.TrimSpace(out)
-}
-
 func ptrTo[T any](v T) *T {
 	return &v
 }

--- a/node/tests/k8st/tests/ipip_graceful_upgrade_test.go
+++ b/node/tests/k8st/tests/ipip_graceful_upgrade_test.go
@@ -1,0 +1,444 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// ipip_graceful_upgrade_test.go covers what a cluster is left with when ownership of the IPIP
+// cluster routes moves from confd and BIRD to Felix.
+//
+// BIRD's kernel protocol is configured with `persist`, so BIRD deliberately leaves its routes in
+// the kernel when it exits.  A BIRD that comes back reconciles them away itself once its
+// graceful-restart recovery period ends.  This test covers the case where it does not come back,
+// because BGP was disabled as part of the same migration -- there, only Felix can clean up.
+//
+// Note that destinations Felix *does* want a route to were never the problem: Felix replaces any
+// previous route for a prefix it wants, whatever protocol that route carried.  What needs Felix's
+// ownership rule is a destination Felix does not want, which is what orphanCIDR below stands in
+// for: a block that was released while this node was down.
+
+package k8stests
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+	v3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
+	operatorv1 "github.com/tigera/operator/api/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/projectcalico/calico/node/tests/k8st/utils"
+)
+
+const (
+	// orphanCIDR is inside the cluster's default IPv4 pool but is backed by no IPAM block, so
+	// Felix never wants a route to it.  It stands in for a block released while the node was
+	// down: BIRD had a route to it, Felix has no route of its own to replace it with.
+	orphanCIDR = "192.168.240.0/26"
+
+	// defaultV4PoolPrefix matches the blocks of the cluster's default IPv4 pool.
+	defaultV4PoolPrefix = "192.168."
+)
+
+// TestIPIPGracefulUpgradeWithBGPDisabled walks a cluster through the migration:
+//
+//  1. hand the IPIP cluster routes to confd and BIRD, as they were before v3.33;
+//  2. take calico-node off the node, so that nothing there can react to what follows;
+//  3. leave an orphaned BIRD route behind, of the kind BIRD's `persist` guarantees will survive;
+//  4. hand the routes to Felix and disable BGP, in one Installation patch;
+//  5. bring calico-node back -- with no BIRD in it at all.
+//
+// The orphan must survive steps 2 to 4 and be gone after 5.  Because the returning pod has no
+// BIRD, only Felix can be what removed it.
+//
+// Ownership moves via clusterRoutingMode rather than the two programClusterRoutes fields directly,
+// because disabling BGP is only a valid Installation once Felix owns the routes -- including the
+// unencapsulated ones, which this cluster has (the IPv6 default pool and the LoadBalancer pools),
+// so the mode has to be Felix rather than FelixIPIPOnly.
+func TestIPIPGracefulUpgradeWithBGPDisabled(t *testing.T) {
+	defer utils.CollectDiagsOnFailure(t)()
+
+	g := NewWithT(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Minute)
+	t.Cleanup(cancel)
+
+	cli := newClient(g)
+
+	// NodeInfo returns the control-plane node first, then workers.
+	nodes, ips, _ := utils.NodeInfo(t)
+	g.Expect(len(nodes)).To(BeNumerically(">=", 3),
+		"need a control-plane node and at least two workers")
+	node, peerIP := nodes[1], ips[2]
+
+	// Step 1: BIRD owns the IPIP cluster routes, as before v3.33.
+	setClusterRouteOwnership(t, g, cli, ctx, ptrTo(v3.EnabledIPIPOnly), ptrTo(v3.EnabledNoEncapOnly))
+	t.Cleanup(func() {
+		// Back to the defaults, whatever the test did.  Registered before the Installation
+		// cleanup so that it runs after it: the operator writes these two fields whenever
+		// clusterRoutingMode is set, so they have to be cleared once the mode is gone.
+		setClusterRouteOwnership(t, g, cli, context.Background(), nil, nil)
+	})
+
+	t.Log("Waiting for BIRD to take over the IPIP cluster routes")
+	utils.AssertRouteOwnership(t, node, defaultV4PoolPrefix, "tunl0", utils.RouteProtoBIRD)
+
+	// Step 2: take calico-node off this node, so nothing there can react to what follows.
+	restoreScheduling := evictCalicoNodeFrom(t, g, cli, ctx, node)
+
+	// Step 3: the orphan.  Injected rather than produced by releasing a real block, so that the
+	// test does not depend on IPAM timing; the route is identical in form to one BIRD leaves.
+	//
+	// It has to be installed while no BIRD is running.  BIRD treats routes carrying its own
+	// protocol as its own, so a running BIRD reconciles away any it has no record of exporting --
+	// within its `scan time` of 2s.  That is only true of a synthetic route: the ones a real
+	// upgrade leaves behind are BIRD's own, and they outlive BIRD because of `persist`.
+	t.Logf("Installing an orphaned BIRD route to %s on %s", orphanCIDR, node)
+	_, err := utils.Run(t, fmt.Sprintf(
+		"docker exec %s ip route add %s via %s dev tunl0 onlink proto bird",
+		node, orphanCIDR, peerIP))
+	g.Expect(err).NotTo(HaveOccurred(), "installing the orphaned BIRD route")
+
+	// Step 4: hand the routes to Felix and drop BGP, in one patch.  Disabling BGP is only a valid
+	// Installation once Felix owns the routes, so the two have to move together.
+	t.Log("Handing the cluster routes to Felix and disabling BGP")
+	restoreInstallation := setClusterRoutingModeAndBGP(
+		t, g, cli, ctx, ptrTo(operatorv1.ClusterRoutingModeFelix), operatorv1.BGPDisabled)
+	t.Cleanup(restoreInstallation)
+
+	// The orphan must still be there: nothing has run on this node since it was installed.
+	// Without this check, step 5 could be passing because something else cleaned up.
+	g.Expect(routesOnNodeViaDocker(t, node)).To(ContainSubstring(orphanCIDR),
+		"the orphaned route disappeared while calico-node was down, so this test would not be "+
+			"showing that Felix removed it")
+
+	// Step 5: bring calico-node back.  This pod has no BIRD in it, so anything that happens to
+	// BIRD's leftovers from here is Felix's doing.
+	restoreScheduling()
+	g.Expect(calicoNodeBackend(t, g, node)).NotTo(Equal("bird"),
+		"calico-node came back still running BIRD, so the cleanup could not be attributed to Felix")
+
+	t.Log("Waiting for Felix to remove the orphaned BIRD route")
+	utils.AssertNoRouteWithProto(t, node, orphanCIDR, utils.RouteProtoBIRD)
+
+	// ...and the destinations Felix does want end up as Felix's.  (This part would hold with or
+	// without the ownership rule: Felix replaces any previous route for a prefix it wants.)
+	utils.AssertRouteOwnership(t, node, defaultV4PoolPrefix, "tunl0", utils.RouteProtoFelix)
+}
+
+// TestIPIPGracefulUpgradeWithBGPRetained models the mainstream upgrade, where BGP is still in use
+// afterwards because the cluster peers with external infrastructure.
+//
+// The real upgrade changes no configuration at all: both programClusterRoutes fields are unset
+// before and after, and it is the default each component derives from unset that moves when the
+// code does.  That is not reproducible at a single code level, so the test fakes it -- but it must
+// fake it while calico-node is *down*, otherwise confd sees the change live, BIRD reconfigures in
+// place and withdraws its own routes, and the test would be exercising a path an upgrade never
+// takes.  calico-node is evicted from the node under test for the duration.
+//
+// Unlike the BGP-disabled case, this one cannot attribute the cleanup to Felix, and in fact almost
+// certainly is not Felix: a returning BIRD removes routes carrying its own protocol that it has no
+// record of exporting, within its `scan time` of 2s, well before Felix has finished starting.  This
+// test is here to show that the transition converges and leaves nothing behind, not to show that
+// the ownership rule works -- TestIPIPGracefulUpgradeWithBGPDisabled is the one that does that.
+func TestIPIPGracefulUpgradeWithBGPRetained(t *testing.T) {
+	defer utils.CollectDiagsOnFailure(t)()
+
+	g := NewWithT(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Minute)
+	t.Cleanup(cancel)
+
+	cli := newClient(g)
+
+	nodes, ips, _ := utils.NodeInfo(t)
+	g.Expect(len(nodes)).To(BeNumerically(">=", 3),
+		"need a control-plane node and at least two workers")
+	node, peerIP := nodes[1], ips[2]
+
+	// BIRD owns the IPIP cluster routes, as before v3.33.
+	setClusterRouteOwnership(t, g, cli, ctx, ptrTo(v3.EnabledIPIPOnly), ptrTo(v3.EnabledNoEncapOnly))
+	t.Cleanup(func() {
+		setClusterRouteOwnership(t, g, cli, context.Background(), nil, nil)
+	})
+
+	t.Log("Waiting for BIRD to take over the IPIP cluster routes")
+	utils.AssertRouteOwnership(t, node, defaultV4PoolPrefix, "tunl0", utils.RouteProtoBIRD)
+
+	// Take calico-node off this node, so that the ownership change lands while it is down and no
+	// running confd or BIRD can react to it.
+	restoreScheduling := evictCalicoNodeFrom(t, g, cli, ctx, node)
+
+	// BIRD's own routes outlive the pod: that is what `persist` guarantees.
+	g.Expect(routesOnNodeViaDocker(t, node)).To(ContainSubstring("proto bird"),
+		"BIRD's routes did not survive calico-node being removed from the node")
+
+	// Add the orphan now, while nothing is running that could reconcile it away.  A running BIRD
+	// removes routes carrying its protocol that it has no record of exporting; with the pod gone
+	// there is no BIRD, and no calico-node to exec into either, so this goes in via the node
+	// container.
+	t.Logf("Installing an orphaned BIRD route to %s on %s", orphanCIDR, node)
+	_, err := utils.Run(t, fmt.Sprintf(
+		"docker exec %s ip route add %s via %s dev tunl0 onlink proto bird",
+		node, orphanCIDR, peerIP))
+	g.Expect(err).NotTo(HaveOccurred(), "installing the orphaned BIRD route")
+
+	t.Log("Handing the IPIP cluster routes to Felix while calico-node is down")
+	setClusterRouteOwnership(t, g, cli, ctx, nil, nil)
+
+	// Bring calico-node back: this is the upgraded pod, seeing the new ownership for the first
+	// time, with BIRD's routes already in the kernel.
+	restoreScheduling()
+
+	t.Log("Waiting for the transition to converge")
+	utils.AssertRouteOwnership(t, node, defaultV4PoolPrefix, "tunl0", utils.RouteProtoFelix)
+	utils.AssertNoRouteWithProto(t, node, orphanCIDR, utils.RouteProtoBIRD)
+}
+
+// evictCalicoNodeFrom removes calico-node from one node by labelling every *other* node and
+// pinning the DaemonSet to that label through the operator's Installation override.  It returns a
+// function that undoes both and waits for the pod to come back.
+func evictCalicoNodeFrom(
+	t *testing.T,
+	g *WithT,
+	cli ctrlclient.Client,
+	ctx context.Context,
+	targetNode string,
+) func() {
+	t.Helper()
+
+	const labelKey = "calico-st-run-calico-node"
+
+	cs := utils.K8sClient(t)
+	nodeList, err := cs.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+	g.Expect(err).NotTo(HaveOccurred(), "listing nodes")
+
+	setLabel := func(ctx context.Context, nodeName string, present bool) {
+		var patch string
+		if present {
+			patch = fmt.Sprintf(`{"metadata":{"labels":{%q:"true"}}}`, labelKey)
+		} else {
+			patch = fmt.Sprintf(`{"metadata":{"labels":{%q:null}}}`, labelKey)
+		}
+		_, err := cs.CoreV1().Nodes().Patch(
+			ctx, nodeName, types.StrategicMergePatchType, []byte(patch), metav1.PatchOptions{})
+		g.Expect(err).NotTo(HaveOccurred(), "patching labels of node %s", nodeName)
+	}
+
+	for _, n := range nodeList.Items {
+		if n.Name != targetNode {
+			setLabel(ctx, n.Name, true)
+		}
+	}
+
+	setNodeSelector := func(ctx context.Context, selector map[string]string) {
+		inst := &operatorv1.Installation{}
+		g.Expect(cli.Get(ctx, ctrlclient.ObjectKey{Name: "default"}, inst)).
+			To(Succeed(), "reading Installation default")
+		patch := ctrlclient.MergeFrom(inst.DeepCopy())
+		if selector == nil {
+			inst.Spec.CalicoNodeDaemonSet = nil
+		} else {
+			inst.Spec.CalicoNodeDaemonSet = &operatorv1.CalicoNodeDaemonSet{
+				Spec: &operatorv1.CalicoNodeDaemonSetSpec{
+					Template: &operatorv1.CalicoNodeDaemonSetPodTemplateSpec{
+						Spec: &operatorv1.CalicoNodeDaemonSetPodSpec{NodeSelector: selector},
+					},
+				},
+			}
+		}
+		g.Expect(cli.Patch(ctx, inst, patch)).To(Succeed(), "patching Installation calicoNodeDaemonSet")
+	}
+
+	calicoNodePodsOn := func(ctx context.Context, nodeName string) int {
+		pods, err := cs.CoreV1().Pods("calico-system").List(ctx, metav1.ListOptions{
+			LabelSelector: "k8s-app=calico-node",
+			FieldSelector: "spec.nodeName=" + nodeName,
+		})
+		if err != nil {
+			return -1
+		}
+		return len(pods.Items)
+	}
+
+	t.Logf("Removing calico-node from %s", targetNode)
+	setNodeSelector(ctx, map[string]string{labelKey: "true"})
+	g.Eventually(func() int { return calicoNodePodsOn(ctx, targetNode) }, "3m", "2s").
+		Should(BeZero(), "calico-node did not go away on %s", targetNode)
+
+	restored := false
+	restore := func() {
+		if restored {
+			return
+		}
+		restored = true
+		ctx := context.Background()
+		t.Logf("Restoring calico-node on %s", targetNode)
+		setNodeSelector(ctx, nil)
+		for _, n := range nodeList.Items {
+			if n.Name != targetNode {
+				setLabel(ctx, n.Name, false)
+			}
+		}
+		utils.WaitForPodsReady(t, "calico-system", "k8s-app=calico-node", 5*time.Minute)
+	}
+	t.Cleanup(restore)
+	return restore
+}
+
+// setClusterRouteOwnership sets BGPConfiguration.programClusterRoutes and
+// FelixConfiguration.programClusterRoutes, each to the given value or, for nil, back to unset so
+// that Calico's own defaults apply.
+func setClusterRouteOwnership(
+	t *testing.T,
+	g *WithT,
+	cli ctrlclient.Client,
+	ctx context.Context,
+	bgpValue, felixValue *string,
+) {
+	t.Helper()
+
+	bgpCfg := &v3.BGPConfiguration{}
+	g.Expect(cli.Get(ctx, ctrlclient.ObjectKey{Name: "default"}, bgpCfg)).
+		To(Succeed(), "reading default BGPConfiguration")
+	bgpCfg.Spec.ProgramClusterRoutes = bgpValue
+	g.Expect(cli.Update(ctx, bgpCfg)).To(Succeed(), "updating default BGPConfiguration")
+
+	felixCfg := &v3.FelixConfiguration{}
+	g.Expect(cli.Get(ctx, ctrlclient.ObjectKey{Name: "default"}, felixCfg)).
+		To(Succeed(), "reading default FelixConfiguration")
+	felixCfg.Spec.ProgramClusterRoutes = felixValue
+	g.Expect(cli.Update(ctx, felixCfg)).To(Succeed(), "updating default FelixConfiguration")
+
+	t.Logf("Cluster route ownership set: BGPConfiguration=%s FelixConfiguration=%s",
+		derefOr(bgpValue, "<unset>"), derefOr(felixValue, "<unset>"))
+}
+
+// setClusterRoutingModeAndBGP patches the operator Installation's clusterRoutingMode and BGP
+// settings together, and returns a function that restores both.  They move together because
+// disabling BGP is only a valid Installation once Felix owns the cluster routes: the operator
+// rejects the intermediate state outright, degrading without touching the DaemonSet.
+//
+// Note this does not wait for a rollout.  The caller has calico-node evicted from the node under
+// test, so there is nothing to wait for there; the other nodes roll in the background.
+func setClusterRoutingModeAndBGP(
+	t *testing.T,
+	g *WithT,
+	cli ctrlclient.Client,
+	ctx context.Context,
+	mode *operatorv1.ClusterRoutingMode,
+	bgp operatorv1.BGPOption,
+) func() {
+	t.Helper()
+
+	inst := &operatorv1.Installation{}
+	g.Expect(cli.Get(ctx, ctrlclient.ObjectKey{Name: "default"}, inst)).
+		To(Succeed(), "reading Installation default")
+	g.Expect(inst.Spec.CalicoNetwork).NotTo(BeNil(), "Installation has no calicoNetwork")
+	previousMode, previousBGP := inst.Spec.CalicoNetwork.ClusterRoutingMode, inst.Spec.CalicoNetwork.BGP
+
+	patch := func(ctx context.Context, mode *operatorv1.ClusterRoutingMode, bgp *operatorv1.BGPOption) {
+		inst := &operatorv1.Installation{}
+		g.Expect(cli.Get(ctx, ctrlclient.ObjectKey{Name: "default"}, inst)).
+			To(Succeed(), "reading Installation default")
+		p := ctrlclient.MergeFrom(inst.DeepCopy())
+		inst.Spec.CalicoNetwork.ClusterRoutingMode = mode
+		inst.Spec.CalicoNetwork.BGP = bgp
+		g.Expect(cli.Patch(ctx, inst, p)).To(Succeed(), "patching Installation")
+
+		// The operator reports a rejected Installation through TigeraStatus rather than by
+		// failing the patch, so check that it actually accepted this one.
+		g.Eventually(func() string {
+			return tigeraStatusDegradedMessage(t, "calico")
+		}, "60s", "2s").Should(BeEmpty(), "the operator rejected the Installation")
+	}
+
+	patch(ctx, mode, &bgp)
+	return func() {
+		ctx := context.Background()
+		patch(ctx, previousMode, previousBGP)
+
+		// Re-enabling BGP cannot be left to the DaemonSet's rolling update.  calico-node's
+		// readiness gate requires BGP to be established with its peers, and a rolling update
+		// brings the nodes back one at a time -- so the first node to roll waits for peers that
+		// have no BIRD yet, never becomes ready, and the roll never advances.  Deleting the pods
+		// together lets them come back and peer with each other.  `make kind-reload` does the
+		// same thing after a Helm upgrade, for what looks like the same reason.
+		_, err := utils.Run(t, "kubectl delete pods -n calico-system -l k8s-app=calico-node")
+		g.Expect(err).NotTo(HaveOccurred(), "deleting calico-node pods to re-establish BGP")
+
+		utils.WaitForPodsReady(t, "calico-system", "k8s-app=calico-node", 5*time.Minute)
+	}
+}
+
+// tigeraStatusDegradedMessage returns the Degraded condition's message for a TigeraStatus, or "" if
+// it is not degraded.
+func tigeraStatusDegradedMessage(t testing.TB, name string) string {
+	t.Helper()
+	out, err := utils.Run(t,
+		"kubectl get tigerastatus "+name+
+			` -o jsonpath='{.status.conditions[?(@.type=="Degraded")].message}'`,
+		utils.RunOptions{AllowFail: true, SuppressErrLog: true})
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(strings.Trim(out, "'"))
+}
+
+// calicoNodeBackend returns the CALICO_NETWORKING_BACKEND that the calico-node pod on nodeName is
+// running with, which is "bird" only when BGP is enabled.
+func calicoNodeBackend(t *testing.T, g *WithT, nodeName string) string {
+	t.Helper()
+	pod := utils.CalicoNodePodName(t, nodeName)
+	out, err := utils.Run(t,
+		"kubectl get pod -n calico-system "+pod+" -o "+
+			`jsonpath='{.spec.containers[0].env[?(@.name=="CALICO_NETWORKING_BACKEND")].value}'`,
+		utils.RunOptions{AllowFail: true})
+	g.Expect(err).NotTo(HaveOccurred(), "reading calico-node's networking backend on %s", nodeName)
+	return strings.TrimSpace(strings.Trim(out, "'"))
+}
+
+// routesOnNodeViaDocker returns the node's routing table read from the node container, for use when
+// there is no calico-node pod to exec into.
+func routesOnNodeViaDocker(t testing.TB, nodeName string) string {
+	t.Helper()
+	out, err := utils.Run(t, "docker exec "+nodeName+" ip route show",
+		utils.RunOptions{AllowFail: true})
+	if err != nil {
+		return fmt.Sprintf("ERROR: %v", err)
+	}
+	return strings.TrimSpace(out)
+}
+
+// routesOnNode returns the node's whole main routing table, for substring assertions.
+func routesOnNode(t testing.TB, nodeName string) string {
+	t.Helper()
+	out, err := utils.ExecInCalicoNode(t, nodeName, "ip route show", utils.RunOptions{AllowFail: true})
+	if err != nil {
+		return fmt.Sprintf("ERROR: %v", err)
+	}
+	return strings.TrimSpace(out)
+}
+
+func ptrTo[T any](v T) *T {
+	return &v
+}
+
+func derefOr(s *string, fallback string) string {
+	if s == nil {
+		return fallback
+	}
+	return *s
+}


### PR DESCRIPTION
Follows #13470, which made Felix the default owner of the cluster routes for IPIP IP Pools. This
closes the third of the three gaps that PR recorded: what a cluster is left with when ownership
moves from confd and BIRD to Felix.

## What this fixes, precisely

BIRD's kernel protocol is configured with `persist`
(`node/filesystem/etc/calico/confd/templates/bird.cfg.template`), so BIRD deliberately leaves its
routes in the kernel when it exits. A BIRD that comes back reconciles them away itself, once its
graceful-restart recovery period ends. Where BIRD does **not** come back, nothing removes them —
they are not Felix's by protocol, and BIRD is not there to reconcile them. That happens when BGP is
disabled as part of the same migration, when there are no BGP peers to run BIRD for, or when BIRD
never completes recovery.

So when Felix is the configured owner of the IPIP cluster routes, routes via `tunl0` carrying
`RTPROT_BIRD` are now inside Felix's ownership boundary (`OwnBIRDIPIPRoutes` in
`felix/routetable/ownershippol`), and reconciliation removes them.

## What this does *not* do

Worth stating plainly, because it is easy to assume this PR does more than it does.

**Destinations Felix wants a route to were never a problem.** When Felix wants a route to exist it
atomically replaces any previous route for the same prefix, whether or not that route was within its
logical ownership — it programs with `RouteReplace`. That is long-standing behaviour and does not
depend on this change. So the ordinary upgrade already converged, with no window in which a wanted
destination had no route.

What this adds is only the removal of BIRD's routes to destinations Felix does **not** want: a block
released while the node was down, a node that has left the cluster, a pool that has been deleted.

## Scope decisions

- **Not time-bounded, and not conditional on having recently upgraded.** Felix has no notion of "we
  just upgraded", and a bounded window would fail precisely the cases the rule exists for: a node
  down across the window, a rolling upgrade slower than it, or BGP being switched off weeks after
  the version moved.
- **Only BIRD's protocol**, not every protocol on `tunl0`. Felix's own routes there are already
  claimed by protocol whoever the configured owner is, so widening would only take in routes
  belonging to neither component.
- **Not scoped by destination.** Felix already owns the IPIP device outright — it creates it, keeps
  its MTU in sync, assigns its address, and removes addresses it did not add — so owning the routes
  through it is consistent with that; and a destination test would not reclaim a route whose pool
  has since been deleted.
- `tunl0` stays out of `CalicoSpecialInterfaces`: unlike the other devices there, BIRD may
  legitimately program routes on it, so claiming every protocol would make Felix delete BIRD's
  routes even when BIRD is the configured owner.

## Design

`design/cluster-route-programming/DESIGN.md` §4 is rewritten. It described a handover driven by a
datastore change, but the real upgrade changes no configuration at all: both `programClusterRoutes`
fields are unset before and after, and what moves is the default each component derives from unset.
The section now separates that from a deliberate configuration change on a running cluster, and
notes which of the two actually has a gap — it is the configuration change, where BIRD withdraws
promptly while Felix restarts, not the code upgrade.

## Testing

- **Felix UT**: `TestRouteIsOurs_BIRDRoutesOnIPIPDevice`, five cases, including the two that pin the
  scope decisions above (a third party's protocol on `tunl0` is left alone; Felix's own routes are
  claimed regardless of the flag).
- **Felix FV** (`felix/fv/ipip_bird_routes_test.go`): four specs over two topologies — takes back a
  wanted destination, removes an unwanted one, leaves a third party's route alone, and leaves
  BIRD's routes alone when BIRD is the configured owner. Only the second exercises the new rule;
  the others guard against over-widening, and the comments say so.
- **Node ST** (`node/tests/k8st/tests/ipip_graceful_upgrade_test.go`): two cases. With BGP retained,
  the transition is modelled faithfully by evicting calico-node from the node under test so the
  ownership change lands while it is down — otherwise confd reconfigures BIRD in place, which is a
  path no upgrade takes. With BGP disabled, the returning pod has no BIRD in it at all, which is
  asserted, so the cleanup is attributable to Felix.
- Verified on kind: both ST cases pass, and the FV specs pass against a real Felix and a real
  kernel.

### Note on operator#5201

An earlier revision of this description said the BGP-disabled ST case depended on
tigera/operator#5201 and that this PR had to merge after it. That was wrong. The test sets
`clusterRoutingMode: Felix` explicitly, and the operator's validation has always accepted that;
#5201 only changes what an *unset* mode means. Both ST cases have since passed in CI ("Node:
kind-cluster tests") with #5201 unmerged.

#5201 came out of this work and is worth having on its own merits — without it, an operator cluster
that has simply taken Calico's new default cannot disable BGP even with only IPIP pools — but it is
not a prerequisite here.

**Release note:**
```release-note
Felix now cleans up cluster routes left behind by BIRD for destinations it no longer routes to, when Felix is the configured owner of the IPIP cluster routes.
```
