### PR TITLE
docs: compress oversized design docs

### DIFF
--- a/design/cluster-route-programming/DESIGN.md
+++ b/design/cluster-route-programming/DESIGN.md
@@ -224,13 +224,13 @@ of no-encap.
 ## 4. Transitioning a running cluster
 
 A cluster moves between BIRD-programmed and Felix-programmed IPIP cluster routes
-in one of two ways, and they do not behave the same.
+in one of two ways, and only one of them has a gap.
 
 **Upgrading the code.**  On upgrade to v3.33, a cluster with IPIP pools and no
-explicit configuration changes owner without anything in the datastore changing
-at all: both `programClusterRoutes` fields are unset before and after, and what
-moves is the *default* each component derives from unset.  The calico-node pod
-is replaced, so:
+explicit configuration changes owner without anything in the datastore changing:
+both `programClusterRoutes` fields are unset before and after, and what moves is
+the *default* each component derives from unset.  The calico-node pod is
+replaced, so:
 
 1. The old BIRD exits.  Its kernel protocol is configured with `persist`, so it
    deliberately leaves its routes in the kernel instead of withdrawing them.
@@ -244,12 +244,10 @@ is replaced, so:
    alien routes that it learns rather than removes; what is left to reconcile is
    whatever Felix did not want.
 
-There is no window in which a destination Felix wants has no route.  When Felix
-wants a route to exist, it atomically replaces any previous route for the same
-prefix, regardless of whether that previous route was within its logical
-ownership — it programs with `RouteReplace` (`felix/routetable/route_table.go`).
-That is long-standing behaviour and does not depend on the ownership rule
-described below.
+There is no window in which a destination Felix wants has no route: Felix
+programs with `RouteReplace` (`felix/routetable/route_table.go`), which
+atomically replaces any previous route for the same prefix whether or not it was
+within Felix's logical ownership.
 
 **Changing the configuration on a running cluster.**  Setting either
 `programClusterRoutes` field explicitly is picked up live: confd re-renders and
@@ -257,19 +255,16 @@ BIRD reconfigures in place.  That BIRD knows it exported those routes, so it
 withdraws them itself.  Felix restarts on the config change and starts
 programming the same CIDRs.
 
-The two paths differ in whether there is a gap, and not in the direction one
-might expect.  Replacing the pod has none, as above.  Changing the configuration
-on a running cluster does: BIRD withdraws promptly, while Felix *restarts*
-because its configuration changed, and only programs the destinations once it is
-back.  The gap is therefore about the length of a Felix restart, and it is
-unmeasured.  A cluster that cannot tolerate any cross-node packet loss should
-prefer the upgrade path, or make the change during a maintenance window.
+This is the path with the gap: BIRD withdraws promptly, while Felix *restarts*
+because its configuration changed and only programs the destinations once it is
+back.  The gap is the length of a Felix restart, and it is unmeasured.  A cluster
+that cannot tolerate any cross-node packet loss should prefer the upgrade path,
+or make the change during a maintenance window.
 
-Once Felix has re-programmed a destination, BIRD can no longer withdraw it out
-from under Felix: the kernel matches on route protocol when the delete specifies
-one, so a delete carrying `RTPROT_BIRD` does not match a route that is now
-Felix's proto 80.  (Verified against the kernel; it assumes BIRD sets the
-protocol on its delete messages, which its kernel protocol does.)
+Once Felix has re-programmed a destination, BIRD cannot withdraw it out from
+under Felix: a delete carrying `RTPROT_BIRD` does not match a route that is now
+Felix's proto 80, since the kernel matches on protocol when the delete specifies
+one.
 
 **Where BIRD does not come back.**  Step 3 is what removes BIRD's persisted
 routes in the ordinary upgrade, and it does not happen if BGP is disabled as
@@ -281,13 +276,11 @@ BIRD's protocol, whenever Felix is the configured owner of the IPIP cluster
 routes (`OwnBIRDIPIPRoutes`, `felix/routetable/ownershippol`), so that
 reconciliation removes them.
 
-Note what this does and does not cover.  Destinations Felix *does* want were
-already handled, by the atomic replace above; the rule adds nothing there.  What
-it adds is the removal of BIRD's routes to destinations Felix does **not** want
-— a block released while the node was down, a node that has left the cluster, a
-pool that has been deleted.  Those have no desired route to overwrite them, so
-without the rule, and without a BIRD to reconcile them, they would stay in the
-kernel indefinitely.
+The rule matters only for destinations Felix does **not** want — a block
+released while the node was down, a node that has left the cluster, a deleted
+pool.  Destinations it does want are covered by the atomic replace above; these
+have no desired route to overwrite them, so without the rule and without a BIRD
+to reconcile them they would stay in the kernel indefinitely.
 
 ### Review notes — §4
 

--- a/felix/design/bpf-observability.md
+++ b/felix/design/bpf-observability.md
@@ -149,7 +149,7 @@ log / observability pipeline (Goldmane and friends).
 
 They are distinct from:
 
-- **Debug log filters (Debug log filters)**, which emit per-packet textual
+- **[Debug log filters](#debug-log-filters)**, which emit per-packet textual
   traces for diagnosis. Log filters are off by default; flow
   logs are a feature.
 - **BPF counters**, which produce aggregate counts, not
@@ -191,21 +191,18 @@ counters, timestamps and a verdict code.
 
 ### Why ring buffer, not perf buffer
 
-BPF ring buffer (`BPF_MAP_TYPE_RINGBUF`, kernel 5.8+) is
-preferred over the older per-CPU perf-event buffer for this
-use because it is MPSC (multi-producer, single-consumer), so
-the userspace side does not need to fan in from `nCPU`
-readers, and it has the correct backpressure semantics
-— drops are explicit and countable rather than per-CPU
-reorderings. Calico's minimum kernel (5.10) supports it.
+`BPF_MAP_TYPE_RINGBUF` (kernel 5.8+, so within Calico's 5.10
+minimum) is MPSC, so userspace reads one stream instead of fanning in
+`nCPU` per-CPU buffers, and its backpressure is explicit: drops are
+countable rather than showing up as per-CPU reordering.
 
 ### Fast-path discipline
 
-The emission sites are on the flow-creation path, not on every
-packet of an established flow, so the per-packet fast-path cost
-([bpf-overview.md → Fast-path performance discipline](./bpf-overview.md)) is unaffected when flow logs are on. The `FLOWLOGS_ENABLED`
-branch that guards emission is also a single mark-style load,
-which is acceptable on the fast path.
+Emission sites are on the flow-creation path, never on every packet of
+an established flow, so enabling flow logs does not move the
+per-packet cost ([bpf-overview.md → Fast-path performance discipline](./bpf-overview.md)).
+The `FLOWLOGS_ENABLED` guard is a single mark-style load, which is
+acceptable on the fast path.
 
 ### Review notes
 
@@ -251,11 +248,11 @@ loop), and `felix/bpf-gpl/qos.h` (C).
 ### Two maps: `cali_qos` (packet rate) and `cali_qos_conn` (connlimit)
 
 Packet-rate and connection-limit state live in two separate BPF maps
-that share the same key shape but have disjoint values. Splitting
-them is what allows the userspace `ConnLimitScanner` to write
-`current_count` back without clobbering the BPF dataplane's running
-token-bucket state — see PR #13009 for the lost-update bug the split
-fixes.
+that share the same key shape but have disjoint values. The split is
+what lets the userspace `ConnLimitScanner` write `current_count` back
+without clobbering the dataplane's running token-bucket state:
+userspace cannot read-modify-write under a BPF spinlock, so a value
+holding both would lose one writer's update.
 
 Shared key (`felix/bpf/qos/map.go`):
 
@@ -402,7 +399,8 @@ annotation on a HEP or WEP. The value is carried in BPF globals as
 
 The ECN bits are preserved in both address families. Istio's DSCP
 hook (for L7 mesh identification at connection setup) uses a second
-global, `ISTIO_DSCP`; see Istio ambient mode integration for the integration.
+global, `ISTIO_DSCP`; see
+[Istio ambient mode](#istio-ambient-mode-integration).
 
 ### Review notes for this section
 
@@ -494,7 +492,7 @@ the main program in `tc.c` does:
    a mesh member.
 4. On match, `qos_dscp_set(ctx, ISTIO_DSCP)` rewrites the DSCP
    bits in the IPv4 TOS / IPv6 traffic-class byte — same
-   mechanics as QoS QoS DSCP.
+   mechanics as [QoS DSCP](#dscp).
 
 The `ALL_ISTIO_WEPS_ID` IP set is populated by Felix with every
 mesh WEP in the cluster (local and remote); it lives in the
@@ -527,7 +525,8 @@ a convention shared with Istio ztunnel).
 ### Review notes
 
 - The SYN-only path is load-bearing. A change that moves Istio
-  DSCP marking onto every packet breaks [bpf-overview.md → Fast-path performance discipline](./bpf-overview.md) fast-path discipline.
+  DSCP marking onto every packet breaks the
+  [fast-path discipline](./bpf-overview.md).
   If a future feature genuinely needs per-packet Istio DSCP,
   reuse `CALI_CT_FLAG_SET_DSCP` / `CALI_ST_SET_DSCP` from QoS
   rather than introducing a second per-packet rewrite.

--- a/felix/design/bpf-observability.md
+++ b/felix/design/bpf-observability.md
@@ -342,31 +342,19 @@ on connection close.
   carrying any FIN or RST bit so it doesn't double-count a close
   those paths have already accounted for.
 
-  It deliberately does **not** skip entries carrying
-  `CONNLIMIT_DEC`. That flag is cleared only on the spurious-RST
-  path below, and never at all for an entry that no longer sees
-  traffic, so skipping on it excluded a connection from future
-  recounts — and since the recount is the only mechanism that can
-  return a slot, the exclusion was effectively permanent. Because
-  the fast path decrements on any
-  RST, including a spurious one that is out of window and ignored by
-  both peers, and because the per-leg RST bits clear as soon as
-  traffic resumes, that produced live, established entries the
-  scanner would never count again: N spurious RSTs against N live
-  connections parked `current_count` at 0 with all N still up. An
-  established entry with no FIN and no RST is live and is counted,
-  whatever `CONNLIMIT_DEC` says; the FIN/RST skips are what prevent
-  double-counting, since a genuinely closed entry keeps those bits
-  until it is purged.
+  It deliberately does **not** skip on `CONNLIMIT_DEC`: that flag can
+  be claimed for a live connection (the fast path decrements on any
+  RST, validated or not) and does not clear while an entry sees no
+  traffic, so skipping on it would exclude a live connection from
+  every future recount. An established entry with no FIN and no RST
+  is live and is counted, whatever `CONNLIMIT_DEC` says.
 
-This is why the RST decrement stays on the fast path even though an
-RST is weak evidence of a close. Prompt release is a requirement —
-`felix/fv` asserts a genuine RST close frees a slot within 5s, and
-deferring RST closes to the cleanup path makes them wait for
-`TCPResetSeen` (40s). The recount makes the resulting under-count
-self-correcting instead of permanent, which is the property that
-matters: a spurious RST costs one scan cycle, not the connection's
-lifetime.
+The RST decrement stays on the fast path even though an RST is weak
+evidence of a close, because prompt release is a requirement:
+`felix/fv` asserts a genuine RST close frees a slot within 5s, while
+the cleanup path would wait for `TCPResetSeen` (40s). The recount is
+what makes the resulting under-count self-correcting — a spurious RST
+costs one scan cycle, not the connection's lifetime.
 
 Host-originated traffic — including from host-networked pods — is
 exempt from the ingress limit: it takes the `skip_policy` path in
@@ -425,33 +413,24 @@ global, `ISTIO_DSCP`; see
   scanner) set it before decrementing. It is what stops the same
   close being counted twice when both paths see one entry.
 - `CONNLIMIT_DEC` is an idempotence latch, **not** a statement that
-  the connection is gone. Do not gate the userspace recount on it,
-  and do not add any other long-lived "already handled" marker that
-  the recount honours. The recount is the only path that can return
-  a slot, so anything it skips unconditionally is leaked for the
-  life of the entry — and the fast path claims the latch on signals
-  a live connection can survive (any RST, unvalidated). Keep the
-  skip conditions to state that clears itself or dies with the
-  entry: the per-leg FIN/RST bits.
-- The latch describes a decrement that is only meaningful while the
-  counter still reflects it, and the recount rebases the counter
-  every ~30s. That is why `calico_ct_lookup` releases the latch at
-  the same point it concludes an RST was spurious — two minutes of
-  continued traffic, where it also clears `v->rst_seen`. Without
-  that release, a connection that survived a spurious RST would find
-  the latch already taken when it genuinely closed, and free its
-  slot at recount speed rather than immediately. Release it with an
-  atomic AND on `type_flags_word`, mirroring the claim: a byte-wide
-  `ct_value_clear_flags()` would race with a concurrent claim on
-  another CPU. Note this re-arms the latch for that entry, so a
-  connection can be decremented once per spurious RST rather than
-  once ever; the recount bounds the resulting under-count either
-  way.
-- When choosing between holding a slot too long and releasing one
-  too early, hold. Over-counting fails closed — a pod is briefly
-  refused a connection it could have had. Under-counting fails open:
-  the limit stops being a limit, and if the under-count is permanent
-  an unauthenticated packet defeats it outright.
+  the connection is gone. The recount is the only path that returns a
+  slot, so anything it skips unconditionally leaks for the life of the
+  entry: do not gate it on the latch, or on any other long-lived
+  "already handled" marker. Keep its skip conditions to state that
+  clears itself or dies with the entry — the per-leg FIN/RST bits.
+- The latch is released where `calico_ct_lookup` concludes an RST was
+  spurious (two minutes of continued traffic, where it also clears
+  `v->rst_seen`), so a connection that survives one still frees its
+  slot immediately when it genuinely closes. Release it with an atomic
+  AND on `type_flags_word`, mirroring the claim — a byte-wide
+  `ct_value_clear_flags()` races with a concurrent claim on another
+  CPU. Releasing re-arms the latch, so a connection can be decremented
+  once per spurious RST rather than once ever; the recount bounds the
+  under-count either way.
+- When choosing between holding a slot too long and releasing one too
+  early, hold. Over-counting fails closed — a pod is briefly refused a
+  connection it could have had. Under-counting fails open: the limit
+  stops being a limit.
 - ep_mgr writes to `cali_qos` / `cali_qos_conn` must skip the
   UpdateWithFlags when the configured fields match the existing
   entry. The dataplane owns the dynamic fields between configuration

--- a/felix/design/bpf-services.md
+++ b/felix/design/bpf-services.md
@@ -29,7 +29,7 @@ listed in [`felix/DESIGN.md`](../DESIGN.md).
 ### The common case: pod to service
 
 > **Note.** Everything in this subsection describes the TC path.
-> When CTLB (Connect-Time Load Balancer (CTLB)) is enabled, a pod's service traffic never takes
+> When [CTLB](#connect-time-load-balancer-ctlb) is enabled, a pod's service traffic never takes
 > this path: CTLB rewrites the destination at `connect(2)` time and
 > the TC program on `cali*` only ever sees pod→pod packets with the
 > backend's address. The TC path below applies when CTLB is
@@ -94,7 +94,7 @@ and the socket pair is set up pod-to-pod-same-address. No packet
 is ever emitted on the network — a substantial deviation from
 `*tables`, where every pod-service-self packet makes a MASQ
 round-trip through the host. This is one of the reasons CTLB is
-an important performance feature (Connect-Time Load Balancer (CTLB)).
+an important performance feature ([CTLB](#connect-time-load-balancer-ctlb)).
 
 Without CTLB, the host would have to loop the packet back, which
 fails: `accept_local` is `0` by default on the pod's veth, and no
@@ -144,34 +144,23 @@ runs:
 1. Look up the `(local-host-IP, dst-port, proto)` tuple in the NAT
    frontend map. If the service exists, pick a backend.
 2. If the chosen backend is a **local** pod, DNAT the packet and
-   forward it to the pod's host-side veth as in Intra-cluster traffic & service NAT.
+   forward it to the pod's host-side veth as in
+   [intra-cluster service NAT](#intra-cluster-traffic--service-nat).
 3. If the chosen backend is on a **remote** node, wrap the packet in a
    VXLAN header ([bpf-encap-fragments-icmp.md → VXLAN in eBPF mode](./bpf-encap-fragments-icmp.md)) with the destination being the node that hosts
    the backend, and hand it to the host stack to route out. The
    packet is marked "seen/approved" so Calico's egress HEP does not
    re-run policy on it.
 
-> **VXLAN ambiguity — worth flagging for readers.** The VXLAN used
-> here for NodePort forwarding is a separate use of the VXLAN
-> device from the pod-to-pod VXLAN overlay. Calico programs both on
-> the same `vxlan.calico` device (flow-mode, see [bpf-encap-fragments-icmp.md → VXLAN in eBPF mode](./bpf-encap-fragments-icmp.md)), but:
->
-> - **NodePort-forwarding VXLAN** (this step) is always present in
->   BPF mode, regardless of whether the overlay uses VXLAN, IPIP,
->   WireGuard, or no encap. It carries external traffic that has
->   hit a NodePort on a node whose selected backend is on a
->   different node. It uses a fixed VNI of **`0xca11c0`**
->   (`CALI_VXLAN_VNI` in `felix/bpf-gpl/nat.h`) — reserving that
->   value so receivers can tell NodePort-forwarding packets from
->   overlay packets on the same device.
-> - **Pod-to-pod overlay VXLAN** is what pod→pod traffic uses when
->   the cluster's overlay is configured as VXLAN. Its VNI is the
->   operator-configured overlay VNI, not `0xca11c0`.
->
-> A reader familiar with the overlay may assume one implies the
-> other; it doesn't. The BPF program picks per-packet which
-> semantics apply and sets the VXLAN tunnel key (destination
-> node IP + VNI) accordingly.
+> **Two uses of `vxlan.calico`.** NodePort forwarding and the
+> pod-to-pod overlay share the device (flow-mode, see
+> [bpf-encap-fragments-icmp.md → VXLAN in eBPF mode](./bpf-encap-fragments-icmp.md))
+> and are told apart by VNI. NodePort forwarding is always present in
+> BPF mode whatever the overlay encap is, and uses the reserved VNI
+> **`0xca11c0`** (`CALI_VXLAN_VNI` in `felix/bpf-gpl/nat.h`); overlay
+> traffic uses the operator-configured VNI. The BPF program sets the
+> tunnel key (destination node IP + VNI) per packet, so neither use
+> implies the other.
 
 ### Return path (non-DSR)
 
@@ -215,7 +204,8 @@ accepting of it.
 
 The cluster admin opts in via `BPFExternalServiceMode = dsr` (vs.
 the default `tunnel`) with `BPFDSROptoutCIDRs` for per-destination
-opt-out. DSR is also a prerequisite for Maglev (Maglev load balancer).
+opt-out. DSR is also a prerequisite for
+[Maglev](#maglev-load-balancer).
 
 ### Intra-cluster access to NodePorts
 
@@ -272,13 +262,12 @@ flow — return packets must still match the CT entry.
 
 ## Maglev load balancer
 
-> **Relationship to External traffic (NodePort, DSR).** Maglev layers on top of the NodePort
-> VXLAN-forwarding path described in External traffic (NodePort, DSR). The forwarding mechanics —
-> VXLAN-wrap to the backend node, DSR return, conntrack bookkeeping
-> — are reused unchanged. What Maglev adds is consistent-hash
-> backend selection in place of the usual per-node random/round-robin,
-> plus a re-run of policy on mid-flow packets that may have failed
-> over from another lb-node.
+> **Relationship to [external traffic](#external-traffic-nodeport-dsr).**
+> Maglev reuses that path's forwarding mechanics — VXLAN-wrap to the
+> backend node, DSR return, conntrack bookkeeping — unchanged. It adds
+> consistent-hash backend selection in place of the per-node
+> random/round-robin, and a re-run of policy on mid-flow packets that
+> may have failed over from another lb-node.
 
 ### What it is for
 
@@ -312,10 +301,9 @@ hashing (`jenkins_hash.h`), reduces modulo the LUT size, and reads the
 NAT destination out of the Maglev map. The LUT size is a per-service
 parameter carried in globals (`MAGLEV_LUT_SIZE`).
 
-The selection code is small, but the hashing code _was not_ — the
-original inlined form exceeded the kernel verifier's instruction
-budget when placed inside the main program. Maglev therefore lives in
-its own tail-called sub-program (`calico_tc_maglev` in `tc.c`,
+Maglev lives in its own tail-called sub-program because the hashing
+code inlined into the main program exceeds the verifier's instruction
+budget (`calico_tc_maglev` in `tc.c`,
 registered as `SubProgMaglev` in `felix/bpf/hook/map.go`). The main
 program detects that the target is a Maglev service and tail-calls
 into the Maglev program before policy. Maglev fills in the post-NAT
@@ -330,13 +318,13 @@ where this is true.
 
 ### Mid-flow packets that don't match conntrack
 
-Before Maglev, a mid-flow TCP packet with no conntrack hit was either
-let through to `*tables` (might match a pre-existing kernel CT entry;
-see [bpf-conntrack-flowstate.md → Switching from `*tables` to eBPF](./bpf-conntrack-flowstate.md)) or dropped as unsolicited. Maglev adds a third class: a
-mid-flow packet with no BPF CT hit whose destination is a Maglev
-service. In this case the lb-node has just failed over onto this
-node, so the packet genuinely is mid-flow but this node doesn't know
-it yet. The handling is:
+A mid-flow TCP packet with no BPF conntrack hit is either let through
+to `*tables` (it may match a pre-existing kernel CT entry; see
+[bpf-conntrack-flowstate.md → Switching from `*tables` to eBPF](./bpf-conntrack-flowstate.md)),
+dropped as unsolicited, or — if its destination is a Maglev service —
+treated as a failover: an lb-node has just moved the flow onto this
+node, so the packet genuinely is mid-flow and this node does not know
+it yet. That last case is handled as:
 
 - Tail-call the Maglev program to pick the _same_ backend the previous
   node would have picked.
@@ -363,7 +351,7 @@ miss, go through the new-flow path" signal to the rest of the chain.
   be Maglev because each node has its own NodePort IP — failing over
   to a different node means hashing into a different LUT keyed by a
   different IP.
-- **CTLB.** The connect-time LB (Connect-Time Load Balancer (CTLB)) resolves the service at syscall
+- **CTLB.** The [connect-time LB](#connect-time-load-balancer-ctlb) resolves the service at syscall
   time, before the TC program runs, so Maglev has no visibility. For
   pod-originated traffic this is not a regression (pods don't fail
   over), but it means Maglev is effectively external-traffic-only.
@@ -502,13 +490,14 @@ node-local clients coalesce onto one backend at any timeout value.
 
 `felix/bpf/proxy/` is Calico's in-Felix replacement for kube-proxy.
 It watches Kubernetes Service, Endpoints and EndpointSlice resources
-and translates them into the BPF maps that the TC programs
-([bpf-xdp.md → XDP programs and the XDP→TC handoff](./bpf-xdp.md)–Maglev load balancer) and the CTLB (Connect-Time Load Balancer (CTLB)) read. When BPF mode is on, Calico
-disables kube-proxy and takes full responsibility for service
-implementation.
+and translates them into the BPF maps that the TC, XDP
+([bpf-xdp.md](./bpf-xdp.md)) and
+[CTLB](#connect-time-load-balancer-ctlb) programs read. When BPF mode
+is on, Calico disables kube-proxy and takes full responsibility for
+service implementation.
 
-This is the userspace half of "service NAT" — the TC-side view
-(Intra-cluster traffic & service NAT–External traffic (NodePort, DSR)) only sees "a map with a frontend pointing at a backend".
+This is the userspace half of "service NAT": the packet-path sections
+above only see "a map with a frontend pointing at a backend".
 The proxy package is what fills those maps, keeps them consistent
 as Services/Endpoints churn, and applies the Kubernetes
 semantics (topology, traffic policies, health, affinity) before
@@ -542,8 +531,8 @@ the BPF program ever runs.
 
 - Frontend map — `(service-IP, port, proto) → service_id`.
 - Backend map — `(service_id, ordinal) → (backend_IP, port)`.
-- Affinity map — see Service session affinity.
-- Maglev LUT — see Maglev load balancer.
+- Affinity map — see [service session affinity](#service-session-affinity).
+- Maglev LUT — see [Maglev](#maglev-load-balancer).
 - Reverse-SNAT map (`cali_v4_srmsg` / `cali_v6_srmsg`) — used by
   the CTLB's `recvmsg` hook to undo destination rewrites.
 
@@ -558,28 +547,18 @@ LoadBalancer) frontends; that is how `applyDerived` points them at one
 block of backends.
 
 IDs are handed out by `newSvcID` and, on restart, re-adopted from the
-maps by `startupBuildPrev`, which pairs each frontend entry with the
-service that must have written it. Re-adoption keeps a restart from
-disrupting traffic, but it means Felix trusts the maps — and Felix is
-not their only writer:
+maps by `startupBuildPrev` so a restart does not disrupt traffic. That
+makes Felix trust maps it does not own alone: they are pinned, so they
+outlive both Felix and calico-node, and under `bpfNetworkBootstrap`
+the `ebpf-bootstrap` init container programs the API server service
+into them before Felix runs (`node/pkg/nodeinit`).
 
-- the maps are pinned, so they outlive both Felix and calico-node;
-- with `bpfNetworkBootstrap` enabled the `ebpf-bootstrap` init
-  container programs the API server service into them on every
-  calico-node start, before Felix runs (`node/pkg/nodeinit`).
-
-So `startupBuildPrev` must **not** adopt an ID it finds shared by two
-different services: adopting it makes the conflict permanent, since
-`applySvc` keeps an unchanged service's ID forever and every later
-restart re-adopts it. Both services are instead left out of
-`prevSvcMap`, which gives each a fresh ID and rewrites its frontends
-and backends; nothing read through a duplicated ID is carried over,
-because those backends may belong to the other service.
-
-The bootstrap writer holds up the other end of the invariant: it
-reuses the ID already recorded for the service it is programming, and
-otherwise picks one no frontend entry uses, rather than assuming an ID
-is free.
+Both writers therefore hold up uniqueness. Felix does not adopt an ID
+it finds shared by two services — adopting it would make the conflict
+permanent, since an unchanged service keeps its ID across every later
+restart — so both are dropped from `prevSvcMap` and rewritten under
+fresh IDs. The bootstrap reuses the ID already recorded for the
+service it programs, and otherwise picks one no frontend entry uses.
 
 ### Semantics it enforces
 
@@ -589,36 +568,16 @@ is free.
 - Topology-aware routing weights backends by zone/region.
 - Unready endpoints excluded; terminating endpoints handled via
   the Kubernetes draining semantics.
-- Session affinity populated and refreshed (Service session affinity).
-- Maglev LUTs regenerated consistently across nodes (Maglev load balancer).
-- The `default/kubernetes` API server service is never allowed to
-  drop to zero backends — see below.
-
-### API server service: never drop to zero backends
-
-With `bpfNetworkBootstrap` enabled, Felix reaches the API server
-*through* the `default/kubernetes` ClusterIP service's NAT entry
-(`KUBERNETES_SERVICE_HOST` is the ClusterIP, and the
-`ebpf-bootstrap` init container seeds the frontend/backend from
-`KUBERNETES_SERVICE_IPS_PORTS` / `KUBERNETES_APISERVER_ENDPOINTS`
-before Felix starts — see `node/pkg/nodeinit/calico-init_linux.go`).
-
-This creates a hazard the generic kube-proxy model doesn't have:
-if that service transiently loses all its (ready) endpoints — e.g.
-the API server's own endpoint reconciler de-lists it across a
-restart — the syncer would write `count=0` and delete the backend,
-**severing Felix's own connection to the API server**. Felix can
-then no longer learn the restored endpoints, so the NAT stays empty
-until calico-node is restarted (which re-seeds it from the init
-container). The deadlock is therefore unique to bootstrap mode.
-
-The syncer therefore retains the last-known-good backend for the
-API server service whenever an update would leave it with zero ready
-endpoints (`apiServerFallbackEps` in `syncer.go`, sourced from
-`prevEpsMap`, which is rebuilt from the BPF maps on restart by
-`startupBuildPrev`). The API server's backend (the control-plane
-host IP) is stable across such an outage, so the retained backend is
-correct; a later update with real ready endpoints overwrites it.
+- Session affinity populated and refreshed
+  ([session affinity](#service-session-affinity)).
+- Maglev LUTs regenerated consistently across nodes
+  ([Maglev](#maglev-load-balancer)).
+- The `default/kubernetes` service keeps its last-known-good backend
+  instead of dropping to zero: under `bpfNetworkBootstrap` Felix
+  reaches the API server through this NAT entry, so an empty backend
+  list is self-severing. Its backend is the control-plane host IP,
+  stable across such an outage, so retaining it is safe. Every other
+  service still drops to zero.
 
 ### Review notes
 
@@ -704,7 +663,7 @@ optimisation rather than a prerequisite. The bpfnat veth workaround
   the packet itself and the cgroup hook never fires. Such packets go
   through the regular TC path instead, which means they depend on
   the bpfnat veth to reach a TC program ([bpf-host-networking.md → Host-networked workaround (bpfnat veth)](./bpf-host-networking.md)).
-- **Per-packet Maglev (Maglev load balancer) does not apply.** CTLB resolves the
+- **Per-packet [Maglev](#maglev-load-balancer) does not apply.** CTLB resolves the
   backend before Maglev's hashing logic has a chance to see the
   packet, so pod-originated traffic to a Maglev service gets a
   non-consistent-hash backend. Since Maglev is intended for external

--- a/felix/design/bpf-services.md
+++ b/felix/design/bpf-services.md
@@ -428,18 +428,14 @@ sending.
 These entries live in the same affinity map as the `sessionAffinity`
 ones. When both apply — a UDP service that also sets
 `sessionAffinity: ClientIP` — `calico_nat_lookup` uses whichever timeout
-is **longer**. Using the shorter one would break the promise the other
-made; in particular, honouring the CTLB's timeout over a service's
-3-hour `sessionAffinity` would re-pick a backend after a few idle
-seconds, which is not the stickiness the user asked for.
+is **longer**, so neither promise is cut short by the other.
 
-A caveat on granularity: the CTLB looks the entry up with `client_ip` set
-to `VOID_IP`, because the source IP is not known at connect/sendmsg time.
-So there is one CTLB affinity entry per (service, port), shared by every
-workload on the node, rather than one per client IP. That is a known
-limitation (see the `XXX` comment in `connect.h`), independent of the
-timeout: within a burst of traffic the entry is refreshed on each use, so
-node-local clients coalesce onto one backend at any timeout value.
+The CTLB looks entries up with `client_ip` set to `VOID_IP`, since the
+source IP is not known at connect/sendmsg time. So there is one CTLB
+affinity entry per (service, port), shared by every workload on the
+node, rather than one per client IP: node-local clients coalesce onto
+one backend at any timeout value (known limitation, `XXX` in
+`connect.h`).
 
 ### Applicability
 
@@ -468,18 +464,15 @@ node-local clients coalesce onto one backend at any timeout value.
   must be treated as a miss, not as a drop. A change that tightens
   the "is backend still valid" check must preserve that.
 - The BPF programs never delete affinity entries; the syncer's
-  `cleanupSticky()` is the only reclaim path, and it runs on every
-  sync. Its notion of which frontends may hold entries, and for how
-  long, must therefore cover **every** writer — including the CTLB's
-  enforced UDP affinity, which has no `sessionAffinity` on the service
-  to key off. An entry the syncer does not recognise is deleted on the
-  next sync, which silently un-pins a live client. There are two
-  frontend writers — `writeSvc()` and, for a `LoadBalancer` or
-  `ExternalIP` frontend with `loadBalancerSourceRanges`,
-  `writeLBSrcRangeSvcNATKeys()` — and both must register the frontend
-  with `registerStickyFrontend()`. The BPF programs key affinity
-  entries on the destination alone, so all of a service's source-range
-  frontends share the affinity key of its zero-source-range frontend.
+  `cleanupSticky()` is the only reclaim path, and it deletes any entry
+  whose frontend it does not recognise — silently un-pinning a live
+  client. So every frontend writer must register with
+  `registerStickyFrontend()` (today `writeSvc()` and
+  `writeLBSrcRangeSvcNATKeys()`), and its notion of which frontends may
+  hold entries must cover every writer of them, including the CTLB's
+  enforced UDP affinity, which has no `sessionAffinity` to key off.
+  Affinity keys are built from the destination alone, so a service's
+  source-range frontends share the key of its zero-source-range one.
 
 
 

--- a/felix/design/bpf-services.md
+++ b/felix/design/bpf-services.md
@@ -152,15 +152,17 @@ runs:
    packet is marked "seen/approved" so Calico's egress HEP does not
    re-run policy on it.
 
-> **Two uses of `vxlan.calico`.** NodePort forwarding and the
-> pod-to-pod overlay share the device (flow-mode, see
-> [bpf-encap-fragments-icmp.md → VXLAN in eBPF mode](./bpf-encap-fragments-icmp.md))
-> and are told apart by VNI. NodePort forwarding is always present in
-> BPF mode whatever the overlay encap is, and uses the reserved VNI
-> **`0xca11c0`** (`CALI_VXLAN_VNI` in `felix/bpf-gpl/nat.h`); overlay
-> traffic uses the operator-configured VNI. The BPF program sets the
-> tunnel key (destination node IP + VNI) per packet, so neither use
-> implies the other.
+> **Two uses of the VXLAN wire format, one device.** The pod-to-pod
+> overlay encapsulates *through* the kernel `vxlan.calico` device
+> (flow-mode, see
+> [bpf-encap-fragments-icmp.md → VXLAN in eBPF mode](./bpf-encap-fragments-icmp.md)),
+> with the operator-configured VNI. NodePort forwarding does **not**
+> use that device: `vxlan_encap` (`felix/bpf-gpl/nat4.h`) writes the
+> eth/IP/UDP/VXLAN headers into the packet itself, with the reserved
+> VNI **`0xca11c0`** (`CALI_VXLAN_VNI` in `felix/bpf-gpl/nat.h`), and
+> the packet leaves as ordinary host traffic. It is present in BPF
+> mode whatever the overlay encap is. VNI is how the receiving node's
+> program tells the two apart.
 
 ### Return path (non-DSR)
 

--- a/felix/design/bpf-tc-programs.md
+++ b/felix/design/bpf-tc-programs.md
@@ -87,11 +87,11 @@ switch safe:
   dataplanes at once, each with its own policy and conntrack
   state. Detaching is safe because a netkit pair created with
   `NETKIT_POLICY_FORWARD` and no programs forwards like a veth.
-- `wepStateFillJumps` returns jump-map indices to whichever
-  allocator issued them — the two are disjoint — using the
-  `netkitJumps` record, which at start of day comes from the
-  netkit link pin rather than the device type, since the device
-  is still netkit while the mechanism may already have changed.
+- Jump-map indices are returned to whichever allocator issued them;
+  the netkit and TC/TCX allocators are disjoint. At start of day
+  which one issued them is read from the netkit link pin, not the
+  device type — the device is still netkit while the mechanism may
+  already have changed.
 - `ensureQdisc` keys off the mechanism, not the link type, so a
   TC-driven device gets the qdisc it now needs.
 

--- a/felix/design/dataplane.md
+++ b/felix/design/dataplane.md
@@ -492,12 +492,12 @@ entire table.
 A node can switch backends across a Felix restart, so Felix sweeps
 every dataplane it isn't currently programming. There are three, and
 `iptablesBackend: Auto` can move a node between the last two on its
-own — detection keys off kube-proxy's chains, so boot ordering
-changes the answer:
+own, since detection keys off kube-proxy's chains and so depends on
+boot ordering.
 
 The shared tables (`filter`/`nat`/`mangle`/`raw`) exist twice in the
-kernel, once per iptables backend, so this doc calls them the
-**legacy copies** and the **nftables copies**.
+kernel, once per iptables backend; this doc calls them the **legacy
+copies** and the **nftables copies**.
 
 | Dataplane | Swept by | Needed when |
 |---|---|---|
@@ -505,35 +505,30 @@ kernel, once per iptables backend, so this doc calls them the
 | the nftables copies of the shared tables, where `iptables-nft` writes | `nftables.IPTablesNFTCleanup` | nftables mode, or iptables mode on iptables-legacy |
 | the legacy copies of the shared tables, where `iptables-legacy` writes | `iptables.Table` pinned to iptables-legacy, `CleanupOnly` | nftables mode, or iptables mode on iptables-nft |
 
-Two details that are easy to get wrong:
+Four constraints on the sweep:
 
 - The nftables copies are read over **netlink**, not with
-  `iptables-nft-save`, which refuses to read a table holding anything
-  iptables can't express - a neighbouring tool's native nft rules used
-  to crash-loop Felix that way. Only **base chains** are read for
-  rules, the only chains Felix ever inserted into, which is what keeps
-  the rule dumps off kube-proxy's thousands of chains. The chain list
-  itself is one dump of the whole family, since netlink has no
-  per-table filter for it, so the sweep is paced by the refresh
-  interval rather than run on every apply.
+  `iptables-nft-save`, which refuses a table holding anything iptables
+  can't express — a neighbouring tool's native nft rules are enough.
+  Only **base chains** are read for rules, the only chains Felix ever
+  inserted into, which keeps the dumps off kube-proxy's thousands of
+  chains. The chain list is one dump of the whole family (netlink has
+  no per-table filter), so the sweep is paced by the refresh interval
+  rather than run every apply.
 - A `CleanupOnly` table never panics: the backend it names may have no
-  kernel support on this host, in which case there is nothing of ours
-  in it anyway. It also retries on a latch rather than on every apply,
-  so a backend Felix can't read doesn't burn a retry budget each time
-  round the loop.
-- Felix declines to build the legacy tables at all unless **both**
-  sets of binaries are present. Without the legacy ones,
-  `FindBestBinary` falls back to the default `iptables` and the sweep
-  lands on the backend Felix is programming; without the nft ones, the
-  tables Felix programs take that same fallback and *are* the legacy
-  ones. The first check also gates the nft view in iptables mode.
-- Nor does Felix build them unless the legacy modules are already
-  loaded, since `iptables-legacy-save` would autoload them onto a node
-  running pure nftables. `environment.DetectBackend` shares that check
-  for the same reason, so backend detection no longer probes a backend
-  the kernel hasn't got - which used to load the modules before the
-  cleanup path got a chance to decline, and to count nft's rules as
-  legacy ones when `FindBestBinary` fell back.
+  kernel support here, in which case nothing of ours is in it. It
+  retries on a latch rather than every apply, so an unreadable backend
+  doesn't burn a retry budget each time round the loop.
+- The legacy tables are built only when **both** sets of binaries are
+  present. Otherwise `FindBestBinary` falls back to the default
+  `iptables`: with the legacy binaries missing the sweep would land on
+  the backend Felix is programming, and with the nft ones missing the
+  tables Felix programs are themselves the legacy copies. The same
+  check gates the nft view in iptables mode.
+- They are also built only when the legacy modules are already loaded,
+  since `iptables-legacy-save` would autoload them onto a node running
+  pure nftables. `environment.DetectBackend` shares that check, so
+  backend detection never probes a backend the kernel hasn't got.
 
 Cleanup **never terminates**. A shared table can be written again at
 any point (kube-proxy restarting, say), so one clean read proves
@@ -609,9 +604,6 @@ Mechanism and invariants:
   *before* the endpoint-mark block grab. Reserved from packet-mark
   space because the Log rules below also use it as a scratch packet
   mark, and so user `CONNMARK --save-mark` rules can't corrupt it.
-  `Config.validate()`'s reflection scan has an explicit
-  exception allowing this one `Mark*` field to be zero when the
-  feature is disabled.
 - **Setting the bit** (`rules/policy.go`): a rendered `Log` rule is
   followed by a `CONNMARK` rule with the same match. When
   `LogActionRateLimit` is set, both must instead hang off a single
@@ -652,19 +644,16 @@ Mechanism and invariants:
   so only real ICMP errors get the `-icmp-err` log (conntrack
   associates ICMP errors with the *original* connection's entry,
   which is why they carry its connmark; other RELATED flows, e.g.
-  helper children, fall through to the established branch). Nothing
-  in the chain is rate-limited: the bit that brings a packet here is
-  only set when the policy LOG fired, so these logs are already
-  bounded by `LogActionRateLimit` and each one pairs with a log the
-  user has seen.
+  helper children, fall through to the established branch). The
+  chain needs no rate limiting of its own: a packet only gets here
+  if the policy LOG fired, so these logs are already bounded by
+  `LogActionRateLimit`.
 - **Log prefixes** come from the dedicated
   `LogConnectionTransitionsPrefix` param (default
-  `calico-response`), used verbatim — the chain is static and
-  shared by all policies, so `LogPrefix`-style `%`-specifiers
-  cannot be resolved and are rendered literally (the API doc says
-  so) — with the base truncated so suffix plus the `": "` appended
-  by the Log action fit the backend limit (29 chars iptables, 127
-  nftables).
+  `calico-response`) and are used verbatim: the chain is static and
+  shared by all policies, so `LogPrefix`-style `%`-specifiers cannot
+  be resolved and render literally. The base is truncated to leave
+  room for the suffix within the backend's prefix limit.
 - **RST visibility**: netfilter hooks run before the TCP stack sees
   a packet (forwarded traffic never touches the host TCP stack at
   all), and conntrack only *classifies* an RST (valid → ESTABLISHED

--- a/felix/design/dataplane.md
+++ b/felix/design/dataplane.md
@@ -234,12 +234,10 @@ These are distinct mechanisms with overlapping effect:
   against **drift Felix didn't cause and wasn't told about** — the
   drift-detection job noted in
   [`DESIGN.md` §1](../DESIGN.md#dataplane-managers-and-drivers).
-  Most drivers resync everything in one pass. The **legacy ipsets
-  driver is the exception**: a periodic refresh there is satisfied
-  *incrementally* over several apply loops (see
-  [IP sets](#ip-sets)), because re-listing every set at once is too
-  slow. Start-of-day and error-triggered ipset resyncs stay full and
-  synchronous.
+  Most drivers resync everything in one pass; the legacy ipsets
+  driver satisfies a periodic refresh *incrementally* over several
+  apply loops, because re-listing every set at once is too slow (see
+  [IP sets](#ip-sets)).
 
 ### Review notes for this section
 
@@ -476,11 +474,10 @@ Two invariants follow:
   it does not disqualify an endpoint.
 
   Keeping the endpoint's veth out of the flowtable device set is
-  **not** a substitute, and this was measured rather than assumed: the
-  offload rule creates the entry whichever devices the flow uses, and
-  the fast path then fires from the *ingress* device. A plain pod
-  talking to a connection-limited pod still short-circuits at its own
-  veth, skipping the limit. Only the reply direction would be
+  **not** a substitute: the offload rule creates the entry whichever
+  devices the flow uses, and the fast path fires from the *ingress*
+  device, so a plain pod talking to a connection-limited pod still
+  short-circuits at its own veth. Only the reply direction would be
   protected.
 
 Membership is also gated on the interface being up, in both the
@@ -572,9 +569,8 @@ converts lists of Calico-internal rules/endpoints/etc into concrete
   per-endpoint dispatch rules is a real per-packet tax. This really is
   per-*packet*, not per-connection: the conntrack accept lives in the
   per-endpoint chain, downstream of dispatch, so even established flows
-  traverse the dispatch chains (an earlier short-circuit further up the
-  path was moved into the per-endpoint chain because it broke setups
-  with non-Calico rules). Felix builds
+  traverse the dispatch chains; it cannot be hoisted above dispatch
+  without breaking setups that carry non-Calico rules. Felix builds
   a **shallow (typically single-level) tree of dispatch chains**,
   binning endpoints by the next character after the common
   interface-name prefix (`sortAndDivideEndpointNamesToPrefixTree` /
@@ -710,26 +706,19 @@ kernel constraints behind them:
   caps deletions per iteration (`MaxIPSetDeletionsPerIteration = 1`,
   rescheduling with a ~100ms floor), so a big policy teardown of
   thousands of sets doesn't stall the whole dataplane on cleanup.
-- **Periodic resyncs are incremental**, for the same reason. Felix
-  reads back each set with its own `ipset list <name>` (needed for an
-  ipset compatibility issue), so re-listing every set on each refresh
-  is far too slow. A refresh instead lists only the *names* cheaply,
-  repairs any set that vanished or appeared unexpectedly right away,
-  and re-checks the surviving sets' contents from a two-tier queue
-  (`resyncQueue`) drained a time-boxed batch per apply
-  (`BackgroundResyncTimeBudget`), paced by the same ≤100ms reschedule
-  as deletions. The **must** tier (start-of-day and error-forced
-  resyncs) is drained fully before Felix trusts the dataplane; the
-  **background** tier (periodic refresh) is spread over apply loops. A
-  desired set found missing from the name listing is repaired in the
-  *same* apply — its dataplane view is cleared so the normal
-  create-path recreates it — rather than being queued for a wasted
-  per-set list. On nodes with many sets the queue may never fully
-  drain between refreshes; re-adds keep an entry's queue position, so
-  the sweep degrades into a continuous rolling scan and a given set's
-  contents are re-checked roughly once per *sweep* time, which can
-  exceed `IpsetsRefreshInterval`. That is the intended trade-off, not
-  a pacing bug.
+- **Periodic resyncs are incremental**, for the same reason: each set
+  is read back with its own `ipset list <name>`, so re-listing every
+  set per refresh is far too slow. A refresh lists only the *names*,
+  repairs any set that vanished or appeared unexpectedly in the same
+  apply, and queues the survivors' contents for re-checking a
+  time-boxed batch per apply, paced by the same ≤100ms reschedule as
+  deletions. The queue has two tiers: **must** (start-of-day and
+  error-forced) is drained fully before Felix trusts the dataplane,
+  **background** (periodic refresh) is spread over apply loops. On
+  nodes with many sets it may never fully drain, so the sweep becomes
+  a continuous rolling scan whose effective re-check period is one
+  sweep — which can exceed `IpsetsRefreshInterval`. That is the
+  intended trade-off, not a pacing bug.
 
 **The cross-layer invariant: never reference an IP set before it is
 programmed.** This is enforced jointly by the calc graph and the
@@ -817,16 +806,11 @@ programming.
 For those components the dual-stack trap is not "did you duplicate
 the code" but **"did you fan out to every family's manager"**. A
 singleton holding a *single* reference to its downstream manager
-silently serves IPv4 only, and nothing fails loudly: the IPv6
-manager simply never learns the state, so its routes keep their
-default behaviour. That was CORE-12806 — the live migration
-monitor's `listener` field was assigned the IPv4 endpoint manager
-only, so IPv6 workload routes were never suppressed on a migration
-target nor elevated after cutover, and IPv6 traffic to a migrating
-VM could black-hole for the duration of the migration. Prefer a list
+serves IPv4 only and fails silently — the IPv6 manager never learns
+the state, so its routes keep their default behaviour. Prefer a list
 plus an explicit registration call (`registerListener`) over a
-single-valued field: a missing family then shows up as a missing
-call at the construction site in `int_dataplane.go`, alongside the
+single-valued field: a missing family then shows up as a missing call
+at the construction site in `int_dataplane.go`, alongside the
 `RegisterManager` call it belongs with.
 
 ### Review notes for this section


### PR DESCRIPTION
Follow-up to #13549, now that it has merged. The rule it added asks the next PR that touches a design doc past ~500 lines to compress rather than grow it. These are the docs over that line, plus the design prose that landed while the rule was in review. **No design content is removed** — every invariant, review note and data-model statement is still here, at a shorter length or a higher altitude.

| file | master | after |
|---|---|---|
| `felix/design/dataplane.md` | 954 | 927 |
| `felix/design/bpf-services.md` | 741 | 693 |
| `felix/design/bpf-observability.md` | 549 | 527 |
| `design/cluster-route-programming/DESIGN.md` | 376 | 369 |
| `felix/design/bpf-tc-programs.md` | 403 | 403 |

## Commit 1 — the docs that were already oversized

- **`bpf-services.md`**: the 34-line `### API server service: never drop to zero backends` section retold its own commit message under its own heading, while the invariant list directly above it already carried the one-line placeholder. It collapses into that list as the single bullet the merged rule uses as its worked example — so the rule and the doc now agree. The service-ID section loses the walk-through of how re-adoption works and keeps both halves of the uniqueness invariant; the "VXLAN ambiguity" aside (24 lines) drops the reader-directed framing and keeps the distinction it exists to draw; Maglev's sub-program rationale becomes the present verifier-budget constraint rather than the history of the inlined form.
- **`dataplane.md`**: the dual-stack singleton section keeps the rule and drops the six-line retelling of the incident that established it. The periodic-ipset-resync paragraph keeps its shape and the rolling-scan trade-off and drops the per-step narration — its three invariants were already in the review note below it. Also "and this was measured rather than assumed", and the dispatch-chain change history (now stated as the constraint it established).
- **`bpf-observability.md`**: already compressed once (`9a0e582331`), so little fat — a PR reference standing in for a rationale becomes the rationale, and two paragraphs lose their padding.
## Commit 3 — a factual correction found while reviewing the compression

The VXLAN note in `bpf-services.md` said Calico programs both the pod-to-pod overlay and NodePort forwarding "on the same `vxlan.calico` device". Only the overlay uses that device. NodePort forwarding builds its own encapsulation — `vxlan_encap` (`felix/bpf-gpl/nat4.h`, `nat6.h`) writes the eth/IP/UDP/VXLAN headers into the packet with `bpf_skb_adjust_room`, and it then leaves as ordinary host traffic. No tunnel device, and no `bpf_skb_set_tunnel_key`, which is what the overlay path uses instead (`fib_co_re.h`). VNI is the only thing that distinguishes them on the wire, which is what the reserved `0xca11c0` is for.

The claim predates this branch — commit 1 carried it into the note's opening line, which is what made it worth checking.

- Repairs **18 intra-file references** that the original `bpf-dataplane.md` split flattened into bare section titles — `(Connect-Time Load Balancer (CTLB))`, `see Service session affinity`, `same mechanics as QoS QoS DSCP`, and two garbled past reading in the kube-proxy section. All links and fragments verified to resolve.

## Commit 2 — design prose added while the rule was in review

Five docs took ~275 lines on master since this branch was cut, repeating the patterns the rule names. Authors: worth a sanity check that nothing load-bearing was cut.

- **`bpf-observability.md` connlimit** (the `CONNLIMIT_DEC` / spurious-RST fix, `30cae85e75`): the reason the userspace recount does not skip on `CONNLIMIT_DEC` was told as the story of the leak it caused; it now states the property that makes the flag unsafe to skip on. The latch review note keeps the release point, the atomic-AND requirement and the re-arm consequence.
- **`dataplane.md`, cleaning up after the other backend**: "Two details that are easy to get wrong" listed four, and a colon introduced a paragraph that did not answer it — both fixed. The netlink read, the `CleanupOnly` latch and both build preconditions stay; the history of the two fixes that established them goes to git.
- **`bpf-services.md` affinity**: the longer-timeout-wins rule no longer re-argues itself from the user's point of view; the `cleanupSticky` note leads with the rule rather than walking through the two writers first.
- **`design/cluster-route-programming/DESIGN.md`**, the BIRD transition: drops "and they do not behave the same" / "not in the direction one might expect", the verification aside, and a paragraph that re-covered the one above it. The two paths, the `RouteReplace` guarantee, the protocol-matched delete and the ownership rule's scope all stay.
- **`bpf-tc-programs.md`**: one bullet moves off three identifiers onto the invariant they implement.
- **`dataplane.md`, connection transition logging** (`f5ca880b3d`, landed after the rule): dense but already written at invariant altitude, so it keeps its length. What goes is a reflection-scan detail, a rate-limit rationale given twice, and the prefix string handling — leaving the constraint.

## What needed nothing

Worth recording, since the rule is not asking for zero doc changes. Four additions are already what it asks for and are untouched: `bpf-overview.md`'s netkit bullet and `felix/DESIGN.md`'s nftables paragraph (one clause each), and the two written *after* the rule landed — `goldmane/DESIGN.md` corrects two now-false sentences about deduplication and names the new emission-claims concept in seven lines, and `felix/DESIGN.md` states the `nftrender`/`nftables` split as an invariant about what Windows may import.

**Release note:**
```release-note
None
```

