### PR TITLE
fix(manifests): version the calico image in static manifests

### DIFF
--- a/manifests/calicoctl-etcd.yaml
+++ b/manifests/calicoctl-etcd.yaml
@@ -1,7 +1,7 @@
 # Calico Version master
 # https://projectcalico.docs.tigera.io/releases#master
 # This manifest includes the following component versions:
-#   calico/ctl:master
+#   calico/calico:master
 
 apiVersion: v1
 kind: Pod
@@ -14,9 +14,9 @@ spec:
   hostNetwork: true
   containers:
     - name: calicoctl
-      image: quay.io/calico/ctl:master
+      image: quay.io/calico/calico:master
       command:
-        - calicoctl
+        - /usr/bin/calicoctl
       args:
         - version
         - --poll=1m

--- a/manifests/generate.sh
+++ b/manifests/generate.sh
@@ -190,8 +190,11 @@ echo "Replacing image versions for static manifests"
 for img in $NON_HELM_MANIFEST_IMAGES; do
   new_img=${REGISTRY}/${img}
   echo "Update $img image to $new_img:$CALICO_VERSION"
-  find . -type f -exec sed -i "s|image: [a-zA-Z0-9/._-]*/${img}:[A-Za-z0-9_.-]*|image: ${new_img}:$CALICO_VERSION|g" {} \;
+  find . -type f -exec sed -i "s|image: [a-zA-Z0-9/._:-]*/${img}:[A-Za-z0-9_.-]*|image: ${new_img}:$CALICO_VERSION|g" {} \;
 done
 
-# Version the component list in manifest header comments, which carry no "image:" prefix.
-find . -type f -name "*.yaml" -exec sed -i -E "s|^(#[[:space:]]+)calico/calico:[A-Za-z0-9_.-]*|\1calico/calico:$CALICO_VERSION|g" {} \;
+# Version the manifest header comments, which carry no "image:" prefix.
+find . -type f -name "*.yaml" -exec sed -i -E \
+  -e "s|^(#[[:space:]]+)calico/calico:[A-Za-z0-9_.-]*|\1calico/calico:$CALICO_VERSION|g" \
+  -e "s|^(#[[:space:]]*Calico Version[[:space:]]+)[A-Za-z0-9_.-]*|\1$CALICO_VERSION|g" \
+  -e "s|^(#[[:space:]]*https://\S*/releases#)[A-Za-z0-9_.-]*|\1$CALICO_VERSION|g" {} \;

--- a/manifests/generate.sh
+++ b/manifests/generate.sh
@@ -44,7 +44,7 @@ OPERATOR_REGISTRY=${OPERATOR_REGISTRY_OVERRIDE:-$defaultOperatorRegistry}
 defaultOperatorImage=$($YQ .tigeraOperator.image <../charts/tigera-operator/values.yaml)
 OPERATOR_IMAGE=${OPERATOR_IMAGE_OVERRIDE:-$defaultOperatorImage}
 
-NON_HELM_MANIFEST_IMAGES="node-windows"
+NON_HELM_MANIFEST_IMAGES="node-windows calico"
 
 echo "Generating manifests for Calico=$CALICO_VERSION and tigera-operator=$OPERATOR_VERSION"
 
@@ -192,3 +192,6 @@ for img in $NON_HELM_MANIFEST_IMAGES; do
   echo "Update $img image to $new_img:$CALICO_VERSION"
   find . -type f -exec sed -i "s|image: [a-zA-Z0-9/._-]*/${img}:[A-Za-z0-9_.-]*|image: ${new_img}:$CALICO_VERSION|g" {} \;
 done
+
+# Version the component list in manifest header comments, which carry no "image:" prefix.
+find . -type f -name "*.yaml" -exec sed -i -E "s|^(#[[:space:]]+)calico/calico:[A-Za-z0-9_.-]*|\1calico/calico:$CALICO_VERSION|g" {} \;


### PR DESCRIPTION
Static manifests that Helm doesn't render kept their image tag at `master` instead of the release version. Consolidating the components into one `calico` image left no image name for the version-substitution step to match, so `calicoctl.yaml`, `calicoctl-etcd.yaml`, `apiserver.yaml` and `csi-driver.yaml` stopped getting stamped. Add `calico` to the substitution list and version the header comments too. `calicoctl-etcd.yaml` also referenced `calico/ctl`, which is no longer built, so it now uses the `calico` image and the same `/usr/bin/calicoctl` command as `calicoctl.yaml`.

**Release note:**
```release-note
TBD
```
