### PR TITLE
Retry the controller-tools download in the calico-controller-gen build

### DIFF
--- a/hack/cmd/calico-controller-gen/build.sh
+++ b/hack/cmd/calico-controller-gen/build.sh
@@ -62,7 +62,6 @@ TARBALL=$(mktemp)
 trap 'rm -rf "$SRC" "$TARBALL"' EXIT
 
 echo "Fetching controller-tools $VERSION ..."
-# Not piped into tar, so curl can retry and report GitHub archive download failures.
 curl -fL --retry 5 --retry-all-errors --silent --show-error -o "$TARBALL" \
     "https://github.com/kubernetes-sigs/controller-tools/archive/refs/tags/${VERSION}.tar.gz"
 tar xzf "$TARBALL" --strip-components 1 -C "$SRC"

--- a/hack/cmd/calico-controller-gen/build.sh
+++ b/hack/cmd/calico-controller-gen/build.sh
@@ -58,11 +58,14 @@ fi
 mkdir -p "$(dirname "$OUT")"
 
 SRC=$(mktemp -d)
-trap 'rm -rf "$SRC"' EXIT
+TARBALL=$(mktemp)
+trap 'rm -rf "$SRC" "$TARBALL"' EXIT
 
 echo "Fetching controller-tools $VERSION ..."
-curl -sfL "https://github.com/kubernetes-sigs/controller-tools/archive/refs/tags/${VERSION}.tar.gz" \
-    | tar xz --strip-components 1 -C "$SRC"
+# Not piped into tar, so curl can retry and report GitHub archive download failures.
+curl -fL --retry 5 --retry-all-errors --silent --show-error -o "$TARBALL" \
+    "https://github.com/kubernetes-sigs/controller-tools/archive/refs/tags/${VERSION}.tar.gz"
+tar xzf "$TARBALL" --strip-components 1 -C "$SRC"
 
 for p in "$SCRIPT_DIR"/*.patch; do
     echo "Applying $(basename "$p") ..."


### PR DESCRIPTION
The Calico-patched controller-gen build pipes curl straight into tar, so curl can't retry and its exit code is lost (the script is `sh` with no `pipefail`). During the GitHub archive outage today this failed the manifests check with `gzip: stdin: unexpected end of file` and no mention of the download.

Downloads to a file first with `--retry 5 --retry-all-errors`, matching how the bird tarball is fetched in `node/Makefile`.

**Release note:**
```release-note
None
```
