### PR TITLE
kube-controllers: trust a matching Pod IP over a stale node attribute in IPAM GC

### DIFF
--- a/design/ipam/ipam-gc.md
+++ b/design/ipam/ipam-gc.md
@@ -43,11 +43,14 @@ leakGracePeriod set:             markLeak(leakGracePeriod)
 
 After the walk, if every allocation on a node is released and no valid ones remain, the node's tunnel IPs are confirmed-leaked and the node is added to `nodesToRelease`.
 
-`allocationIsValid` (`ipam.go:999`) is the truth check. The design-relevant rules:
+`allocationIsValid` (`ipam.go:1083`) is the truth check. The design-relevant rules:
 
 - **Tunnel IPs validate via node existence only.** They never validate via pods. Mixing the paths would release a live tunnel IP whenever the pod-side check failed.
 - **Missing `pod` / `namespace` attributes ⇒ assume valid.** Conservative on purpose. Tightening this without a real reason will release allocations made by paths that don't
   stamp the attrs.
+- **A live IP beats a stale node attribute.** `pod.Spec.NodeName` vs. the allocation's recorded node is only a leak signal before the pod has reported an IP (the migration
+  case). Once an IP is reported, only the IP match against `wep.Spec.IPNetworks` determines validity - a node mismatch alone is not sufficient once there's IP evidence to
+  check.
 - **Multus produces multiple WorkloadEndpoints per pod.** The IP must appear in at least one `wep.Spec.IPNetworks` to be valid. A single-WEP check would falsely release
   secondary-network IPs.
 - **Pod lookup mode is preferCache vs live.** Cache for the node-deleted path (where the source data is presumed stale), live for sync. A live read can win against the cache in the
@@ -58,13 +61,16 @@ later sync re-validates the allocation. The transition is what the [grace period
 
 **Review notes**
 
-- `allocationIsValid` compares `pod.Spec.NodeName` against `attrs["node"]`. Stale source data makes valid allocations look like leaks -
-  https://github.com/projectcalico/calico/issues/12257. Don't expand the comparison without thinking about stale-source-data scenarios.
+- `allocationIsValid`'s node-mismatch check no longer overrides IP-match evidence once the pod has reported an IP - https://github.com/projectcalico/calico/issues/12257 was
+  exactly this: a stale on-disk CNI identity stamped the wrong node into `attrs["node"]` at ADD time while the pod's real IP kept working, and the old node comparison released
+  it anyway. Don't revert to trusting the node comparison over a matching reported IP without re-litigating #12257.
 - Missing `pod` / `namespace` attributes must remain "assume valid." Tightening this without a real reason will cause spurious releases.
 - Tunnel IPs do not validate via pods. Only the node-existence path releases them.
 - Don't add per-IP API GETs in this loop. The hot path uses informer cache reads after https://github.com/projectcalico/calico/pull/10333.
-- The `ipam.go:1043` TODO on pod-NodeName mismatch is unresolved. Currently releases the old allocation; the comment expresses uncertainty. Don't touch without understanding the
-  migration cases.
+- The pod-NodeName-mismatch TODO is resolved: node mismatch is now only a fast leak signal in the window before the pod has reported an IP (the migration case - a pod
+  recreated on a new node before it has an IP). Once an IP is reported, node mismatch is corroborating evidence only, logged but not gating - see #12257. A brief false-candidate
+  window can still occur for a brand-new pod between its allocation and its first status report (no IP evidence yet, node already mismatched); this self-heals via the standard
+  grace-period/re-validate mechanism and is not a gap to close here.
 
 ## Grace periods
 

--- a/kube-controllers/pkg/controllers/node/ipam.go
+++ b/kube-controllers/pkg/controllers/node/ipam.go
@@ -1123,19 +1123,25 @@ func (c *IPAMController) allocationIsValid(a *allocation, preferCache bool) bool
 		return false
 	}
 
-	// The pod exists - check if it is still on the original node.
-	// TODO: Do we need this check?
-	if p.Spec.NodeName != "" && a.knode != "" && p.Spec.NodeName != a.knode {
-		// If the pod has been rescheduled to a new node, we can treat the old allocation as
-		// gone and clean it up.
-		fields := log.Fields{"old": a.knode, "new": p.Spec.NodeName}
-		logc.WithFields(fields).Info("Pod rescheduled on new node. Allocation no longer valid")
-		return false
-	}
+	// A pod.Spec.NodeName that differs from the allocation's recorded node is not proof the pod
+	// moved: the CNI plugin can mis-stamp attrs["node"] at ADD time (e.g. a stale on-disk identity
+	// surviving a node re-image - https://github.com/projectcalico/calico/issues/12257) while the
+	// pod itself is placed correctly and its IP keeps working. Once the pod has reported an IP,
+	// that IP - matched against the pod's WorkloadEndpoint(s) below - is stronger evidence than
+	// this comparison and takes precedence. Before any IP has been reported there's no IP evidence
+	// to consult, so a node mismatch is still used as a fast leak signal there: this protects the
+	// "pod recreated on a new node before receiving an IP" migration case from sitting as
+	// "assumed valid" far longer than necessary.
+	nodeMismatch := p.Spec.NodeName != "" && a.knode != "" && p.Spec.NodeName != a.knode
+	nodeFields := log.Fields{"old": a.knode, "new": p.Spec.NodeName}
 
 	// Check to see if the pod actually has the IP in question. Gate based on the presence of the
 	// status field, which is populated by kubelet.
 	if p.Status.PodIP == "" || len(p.Status.PodIPs) == 0 {
+		if nodeMismatch {
+			logc.WithFields(nodeFields).Info("Pod rescheduled on new node before reporting an IP. Allocation no longer valid")
+			return false
+		}
 		// The pod hasn't received an IP yet.
 		log.Debugf("Pod IP has not yet been reported, consider allocation valid")
 		return true
@@ -1177,13 +1183,23 @@ func (c *IPAMController) allocationIsValid(a *allocation, preferCache bool) bool
 			}
 
 			if allocIP.Equal(ip) {
-				// Found a match.
-				logc.Debugf("Pod has matching IP, allocation is valid")
+				// Found a match. The pod is provably still using this IP - a node mismatch at this
+				// point means the allocation's node attribute is stale, not that the pod moved.
+				if nodeMismatch {
+					logc.WithFields(nodeFields).Info("Pod has matching IP despite node mismatch; treating allocation as valid (stale node attribute, not a leak)")
+				} else {
+					logc.Debugf("Pod has matching IP, allocation is valid")
+				}
 				return true
 			}
 		}
 	}
 
+	// No IP match. If the node also mismatches, log it as corroborating evidence only - the IP
+	// mismatch, not the node mismatch, is what makes this invalid.
+	if nodeMismatch {
+		logc.WithFields(nodeFields).Info("Allocated IP no longer in-use by pod; pod has also been rescheduled to a new node")
+	}
 	logc.Debugf("Allocated IP no longer in-use by pod")
 	return false
 }

--- a/kube-controllers/pkg/controllers/node/ipam_test.go
+++ b/kube-controllers/pkg/controllers/node/ipam_test.go
@@ -1327,6 +1327,254 @@ var _ = Describe("IPAM controller UTs", func() {
 		}, assertionTimeout, 100*time.Millisecond).Should(BeFalse())
 	})
 
+	It("should NOT clean up a valid IP address when the allocation's recorded node is stale (issue #12257)", func() {
+		// The CNI plugin can stamp the wrong node into an allocation's attrs["node"] at ADD time
+		// (e.g. a stale on-disk CNI config left behind by a previous node identity), even though
+		// the pod itself is placed correctly and genuinely holds the IP it was given. A node
+		// mismatch alone must not be treated as proof the pod was rescheduled.
+
+		// Create the Calico node the allocation is (stale-)recorded against, and its matching k8s node.
+		n := internalapi.Node{}
+		n.Name = "cnode-a"
+		n.Spec.OrchRefs = []internalapi.OrchRef{{NodeName: "kname-a", Orchestrator: apiv3.OrchestratorKubernetes}}
+		_, err := cli.Nodes().Create(context.TODO(), &n, options.SetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		kn := v1.Node{}
+		kn.Name = "kname-a"
+		_, err = cs.CoreV1().Nodes().Create(context.TODO(), &kn, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		var node *v1.Node
+		Eventually(nodes).WithTimeout(time.Second).Should(Receive(&node))
+
+		// Create the second node the pod is actually running on.
+		knB := v1.Node{}
+		knB.Name = "kname-b"
+		_, err = cs.CoreV1().Nodes().Create(context.TODO(), &knB, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		Eventually(nodes).WithTimeout(time.Second).Should(Receive(&node))
+
+		// Create a pod that is actually running on kname-b, with the IP it was really given.
+		pod := v1.Pod{}
+		pod.Name = "test-pod-stale-node"
+		pod.Namespace = "test-namespace"
+		pod.Spec.NodeName = "kname-b"
+		pod.Status.PodIP = "10.0.0.0"
+		pod.Status.PodIPs = []v1.PodIP{{IP: "10.0.0.0"}}
+		pod.Status.Phase = v1.PodRunning
+		_, err = createPod(context.TODO(), cs, &pod)
+		Expect(err).NotTo(HaveOccurred())
+		var gotPod *v1.Pod
+		Eventually(pods).WithTimeout(time.Second).Should(Receive(&gotPod))
+
+		// Allocate the IP, but record it against cnode-a - the stale bookkeeping this fix targets.
+		idx := 0
+		handle := "test-handle-stale-node"
+		cidr := net.MustParseCIDR("10.0.0.0/30")
+		aff := "host:cnode-a"
+		key := model.BlockKey{CIDR: model.PrefixFromIPNet(cidr)}
+		b := model.AllocationBlock{
+			CIDR:        cidr,
+			Affinity:    &aff,
+			Allocations: []*int{&idx, nil, nil, nil},
+			Unallocated: []int{1, 2, 3},
+			Attributes: []model.AllocationAttribute{
+				{
+					HandleID: &handle,
+					ActiveOwnerAttrs: map[string]string{
+						ipam.AttributeNode:      "cnode-a",
+						ipam.AttributePod:       pod.Name,
+						ipam.AttributeNamespace: pod.Namespace,
+					},
+				},
+			},
+		}
+		kvp := model.KVPair{Key: key, Value: &b}
+		update := bapi.Update{KVPair: kvp, UpdateType: bapi.UpdateTypeKVNew}
+		c.onUpdate(update)
+
+		c.Start(stopChan)
+
+		blockCIDR := kvp.Key.(model.BlockKey).CIDR.String()
+		Eventually(func() bool {
+			done := c.pause()
+			defer done()
+			_, ok := c.allBlocks[blockCIDR]
+			return ok
+		}, 1*time.Second, 100*time.Millisecond).Should(BeTrue())
+
+		c.onStatusUpdate(bapi.InSync)
+
+		fakeClient := cli.IPAM().(*fakeIPAMClient)
+		// The allocation's recorded node (cnode-a) no longer matches the pod's real node (kname-b),
+		// but the pod is genuinely running with this IP - it must never be released.
+		Consistently(func() bool {
+			return fakeClient.handlesReleased[handle]
+		}, assertionTimeout, 100*time.Millisecond).Should(BeFalse())
+	})
+
+	It("should GC an allocation whose recorded node mismatches the pod's node, if the pod has not yet reported an IP", func() {
+		// Guards the other half of the #12257 fix: a pod that has genuinely moved to a new node
+		// and hasn't been given an IP yet must still fast-path the old allocation as leaked,
+		// rather than waiting indefinitely on an IP report that will never match.
+
+		n := internalapi.Node{}
+		n.Name = "cnode-a2"
+		n.Spec.OrchRefs = []internalapi.OrchRef{{NodeName: "kname-a2", Orchestrator: apiv3.OrchestratorKubernetes}}
+		_, err := cli.Nodes().Create(context.TODO(), &n, options.SetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		kn := v1.Node{}
+		kn.Name = "kname-a2"
+		_, err = cs.CoreV1().Nodes().Create(context.TODO(), &kn, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		var node *v1.Node
+		Eventually(nodes).WithTimeout(time.Second).Should(Receive(&node))
+
+		knB := v1.Node{}
+		knB.Name = "kname-b2"
+		_, err = cs.CoreV1().Nodes().Create(context.TODO(), &knB, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		Eventually(nodes).WithTimeout(time.Second).Should(Receive(&node))
+
+		// Create a fresh pod on the new node, with no IP reported yet - simulates the pod having
+		// been deleted and recreated on a different node before kubelet has assigned it an address.
+		pod := v1.Pod{}
+		pod.Name = "test-pod-stale-node-no-ip"
+		pod.Namespace = "test-namespace"
+		pod.Spec.NodeName = "kname-b2"
+		_, err = createPod(context.TODO(), cs, &pod)
+		Expect(err).NotTo(HaveOccurred())
+		var gotPod *v1.Pod
+		Eventually(pods).WithTimeout(time.Second).Should(Receive(&gotPod))
+
+		idx := 0
+		handle := "test-handle-stale-node-no-ip"
+		cidr := net.MustParseCIDR("10.0.1.0/30")
+		aff := "host:cnode-a2"
+		key := model.BlockKey{CIDR: model.PrefixFromIPNet(cidr)}
+		b := model.AllocationBlock{
+			CIDR:        cidr,
+			Affinity:    &aff,
+			Allocations: []*int{&idx, nil, nil, nil},
+			Unallocated: []int{1, 2, 3},
+			Attributes: []model.AllocationAttribute{
+				{
+					HandleID: &handle,
+					ActiveOwnerAttrs: map[string]string{
+						ipam.AttributeNode:      "cnode-a2",
+						ipam.AttributePod:       pod.Name,
+						ipam.AttributeNamespace: pod.Namespace,
+					},
+				},
+			},
+		}
+		kvp := model.KVPair{Key: key, Value: &b}
+		update := bapi.Update{KVPair: kvp, UpdateType: bapi.UpdateTypeKVNew}
+		c.onUpdate(update)
+
+		c.Start(stopChan)
+
+		blockCIDR := kvp.Key.(model.BlockKey).CIDR.String()
+		Eventually(func() bool {
+			done := c.pause()
+			defer done()
+			_, ok := c.allBlocks[blockCIDR]
+			return ok
+		}, 1*time.Second, 100*time.Millisecond).Should(BeTrue())
+
+		c.onStatusUpdate(bapi.InSync)
+
+		fakeClient := cli.IPAM().(*fakeIPAMClient)
+		// No IP evidence exists yet, and the node mismatches - the fast-path leak signal should
+		// still fire and release the allocation once the grace period elapses.
+		Eventually(func() bool {
+			return fakeClient.handlesReleased[handle]
+		}, assertionTimeout, 100*time.Millisecond).Should(BeTrue())
+	})
+
+	It("should GC an allocation whose recorded node mismatches the pod's node, when the pod has a different IP", func() {
+		// Exercises the fallthrough branch of the #12257 fix: the node mismatch is real
+		// corroborating evidence once the pod's reported IP genuinely doesn't match the
+		// allocation, and the allocation must still be released.
+
+		n := internalapi.Node{}
+		n.Name = "cnode-a3"
+		n.Spec.OrchRefs = []internalapi.OrchRef{{NodeName: "kname-a3", Orchestrator: apiv3.OrchestratorKubernetes}}
+		_, err := cli.Nodes().Create(context.TODO(), &n, options.SetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		kn := v1.Node{}
+		kn.Name = "kname-a3"
+		_, err = cs.CoreV1().Nodes().Create(context.TODO(), &kn, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		var node *v1.Node
+		Eventually(nodes).WithTimeout(time.Second).Should(Receive(&node))
+
+		knB := v1.Node{}
+		knB.Name = "kname-b3"
+		_, err = cs.CoreV1().Nodes().Create(context.TODO(), &knB, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		Eventually(nodes).WithTimeout(time.Second).Should(Receive(&node))
+
+		// Pod is on the other node, running, but with an IP that doesn't match the allocation -
+		// unlike the "stale node attribute" test, this is a genuine leak.
+		pod := v1.Pod{}
+		pod.Name = "test-pod-stale-node-diff-ip"
+		pod.Namespace = "test-namespace"
+		pod.Spec.NodeName = "kname-b3"
+		pod.Status.PodIP = "10.0.2.5"
+		pod.Status.PodIPs = []v1.PodIP{{IP: "10.0.2.5"}}
+		pod.Status.Phase = v1.PodRunning
+		_, err = createPod(context.TODO(), cs, &pod)
+		Expect(err).NotTo(HaveOccurred())
+		var gotPod *v1.Pod
+		Eventually(pods).WithTimeout(time.Second).Should(Receive(&gotPod))
+
+		idx := 0
+		handle := "test-handle-stale-node-diff-ip"
+		cidr := net.MustParseCIDR("10.0.2.0/30")
+		aff := "host:cnode-a3"
+		key := model.BlockKey{CIDR: model.PrefixFromIPNet(cidr)}
+		b := model.AllocationBlock{
+			CIDR:        cidr,
+			Affinity:    &aff,
+			Allocations: []*int{&idx, nil, nil, nil},
+			Unallocated: []int{1, 2, 3},
+			Attributes: []model.AllocationAttribute{
+				{
+					HandleID: &handle,
+					ActiveOwnerAttrs: map[string]string{
+						ipam.AttributeNode:      "cnode-a3",
+						ipam.AttributePod:       pod.Name,
+						ipam.AttributeNamespace: pod.Namespace,
+					},
+				},
+			},
+		}
+		kvp := model.KVPair{Key: key, Value: &b}
+		update := bapi.Update{KVPair: kvp, UpdateType: bapi.UpdateTypeKVNew}
+		c.onUpdate(update)
+
+		c.Start(stopChan)
+
+		blockCIDR := kvp.Key.(model.BlockKey).CIDR.String()
+		Eventually(func() bool {
+			done := c.pause()
+			defer done()
+			_, ok := c.allBlocks[blockCIDR]
+			return ok
+		}, 1*time.Second, 100*time.Millisecond).Should(BeTrue())
+
+		c.onStatusUpdate(bapi.InSync)
+
+		fakeClient := cli.IPAM().(*fakeIPAMClient)
+		// Neither the node nor the IP match - this is a genuine leak, and must still be released.
+		Eventually(func() bool {
+			return fakeClient.handlesReleased[handle]
+		}, assertionTimeout, 100*time.Millisecond).Should(BeTrue())
+	})
+
 	It("should handle blocks losing their affinity", func() {
 		// Create Calico and k8s nodes for the test.
 		n := internalapi.Node{}

--- a/kube-controllers/pkg/controllers/node/kdd_ipam_gc_fv_test.go
+++ b/kube-controllers/pkg/controllers/node/kdd_ipam_gc_fv_test.go
@@ -574,6 +574,150 @@ var _ = Describe("IPAM garbage collection FV tests with short leak grace period"
 			return nil
 		}, time.Minute, retryInterval).Should(BeNil())
 	})
+
+	It("should NOT garbage collect a valid IP address when the allocation's recorded node is stale (issue #12257)", func() {
+		// The CNI plugin can stamp the wrong node into an allocation's attrs["node"] at ADD time
+		// (e.g. a stale on-disk CNI config left behind by a previous node identity), even though
+		// the pod itself is placed correctly and genuinely holds the IP it was given. A node
+		// mismatch alone must not be treated as proof the pod was rescheduled.
+		var err error
+		nodeB := "node-b"
+		By("creating a second node to reschedule the pod onto", func() {
+			_, err = k8sClient.CoreV1().Nodes().Create(context.Background(),
+				&v1.Node{
+					TypeMeta:   metav1.TypeMeta{Kind: "Node", APIVersion: "v1"},
+					ObjectMeta: metav1.ObjectMeta{Name: nodeB},
+					Spec:       v1.NodeSpec{},
+				},
+				metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		handleStaleNodeValidIP := "handle-stale-node-valid-ip"
+		By("allocating an IP with a node attribute that will turn out to be stale", func() {
+			attrs := map[string]string{"node": nodeA, "pod": "pod-stale-node", "namespace": "default"}
+			err = calicoClient.IPAM().AssignIP(context.Background(), ipam.AssignIPArgs{
+				IP: net.MustParseIP("192.168.0.5"), HandleID: &handleStaleNodeValidIP, Attrs: attrs, Hostname: nodeA,
+			})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		var pod *v1.Pod
+		By("creating a Pod that is actually scheduled on the other node", func() {
+			pod = &v1.Pod{
+				TypeMeta:   metav1.TypeMeta{Kind: "Pod", APIVersion: "v1"},
+				ObjectMeta: metav1.ObjectMeta{Name: "pod-stale-node", Namespace: "default"},
+				Spec: v1.PodSpec{
+					NodeName: nodeB,
+					Containers: []v1.Container{
+						{
+							Name:    "container1",
+							Image:   "busybox",
+							Command: []string{"sleep", "3600"},
+						},
+					},
+				},
+			}
+			pod, err = k8sClient.CoreV1().Pods("default").Create(context.Background(), pod, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		By("updating the Pod to be running with the IP it was actually allocated", func() {
+			pod.Status.PodIP = "192.168.0.5"
+			pod.Status.Phase = v1.PodRunning
+			_, err = k8sClient.CoreV1().Pods("default").UpdateStatus(context.Background(), pod, metav1.UpdateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		blocks, err := bc.List(context.Background(), model.BlockListOptions{}, "")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(len(blocks.KVPairs)).To(Equal(1))
+		affs, err := bc.List(context.Background(), model.BlockAffinityListOptions{Host: nodeA, AffinityType: string(ipam.AffinityTypeHost)}, "")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(len(affs.KVPairs)).To(Equal(1))
+
+		// The allocation's recorded node no longer matches the pod's real node, but the pod is
+		// genuinely running with this IP - it must survive every scan.
+		Consistently(func() error {
+			if err := assertIPsWithHandle(calicoClient.IPAM(), handleStaleNodeValidIP, 1); err != nil {
+				return err
+			}
+			if err := assertNumBlocks(bc, 1); err != nil {
+				return err
+			}
+			return nil
+		}, consistentlyTimeout, consistentlyInterval).Should(BeNil())
+	})
+
+	It("should GC an allocation whose recorded node mismatches the pod's node, if the pod has not yet reported an IP", func() {
+		// Guards the other half of the #12257 fix: a pod that has genuinely moved to a new node
+		// and hasn't been given an IP yet must still fast-path the old allocation as leaked,
+		// rather than waiting indefinitely on an IP report that will never match.
+		var err error
+		nodeB := "node-b"
+		By("creating a second node to reschedule the pod onto", func() {
+			_, err = k8sClient.CoreV1().Nodes().Create(context.Background(),
+				&v1.Node{
+					TypeMeta:   metav1.TypeMeta{Kind: "Node", APIVersion: "v1"},
+					ObjectMeta: metav1.ObjectMeta{Name: nodeB},
+					Spec:       v1.NodeSpec{},
+				},
+				metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		handleStaleNodeNoIP := "handle-stale-node-no-ip"
+		By("allocating an IP that will be superseded by a fresh pod on a different node", func() {
+			attrs := map[string]string{"node": nodeA, "pod": "pod-stale-node-no-ip", "namespace": "default"}
+			err = calicoClient.IPAM().AssignIP(context.Background(), ipam.AssignIPArgs{
+				IP: net.MustParseIP("192.168.0.6"), HandleID: &handleStaleNodeNoIP, Attrs: attrs, Hostname: nodeA,
+			})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		By("creating a Pod of the same name/namespace on the other node, without an IP yet", func() {
+			// Simulates the pod having been deleted and recreated fresh on a different node: the
+			// new pod instance hasn't been given an IP by kubelet yet, so there's no IP evidence to
+			// check - the stale allocation should still be recognized as no-longer-valid via the
+			// node mismatch.
+			pod := &v1.Pod{
+				TypeMeta:   metav1.TypeMeta{Kind: "Pod", APIVersion: "v1"},
+				ObjectMeta: metav1.ObjectMeta{Name: "pod-stale-node-no-ip", Namespace: "default"},
+				Spec: v1.PodSpec{
+					NodeName: nodeB,
+					Containers: []v1.Container{
+						{
+							Name:    "container1",
+							Image:   "busybox",
+							Command: []string{"sleep", "3600"},
+						},
+					},
+				},
+			}
+			_, err = k8sClient.CoreV1().Pods("default").Create(context.Background(), pod, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		blocks, err := bc.List(context.Background(), model.BlockListOptions{}, "")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(len(blocks.KVPairs)).To(Equal(1))
+		affs, err := bc.List(context.Background(), model.BlockAffinityListOptions{Host: nodeA, AffinityType: string(ipam.AffinityTypeHost)}, "")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(len(affs.KVPairs)).To(Equal(1))
+
+		// Eventually the stale allocation will be GC'd, since there's no IP evidence to save it
+		// and the node mismatch is the only signal available. The block itself remains (it's
+		// node A's only block).
+		Eventually(func() error {
+			if err := assertIPsWithHandle(calicoClient.IPAM(), handleStaleNodeNoIP, 0); err != nil {
+				return err
+			}
+			if err := assertNumBlocks(bc, 1); err != nil {
+				return err
+			}
+			return nil
+		}, time.Minute, retryInterval).Should(BeNil())
+	})
 })
 
 var _ = Describe("IPAM garbage collection FV tests with long leak grace period", Ordered, ContinueOnFailure, func() {


### PR DESCRIPTION
Fixes a bug where kube-controllers' IPAM garbage collector could release an IP address that a Pod was still actively using, opening the door to duplicate Pod IPs.

## What was happening

The CNI plugin can record the wrong node into an IPAM allocation's `attrs["node"]` at ADD time — e.g. a stale on-disk CNI config surviving a node re-image, still carrying a previous node's identity. The Pod itself is placed correctly and keeps a real, working IP; the bug is pure bookkeeping.

`allocationIsValid()` in kube-controllers treated any mismatch between the allocation's recorded node and `Pod.Spec.NodeName` as proof the Pod had been rescheduled, and released the allocation — even when the Pod was still genuinely running with that exact IP. `leakGracePeriod` later, the address is handed back to the pool while a live Pod is still using it, and a second Pod can be assigned the same address.

Reproduced end-to-end on a real 2-node cluster: corrupted a node's CNI conflist to record a different (but real) node, triggered a genuine CNI ADD, and watched kube-controllers log `Pod rescheduled on new node. Allocation no longer valid` → `Confirmed IP leak` → `Successfully garbage collected leaked IP address` for an allocation whose Pod was still `Running` on that exact IP the whole time.

## Fix

Check the Pod's reported IP against the allocation before trusting the node comparison. A node mismatch is now only used as a fast leak signal in the window *before* the Pod has reported an IP (protecting the case of a Pod genuinely recreated on a new node, not yet given an address — a case `design/ipam/ipam-gc.md`'s existing review notes already call out as needing care). Once an IP is reported, only the IP match against the Pod's WorkloadEndpoint determines validity.

`design/ipam/ipam-gc.md` updated to reflect the new invariant.

**Scope:** this closes the duplicate-IP path described in #12257 regardless of how the allocation's node attribute went stale in the first place. It doesn't address *why* the CNI plugin can record the wrong node at ADD time in the first place — that's a distinct root cause with its own fix, which will be tracked in a separate issue rather than kept open here.

## Testing

- 3 new unit tests in `kube-controllers/pkg/controllers/node/ipam_test.go`: node-mismatch with a matching reported IP (the bug), node-mismatch with no IP reported yet (the protected fast-path), node-mismatch with a genuinely different reported IP (still correctly GC'd).
- 2 new FV tests in `kube-controllers/pkg/controllers/node/kdd_ipam_gc_fv_test.go` covering the primary scenarios against a real etcd/apiserver/kube-controllers.

Fixes #12257

**Release note:**
```release-note
Fixed a bug where kube-controllers could garbage-collect (release) an IP address that a Pod was still actively using, if the CNI plugin had recorded the wrong node for that allocation (e.g. a stale on-disk CNI identity surviving a node re-image). This could result in the same IP address being assigned to two Pods.
```
