### PR TITLE
docs: make the design-doc update rule terse and default to no edit

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -141,11 +141,32 @@ every matching sub-design.
 1. Before writing or reviewing code in a component, read that component's
    `DESIGN.md` (or, for Felix, the sub-designs matching the paths you touch).
 2. Follow links. A design is a graph, not a single node.
-3. A PR that changes how a component works — its behaviour, data model,
-   configuration surface, or any invariant the design records — must update the
-   relevant `DESIGN.md` in the same PR. Exemptions: bug fix restoring documented
-   behaviour, mechanical refactor, comment or log-message edits, dependency
-   bumps. If in doubt, update the doc.
+3. A design doc records the design, not the change that introduced it, and
+   **the default is no edit**. Edit one only when a sentence in it is now
+   false, a new invariant exists that a future change could silently break, or
+   a new concept exists that the doc's mental model does not name. A new
+   behaviour, flag, field, config key, or bug fix is not by itself any of
+   those. A warranted edit lands **in the same PR as the code**, in the doc
+   covering the area — for Felix, the matching sub-design, not the index.
+4. A warranted edit is normally **one to three lines**, into the section that
+   already covers the area — never a paraphrase of the commit message or PR
+   description, and no new `###` heading for a new behaviour. Past about five
+   lines you are narrating the change. A doc already past ~500 lines gets
+   compressed by the next PR that touches it, not grown.
+5. **In doubt, propose — don't write.** Keep the edit out of the PR: show the
+   user the target file, the target section and the exact lines, and wait for
+   approval. Raise it at the pre-commit checkpoint, batched into a single ask,
+   so it never blocks the code work. When one of the three conditions in rule 3
+   clearly holds, just make the edit.
+6. Before writing or reviewing a design-doc edit, load the
+   [`design-doc-edits`](skills/design-doc-edits/SKILL.md) skill — the altitude
+   rule, the worked example and the reviewer criteria are there rather than
+   here, so they are not in context for every session.
+
+Rules 3-5 are mirrored for Copilot in
+[`.github/copilot-instructions.md` → Documentation map](../.github/copilot-instructions.md)
+— keep the two in sync. Copilot has no skills, so rule 6's content is a file it
+reads rather than a skill it loads.
 
 ## Tests required for code changes
 

--- a/.claude/skills/design-doc-edits/SKILL.md
+++ b/.claude/skills/design-doc-edits/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: design-doc-edits
+description: Write or review an edit to a DESIGN.md — the altitude to write at, a worked example of an edit that was 34 lines too long, and the criteria for reviewing a design-doc diff. Use when about to add or change prose in any DESIGN.md or design/ sub-design, when reviewing a design-doc diff, or when compressing a design doc that has grown too large.
+---
+
+# Editing a design doc
+
+Whether an edit is warranted at all, and the size budget for one, are in
+[`.claude/CLAUDE.md` → Documentation map](../../CLAUDE.md): the default is no
+edit; a warranted one is one to three lines in the same PR as the code. This
+skill is the rest — how to write those lines, and how to review someone else's.
+
+## Who you are writing for
+
+Someone who has never seen your diff and has to make the *next* change safely.
+The doc records what the code promises: the mental model, the invariants, the
+concepts and where their boundaries are.
+
+The story of *your* change — the bug, the old behaviour, why it broke, what you
+tried — belongs in the commit message and the PR description, which is where git
+already keeps it. **Never copy or paraphrase either into a design doc.** Same
+rule the repo applies to code comments: write for a reader with no diff in front
+of them.
+
+## Altitude
+
+Write what stays true after a rename or a refactor.
+
+- State the invariant, not the mechanism that currently enforces it.
+- Name identifiers, functions and files as **one orientation pointer per
+  concept**, not as a description of the plumbing.
+- If a sentence would need editing when somebody renames a variable, it is too
+  low.
+
+## Worked example
+
+A change taught Felix's BPF service syncer to keep the `default/kubernetes`
+backend rather than let it drop to zero. It added 34 lines to
+[`felix/design/bpf-services.md`](../../../felix/design/bpf-services.md) under a
+new `### API server service: never drop to zero backends` heading, re-telling
+the commit message ("This creates a hazard the generic kube-proxy model doesn't
+have…", "The deadlock is therefore unique to bootstrap mode") and naming three
+internal identifiers.
+
+The durable content was one bullet, in the invariant list that was already
+there:
+
+> - The `default/kubernetes` service keeps its last-known-good backend instead
+>   of dropping to zero: under `bpfNetworkBootstrap` Felix reaches the API
+>   server through this NAT entry, so an empty backend list is self-severing.
+>   Its backend is the control-plane host IP, stable across such an outage, so
+>   retaining it is safe. Every other service still drops to zero.
+
+A new invariant, stated in one sentence, in the section that already covered the
+area, at an altitude that survives a rename.
+
+## Reviewing a design-doc diff
+
+- Reject prose that reads like the commit message or the PR description.
+- Reject a new heading added for a single fix, and additions where a sentence
+  already in the doc covers the area.
+- Check the altitude: a paragraph that walks through identifiers is describing
+  the plumbing, and the code already does that.
+- A missing doc update that the author explicitly considered and skipped is
+  **not** a blocker on its own.
+
+## Compressing an oversized doc
+
+A file past ~500 lines should be compressed by the next PR that touches it,
+rather than grown. Compress by category, not by feel:
+
+- change narration — the bug, the incident, "this used to", "was measured";
+- claims made twice, usually once in prose and once in a review note;
+- plumbing enumeration the code already states;
+- editorial framing addressed at a reviewer ("worth flagging for readers").
+
+Keep every invariant, review note and data-model statement. If a cut removes a
+rule rather than the story around it, it is the wrong cut.
+
+## Not covered here
+
+User-facing install and upgrade instructions — the chart READMEs — are **not**
+design docs; see
+[`helm-charts.instructions.md`](../../../.github/instructions/helm-charts.instructions.md).
+They must track every documented step, and there the safe default is the
+opposite one: update.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -262,16 +262,33 @@ for architecture in `CLAUDE.md`.
   (the update rule, the `@copilot` invocation pattern). They do
   not restate design content — always read the pointed-at
   `DESIGN.md`.
-- A PR changing how a component works — its behaviour, data
-  model, configuration surface, or any invariant the design doc
-  records — must update the relevant `DESIGN.md` in the same PR.
-  For components with a design directory (Felix uses
-  `felix/design/`), this means updating the relevant file under
-  that directory — the sub-design covering the area — and/or
-  the index itself when the sub-design table or scope changes.
-  Exemptions: bug fix restoring documented behaviour, mechanical
-  refactor, comment/log edits, dependency bump. If in doubt,
-  update the doc.
+A design doc records the design, not the change that introduced
+it, and **the default is no edit**. Edit one only when a sentence
+in it is now false, a new invariant exists that a future change
+could silently break, or a new concept exists that the doc's
+mental model does not name. A new behaviour, flag, field, config
+key, or bug fix is not by itself any of those. A warranted edit
+lands **in the same PR as the code**, not in a follow-up, and is
+normally **one to three lines** in the section that already covers
+the area — not a new heading, and never a paraphrase of the commit
+message. For components with a design directory (Felix uses
+`felix/design/`), it goes in the sub-design covering the area, and
+in the index only when the sub-design table or scope changes.
+
+**If in doubt, make no change** — name what you considered and
+skipped in the PR description so a reviewer can ask for it. (The
+Copilot coding agent and automated review have no interactive
+user; a human-driven agent proposes the edit and waits for
+approval instead.) A missing doc update the author explicitly
+considered and skipped is not a review blocker on its own.
+
+This rule mirrors
+[`.claude/CLAUDE.md` → Documentation map](../.claude/CLAUDE.md) —
+keep the two in sync. The altitude rule, a worked example and the
+reviewer-side criteria are in
+[`.claude/skills/design-doc-edits/SKILL.md`](../.claude/skills/design-doc-edits/SKILL.md);
+read it before editing a design doc or reviewing a design-doc
+diff.
 
 ## Tests required for code changes
 
@@ -291,11 +308,11 @@ Per-area sub-designs carry the area-specific test conventions on top of this gen
 
 The eBPF dataplane design is split across the `bpf-*.md` files under [`felix/design/`](../felix/design/), with [`bpf-overview.md`](../felix/design/bpf-overview.md) as the always-pulled umbrella (packet-path mental model, fast-path cost rule, cross-cutting review rules) and topic-specific sub-designs covering each area of the dataplane. See [`felix/DESIGN.md`](../felix/DESIGN.md) for the authoritative table mapping code paths to sub-design files.
 
-Path-specific reviewer rules live in [`.github/instructions/bpf.instructions.md`](instructions/bpf.instructions.md) — a single thin pointer that scopes to all BPF paths and directs the agent to load the matching sub-design(s) from [`felix/DESIGN.md`](../felix/DESIGN.md)'s topic table, with `bpf-overview.md` as the always-read companion. The doc-update rule above applies; for BPF, "changes how it works" specifically means a new sub-program, CT flag, mark bit, map or map field, or any change to the packet path or forwarding decision.
+Path-specific reviewer rules live in [`.github/instructions/bpf.instructions.md`](instructions/bpf.instructions.md) — a single thin pointer that scopes to all BPF paths and directs the agent to load the matching sub-design(s) from [`felix/DESIGN.md`](../felix/DESIGN.md)'s topic table, with `bpf-overview.md` as the always-read companion. The doc-update rule above applies. For BPF, the changes that usually earn a doc edit are a new sub-program, CT flag, mark bit, map or map field, or a change to the packet path or forwarding decision — candidates for the test above, not triggers on their own.
 
 ## Helm Chart Review
 
-The user-facing install and upgrade instructions are hand-written READMEs ([`charts/tigera-operator/README.md`](../charts/tigera-operator/README.md) and [`charts/crd.projectcalico.org.v1/README.md`](../charts/crd.projectcalico.org.v1/README.md)), not generated, so they drift silently when a chart change alters the steps a user has to run. [`.github/instructions/helm-charts.instructions.md`](instructions/helm-charts.instructions.md) scopes to `charts/**` and directs the reviewer to cross-check those READMEs against the change. The doc-update rule above applies; for charts, "changes how it works" means anything that alters how a user installs or upgrades Calico via Helm — moving resources between charts (CRDs especially), adding or removing a manual step, renaming a chart, or changing a documented values key or example command.
+The user-facing install and upgrade instructions are hand-written READMEs ([`charts/tigera-operator/README.md`](../charts/tigera-operator/README.md) and [`charts/crd.projectcalico.org.v1/README.md`](../charts/crd.projectcalico.org.v1/README.md)), not generated, so they drift silently when a chart change alters the steps a user has to run. [`.github/instructions/helm-charts.instructions.md`](instructions/helm-charts.instructions.md) scopes to `charts/**` and directs the reviewer to cross-check those READMEs against the change. These READMEs are **user-facing documentation, not design docs**, so the design-doc rule above — with its default of no edit — does not apply to them: a chart change that alters how a user installs or upgrades Calico must update them, and there the safe default is to update. That covers moving resources between charts (CRDs especially), adding or removing a manual step, renaming a chart, and changing a documented values key or example command.
 
 `charts/calico` is the exception, and it is exempt: nobody installs it with Helm. It is only the template source that `make gen-manifests` renders into `manifests/calico*.yaml`, so the rendered manifests are the whole contract - no Helm upgrade path, no install docs to sync. Review such a PR by reading the regenerated `manifests/` diff. Its `values.yaml` keys are an internal interface rather than a user-facing one: renaming one is fine, but the same PR has to update the in-repo consumers (`manifests/generate.sh`, the root `Makefile`, `hack/check-images-availability.sh`, and the overlays in `charts/values/`).
 

--- a/.github/instructions/bpf.instructions.md
+++ b/.github/instructions/bpf.instructions.md
@@ -43,15 +43,15 @@ and external resources. Follow the links.
 
 ## Update rule
 
-The repo-wide doc-update rule
+The repo-wide rule
 ([`.github/copilot-instructions.md` → Documentation map](../copilot-instructions.md),
-mirrored in
-[`.claude/CLAUDE.md`](../../.claude/CLAUDE.md)) applies. For the
-BPF dataplane, "changes how it works" means a new sub-program,
-CT flag, mark bit, map or map field, or any change to the packet
-path or forwarding decision. The relevant section of the matching
+mirrored in [`.claude/CLAUDE.md`](../../.claude/CLAUDE.md)) applies;
+**the default is no edit**. In the BPF dataplane the usual candidates
+for it are a new sub-program, CT flag, mark bit, map or map field, or
+a change to the packet path or forwarding decision — candidates, not
+triggers on their own. A warranted edit goes in the matching
 sub-design (and `bpf-overview.md` if cross-cutting content is
-affected) must be updated in the same PR.
+affected) in the same PR.
 
 ## Amending the PR
 
@@ -59,10 +59,10 @@ The Copilot automated code-review step is read-only with respect
 to the PR branch — it cannot push the doc amendment itself. When
 the review flags a missing update per the rule above, its comment
 should include a ready-to-paste `@copilot` prompt naming the
-sub-design, the section, and the new invariant or mechanic, for
-example:
+sub-design, the section, and the one invariant to state — not a
+list of mechanics to describe. For example:
 
-> `@copilot update felix/design/bpf-conntrack-flowstate.md "Conntrack & cleanup" to cover the new CT flag CALI_CT_FLAG_FOO — the fields it uses, where it is set, how it interacts with the fast path.`
+> `@copilot update felix/design/bpf-conntrack-flowstate.md "Conntrack & cleanup": state in one sentence the invariant CALI_CT_FLAG_FOO introduces. Edit the existing prose in that section; do not add a heading, and do not restate the commit message.`
 
 The reviewer (or author) drops that into a new PR comment; the
 Copilot coding agent picks it up and pushes a commit with the

--- a/.github/instructions/calc-graph.instructions.md
+++ b/.github/instructions/calc-graph.instructions.md
@@ -40,17 +40,19 @@ resources.
 
 ## Doc update rule
 
-The repo-wide doc-update rule and its exemptions
+The repo-wide rule
 ([`.github/copilot-instructions.md` → Documentation map](../copilot-instructions.md),
-mirrored in [`.claude/CLAUDE.md`](../../.claude/CLAUDE.md)) apply.
-For the calc graph, "changes how it works" means: a new calculation
-node or rewiring; a new emitted message type or a change to the
-`EventSequencer` flush order; a change to a label index or other
-refcounting structure; or a change to how the graph treats
-inconsistency, in-sync, or the upstream contract. Update the
-relevant section of
-[`calc-graph.md`](../../felix/design/calc-graph.md) in the same PR
-(and `dataplane.md` if the output contract changes), and update the
-hand-maintained node diagram in
+mirrored in [`.claude/CLAUDE.md`](../../.claude/CLAUDE.md)) applies;
+**the default is no edit**. For the calc graph the usual candidates
+for it are a new node or rewiring, a new emitted message type or a
+change to the `EventSequencer` flush order, a change to a label index
+or other refcounting structure, or a change to how the graph treats
+inconsistency, in-sync, or the upstream contract — candidates, not
+triggers on their own. A warranted edit goes in
+[`calc-graph.md`](../../felix/design/calc-graph.md) in the same PR,
+and in `dataplane.md` too if the output contract changes.
+
+The hand-maintained node diagram in
 [`felix/docs/calc-graph-diagram.md`](../../felix/docs/calc-graph-diagram.md)
-when you add or rewire a node.
+is a separate case: it must be updated whenever you add or rewire a
+node, since it is a picture of the wiring rather than prose about it.

--- a/.github/instructions/cluster-route-programming.instructions.md
+++ b/.github/instructions/cluster-route-programming.instructions.md
@@ -36,15 +36,12 @@ both.
 
 ## Update rule
 
-A PR that **changes how cluster routes are programmed** — which
-component owns which encapsulation type, the enum values or
-defaults of either `programClusterRoutes` field, the BIRD
-kernel-programming filter, or the deprecation and removal plan —
-must update `design/cluster-route-programming/DESIGN.md` in the
-same PR.
-
-**Exemption.** No doc update is needed if the PR is exclusively
-one of: (a) a bug fix that restores behavior the doc already
-describes, (b) a mechanical refactor with no observable change,
-(c) comment / log-message edits, (d) a dependency bump. If in
-doubt, update the doc.
+The repo-wide rule
+([`.github/copilot-instructions.md` → Documentation map](../copilot-instructions.md),
+mirrored in [`.claude/CLAUDE.md`](../../.claude/CLAUDE.md)) applies;
+**the default is no edit**. Here the usual candidates for it are a
+change to which component owns which encapsulation type, to the enum
+values or defaults of either `programClusterRoutes` field, to the BIRD
+kernel-programming filter, or to the deprecation and removal plan —
+candidates, not triggers on their own. A warranted edit goes in
+`design/cluster-route-programming/DESIGN.md` in the same PR.

--- a/.github/instructions/dataplane.instructions.md
+++ b/.github/instructions/dataplane.instructions.md
@@ -62,16 +62,17 @@ the design is a graph.
 
 ## Doc update rule
 
-The repo-wide doc-update rule and its exemptions
+The repo-wide rule
 ([`.github/copilot-instructions.md` → Documentation map](../copilot-instructions.md),
-mirrored in [`.claude/CLAUDE.md`](../../.claude/CLAUDE.md)) apply.
-For the Linux dataplane, "changes how it works" means: a new manager
-or driver, or a change to the manager/driver split; a change to the
-`apply()` ordering or the `OnUpdate`/`CompleteDeferredWork`
-contract; a new kind of kernel resource or a change to how Calico
-resources are identified for resync; a change to `*tables` Table
-reconciliation, dispatch-chain structure, mark-bit allocation,
-IP-set ordering, or route ownership classification; or a change to
-the `proto.*` dataplane API. Update the relevant section of
-[`dataplane.md`](../../felix/design/dataplane.md) in the same PR
-(and `calc-graph.md` if the proto contract changes).
+mirrored in [`.claude/CLAUDE.md`](../../.claude/CLAUDE.md)) applies;
+**the default is no edit**. For the Linux dataplane the usual
+candidates for it are a new manager or driver or a change to the
+manager/driver split; a change to the `apply()` ordering or the
+`OnUpdate`/`CompleteDeferredWork` contract; a new kind of kernel
+resource or a change to how Calico resources are identified for
+resync; a change to `*tables` Table reconciliation, dispatch-chain
+structure, mark-bit allocation, IP-set ordering, or route ownership
+classification; or a change to the `proto.*` dataplane API —
+candidates, not triggers on their own. A warranted edit goes in
+[`dataplane.md`](../../felix/design/dataplane.md) in the same PR, and
+in `calc-graph.md` too if the proto contract changes.

--- a/.github/instructions/goldmane.instructions.md
+++ b/.github/instructions/goldmane.instructions.md
@@ -19,17 +19,14 @@ design references siblings, code, and external resources.
 
 ## Update rule
 
-A goldmane PR that **changes how goldmane works** — gRPC service
-shape or behaviour, data flow, retention or eviction logic, the
-configuration surface, or the Prometheus metric set — must
-update the relevant section of `goldmane/DESIGN.md` in the same
-PR.
-
-**Exemption.** No doc update is needed if the PR is exclusively
-one of: (a) a bug fix that restores behaviour the doc already
-describes, (b) a mechanical refactor with no observable change,
-(c) comment / log-message edits, (d) a dependency bump. If in
-doubt, update the doc.
+The repo-wide rule
+([`.github/copilot-instructions.md` → Documentation map](../copilot-instructions.md),
+mirrored in [`.claude/CLAUDE.md`](../../.claude/CLAUDE.md)) applies;
+**the default is no edit**. In goldmane the usual candidates for it
+are a change to gRPC service shape or behaviour, data flow, retention
+or eviction logic, the configuration surface, or the Prometheus metric
+set — candidates, not triggers on their own. A warranted edit goes in
+`goldmane/DESIGN.md` in the same PR.
 
 ## Amending the PR
 
@@ -37,9 +34,10 @@ The Copilot automated code-review step is read-only with respect
 to the PR branch — it cannot push the doc amendment itself. When
 the review flags a missing update per the rule above, its comment
 should include a ready-to-paste `@copilot` prompt naming the
-section and the new behaviour or invariant, for example:
+section and the one invariant or fact to state — not a list of
+details to describe. For example:
 
-> `@copilot update goldmane/DESIGN.md "Prometheus metrics" to cover the new histogram goldmane_flow_age_seconds — the labels it carries, where it is observed, and what the buckets represent.`
+> `@copilot update goldmane/DESIGN.md "Prometheus metrics": add the new histogram goldmane_flow_age_seconds to the existing metric list in one line. Do not add a heading, and do not restate the commit message.`
 
 The reviewer (or author) drops that into a new PR comment; the
 Copilot coding agent picks it up and pushes a commit with the

--- a/.github/instructions/ipam.instructions.md
+++ b/.github/instructions/ipam.instructions.md
@@ -37,17 +37,15 @@ siblings, code, and external resources.
 
 ## Update rule
 
-A PR that **changes how IPAM works** - the data model, the
-allocation or release flow, the handle ID convention, the GC
-reconciliation logic, the `IPAMConfig` resolution rules, or any
-invariant a sub-design records - must update the relevant file
-under `design/ipam/` in the same PR.
-
-**Exemption.** No doc update is needed if the PR is exclusively
-one of: (a) a bug fix that restores behavior the doc already
-describes, (b) a mechanical refactor with no observable change,
-(c) comment / log-message edits, (d) a dependency bump. If in
-doubt, update the doc.
+The repo-wide rule
+([`.github/copilot-instructions.md` → Documentation map](../copilot-instructions.md),
+mirrored in [`.claude/CLAUDE.md`](../../.claude/CLAUDE.md)) applies;
+**the default is no edit**. In IPAM the usual candidates for it are a
+change to the data model, the allocation or release flow, the handle
+ID convention, the GC reconciliation logic, or the `IPAMConfig`
+resolution rules — candidates, not triggers on their own. A warranted
+edit goes in the matching sub-design under `design/ipam/` in the same
+PR.
 
 ## Amending the PR
 
@@ -55,9 +53,10 @@ The Copilot automated code-review step is read-only with respect
 to the PR branch - it cannot push the doc amendment itself. When
 the review flags a missing update per the rule above, its
 comment should include a ready-to-paste `@copilot` prompt naming
-the sub-design and the new behavior or invariant, for example:
+the sub-design, the section, and the one invariant to state - not
+a list of mechanics to describe. For example:
 
-> `@copilot update design/ipam/ipam-gc.md "Reconciliation" to cover the new confirmation-pass step before releasing a suspected leaked allocation - what triggers it, what it checks, and how it interacts with the existing grace period.`
+> `@copilot update design/ipam/ipam-gc.md "Reconciliation": state in one sentence the invariant the new confirmation pass introduces before a suspected leaked allocation is released. Edit the existing prose in that section; do not add a heading, and do not restate the commit message.`
 
 The reviewer (or author) drops that into a new PR comment; the
 Copilot coding agent picks it up and pushes a commit with the

--- a/design/cluster-route-programming/DESIGN.md
+++ b/design/cluster-route-programming/DESIGN.md
@@ -366,16 +366,7 @@ way.  This is a documentation and release-note obligation, not a code one.
 - Closing any of these gaps means editing this section, not appending a new
   one.  A gap list that only grows stops being read.
 
-## 6. Keep this doc in sync with the code
-
-A PR that changes which component programs cluster routes, the enum values or
-defaults of either `programClusterRoutes` field, the BIRD kernel-programming
-filter, or the deprecation and removal plan, must update this file in the same
-PR.  Exemptions: a bug fix restoring behaviour this doc already describes, a
-mechanical refactor with no observable change, comment or log-message edits, and
-dependency bumps.  If in doubt, update.
-
-Related designs:
+## 6. Related designs
 
 - [`felix/design/dataplane.md`](../../felix/design/dataplane.md) — the manager
   and route-table architecture that `ipipManager` and `noEncapManager` sit in.

--- a/design/ipam/DESIGN.md
+++ b/design/ipam/DESIGN.md
@@ -81,10 +81,9 @@ anything goes.
   the glob doesn't list narrowly. When in doubt, pull the topic-relevant sub-design.
 - **Review notes are the checklist.** Each sub-design embeds per-section review notes describing the invariants a PR must respect. At write-time, respect them; at review-time,
   apply them.
-- **Update rule.** A change to how IPAM works in a given area must update the relevant sub-design in this directory in the same PR. This index is also updated when the
-  sub-design table, an `applies to` scope, or §1's architecture overview changes. Exemptions: (a) a bug fix that restores behavior the doc already describes, (b) a mechanical
-  refactor with no observable change, (c) comment or log-message edits, (d) dependency bumps. If in doubt, update. The path-scoped
-  [`.github/instructions/ipam.instructions.md`](../../.github/instructions/ipam.instructions.md) file wires this rule into Copilot's automated review.
+- **Update rule.** A warranted edit goes in the sub-design covering the area; this index is edited when the sub-design table, an `applies to` scope, or §1's architecture
+  overview changes. The path-scoped [`.github/instructions/ipam.instructions.md`](../../.github/instructions/ipam.instructions.md) file wires the rule into Copilot's automated
+  review.
 
 ## 4. Cross-cutting review rubric
 

--- a/felix/DESIGN.md
+++ b/felix/DESIGN.md
@@ -283,18 +283,12 @@ absence as "read the code and ask"; do not assume anything goes.
   per-section review notes describing the invariants a PR must
   respect. At write-time, respect them; at review-time, apply
   them.
-- **Update rule.** A change to how Felix works in a given area
-  must update the relevant file under
-  [`felix/design/`](./design/) in the same PR — typically the
-  sub-design covering the area. This index
-  (`felix/DESIGN.md`) is also updated when the sub-design
-  table, a `applies to` scope, or §1's architecture overview
-  changes. Exemptions: (a) a bug fix that restores behaviour
-  the doc already describes, (b) a mechanical refactor with no
-  observable change, (c) comment or log-message edits, (d)
-  dependency bumps. If in doubt, update. The path-scoped
+- **Update rule.** A warranted edit goes in the sub-design covering
+  the area; this index is edited when the sub-design table, an
+  `applies to` scope, or §1's architecture overview changes. The
+  path-scoped
   [`.github/instructions/*.instructions.md`](../.github/instructions/)
-  files wire this rule into Copilot's automated review.
+  files wire the rule into Copilot's automated review.
 
 ## 4. Adding a new sub-design
 

--- a/felix/design/bpf-conntrack-flowstate.md
+++ b/felix/design/bpf-conntrack-flowstate.md
@@ -422,17 +422,9 @@ What this buys:
 
 ---
 
-## Keep this doc in sync with the code
+## Cross-cutting rules
 
-A change to how the BPF dataplane works in the area this file
-covers must update the relevant section in the same PR — new
-mechanism, new flag, new map field, new config knob, or any
-change to the packet path. Exemptions: (a) bug fix restoring
-documented behaviour, (b) mechanical refactor with no observable
-change, (c) comment / log-message edits, (d) dependency bumps.
-If in doubt, update.
-
-Cross-cutting rules that apply to **every** BPF change (map
-versioning, mark discipline, sub-program registration, kernel-
-version sensitivity) live in
+Rules that apply to **every** BPF change (map versioning, mark
+discipline, sub-program registration, kernel-version sensitivity)
+live in
 [`bpf-overview.md` → Cross-cutting review notes](./bpf-overview.md).

--- a/felix/design/bpf-encap-fragments-icmp.md
+++ b/felix/design/bpf-encap-fragments-icmp.md
@@ -306,17 +306,9 @@ here is acceptable.
 
 ---
 
-## Keep this doc in sync with the code
+## Cross-cutting rules
 
-A change to how the BPF dataplane works in the area this file
-covers must update the relevant section in the same PR — new
-mechanism, new flag, new map field, new config knob, or any
-change to the packet path. Exemptions: (a) bug fix restoring
-documented behaviour, (b) mechanical refactor with no observable
-change, (c) comment / log-message edits, (d) dependency bumps.
-If in doubt, update.
-
-Cross-cutting rules that apply to **every** BPF change (map
-versioning, mark discipline, sub-program registration, kernel-
-version sensitivity) live in
+Rules that apply to **every** BPF change (map versioning, mark
+discipline, sub-program registration, kernel-version sensitivity)
+live in
 [`bpf-overview.md` → Cross-cutting review notes](./bpf-overview.md).

--- a/felix/design/bpf-host-networking.md
+++ b/felix/design/bpf-host-networking.md
@@ -168,17 +168,9 @@ the redirect path.
 
 ---
 
-## Keep this doc in sync with the code
+## Cross-cutting rules
 
-A change to how the BPF dataplane works in the area this file
-covers must update the relevant section in the same PR — new
-mechanism, new flag, new map field, new config knob, or any
-change to the packet path. Exemptions: (a) bug fix restoring
-documented behaviour, (b) mechanical refactor with no observable
-change, (c) comment / log-message edits, (d) dependency bumps.
-If in doubt, update.
-
-Cross-cutting rules that apply to **every** BPF change (map
-versioning, mark discipline, sub-program registration, kernel-
-version sensitivity) live in
+Rules that apply to **every** BPF change (map versioning, mark
+discipline, sub-program registration, kernel-version sensitivity)
+live in
 [`bpf-overview.md` → Cross-cutting review notes](./bpf-overview.md).

--- a/felix/design/bpf-observability.md
+++ b/felix/design/bpf-observability.md
@@ -541,17 +541,9 @@ a convention shared with Istio ztunnel).
 
 ---
 
-## Keep this doc in sync with the code
+## Cross-cutting rules
 
-A change to how the BPF dataplane works in the area this file
-covers must update the relevant section in the same PR — new
-mechanism, new flag, new map field, new config knob, or any
-change to the packet path. Exemptions: (a) bug fix restoring
-documented behaviour, (b) mechanical refactor with no observable
-change, (c) comment / log-message edits, (d) dependency bumps.
-If in doubt, update.
-
-Cross-cutting rules that apply to **every** BPF change (map
-versioning, mark discipline, sub-program registration, kernel-
-version sensitivity) live in
+Rules that apply to **every** BPF change (map versioning, mark
+discipline, sub-program registration, kernel-version sensitivity)
+live in
 [`bpf-overview.md` → Cross-cutting review notes](./bpf-overview.md).

--- a/felix/design/bpf-overview.md
+++ b/felix/design/bpf-overview.md
@@ -313,21 +313,6 @@ a given topic. This final section collects the handful of checks that
 don't belong to any single topic — they come up repeatedly in BPF
 dataplane review because several subsystems happen to share them.
 
-### Keep this document in sync with the code
-
-The repo-wide doc-update rule
-([`.claude/CLAUDE.md` → Documentation map](../../.claude/CLAUDE.md),
-mirrored in
-[`.github/copilot-instructions.md`](../../.github/copilot-instructions.md))
-applies. For the BPF dataplane, "changes how it works" means a
-new sub-program, a new CT flag, a new mark bit, a new map or map
-field, a new config knob affecting any of those, or any change
-to the packet path or forwarding decision. The relevant section
-of the matching sub-design (and `bpf-overview.md` if cross-cutting
-content is affected) must be updated in the same PR. This file
-and its sibling sub-designs under [`felix/design/`](.) are the
-source of truth.
-
 ### Changes that touch shared maps
 
 - A change to the on-wire layout of a pinned BPF map needs a

--- a/felix/design/bpf-services.md
+++ b/felix/design/bpf-services.md
@@ -733,17 +733,9 @@ issue.
 
 ---
 
-## Keep this doc in sync with the code
+## Cross-cutting rules
 
-A change to how the BPF dataplane works in the area this file
-covers must update the relevant section in the same PR — new
-mechanism, new flag, new map field, new config knob, or any
-change to the packet path. Exemptions: (a) bug fix restoring
-documented behaviour, (b) mechanical refactor with no observable
-change, (c) comment / log-message edits, (d) dependency bumps.
-If in doubt, update.
-
-Cross-cutting rules that apply to **every** BPF change (map
-versioning, mark discipline, sub-program registration, kernel-
-version sensitivity) live in
+Rules that apply to **every** BPF change (map versioning, mark
+discipline, sub-program registration, kernel-version sensitivity)
+live in
 [`bpf-overview.md` → Cross-cutting review notes](./bpf-overview.md).

--- a/felix/design/bpf-tc-programs.md
+++ b/felix/design/bpf-tc-programs.md
@@ -395,17 +395,9 @@ track" — which is what each of those callers wants.
 
 ---
 
-## Keep this doc in sync with the code
+## Cross-cutting rules
 
-A change to how the BPF dataplane works in the area this file
-covers must update the relevant section in the same PR — new
-mechanism, new flag, new map field, new config knob, or any
-change to the packet path. Exemptions: (a) bug fix restoring
-documented behaviour, (b) mechanical refactor with no observable
-change, (c) comment / log-message edits, (d) dependency bumps.
-If in doubt, update.
-
-Cross-cutting rules that apply to **every** BPF change (map
-versioning, mark discipline, sub-program registration, kernel-
-version sensitivity) live in
+Rules that apply to **every** BPF change (map versioning, mark
+discipline, sub-program registration, kernel-version sensitivity)
+live in
 [`bpf-overview.md` → Cross-cutting review notes](./bpf-overview.md).

--- a/felix/design/bpf-tests.md
+++ b/felix/design/bpf-tests.md
@@ -161,19 +161,11 @@ needs an external client to exercise that path must restrict to
 
 ---
 
-## Keep this doc in sync with the code
+## Cross-cutting rules
 
-A change to how the BPF dataplane is tested in the area this file
-covers must update the relevant section in the same PR — new
-harness pattern, new matrix axis, new UT category, new
-verifier-time gate. Exemptions: (a) bug fix restoring documented
-behaviour, (b) mechanical refactor with no observable change,
-(c) comment / log-message edits, (d) dependency bumps. If in
-doubt, update.
-
-Cross-cutting rules that apply to **every** BPF change (map
-versioning, mark discipline, sub-program registration, kernel-
-version sensitivity) live in
+Rules that apply to **every** BPF change (map versioning, mark
+discipline, sub-program registration, kernel-version sensitivity)
+live in
 [`bpf-overview.md` → Cross-cutting review notes](./bpf-overview.md).
 Felix-wide test discipline lives in
 [`.claude/CLAUDE.md` → Tests required for code changes](../../.claude/CLAUDE.md).

--- a/felix/design/bpf-xdp.md
+++ b/felix/design/bpf-xdp.md
@@ -100,17 +100,9 @@ the regular tracked path regardless of what XDP would have done.
 
 ---
 
-## Keep this doc in sync with the code
+## Cross-cutting rules
 
-A change to how the BPF dataplane works in the area this file
-covers must update the relevant section in the same PR — new
-mechanism, new flag, new map field, new config knob, or any
-change to the packet path. Exemptions: (a) bug fix restoring
-documented behaviour, (b) mechanical refactor with no observable
-change, (c) comment / log-message edits, (d) dependency bumps.
-If in doubt, update.
-
-Cross-cutting rules that apply to **every** BPF change (map
-versioning, mark discipline, sub-program registration, kernel-
-version sensitivity) live in
+Rules that apply to **every** BPF change (map versioning, mark
+discipline, sub-program registration, kernel-version sensitivity)
+live in
 [`bpf-overview.md` → Cross-cutting review notes](./bpf-overview.md).

--- a/felix/design/calc-graph.md
+++ b/felix/design/calc-graph.md
@@ -429,19 +429,10 @@ case matters (it usually does for indexes/refcounts).
 5. **Skipping the FV suite** — so the orderings and teardown paths
    the expanders would catch go untested.
 
-## Keep this document in sync with the code
+## Siblings that move with this doc
 
-The repo-wide doc-update rule
-([`.claude/CLAUDE.md` → Documentation map](../../.claude/CLAUDE.md),
-mirrored in
-[`.github/copilot-instructions.md`](../../.github/copilot-instructions.md))
-applies. For the calc graph, "changes how it works" means: a new node
-or rewiring; a new emitted message type or a change to the
-`EventSequencer` flush order; a change to a label index or other
-refcounting structure; or a change to how the graph treats
-inconsistency, in-sync, or the upstream contract. Update the relevant
-section here, update the node graph in
-[`felix/docs/calc-graph-diagram.md`](../docs/calc-graph-diagram.md) when
-nodes change, and update
-[`dataplane.md` → The dataplane API](./dataplane.md#the-dataplane-api-calc-graph--dataplane-contract)
-if the output contract changes.
+- The hand-maintained node diagram in
+  [`felix/docs/calc-graph-diagram.md`](../docs/calc-graph-diagram.md) —
+  whenever a node is added or rewired.
+- [`dataplane.md` → The dataplane API](./dataplane.md#the-dataplane-api-calc-graph--dataplane-contract)
+  — whenever the output contract changes.

--- a/felix/design/dataplane.md
+++ b/felix/design/dataplane.md
@@ -861,21 +861,8 @@ only to maps that genuinely can't be rebuilt.
   (rather than diffing and touching only what's wrong) will glitch
   connectivity — push back.
 
-## Keep this document in sync with the code
+## Siblings that move with this doc
 
-The repo-wide doc-update rule
-([`.claude/CLAUDE.md` → Documentation map](../../.claude/CLAUDE.md),
-mirrored in
-[`.github/copilot-instructions.md`](../../.github/copilot-instructions.md))
-applies. For the Linux dataplane, "changes how it works" means: a
-new manager or driver, or a change to the manager/driver split; a
-change to the `apply()` ordering or the `OnUpdate`/`CompleteDeferredWork`
-contract; a new kind of kernel resource or a change to how Calico
-resources are identified for resync; a change to the `*tables` Table
-reconciliation, dispatch-chain structure, mark-bit allocation, IP-set
-ordering, or route ownership classification; or a change to the
-`proto.*` dataplane API. Update the relevant section of this file in
-the same PR — and [`calc-graph.md`](./calc-graph.md) too if the
-[dataplane API contract](#the-dataplane-api-calc-graph--dataplane-contract)
-changes. This file is the source of truth for the Linux dataplane's
-invariants.
+- [`calc-graph.md`](./calc-graph.md) — whenever the
+  [dataplane API contract](#the-dataplane-api-calc-graph--dataplane-contract)
+  changes.

--- a/goldmane/DESIGN.md
+++ b/goldmane/DESIGN.md
@@ -179,12 +179,5 @@ is a contract change for dashboards and alerting; record it here.
 
 ## Cross-cutting review notes
 
-- **Keep this document in sync with the code.** A change to the
-  gRPC services, core components, key concepts, config surface,
-  or Prometheus metrics must update the relevant section in the
-  same PR. Exemptions: (a) a bug fix that restores behaviour
-  this doc already describes, (b) a mechanical refactor with no
-  observable change, (c) comment / log-message edits, (d)
-  dependency bumps. If in doubt, update the doc.
 - Operational recipes (build, test, debug) do not belong here —
   they live in [`goldmane/CLAUDE.md`](./CLAUDE.md).

--- a/node/DESIGN.md
+++ b/node/DESIGN.md
@@ -38,14 +38,7 @@ single container.
   cross-component decision documented in
   [`design/cluster-route-programming/DESIGN.md`](../design/cluster-route-programming/DESIGN.md).
 
-## Keep this doc in sync with the code
-
-A PR that changes how the node container works — startup
-sequence, runit service set, CNI plugin installation path, or
-any documented invariant — must update this file in the same
-PR. Exemptions: bug fix restoring documented behaviour,
-mechanical refactor with no observable change, comment /
-log-message edits, dependency bumps. If in doubt, update.
+## Gaps
 
 This doc is currently a stub. Sections to flesh out as the
 content grows: startup flow detail (datastore-side resource

--- a/typha/DESIGN.md
+++ b/typha/DESIGN.md
@@ -24,14 +24,7 @@ connection.
   [`felix/DESIGN.md`](../felix/DESIGN.md) §1 under the data
   flow / lifecycle sections.
 
-## Keep this doc in sync with the code
-
-A PR that changes how Typha works — its fan-out behaviour, the
-datastore-side connection shape, the Felix-facing protocol, or
-any documented invariant — must update this file in the same PR.
-Exemptions: bug fix restoring documented behaviour, mechanical
-refactor with no observable change, comment / log-message edits,
-dependency bumps. If in doubt, update.
+## Gaps
 
 This doc is currently a stub. Sections to flesh out as the
 content grows: fan-out architecture and connection management,


### PR DESCRIPTION
The repo's doc-update rule reads as an obligation with a narrow escape list, and resolves every ambiguity with **"If in doubt, update the doc."** Agents therefore write something into a `DESIGN.md` on nearly every PR, and what they write is aimed at the reviewer in front of them: a retelling of the diff, biased to detail.

The evidence is in the diffs. Every design-doc change since June is purely additive (`+11 -0`, `+34 -0`, `+17 -0`, `+13 -1`…) — nothing is ever rewritten or compressed, so the docs only grow (`bpf-services.md` 707 lines, `dataplane.md` 881). `ee3dc51152` is the archetype: 34 lines under a new `###` heading, near-verbatim from its own commit message ("This creates a hazard the generic kube-proxy model doesn't have…", "The deadlock is therefore unique to bootstrap mode"), naming three internal identifiers — while the durable content was one bullet in the invariant list immediately above it.

## What changes

**The default is inverted.** A design doc is edited only when one of three conditions holds: a sentence in it is now false; there is a new invariant a future change could silently break; or there is a new concept the doc's mental model does not name. A new behaviour, flag, field, config key or bug fix is none of those on its own. A warranted edit still lands **in the same PR as the code** — that obligation is unchanged.

**In doubt, propose — don't write.** An agent with an interactive user shows the target file, the target section and the exact one to three lines, and waits for approval; it raises this at the pre-commit checkpoint, batched into one ask, so it never blocks the code work. An agent without one (Copilot coding agent, automated review) makes no change and names what it skipped in the PR description. A missing doc update the author considered and skipped is explicitly not a review blocker.

**A size budget and an altitude rule.** One to three lines, edited into the section that already covers the area; fix the existing sentence before adding a new one; a new `###` heading needs a new concept, not a new behaviour; past ~5 lines you are narrating the change. State the invariant, not the mechanism that currently enforces it, and name identifiers as one orientation pointer per concept rather than describing the plumbing. Never paraphrase the commit message or PR description into a design doc — the same rule the repo already applies to code comments. A file already past ~500 lines gets compressed by the next PR that touches it, not grown.

## Where it lives — two files, not seventeen

The rule was restated in **17 places** with drifting wording, each copy carrying its own version of what warrants an edit plus the same exemption list: `.claude/CLAUDE.md`, `.github/copilot-instructions.md`, six path-scoped `.github/instructions/*` files, and a "keep this doc in sync with the code" section inside almost every design doc.

- **[`.claude/CLAUDE.md`](https://github.com/projectcalico/calico/blob/master/.claude/CLAUDE.md) carries the rule that has to fire unprompted** — it already describes itself as holding "the process rules every PR follows", and this rule already lived there. What stays is the three conditions, the same-PR obligation, the size budget and propose-in-doubt: 28 lines, ~440 tokens. `.github/copilot-instructions.md` mirrors it, with the same "keep them in sync" note the tests rule in that file already uses.
- **The expansion is a skill**, `.claude/skills/design-doc-edits/SKILL.md`: the altitude rule, the worked example (the `bpf-services.md` diff above, and the one-bullet version that should have been written), the reviewer criteria, and how to compress an oversized doc. Loaded when an agent is actually writing or reviewing a design-doc edit, rather than in every session. The write-side trigger deliberately does *not* move — it fires as a side effect of changing code, not on an intent a skill can be selected for, and its failure mode is silent. Copilot has no skills, so for it the skill file is a path to read.
- **The design docs carry design.** Their per-file rule sections are deleted, not rewritten: no restatement, no per-file list of what warrants an edit, no pointer back to the rule. What survives in a trailing section is only what is genuinely file-specific: the BPF sub-designs point at `bpf-overview.md`'s cross-cutting rules, `calc-graph.md` names the two siblings that must move with it (the hand-maintained node diagram, and `dataplane.md` when the output contract changes), `dataplane.md` names `calc-graph.md`. The stub docs (`typha`, `node`) keep their "what's missing" note under a heading that says so.
- **The exemption list is gone.** It appeared in fourteen files, and it is redundant under an inverted default: a bug fix restoring documented behaviour, a mechanical refactor, a comment edit and a dependency bump none of them falsify a sentence or introduce an invariant, so "the default is no edit" already covers them.
- The path-scoped `.github/instructions/*` files keep their area-specific candidate list as one sentence, framed as candidates for the test rather than triggers, and defer to the repo-wide rule for the rest.

Net: **25 files, +202/−290** — a net deletion, and every design doc's diff is a removal of stale rule text.

The Copilot `@copilot` amendment templates were part of the problem: they asked for *"the fields it uses, where it is set, how it interacts with the fast path"* — an instruction to write exactly what this change removes. They now ask for the invariant in one sentence, edited into an existing section, with no new heading.

One rule is deliberately left as it was: the chart READMEs keep "if in doubt, update the doc". They are user-facing install instructions rather than design docs, and a missing install step is the failure mode there — so the safe default is the opposite one. `copilot-instructions.md`'s Helm section now says so explicitly rather than inheriting the design-doc default.

Docs-only; no code, generated files or tests are affected.

**Release note:**
```release-note
None
```

