### PR TITLE
Pin the AKS bpf e2e lanes to the current stable Kubernetes

### DIFF
--- a/.argoci/cron/e2e-bpf.yaml
+++ b/.argoci/cron/e2e-bpf.yaml
@@ -265,6 +265,8 @@ steps:
         value: operator
       - name: K8S_E2E_DOCKER_EXTRA_FLAGS
         value: --env EKS_CNI
+      - name: K8S_VERSION
+        value: stable
     matrix:
       - name: azr-aks
         env:
@@ -293,6 +295,8 @@ steps:
         value: operator
       - name: K8S_E2E_DOCKER_EXTRA_FLAGS
         value: --env EKS_CNI
+      - name: K8S_VERSION
+        value: stable
       - name: PROVISIONER
         value: azr-aks
     commands: |
@@ -318,6 +322,8 @@ steps:
         value: 10.244.0.0/16
       - name: K8S_E2E_DOCKER_EXTRA_FLAGS
         value: --env EKS_CNI
+      - name: K8S_VERSION
+        value: stable
       - name: NETWORK_PLUGIN_MODE
         value: overlay
       - name: PROVISIONER
@@ -754,6 +760,8 @@ steps:
         value: operator
       - name: IPV4_POD_CIDR
         value: 10.244.0.0/16
+      - name: K8S_VERSION
+        value: stable
       - name: NETWORK_PLUGIN_MODE
         value: overlay
       - name: PROVISIONER


### PR DESCRIPTION
Every AKS lane in the bpf suite has failed since 7/28, before it provisions anything: they set no `K8S_VERSION`, so they inherit the `stable-3` default, which resolves to 1.33 today, and AKS offers 1.33 only under its long-term support plan. Pinning `stable` fixes it, because the provisioner snaps the resolved 1.36.3 down to the 1.36.2 AKS actually offers, which is what the two managed lanes in the iptables suite already rely on. Four lanes need it, the three `bpf-run-matrix-aks-*` lanes and `wireguard`.

Related: [CORE-13355](https://tigera.atlassian.net/browse/CORE-13355)

**Release note:**
```release-note
None
```


[CORE-13355]: https://tigera.atlassian.net/browse/CORE-13355?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ