### PR TITLE
Select tests by config on the nftables e2e lanes

### DIFF
--- a/.argoci/cron/e2e-nftables.yaml
+++ b/.argoci/cron/e2e-nftables.yaml
@@ -11,7 +11,6 @@ globalPrologue: |
   export ENABLE_AUTOHEP="${ENABLE_AUTOHEP:-true}"
   export FUNCTIONAL_AREA="${FUNCTIONAL_AREA:-nftables.yml}"
   export INSTALLER="${INSTALLER:-operator}"
-  export K8S_E2E_FLAGS="${K8S_E2E_FLAGS:---ginkgo.focus=(\[sig-calico\]|\[Conformance\]) --ginkgo.skip=(\[Slow\]|\[Disruptive\]|sig-node|sig-apps|sig-storage|sig-scheduling|sig-calico-enterprise|\[DataPath\]|Feature:Wireguard)}"
   export K8S_VERSION="${K8S_VERSION:-stable-3}"
   export KUBE_PROXY_MODE="${KUBE_PROXY_MODE:-nftables}"
   export PRIVATE_REGISTRY="${PRIVATE_REGISTRY:-quay.io/}"
@@ -28,6 +27,8 @@ steps:
       - docker
       - http-cache-proxy
     env:
+      - name: E2E_TEST_CONFIG
+        value: e2e/config/nftables/xtables-autohep.yaml
       - name: ENABLE_WIREGUARD
         value: "true"
       - name: GOOGLE_MACHINE_TYPE
@@ -60,6 +61,8 @@ steps:
       - docker
       - http-cache-proxy
     env:
+      - name: E2E_TEST_CONFIG
+        value: e2e/config/nftables/xtables-encap-aws-autohep.yaml
       - name: ENCAPSULATION_TYPE
         value: VXLAN
       - name: PROVISIONER
@@ -78,6 +81,8 @@ steps:
     env:
       - name: CLUSTER_ROUTING_MODE
         value: Felix
+      - name: E2E_TEST_CONFIG
+        value: e2e/config/nftables/xtables-encap-nobgp-v3crd-autohep.yaml
       # gcp-kubeadm uses the fixed semaphore-autotest VPC + reserved IPs, which
       # exist only in us-central1; pin region/zone (the load-spread randomisation
       # in the prologue can't apply to region-fixed jobs). See arm64-wg.
@@ -98,6 +103,8 @@ steps:
       - docker
       - http-cache-proxy
     env:
+      - name: E2E_TEST_CONFIG
+        value: e2e/config/nftables/xtables-v3crd-aws-autohep.yaml
       - name: K8S_VERSION
         value: stable-3
       - name: PROVISIONER
@@ -111,6 +118,8 @@ steps:
       - docker
       - http-cache-proxy
     env:
+      - name: E2E_TEST_CONFIG
+        value: e2e/config/nftables/eks-xtables-nobgp-aws-autohep.yaml
       - name: K8S_VERSION
         value: stable-1
       - name: PROVISIONER
@@ -152,6 +161,8 @@ steps:
       - docker
       - http-cache-proxy
     env:
+      - name: E2E_TEST_CONFIG
+        value: e2e/config/nftables/xtables-encap-autohep.yaml
       - name: ENABLE_DUAL_STACK
         value: "true"
       - name: ENCAPSULATION_TYPE
@@ -176,6 +187,8 @@ steps:
       - docker
       - http-cache-proxy
     env:
+      - name: E2E_TEST_CONFIG
+        value: e2e/config/nftables/xtables-autohep.yaml
       - name: ENABLE_DUAL_STACK
         value: "true"
       - name: ENCAPSULATION_TYPE_V6

--- a/.semaphore/end-to-end/pipelines/nftables.yml
+++ b/.semaphore/end-to-end/pipelines/nftables.yml
@@ -21,9 +21,6 @@ global_job_config:
     - name: marvin-github-ssh-private-key
     - name: banzai-secrets
   env_vars:
-    # The skips for sig-* are tests that are not relevant to OSS Calico
-    - name: K8S_E2E_FLAGS
-      value: --ginkgo.focus=(\[sig-calico\]|\[Conformance\]) --ginkgo.skip=(\[Slow\]|\[Disruptive\]|sig-node|sig-apps|sig-storage|sig-scheduling|sig-calico-enterprise|\[DataPath\]|Feature:Wireguard)
     - name: K8S_VERSION
       value: "stable-3"
     - name: FUNCTIONAL_AREA
@@ -71,6 +68,8 @@ blocks:
               value: t2a-standard-2
             - name: ENABLE_WIREGUARD
               value: "true"
+            - name: E2E_TEST_CONFIG
+              value: "e2e/config/nftables/xtables-autohep.yaml"
 
   - name: Nftables, Talos
     dependencies: []
@@ -89,6 +88,8 @@ blocks:
               value: aws-talos
             - name: ENCAPSULATION_TYPE
               value: "VXLAN"
+            - name: E2E_TEST_CONFIG
+              value: "e2e/config/nftables/xtables-encap-aws-autohep.yaml"
 
         - name: Native v3 CRDs (GCP)
           execution_time_limit:
@@ -104,6 +105,8 @@ blocks:
               value: "false"
             - name: CLUSTER_ROUTING_MODE
               value: Felix
+            - name: E2E_TEST_CONFIG
+              value: "e2e/config/nftables/xtables-encap-nobgp-v3crd-autohep.yaml"
 
         - name: Native v3 CRDs (AWS)
           execution_time_limit:
@@ -117,6 +120,8 @@ blocks:
               value: "stable-3"
             - name: USE_API_SERVER
               value: "false"
+            - name: E2E_TEST_CONFIG
+              value: "e2e/config/nftables/xtables-v3crd-aws-autohep.yaml"
 
   - name: Nftables mode, EKS
     dependencies: []
@@ -135,6 +140,8 @@ blocks:
               value: "aws-eks"
             - name: K8S_VERSION
               value: "stable-1"
+            - name: E2E_TEST_CONFIG
+              value: "e2e/config/nftables/eks-xtables-nobgp-aws-autohep.yaml"
 
         - name: EKS w/ Calico CNI
           execution_time_limit:
@@ -189,6 +196,8 @@ blocks:
               value: "VXLAN"
             - name: IPV4_POD_CIDR
               value: "192.168.0.0/16"
+            - name: E2E_TEST_CONFIG
+              value: "e2e/config/nftables/xtables-encap-autohep.yaml"
 
         - name: Nftables mode, ipv6-only
           execution_time_limit:
@@ -200,6 +209,8 @@ blocks:
               value: ipv6
             - name: ENCAPSULATION_TYPE_V6
               value: "None"
+            - name: E2E_TEST_CONFIG
+              value: "e2e/config/nftables/xtables-autohep.yaml"
 
   - name: KubeVirt e2e tests
     dependencies: []

--- a/e2e/pkg/testconfig/repoconfigs_test.go
+++ b/e2e/pkg/testconfig/repoconfigs_test.go
@@ -222,13 +222,7 @@ func TestFragmentsAreNotUsedDirectly(t *testing.T) {
 // Asserted in both directions below, so a config added without a cell fails
 // immediately and a stale entry fails too.
 var unwiredConfigs = map[string]bool{
-	"iptables/gke-xtables-nobgp-v3crd.yaml":           true,
-	"nftables/eks-xtables-nobgp-aws-autohep.yaml":     true,
-	"nftables/xtables-autohep.yaml":                   true,
-	"nftables/xtables-encap-autohep.yaml":             true,
-	"nftables/xtables-encap-aws-autohep.yaml":         true,
-	"nftables/xtables-encap-nobgp-v3crd-autohep.yaml": true,
-	"nftables/xtables-v3crd-aws-autohep.yaml":         true,
+	"iptables/gke-xtables-nobgp-v3crd.yaml": true,
 }
 
 // TestNoOrphanedConfigs checks the reverse of TestReferencedConfigsExist: a config

--- a/e2e/testsets/index.txt
+++ b/e2e/testsets/index.txt
@@ -71,14 +71,14 @@
 .argoci/cron/e2e-iptables.yaml | wireguard-regression-k8s-e2e-kdd-old | iptables/xtables-v3crd-aws | 216
 .argoci/cron/e2e-iptables.yaml | wireguard-vxlan-k8s-e2e | iptables/xtables-wireguard | 216
 .argoci/cron/e2e-nftables.yaml | kubevirt-e2e-tests | gcp/kubevirt | 8
-.argoci/cron/e2e-nftables.yaml | nftables-mode-arm64-wg | legacy/nftables | 194
-.argoci/cron/e2e-nftables.yaml | nftables-mode-eks-eks-w-aws-cni | legacy/nftables | 194
+.argoci/cron/e2e-nftables.yaml | nftables-mode-arm64-wg | nftables/xtables-autohep | 222
+.argoci/cron/e2e-nftables.yaml | nftables-mode-eks-eks-w-aws-cni | nftables/eks-xtables-nobgp-aws-autohep | 209
 .argoci/cron/e2e-nftables.yaml | nftables-mode-eks-eks-w-calico-cni | nftables/eks-xtables-aws-autohep | 212
-.argoci/cron/e2e-nftables.yaml | nftables-mode-kind-nftables-mode-ipv6-only | legacy/nftables | 194
-.argoci/cron/e2e-nftables.yaml | nftables-mode-kind-nftables-mode-vxlan-dual-stack | legacy/nftables | 194
-.argoci/cron/e2e-nftables.yaml | nftables-talos-native-v3-crds-aws | legacy/nftables | 194
-.argoci/cron/e2e-nftables.yaml | nftables-talos-native-v3-crds-gcp | legacy/nftables | 194
-.argoci/cron/e2e-nftables.yaml | nftables-talos-nftables-talos | legacy/nftables | 194
+.argoci/cron/e2e-nftables.yaml | nftables-mode-kind-nftables-mode-ipv6-only | nftables/xtables-autohep | 222
+.argoci/cron/e2e-nftables.yaml | nftables-mode-kind-nftables-mode-vxlan-dual-stack | nftables/xtables-encap-autohep | 218
+.argoci/cron/e2e-nftables.yaml | nftables-talos-native-v3-crds-aws | nftables/xtables-v3crd-aws-autohep | 218
+.argoci/cron/e2e-nftables.yaml | nftables-talos-native-v3-crds-gcp | nftables/xtables-encap-nobgp-v3crd-autohep | 213
+.argoci/cron/e2e-nftables.yaml | nftables-talos-nftables-talos | nftables/xtables-encap-aws-autohep | 218
 .argoci/cron/e2e-openstack.yaml | full-fv | (openstack-e2e) | -
 .argoci/cron/e2e-openstack.yaml | multi-region | (openstack-e2e) | -
 .argoci/cron/e2e-patch-verification.yaml | kind-tests | patch-verification/xtables | 83
@@ -189,13 +189,13 @@
 .semaphore/end-to-end/pipelines/iptables.yml | usage reporting / mainline | (usage-reporting) | -
 .semaphore/end-to-end/pipelines/nftables.yml | KubeVirt e2e tests / KubeVirt IP persistence and live migration | gcp/kubevirt | 8
 .semaphore/end-to-end/pipelines/nftables.yml | Nftables mode, EKS / EKS w/ Calico CNI | nftables/eks-xtables-aws-autohep | 212
-.semaphore/end-to-end/pipelines/nftables.yml | Nftables mode, EKS / EKS w/ aws CNI | legacy/nftables | 194
-.semaphore/end-to-end/pipelines/nftables.yml | Nftables mode, KinD / Nftables mode, ipv6-only | legacy/nftables | 194
-.semaphore/end-to-end/pipelines/nftables.yml | Nftables mode, KinD / Nftables mode, vxlan, dual-stack | legacy/nftables | 194
-.semaphore/end-to-end/pipelines/nftables.yml | Nftables mode, arm64, WG / Nftables mode, arm64, WG | legacy/nftables | 194
-.semaphore/end-to-end/pipelines/nftables.yml | Nftables, Talos / Native v3 CRDs (AWS) | legacy/nftables | 194
-.semaphore/end-to-end/pipelines/nftables.yml | Nftables, Talos / Native v3 CRDs (GCP) | legacy/nftables | 194
-.semaphore/end-to-end/pipelines/nftables.yml | Nftables, Talos / Nftables, Talos | legacy/nftables | 194
+.semaphore/end-to-end/pipelines/nftables.yml | Nftables mode, EKS / EKS w/ aws CNI | nftables/eks-xtables-nobgp-aws-autohep | 209
+.semaphore/end-to-end/pipelines/nftables.yml | Nftables mode, KinD / Nftables mode, ipv6-only | nftables/xtables-autohep | 222
+.semaphore/end-to-end/pipelines/nftables.yml | Nftables mode, KinD / Nftables mode, vxlan, dual-stack | nftables/xtables-encap-autohep | 218
+.semaphore/end-to-end/pipelines/nftables.yml | Nftables mode, arm64, WG / Nftables mode, arm64, WG | nftables/xtables-autohep | 222
+.semaphore/end-to-end/pipelines/nftables.yml | Nftables, Talos / Native v3 CRDs (AWS) | nftables/xtables-v3crd-aws-autohep | 218
+.semaphore/end-to-end/pipelines/nftables.yml | Nftables, Talos / Native v3 CRDs (GCP) | nftables/xtables-encap-nobgp-v3crd-autohep | 213
+.semaphore/end-to-end/pipelines/nftables.yml | Nftables, Talos / Nftables, Talos | nftables/xtables-encap-aws-autohep | 218
 .semaphore/end-to-end/pipelines/patch-verification.yml | KinD tests / IPv6 | patch-verification/xtables | 83
 .semaphore/end-to-end/pipelines/patch-verification.yml | KubeVirt e2e tests / KubeVirt IP persistence and live migration | gcp/kubevirt | 8
 .semaphore/end-to-end/pipelines/patch-verification.yml | Manifests / Calico etcd | patch-verification/xtables-encap-manifest | 80

--- a/e2e/testsets/sets/nftables/eks-xtables-nobgp-aws-autohep.txt
+++ b/e2e/testsets/sets/nftables/eks-xtables-nobgp-aws-autohep.txt
@@ -1,0 +1,209 @@
+[sig-calico] [Team:CORE] [Category:Networking] [Feature:HostPorts] HostPorts tests with host port resources active on :8080 should support Pod HostPorts [Conformance] [Serial]
+[sig-calico] [Team:CORE] [Category:Networking] [Feature:Pods] Pod Termination Grace Period should allow client to reach server while client is terminating [Conformance]
+[sig-calico] [Team:CORE] [Category:Networking] [Feature:Pods] Pod Termination Grace Period should allow pinging a server pod while it is terminating
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:AutoHEPs] auto host endpoint tests should create host endpoints for each node [Conformance] [Serial]
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:AutoHEPs] auto host endpoint tests with policies in place with egress policy should block one node 1 from reaching node 0 on port 9091 with egress policy [Serial]
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:AutoHEPs] auto host endpoint tests with policies in place with ingress policy should block one node 1 from entering node 0 on port 9090 with ingress policy [Serial]
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Host-Protection] host endpoint tests doNotTrack policy should deny connections to the specified port in a doNotTrack deny policy [Serial]
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Host-Protection] host endpoint tests should allow connections using a named port [Conformance] [Serial]
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Host-Protection] host endpoint tests should allow inbound connections with an allow-all [Serial]
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Host-Protection] host endpoint tests should block all inbound connections by default [Serial]
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-Policy] [RunsOnWindows] Tiered policy tests with a second tier can explicitly pass traffic
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-Policy] [RunsOnWindows] Tiered policy tests with a second tier should enforce a default deny
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-Policy] [RunsOnWindows] Tiered policy tests with a single tier taking precedence over the default tier can pass to the default tier, and allow traffic explicitly. [Conformance]
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] Tiered RBAC with tier-prefixed names should allow create and deny based on tier RBAC with prefixed names
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC GlobalNetworkPolicy should allow creation by a user with full tier RBAC
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC GlobalNetworkPolicy should deny creation by a user without tier access
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC NetworkPolicy should allow creation by a user with full tier RBAC [Conformance]
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC NetworkPolicy should allow deletion by a user with full tier RBAC
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC NetworkPolicy should allow update by a user with full tier RBAC
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC NetworkPolicy should deny creation by a user without tier GET access [Conformance]
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC NetworkPolicy should deny creation by a user without tier policy access
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC NetworkPolicy should deny update by a user without tier GET access
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC default tier should not allow deleting the default tier
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC default tier should not allow updating the default tier
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC list via tier RBAC [RequiresCalicoAPIServer] should allow listing policies in the permitted tier
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC list via tier RBAC [RequiresCalicoAPIServer] should deny listing when user lacks tier policy access
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC old-style vs new-style name disambiguation [RequiresCalicoAPIServer] should independently authorize bare and tier-prefixed policy names
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC read-only access should allow reading but deny writing for a read-only user [Conformance]
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC resource-name exact match [RequiresCalicoAPIServer] should allow access to the named policy but deny access to others
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC tier isolation should restrict a user to only their permitted tier [Conformance]
+[sig-calico] [Team:CORE] [Category:Policy] [RequiresGoldmane] staged network policy Test presence in flow logs StagedGlobalNetworkPolicy Validate name, tier, action [Conformance]
+[sig-calico] [Team:CORE] [Category:Policy] [RequiresGoldmane] staged network policy Test presence in flow logs StagedKubernetesNetworkPolicy Validate name, tier, action [Conformance]
+[sig-calico] [Team:CORE] [Category:Policy] [RequiresGoldmane] staged network policy Test presence in flow logs StagedNetworkPolicy Validate name, tier, action [Conformance]
+[sig-calico] [Team:CORE] [Category:Policy] [RequiresGoldmane] staged network policy enforcing staged-policies StagedGlobalNetworkPolicy should enforce a deny policy
+[sig-calico] [Team:CORE] [Category:Policy] [RequiresGoldmane] staged network policy enforcing staged-policies StagedKubernetesNetworkPolicy should enforce a deny policy
+[sig-calico] [Team:CORE] [Category:Policy] [RequiresGoldmane] staged network policy enforcing staged-policies StagedNetworkPolicy should enforce a deny policy
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Packet Size Verification with different packet sizes using UDP and TCP host to nodeport, different nodes
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Packet Size Verification with different packet sizes using UDP and TCP host to pod, different nodes
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Packet Size Verification with different packet sizes using UDP and TCP host to service, different nodes
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Packet Size Verification with different packet sizes using UDP and TCP pod to nodeport, different nodes
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Packet Size Verification with different packet sizes using UDP and TCP pod to nodeport, same node
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Packet Size Verification with different packet sizes using UDP and TCP pod to pod, different nodes
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Packet Size Verification with different packet sizes using UDP and TCP pod to pod, same node
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Packet Size Verification with different packet sizes using UDP and TCP pod to service, different nodes
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Packet Size Verification with different packet sizes using UDP and TCP pod to service, same node
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath ClusterIP access scenario-0C0: pod0 -> clusterIP -> pod0 (loopback)
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath ClusterIP access scenario-0C1: pod0 -> clusterIP -> pod1 (same node)
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath ClusterIP access scenario-0C2: pod0 -> clusterIP -> pod2 (cross node) [Conformance]
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath ExternalIP access scenario-0EC0: pod0 -> externalIP Cluster -> pod0
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath ExternalIP access scenario-0EC1: pod0 -> externalIP Cluster -> pod1
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath ExternalIP access scenario-0EC2: pod0 -> externalIP Cluster -> pod2 (other node) [Conformance]
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath ExternalIP access scenario-0EL0: pod0 -> externalIP local-only -> pod0
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath ExternalIP access scenario-0EL1: pod0 -> externalIP local-only -> pod1
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath Host-networked destination scenario-0H1: pod0 -> clusterIP -> host-networked pod1 (same node)
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath Host-networked destination scenario-0H2: pod0 -> clusterIP -> host-networked pod2 (other node)
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath NodePort access scenario-0L00: pod0 -> node0 NodePort local-only -> pod0
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath NodePort access scenario-0L01: pod0 -> node0 NodePort local-only -> pod1
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath NodePort access scenario-0L12: pod0 -> node1 NodePort local-only -> pod2
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath NodePort access scenario-0N00: pod0 -> node0 NodePort -> pod0
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath NodePort access scenario-0N01: pod0 -> node0 NodePort -> pod1 (same node)
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath NodePort access scenario-0N02: pod0 -> node0 NodePort -> pod2 (other node) [Conformance]
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath NodePort access scenario-0N10: pod0 -> node1 NodePort -> pod0
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath NodePort access scenario-0N11: pod0 -> node1 NodePort -> pod1 (hairpin)
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath NodePort access scenario-0N12: pod0 -> node1 NodePort -> pod2 (pod on other node)
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Ingress Datapath scenario-10: node1 hostNet=true -> node1NodePort
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Ingress Datapath scenario-11: node0 hostNet=false -> node1NodePort
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Ingress Datapath scenario-12: node0 hostNet=true -> node1NodePort
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Ingress Datapath scenario-1: svcNode hostNet=false -> clusterIP
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Ingress Datapath scenario-2: svcNode hostNet=true -> clusterIP
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Ingress Datapath scenario-3: node1 hostNet=false -> clusterIP [Conformance]
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Ingress Datapath scenario-4: node1 hostNet=true -> clusterIP
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Ingress Datapath scenario-5: svcNode hostNet=false -> svcNodePort
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Ingress Datapath scenario-6: svcNode hostNet=true -> svcNodePort
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Ingress Datapath scenario-7: node1 hostNet=false -> svcNodePort
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Ingress Datapath scenario-8: node1 hostNet=true -> svcNodePort
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Ingress Datapath scenario-9: node1 hostNet=false -> node1NodePort
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-0-2 ApplyOnForward=false, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-0-2 ApplyOnForward=true, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-0C2 ApplyOnForward=false, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-0C2 ApplyOnForward=true, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-0C3 ApplyOnForward=false, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-0C3 ApplyOnForward=true, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-0N2 ApplyOnForward=false, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-0N2 ApplyOnForward=true, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-0N3 ApplyOnForward=false, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-0N3 ApplyOnForward=true, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-1-2 ApplyOnForward=false, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-1-2 ApplyOnForward=true, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-1C2 ApplyOnForward=false, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-1C2 ApplyOnForward=true, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-1N2 ApplyOnForward=false, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-1N2 ApplyOnForward=true, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-2N1 ApplyOnForward=false, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-2N1 ApplyOnForward=true, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath ingress-2-1 ApplyOnForward=false, ingress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath ingress-2-1 ApplyOnForward=true, ingress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath ingress-2C0 ApplyOnForward=false, ingress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath ingress-2C0 ApplyOnForward=true, ingress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath ingress-2N1 ApplyOnForward=false, ingress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath ingress-2N1 ApplyOnForward=true, ingress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath ingress-3-0 ApplyOnForward=false, ingress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath ingress-3-0 ApplyOnForward=true, ingress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath xtables-only [RequiresXtables] egress-2N2 ApplyOnForward=false, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath xtables-only [RequiresXtables] egress-2N2 ApplyOnForward=true, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath xtables-only [RequiresXtables] ingress-2N2 ApplyOnForward=false, ingress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath xtables-only [RequiresXtables] ingress-2N2 ApplyOnForward=true, ingress [Serial]
+[sig-calico] [Team:CORE] [Feature:IPAM] [Category:Networking] IPAM GC should garbage-collect leaked IP addresses [Serial]
+[sig-calico] [Team:CORE] [Feature:IPIP] [Category:Networking] [NoEncap] IP-in-IP tests should assign an IPIP address to the tunl0 interface [Serial]
+[sig-calico] [Team:CORE] [Feature:IPIP] [Category:Networking] [NoEncap] IP-in-IP tests should support toggling IPIP on and off [Serial]
+[sig-calico] [Team:CORE] [Feature:IPPool] [Category:Operator] operator IPPool management tests should create and delete IP pools [Serial]
+[sig-calico] [Team:CORE] [Feature:Istio] [Category:Networking] Istio OpenShift Platform Configuration should deploy Istio with correct OpenShift platform configuration [Serial]
+[sig-calico] [Team:CORE] [Feature:Istio] [Category:Networking] [RequiresOperator] Istio Ambient Mode should allow UDP traffic to bypass ztunnel while Calico enforces UDP policy [Serial]
+[sig-calico] [Team:CORE] [Feature:Istio] [Category:Networking] [RequiresOperator] Istio Ambient Mode should encrypt traffic with ambient mode and enforce Calico NetworkPolicy [Serial]
+[sig-calico] [Team:CORE] [Feature:MTU] [Category:Networking] Automatic MTU tests should select the correct MTU for the platform
+[sig-calico] [Team:CORE] [Feature:NetworkPolicy] [Category:Policy] [RunsOnWindows] Calico NetworkPolicy should correctly isolate namespaces [Conformance]
+[sig-calico] [Team:CORE] [Feature:NetworkPolicy] [Category:Policy] [RunsOnWindows] Calico NetworkPolicy should provide a default allow [Conformance]
+[sig-calico] [Team:CORE] [Feature:NetworkPolicy] [Category:Policy] [RunsOnWindows] Calico NetworkPolicy should support a 'deny egress' policy [Conformance]
+[sig-calico] [Team:CORE] [Feature:NetworkPolicy] [Category:Policy] [RunsOnWindows] Calico NetworkPolicy should support namespace selectors [Conformance]
+[sig-calico] [Team:CORE] [Feature:NetworkPolicy] [Category:Policy] [RunsOnWindows] Calico NetworkPolicy should support service account selectors [Conformance]
+[sig-calico] [Team:CORE] [Feature:NetworkPolicy] [Category:Policy] service network policy Calico service network policy test ServiceMatch policy client egress by pod-name, server ingress by service [Conformance]
+[sig-calico] [Team:CORE] [Feature:NetworkPolicy] [Category:Policy] service network policy Calico service network policy test ServiceMatch policy client egress by service, server ingress by pod-name [Conformance]
+[sig-calico] [Team:CORE] [Feature:NetworkPolicy] [Category:Policy] service network policy Calico service network policy test ServiceMatch policy client egress by service, server ingress by service [Conformance]
+[sig-calico] [Team:CORE] [Feature:OwnerReferences] [Category:Configuration] OwnerReference tests should delete a NetworkSet if its owner has been deleted
+[sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit bandwidth with QoS annotations
+[sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit packet rate with QoS annotations
+[sig-network] API Server should have Endpoints and EndpointSlices pointing to API Server [Conformance]
+[sig-network] API Server should provide secure master service [Conformance]
+[sig-network] DNS should support configurable pod DNS nameservers [Conformance]
+[sig-network] EndpointSlice should create Endpoints and EndpointSlices for Pods matching a Service [Conformance]
+[sig-network] EndpointSlice should create and delete EndpointSlices for a Service with a selector that matches no pods [Conformance]
+[sig-network] EndpointSlice should support a Service with multiple endpoint IPs specified in multiple EndpointSlices [Conformance]
+[sig-network] EndpointSlice should support a Service with multiple ports specified in multiple EndpointSlices [Conformance]
+[sig-network] EndpointSlice should support creating EndpointSlice API operations [Conformance]
+[sig-network] EndpointSliceMirroring should mirror a custom Endpoints resource through create update and delete [Conformance]
+[sig-network] Endpoints should test the lifecycle of an Endpoint [Conformance]
+[sig-network] EndpointsController should create Endpoints for Pods matching a Service [Conformance]
+[sig-network] EndpointsController should create and delete Endpoints for a Service with a selector that matches no pods [Conformance]
+[sig-network] HostPort validates that there is no conflict between pods with same hostPort but different hostIP and protocol [LinuxOnly] [Conformance]
+[sig-network] Ingress API should support creating Ingress API operations [Conformance]
+[sig-network] IngressClass API should support creating IngressClass API operations [Conformance]
+[sig-network] Netpol NetworkPolicy between server and client should allow egress access on one named port [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should allow egress access to server in CIDR block [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should allow ingress access from namespace on one named port [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should allow ingress access from updated namespace [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should allow ingress access from updated pod [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should allow ingress access on one named port [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should deny egress from all pods in a namespace [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should deny egress from pods based on PodSelector [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should deny ingress access to updated pod [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should deny ingress from pods on other namespaces [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce egress policy allowing traffic to a server in a different namespace based on PodSelector and NamespaceSelector [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce except clause while egress access to server in CIDR block [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce ingress policy allowing any port traffic to a server on a specific protocol [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce multiple egress policies with egress allow-all policy taking precedence [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce multiple ingress policies with ingress allow-all policy taking precedence [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce multiple, stacked policies with overlapping podSelectors [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce policies to check ingress and egress policies can be controlled independently based on PodSelector [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce policy based on Multiple PodSelectors and NamespaceSelectors [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce policy based on NamespaceSelector with MatchExpressions [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce policy based on NamespaceSelector with MatchExpressions using default ns label [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce policy based on PodSelector and NamespaceSelector [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce policy based on PodSelector or NamespaceSelector [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce policy based on PodSelector with MatchExpressions [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce policy based on Ports [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce policy based on any PodSelectors [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce policy to allow ingress traffic for a target [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce policy to allow ingress traffic from pods in all namespaces [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce policy to allow traffic based on NamespaceSelector with MatchLabels using default ns label [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce policy to allow traffic from pods within server namespace based on PodSelector [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce policy to allow traffic only from a different namespace, based on NamespaceSelector [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce policy to allow traffic only from a pod in a different namespace based on PodSelector and NamespaceSelector [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce updated policy [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should ensure an IP overlapping both IPBlock.CIDR and IPBlock.Except is allowed [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should not allow access by TCP when a policy specifies only UDP [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should not allow all ports if it cannot limit to the requested port [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should not mistakenly treat 'protocol: SCTP' as 'protocol: TCP', even if the plugin doesn't support SCTP [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should properly isolate pods that are selected by a policy allowing SCTP, even if the plugin doesn't support SCTP [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should stop enforcing policies after they are deleted [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should support a 'default-deny-all' policy [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should support a 'default-deny-ingress' policy [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should support allow-all policy [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should support denying of egress traffic on the client side (even if the server explicitly allows this traffic) [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should work with Ingress, Egress specified together [Feature:NetworkPolicy]
+[sig-network] Netpol [LinuxOnly] NetworkPolicy between server and client using UDP should enforce policy based on Ports [Feature:NetworkPolicy]
+[sig-network] Netpol [LinuxOnly] NetworkPolicy between server and client using UDP should enforce policy to allow traffic only from a pod in a different namespace based on PodSelector and NamespaceSelector [Feature:NetworkPolicy]
+[sig-network] Netpol [LinuxOnly] NetworkPolicy between server and client using UDP should support a 'default-deny-ingress' policy [Feature:NetworkPolicy]
+[sig-network] Networking Granular Checks: Pods should function for intra-pod communication: http [Conformance] [NodeConformance]
+[sig-network] Networking Granular Checks: Pods should function for intra-pod communication: udp [Conformance] [NodeConformance]
+[sig-network] Networking Granular Checks: Pods should function for node-pod communication: http [LinuxOnly] [Conformance] [NodeConformance]
+[sig-network] Networking Granular Checks: Pods should function for node-pod communication: udp [LinuxOnly] [Conformance] [NodeConformance]
+[sig-network] Proxy version v1 A set of valid responses are returned for both pod and service ProxyWithPath [Conformance]
+[sig-network] Service endpoints latency should not be very high [Conformance]
+[sig-network] ServiceCIDR and IPAddress API should support IPAddress API operations [Conformance]
+[sig-network] ServiceCIDR and IPAddress API should support ServiceCIDR API operations [Conformance]
+[sig-network] Services should be able to change the type from ClusterIP to ExternalName [Conformance]
+[sig-network] Services should be able to change the type from ExternalName to ClusterIP [Conformance]
+[sig-network] Services should be able to change the type from ExternalName to NodePort [Conformance]
+[sig-network] Services should be able to change the type from NodePort to ExternalName [Conformance]
+[sig-network] Services should be able to create a functioning NodePort service [Conformance]
+[sig-network] Services should be able to switch session affinity for NodePort service [LinuxOnly] [Conformance]
+[sig-network] Services should be able to switch session affinity for service with type clusterIP [LinuxOnly] [Conformance]
+[sig-network] Services should complete a service status lifecycle [Conformance]
+[sig-network] Services should delete a collection of services [Conformance]
+[sig-network] Services should find a service from listing all namespaces [Conformance]
+[sig-network] Services should have session affinity work for NodePort service [LinuxOnly] [Conformance]
+[sig-network] Services should have session affinity work for service with type clusterIP [LinuxOnly] [Conformance]
+[sig-network] Services should serve a basic endpoint from pods [Conformance]
+[sig-network] Services should serve endpoints on same port and different protocols [Conformance]
+[sig-network] Services should serve multiport endpoints from pods [Conformance]

--- a/e2e/testsets/sets/nftables/eks-xtables-nobgp-aws-autohep.txt
+++ b/e2e/testsets/sets/nftables/eks-xtables-nobgp-aws-autohep.txt
@@ -28,12 +28,12 @@
 [sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC read-only access should allow reading but deny writing for a read-only user [Conformance]
 [sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC resource-name exact match [RequiresCalicoAPIServer] should allow access to the named policy but deny access to others
 [sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC tier isolation should restrict a user to only their permitted tier [Conformance]
-[sig-calico] [Team:CORE] [Category:Policy] [RequiresGoldmane] staged network policy Test presence in flow logs StagedGlobalNetworkPolicy Validate name, tier, action [Conformance]
-[sig-calico] [Team:CORE] [Category:Policy] [RequiresGoldmane] staged network policy Test presence in flow logs StagedKubernetesNetworkPolicy Validate name, tier, action [Conformance]
-[sig-calico] [Team:CORE] [Category:Policy] [RequiresGoldmane] staged network policy Test presence in flow logs StagedNetworkPolicy Validate name, tier, action [Conformance]
-[sig-calico] [Team:CORE] [Category:Policy] [RequiresGoldmane] staged network policy enforcing staged-policies StagedGlobalNetworkPolicy should enforce a deny policy
-[sig-calico] [Team:CORE] [Category:Policy] [RequiresGoldmane] staged network policy enforcing staged-policies StagedKubernetesNetworkPolicy should enforce a deny policy
-[sig-calico] [Team:CORE] [Category:Policy] [RequiresGoldmane] staged network policy enforcing staged-policies StagedNetworkPolicy should enforce a deny policy
+[sig-calico] [Team:CORE] [Category:Policy] [RequiresGoldmane] [NoTierPrefix] staged network policy Test presence in flow logs StagedGlobalNetworkPolicy Validate name, tier, action [Conformance]
+[sig-calico] [Team:CORE] [Category:Policy] [RequiresGoldmane] [NoTierPrefix] staged network policy Test presence in flow logs StagedKubernetesNetworkPolicy Validate name, tier, action [Conformance]
+[sig-calico] [Team:CORE] [Category:Policy] [RequiresGoldmane] [NoTierPrefix] staged network policy Test presence in flow logs StagedNetworkPolicy Validate name, tier, action [Conformance]
+[sig-calico] [Team:CORE] [Category:Policy] [RequiresGoldmane] [NoTierPrefix] staged network policy enforcing staged-policies StagedGlobalNetworkPolicy should enforce a deny policy
+[sig-calico] [Team:CORE] [Category:Policy] [RequiresGoldmane] [NoTierPrefix] staged network policy enforcing staged-policies StagedKubernetesNetworkPolicy should enforce a deny policy
+[sig-calico] [Team:CORE] [Category:Policy] [RequiresGoldmane] [NoTierPrefix] staged network policy enforcing staged-policies StagedNetworkPolicy should enforce a deny policy
 [sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Packet Size Verification with different packet sizes using UDP and TCP host to nodeport, different nodes
 [sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Packet Size Verification with different packet sizes using UDP and TCP host to pod, different nodes
 [sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Packet Size Verification with different packet sizes using UDP and TCP host to service, different nodes
@@ -104,7 +104,7 @@
 [sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath xtables-only [RequiresXtables] egress-2N2 ApplyOnForward=true, egress [Serial]
 [sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath xtables-only [RequiresXtables] ingress-2N2 ApplyOnForward=false, ingress [Serial]
 [sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath xtables-only [RequiresXtables] ingress-2N2 ApplyOnForward=true, ingress [Serial]
-[sig-calico] [Team:CORE] [Feature:IPAM] [Category:Networking] IPAM GC should garbage-collect leaked IP addresses [Serial]
+[sig-calico] [Team:CORE] [Feature:IPAM] [RequiresCalicoIPAM] [Category:Networking] IPAM GC should garbage-collect leaked IP addresses [Serial]
 [sig-calico] [Team:CORE] [Feature:IPIP] [Category:Networking] [NoEncap] IP-in-IP tests should assign an IPIP address to the tunl0 interface [Serial]
 [sig-calico] [Team:CORE] [Feature:IPIP] [Category:Networking] [NoEncap] IP-in-IP tests should support toggling IPIP on and off [Serial]
 [sig-calico] [Team:CORE] [Feature:IPPool] [Category:Operator] operator IPPool management tests should create and delete IP pools [Serial]

--- a/e2e/testsets/sets/nftables/xtables-autohep.txt
+++ b/e2e/testsets/sets/nftables/xtables-autohep.txt
@@ -4,7 +4,6 @@
 [sig-calico] [Team:CORE] [Category:Policy] [Feature:AutoHEPs] auto host endpoint tests should create host endpoints for each node [Conformance] [Serial]
 [sig-calico] [Team:CORE] [Category:Policy] [Feature:AutoHEPs] auto host endpoint tests with policies in place with egress policy should block one node 1 from reaching node 0 on port 9091 with egress policy [Serial]
 [sig-calico] [Team:CORE] [Category:Policy] [Feature:AutoHEPs] auto host endpoint tests with policies in place with ingress policy should block one node 1 from entering node 0 on port 9090 with ingress policy [Serial]
-[sig-calico] [Team:CORE] [Category:Policy] [Feature:Host-Protection] host endpoint tests doNotTrack policy should deny connections from specified source addresses in a doNotTrack deny policy (DoS mitigation) [ExternalNode] [Serial]
 [sig-calico] [Team:CORE] [Category:Policy] [Feature:Host-Protection] host endpoint tests doNotTrack policy should deny connections to the specified port in a doNotTrack deny policy [Serial]
 [sig-calico] [Team:CORE] [Category:Policy] [Feature:Host-Protection] host endpoint tests should allow connections using a named port [Conformance] [Serial]
 [sig-calico] [Team:CORE] [Category:Policy] [Feature:Host-Protection] host endpoint tests should allow inbound connections with an allow-all [Serial]
@@ -38,7 +37,6 @@
 [sig-calico] [Team:CORE] [Feature:BGPPeer] [RequiresBGP] [Category:Networking] BGP password should enforce BGP password authentication [Serial]
 [sig-calico] [Team:CORE] [Feature:BGPPeer] [RequiresBGP] [Category:Networking] [RequiresBGPMesh] BGP export tests should not export pools with export disabled [Serial]
 [sig-calico] [Team:CORE] [Feature:BGPPeer] [RequiresBGP] [Category:Networking] [RequiresBGPMesh] BGPPeer should support BGP peers [Serial]
-[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Packet Size Verification with different packet sizes external client [ExternalNode] using UDP and TCP external to nodeport
 [sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Packet Size Verification with different packet sizes using UDP and TCP host to nodeport, different nodes
 [sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Packet Size Verification with different packet sizes using UDP and TCP host to pod, different nodes
 [sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Packet Size Verification with different packet sizes using UDP and TCP host to service, different nodes
@@ -67,8 +65,6 @@
 [sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath NodePort access scenario-0N10: pod0 -> node1 NodePort -> pod0
 [sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath NodePort access scenario-0N11: pod0 -> node1 NodePort -> pod1 (hairpin)
 [sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath NodePort access scenario-0N12: pod0 -> node1 NodePort -> pod2 (pod on other node)
-[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Ingress Datapath external node [ExternalNode] scenario-14: external hostNet=false -> node0NodePort
-[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Ingress Datapath external node [ExternalNode] scenario-15: external hostNet=false -> svcNodePort
 [sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Ingress Datapath scenario-10: node1 hostNet=true -> node1NodePort
 [sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Ingress Datapath scenario-11: node0 hostNet=false -> node1NodePort
 [sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Ingress Datapath scenario-12: node0 hostNet=true -> node1NodePort
@@ -119,21 +115,7 @@
 [sig-calico] [Team:CORE] [Feature:Istio] [Category:Networking] Istio OpenShift Platform Configuration should deploy Istio with correct OpenShift platform configuration [Serial]
 [sig-calico] [Team:CORE] [Feature:Istio] [Category:Networking] [RequiresOperator] Istio Ambient Mode should allow UDP traffic to bypass ztunnel while Calico enforces UDP policy [Serial]
 [sig-calico] [Team:CORE] [Feature:Istio] [Category:Networking] [RequiresOperator] Istio Ambient Mode should encrypt traffic with ambient mode and enforce Calico NetworkPolicy [Serial]
-[sig-calico] [Team:CORE] [Feature:KubeVirt] [Category:Networking] KubeVirt IP persistence should assign static IP via annotation and preserve it across migration
-[sig-calico] [Team:CORE] [Feature:KubeVirt] [Category:Networking] KubeVirt IP persistence should preserve VM IP across VMI recreation (reboot)
-[sig-calico] [Team:CORE] [Feature:KubeVirt] [Category:Networking] KubeVirt IP persistence should preserve VM IP across pod recreation
-[sig-calico] [Team:CORE] [Feature:KubeVirt] [Category:Networking] KubeVirt IP persistence should preserve VM IP address across live migration
-[sig-calico] [Team:CORE] [Feature:KubeVirt] [Category:Networking] KubeVirt IP persistence should promote target pod to active IPAM owner after migration
-[sig-calico] [Team:CORE] [Feature:KubeVirt] [Category:Networking] KubeVirt IP persistence should release IPAM handle when VM is deleted
-[sig-calico] [Team:CORE] [Feature:KubeVirt] [RequiresMockVirt] [Category:Networking] KubeVirt live migration (MockVirt) should converge eBGP routes after live migration
-[sig-calico] [Team:CORE] [Feature:KubeVirt] [RequiresMockVirt] [Category:Networking] KubeVirt live migration (MockVirt) should converge iBGP routes after live migration
-[sig-calico] [Team:CORE] [Feature:KubeVirt] [RequiresMockVirt] [Category:Networking] KubeVirt live migration (MockVirt) should enforce NetworkPolicy after live migration
-[sig-calico] [Team:CORE] [Feature:KubeVirt] [RequiresMockVirt] [Category:Networking] KubeVirt live migration (MockVirt) should not have /32 host route on target node after a migration timeout
-[sig-calico] [Team:CORE] [Feature:KubeVirt] [RequiresRealKubeVirt] [Category:Networking] KubeVirt live migration eBGP external client [ExternalNode] should maintain TCP connection from eBGP external client across two consecutive migrations
-[sig-calico] [Team:CORE] [Feature:KubeVirt] [RequiresRealKubeVirt] [Category:Networking] KubeVirt live migration should maintain TCP connection over iBGP across two consecutive live migrations
 [sig-calico] [Team:CORE] [Feature:MTU] [Category:Networking] Automatic MTU tests should select the correct MTU for the platform
-[sig-calico] [Team:CORE] [Feature:Maglev] [Category:Networking] [ExternalNode] [Dataplane:BPF] [RequiresAWS] Maglev load balancing tests test service ip load balancing behavior before and after maglev annotation (IPv4) [Serial]
-[sig-calico] [Team:CORE] [Feature:Maglev] [Category:Networking] [ExternalNode] [Dataplane:BPF] [RequiresAWS] Maglev load balancing tests test service ip load balancing behavior before and after maglev annotation (IPv6) [Serial]
 [sig-calico] [Team:CORE] [Feature:NetworkPolicy] [Category:Policy] [RunsOnWindows] Calico NetworkPolicy should correctly isolate namespaces [Conformance]
 [sig-calico] [Team:CORE] [Feature:NetworkPolicy] [Category:Policy] [RunsOnWindows] Calico NetworkPolicy should provide a default allow [Conformance]
 [sig-calico] [Team:CORE] [Feature:NetworkPolicy] [Category:Policy] [RunsOnWindows] Calico NetworkPolicy should support a 'deny egress' policy [Conformance]
@@ -167,6 +149,52 @@
 [sig-network] HostPort validates that there is no conflict between pods with same hostPort but different hostIP and protocol [LinuxOnly] [Conformance]
 [sig-network] Ingress API should support creating Ingress API operations [Conformance]
 [sig-network] IngressClass API should support creating IngressClass API operations [Conformance]
+[sig-network] Netpol NetworkPolicy between server and client should allow egress access on one named port [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should allow egress access to server in CIDR block [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should allow ingress access from namespace on one named port [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should allow ingress access from updated namespace [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should allow ingress access from updated pod [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should allow ingress access on one named port [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should deny egress from all pods in a namespace [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should deny egress from pods based on PodSelector [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should deny ingress access to updated pod [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should deny ingress from pods on other namespaces [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce egress policy allowing traffic to a server in a different namespace based on PodSelector and NamespaceSelector [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce except clause while egress access to server in CIDR block [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce ingress policy allowing any port traffic to a server on a specific protocol [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce multiple egress policies with egress allow-all policy taking precedence [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce multiple ingress policies with ingress allow-all policy taking precedence [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce multiple, stacked policies with overlapping podSelectors [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce policies to check ingress and egress policies can be controlled independently based on PodSelector [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce policy based on Multiple PodSelectors and NamespaceSelectors [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce policy based on NamespaceSelector with MatchExpressions [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce policy based on NamespaceSelector with MatchExpressions using default ns label [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce policy based on PodSelector and NamespaceSelector [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce policy based on PodSelector or NamespaceSelector [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce policy based on PodSelector with MatchExpressions [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce policy based on Ports [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce policy based on any PodSelectors [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce policy to allow ingress traffic for a target [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce policy to allow ingress traffic from pods in all namespaces [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce policy to allow traffic based on NamespaceSelector with MatchLabels using default ns label [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce policy to allow traffic from pods within server namespace based on PodSelector [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce policy to allow traffic only from a different namespace, based on NamespaceSelector [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce policy to allow traffic only from a pod in a different namespace based on PodSelector and NamespaceSelector [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce updated policy [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should ensure an IP overlapping both IPBlock.CIDR and IPBlock.Except is allowed [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should not allow access by TCP when a policy specifies only UDP [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should not allow all ports if it cannot limit to the requested port [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should not mistakenly treat 'protocol: SCTP' as 'protocol: TCP', even if the plugin doesn't support SCTP [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should properly isolate pods that are selected by a policy allowing SCTP, even if the plugin doesn't support SCTP [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should stop enforcing policies after they are deleted [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should support a 'default-deny-all' policy [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should support a 'default-deny-ingress' policy [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should support allow-all policy [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should support denying of egress traffic on the client side (even if the server explicitly allows this traffic) [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should work with Ingress, Egress specified together [Feature:NetworkPolicy]
+[sig-network] Netpol [LinuxOnly] NetworkPolicy between server and client using UDP should enforce policy based on Ports [Feature:NetworkPolicy]
+[sig-network] Netpol [LinuxOnly] NetworkPolicy between server and client using UDP should enforce policy to allow traffic only from a pod in a different namespace based on PodSelector and NamespaceSelector [Feature:NetworkPolicy]
+[sig-network] Netpol [LinuxOnly] NetworkPolicy between server and client using UDP should support a 'default-deny-ingress' policy [Feature:NetworkPolicy]
 [sig-network] Networking Granular Checks: Pods should function for intra-pod communication: http [Conformance] [NodeConformance]
 [sig-network] Networking Granular Checks: Pods should function for intra-pod communication: udp [Conformance] [NodeConformance]
 [sig-network] Networking Granular Checks: Pods should function for node-pod communication: http [LinuxOnly] [Conformance] [NodeConformance]

--- a/e2e/testsets/sets/nftables/xtables-encap-autohep.txt
+++ b/e2e/testsets/sets/nftables/xtables-encap-autohep.txt
@@ -28,12 +28,12 @@
 [sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC read-only access should allow reading but deny writing for a read-only user [Conformance]
 [sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC resource-name exact match [RequiresCalicoAPIServer] should allow access to the named policy but deny access to others
 [sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC tier isolation should restrict a user to only their permitted tier [Conformance]
-[sig-calico] [Team:CORE] [Category:Policy] [RequiresGoldmane] staged network policy Test presence in flow logs StagedGlobalNetworkPolicy Validate name, tier, action [Conformance]
-[sig-calico] [Team:CORE] [Category:Policy] [RequiresGoldmane] staged network policy Test presence in flow logs StagedKubernetesNetworkPolicy Validate name, tier, action [Conformance]
-[sig-calico] [Team:CORE] [Category:Policy] [RequiresGoldmane] staged network policy Test presence in flow logs StagedNetworkPolicy Validate name, tier, action [Conformance]
-[sig-calico] [Team:CORE] [Category:Policy] [RequiresGoldmane] staged network policy enforcing staged-policies StagedGlobalNetworkPolicy should enforce a deny policy
-[sig-calico] [Team:CORE] [Category:Policy] [RequiresGoldmane] staged network policy enforcing staged-policies StagedKubernetesNetworkPolicy should enforce a deny policy
-[sig-calico] [Team:CORE] [Category:Policy] [RequiresGoldmane] staged network policy enforcing staged-policies StagedNetworkPolicy should enforce a deny policy
+[sig-calico] [Team:CORE] [Category:Policy] [RequiresGoldmane] [NoTierPrefix] staged network policy Test presence in flow logs StagedGlobalNetworkPolicy Validate name, tier, action [Conformance]
+[sig-calico] [Team:CORE] [Category:Policy] [RequiresGoldmane] [NoTierPrefix] staged network policy Test presence in flow logs StagedKubernetesNetworkPolicy Validate name, tier, action [Conformance]
+[sig-calico] [Team:CORE] [Category:Policy] [RequiresGoldmane] [NoTierPrefix] staged network policy Test presence in flow logs StagedNetworkPolicy Validate name, tier, action [Conformance]
+[sig-calico] [Team:CORE] [Category:Policy] [RequiresGoldmane] [NoTierPrefix] staged network policy enforcing staged-policies StagedGlobalNetworkPolicy should enforce a deny policy
+[sig-calico] [Team:CORE] [Category:Policy] [RequiresGoldmane] [NoTierPrefix] staged network policy enforcing staged-policies StagedKubernetesNetworkPolicy should enforce a deny policy
+[sig-calico] [Team:CORE] [Category:Policy] [RequiresGoldmane] [NoTierPrefix] staged network policy enforcing staged-policies StagedNetworkPolicy should enforce a deny policy
 [sig-calico] [Team:CORE] [Feature:BGPPeer] [RequiresBGP] [Category:Networking] BGP password should enforce BGP password authentication [Serial]
 [sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Packet Size Verification with different packet sizes using UDP and TCP host to nodeport, different nodes
 [sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Packet Size Verification with different packet sizes using UDP and TCP host to pod, different nodes
@@ -105,8 +105,8 @@
 [sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath xtables-only [RequiresXtables] egress-2N2 ApplyOnForward=true, egress [Serial]
 [sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath xtables-only [RequiresXtables] ingress-2N2 ApplyOnForward=false, ingress [Serial]
 [sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath xtables-only [RequiresXtables] ingress-2N2 ApplyOnForward=true, ingress [Serial]
-[sig-calico] [Team:CORE] [Feature:IPAM] [Category:Networking] IPAM GC should garbage-collect leaked IP addresses [Serial]
-[sig-calico] [Team:CORE] [Feature:IPAM] [Category:Networking] IPAM StrictAffinity should respect StrictAffinity when toggled [Serial]
+[sig-calico] [Team:CORE] [Feature:IPAM] [RequiresCalicoIPAM] [Category:Networking] IPAM GC should garbage-collect leaked IP addresses [Serial]
+[sig-calico] [Team:CORE] [Feature:IPAM] [RequiresCalicoIPAM] [Category:Networking] IPAM StrictAffinity should respect StrictAffinity when toggled [Serial]
 [sig-calico] [Team:CORE] [Feature:IPPool] [Category:Operator] operator IPPool management tests should create and delete IP pools [Serial]
 [sig-calico] [Team:CORE] [Feature:Istio] [Category:Networking] Istio OpenShift Platform Configuration should deploy Istio with correct OpenShift platform configuration [Serial]
 [sig-calico] [Team:CORE] [Feature:Istio] [Category:Networking] [RequiresOperator] Istio Ambient Mode should allow UDP traffic to bypass ztunnel while Calico enforces UDP policy [Serial]

--- a/e2e/testsets/sets/nftables/xtables-encap-autohep.txt
+++ b/e2e/testsets/sets/nftables/xtables-encap-autohep.txt
@@ -1,0 +1,218 @@
+[sig-calico] [Team:CORE] [Category:Networking] [Feature:HostPorts] HostPorts tests with host port resources active on :8080 should support Pod HostPorts [Conformance] [Serial]
+[sig-calico] [Team:CORE] [Category:Networking] [Feature:Pods] Pod Termination Grace Period should allow client to reach server while client is terminating [Conformance]
+[sig-calico] [Team:CORE] [Category:Networking] [Feature:Pods] Pod Termination Grace Period should allow pinging a server pod while it is terminating
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:AutoHEPs] auto host endpoint tests should create host endpoints for each node [Conformance] [Serial]
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:AutoHEPs] auto host endpoint tests with policies in place with egress policy should block one node 1 from reaching node 0 on port 9091 with egress policy [Serial]
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:AutoHEPs] auto host endpoint tests with policies in place with ingress policy should block one node 1 from entering node 0 on port 9090 with ingress policy [Serial]
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Host-Protection] host endpoint tests doNotTrack policy should deny connections to the specified port in a doNotTrack deny policy [Serial]
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Host-Protection] host endpoint tests should allow connections using a named port [Conformance] [Serial]
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Host-Protection] host endpoint tests should allow inbound connections with an allow-all [Serial]
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Host-Protection] host endpoint tests should block all inbound connections by default [Serial]
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-Policy] [RunsOnWindows] Tiered policy tests with a second tier can explicitly pass traffic
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-Policy] [RunsOnWindows] Tiered policy tests with a second tier should enforce a default deny
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-Policy] [RunsOnWindows] Tiered policy tests with a single tier taking precedence over the default tier can pass to the default tier, and allow traffic explicitly. [Conformance]
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] Tiered RBAC with tier-prefixed names should allow create and deny based on tier RBAC with prefixed names
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC GlobalNetworkPolicy should allow creation by a user with full tier RBAC
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC GlobalNetworkPolicy should deny creation by a user without tier access
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC NetworkPolicy should allow creation by a user with full tier RBAC [Conformance]
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC NetworkPolicy should allow deletion by a user with full tier RBAC
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC NetworkPolicy should allow update by a user with full tier RBAC
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC NetworkPolicy should deny creation by a user without tier GET access [Conformance]
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC NetworkPolicy should deny creation by a user without tier policy access
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC NetworkPolicy should deny update by a user without tier GET access
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC default tier should not allow deleting the default tier
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC default tier should not allow updating the default tier
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC list via tier RBAC [RequiresCalicoAPIServer] should allow listing policies in the permitted tier
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC list via tier RBAC [RequiresCalicoAPIServer] should deny listing when user lacks tier policy access
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC old-style vs new-style name disambiguation [RequiresCalicoAPIServer] should independently authorize bare and tier-prefixed policy names
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC read-only access should allow reading but deny writing for a read-only user [Conformance]
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC resource-name exact match [RequiresCalicoAPIServer] should allow access to the named policy but deny access to others
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC tier isolation should restrict a user to only their permitted tier [Conformance]
+[sig-calico] [Team:CORE] [Category:Policy] [RequiresGoldmane] staged network policy Test presence in flow logs StagedGlobalNetworkPolicy Validate name, tier, action [Conformance]
+[sig-calico] [Team:CORE] [Category:Policy] [RequiresGoldmane] staged network policy Test presence in flow logs StagedKubernetesNetworkPolicy Validate name, tier, action [Conformance]
+[sig-calico] [Team:CORE] [Category:Policy] [RequiresGoldmane] staged network policy Test presence in flow logs StagedNetworkPolicy Validate name, tier, action [Conformance]
+[sig-calico] [Team:CORE] [Category:Policy] [RequiresGoldmane] staged network policy enforcing staged-policies StagedGlobalNetworkPolicy should enforce a deny policy
+[sig-calico] [Team:CORE] [Category:Policy] [RequiresGoldmane] staged network policy enforcing staged-policies StagedKubernetesNetworkPolicy should enforce a deny policy
+[sig-calico] [Team:CORE] [Category:Policy] [RequiresGoldmane] staged network policy enforcing staged-policies StagedNetworkPolicy should enforce a deny policy
+[sig-calico] [Team:CORE] [Feature:BGPPeer] [RequiresBGP] [Category:Networking] BGP password should enforce BGP password authentication [Serial]
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Packet Size Verification with different packet sizes using UDP and TCP host to nodeport, different nodes
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Packet Size Verification with different packet sizes using UDP and TCP host to pod, different nodes
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Packet Size Verification with different packet sizes using UDP and TCP host to service, different nodes
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Packet Size Verification with different packet sizes using UDP and TCP pod to nodeport, different nodes
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Packet Size Verification with different packet sizes using UDP and TCP pod to nodeport, same node
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Packet Size Verification with different packet sizes using UDP and TCP pod to pod, different nodes
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Packet Size Verification with different packet sizes using UDP and TCP pod to pod, same node
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Packet Size Verification with different packet sizes using UDP and TCP pod to service, different nodes
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Packet Size Verification with different packet sizes using UDP and TCP pod to service, same node
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath ClusterIP access scenario-0C0: pod0 -> clusterIP -> pod0 (loopback)
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath ClusterIP access scenario-0C1: pod0 -> clusterIP -> pod1 (same node)
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath ClusterIP access scenario-0C2: pod0 -> clusterIP -> pod2 (cross node) [Conformance]
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath ExternalIP access scenario-0EC0: pod0 -> externalIP Cluster -> pod0
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath ExternalIP access scenario-0EC1: pod0 -> externalIP Cluster -> pod1
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath ExternalIP access scenario-0EC2: pod0 -> externalIP Cluster -> pod2 (other node) [Conformance]
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath ExternalIP access scenario-0EL0: pod0 -> externalIP local-only -> pod0
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath ExternalIP access scenario-0EL1: pod0 -> externalIP local-only -> pod1
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath Host-networked destination scenario-0H1: pod0 -> clusterIP -> host-networked pod1 (same node)
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath Host-networked destination scenario-0H2: pod0 -> clusterIP -> host-networked pod2 (other node)
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath NodePort access scenario-0L00: pod0 -> node0 NodePort local-only -> pod0
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath NodePort access scenario-0L01: pod0 -> node0 NodePort local-only -> pod1
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath NodePort access scenario-0L12: pod0 -> node1 NodePort local-only -> pod2
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath NodePort access scenario-0N00: pod0 -> node0 NodePort -> pod0
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath NodePort access scenario-0N01: pod0 -> node0 NodePort -> pod1 (same node)
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath NodePort access scenario-0N02: pod0 -> node0 NodePort -> pod2 (other node) [Conformance]
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath NodePort access scenario-0N10: pod0 -> node1 NodePort -> pod0
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath NodePort access scenario-0N11: pod0 -> node1 NodePort -> pod1 (hairpin)
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath NodePort access scenario-0N12: pod0 -> node1 NodePort -> pod2 (pod on other node)
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Ingress Datapath scenario-10: node1 hostNet=true -> node1NodePort
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Ingress Datapath scenario-11: node0 hostNet=false -> node1NodePort
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Ingress Datapath scenario-12: node0 hostNet=true -> node1NodePort
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Ingress Datapath scenario-1: svcNode hostNet=false -> clusterIP
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Ingress Datapath scenario-2: svcNode hostNet=true -> clusterIP
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Ingress Datapath scenario-3: node1 hostNet=false -> clusterIP [Conformance]
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Ingress Datapath scenario-4: node1 hostNet=true -> clusterIP
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Ingress Datapath scenario-5: svcNode hostNet=false -> svcNodePort
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Ingress Datapath scenario-6: svcNode hostNet=true -> svcNodePort
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Ingress Datapath scenario-7: node1 hostNet=false -> svcNodePort
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Ingress Datapath scenario-8: node1 hostNet=true -> svcNodePort
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Ingress Datapath scenario-9: node1 hostNet=false -> node1NodePort
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-0-2 ApplyOnForward=false, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-0-2 ApplyOnForward=true, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-0C2 ApplyOnForward=false, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-0C2 ApplyOnForward=true, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-0C3 ApplyOnForward=false, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-0C3 ApplyOnForward=true, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-0N2 ApplyOnForward=false, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-0N2 ApplyOnForward=true, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-0N3 ApplyOnForward=false, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-0N3 ApplyOnForward=true, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-1-2 ApplyOnForward=false, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-1-2 ApplyOnForward=true, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-1C2 ApplyOnForward=false, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-1C2 ApplyOnForward=true, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-1N2 ApplyOnForward=false, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-1N2 ApplyOnForward=true, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-2N1 ApplyOnForward=false, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-2N1 ApplyOnForward=true, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath ingress-2-1 ApplyOnForward=false, ingress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath ingress-2-1 ApplyOnForward=true, ingress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath ingress-2C0 ApplyOnForward=false, ingress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath ingress-2C0 ApplyOnForward=true, ingress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath ingress-2N1 ApplyOnForward=false, ingress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath ingress-2N1 ApplyOnForward=true, ingress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath ingress-3-0 ApplyOnForward=false, ingress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath ingress-3-0 ApplyOnForward=true, ingress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath xtables-only [RequiresXtables] egress-2N2 ApplyOnForward=false, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath xtables-only [RequiresXtables] egress-2N2 ApplyOnForward=true, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath xtables-only [RequiresXtables] ingress-2N2 ApplyOnForward=false, ingress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath xtables-only [RequiresXtables] ingress-2N2 ApplyOnForward=true, ingress [Serial]
+[sig-calico] [Team:CORE] [Feature:IPAM] [Category:Networking] IPAM GC should garbage-collect leaked IP addresses [Serial]
+[sig-calico] [Team:CORE] [Feature:IPAM] [Category:Networking] IPAM StrictAffinity should respect StrictAffinity when toggled [Serial]
+[sig-calico] [Team:CORE] [Feature:IPPool] [Category:Operator] operator IPPool management tests should create and delete IP pools [Serial]
+[sig-calico] [Team:CORE] [Feature:Istio] [Category:Networking] Istio OpenShift Platform Configuration should deploy Istio with correct OpenShift platform configuration [Serial]
+[sig-calico] [Team:CORE] [Feature:Istio] [Category:Networking] [RequiresOperator] Istio Ambient Mode should allow UDP traffic to bypass ztunnel while Calico enforces UDP policy [Serial]
+[sig-calico] [Team:CORE] [Feature:Istio] [Category:Networking] [RequiresOperator] Istio Ambient Mode should encrypt traffic with ambient mode and enforce Calico NetworkPolicy [Serial]
+[sig-calico] [Team:CORE] [Feature:MTU] [Category:Networking] Automatic MTU tests should select the correct MTU for the platform
+[sig-calico] [Team:CORE] [Feature:NetworkPolicy] [Category:Policy] [RunsOnWindows] Calico NetworkPolicy should correctly isolate namespaces [Conformance]
+[sig-calico] [Team:CORE] [Feature:NetworkPolicy] [Category:Policy] [RunsOnWindows] Calico NetworkPolicy should provide a default allow [Conformance]
+[sig-calico] [Team:CORE] [Feature:NetworkPolicy] [Category:Policy] [RunsOnWindows] Calico NetworkPolicy should support a 'deny egress' policy [Conformance]
+[sig-calico] [Team:CORE] [Feature:NetworkPolicy] [Category:Policy] [RunsOnWindows] Calico NetworkPolicy should support namespace selectors [Conformance]
+[sig-calico] [Team:CORE] [Feature:NetworkPolicy] [Category:Policy] [RunsOnWindows] Calico NetworkPolicy should support service account selectors [Conformance]
+[sig-calico] [Team:CORE] [Feature:NetworkPolicy] [Category:Policy] service network policy Calico service network policy test ServiceMatch policy client egress by pod-name, server ingress by service [Conformance]
+[sig-calico] [Team:CORE] [Feature:NetworkPolicy] [Category:Policy] service network policy Calico service network policy test ServiceMatch policy client egress by service, server ingress by pod-name [Conformance]
+[sig-calico] [Team:CORE] [Feature:NetworkPolicy] [Category:Policy] service network policy Calico service network policy test ServiceMatch policy client egress by service, server ingress by service [Conformance]
+[sig-calico] [Team:CORE] [Feature:OwnerReferences] [Category:Configuration] OwnerReference tests should delete a NetworkSet if its owner has been deleted
+[sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit bandwidth with QoS annotations
+[sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit packet rate with QoS annotations
+[sig-network] API Server should have Endpoints and EndpointSlices pointing to API Server [Conformance]
+[sig-network] API Server should provide secure master service [Conformance]
+[sig-network] DNS should provide /etc/hosts entries for the cluster [Conformance]
+[sig-network] DNS should provide DNS for ExternalName services [Conformance]
+[sig-network] DNS should provide DNS for pods for Hostname [Conformance]
+[sig-network] DNS should provide DNS for pods for Subdomain [Conformance]
+[sig-network] DNS should provide DNS for services [Conformance]
+[sig-network] DNS should provide DNS for the cluster [Conformance]
+[sig-network] DNS should resolve DNS of partial qualified names for services [LinuxOnly] [Conformance]
+[sig-network] DNS should support configurable pod DNS nameservers [Conformance]
+[sig-network] EndpointSlice should create Endpoints and EndpointSlices for Pods matching a Service [Conformance]
+[sig-network] EndpointSlice should create and delete EndpointSlices for a Service with a selector that matches no pods [Conformance]
+[sig-network] EndpointSlice should support a Service with multiple endpoint IPs specified in multiple EndpointSlices [Conformance]
+[sig-network] EndpointSlice should support a Service with multiple ports specified in multiple EndpointSlices [Conformance]
+[sig-network] EndpointSlice should support creating EndpointSlice API operations [Conformance]
+[sig-network] EndpointSliceMirroring should mirror a custom Endpoints resource through create update and delete [Conformance]
+[sig-network] Endpoints should test the lifecycle of an Endpoint [Conformance]
+[sig-network] EndpointsController should create Endpoints for Pods matching a Service [Conformance]
+[sig-network] EndpointsController should create and delete Endpoints for a Service with a selector that matches no pods [Conformance]
+[sig-network] HostPort validates that there is no conflict between pods with same hostPort but different hostIP and protocol [LinuxOnly] [Conformance]
+[sig-network] Ingress API should support creating Ingress API operations [Conformance]
+[sig-network] IngressClass API should support creating IngressClass API operations [Conformance]
+[sig-network] Netpol NetworkPolicy between server and client should allow egress access on one named port [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should allow egress access to server in CIDR block [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should allow ingress access from namespace on one named port [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should allow ingress access from updated namespace [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should allow ingress access from updated pod [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should allow ingress access on one named port [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should deny egress from all pods in a namespace [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should deny egress from pods based on PodSelector [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should deny ingress access to updated pod [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should deny ingress from pods on other namespaces [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce egress policy allowing traffic to a server in a different namespace based on PodSelector and NamespaceSelector [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce except clause while egress access to server in CIDR block [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce ingress policy allowing any port traffic to a server on a specific protocol [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce multiple egress policies with egress allow-all policy taking precedence [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce multiple ingress policies with ingress allow-all policy taking precedence [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce multiple, stacked policies with overlapping podSelectors [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce policies to check ingress and egress policies can be controlled independently based on PodSelector [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce policy based on Multiple PodSelectors and NamespaceSelectors [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce policy based on NamespaceSelector with MatchExpressions [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce policy based on NamespaceSelector with MatchExpressions using default ns label [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce policy based on PodSelector and NamespaceSelector [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce policy based on PodSelector or NamespaceSelector [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce policy based on PodSelector with MatchExpressions [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce policy based on Ports [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce policy based on any PodSelectors [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce policy to allow ingress traffic for a target [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce policy to allow ingress traffic from pods in all namespaces [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce policy to allow traffic based on NamespaceSelector with MatchLabels using default ns label [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce policy to allow traffic from pods within server namespace based on PodSelector [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce policy to allow traffic only from a different namespace, based on NamespaceSelector [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce policy to allow traffic only from a pod in a different namespace based on PodSelector and NamespaceSelector [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce updated policy [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should ensure an IP overlapping both IPBlock.CIDR and IPBlock.Except is allowed [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should not allow access by TCP when a policy specifies only UDP [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should not allow all ports if it cannot limit to the requested port [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should not mistakenly treat 'protocol: SCTP' as 'protocol: TCP', even if the plugin doesn't support SCTP [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should properly isolate pods that are selected by a policy allowing SCTP, even if the plugin doesn't support SCTP [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should stop enforcing policies after they are deleted [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should support a 'default-deny-all' policy [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should support a 'default-deny-ingress' policy [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should support allow-all policy [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should support denying of egress traffic on the client side (even if the server explicitly allows this traffic) [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should work with Ingress, Egress specified together [Feature:NetworkPolicy]
+[sig-network] Netpol [LinuxOnly] NetworkPolicy between server and client using UDP should enforce policy based on Ports [Feature:NetworkPolicy]
+[sig-network] Netpol [LinuxOnly] NetworkPolicy between server and client using UDP should enforce policy to allow traffic only from a pod in a different namespace based on PodSelector and NamespaceSelector [Feature:NetworkPolicy]
+[sig-network] Netpol [LinuxOnly] NetworkPolicy between server and client using UDP should support a 'default-deny-ingress' policy [Feature:NetworkPolicy]
+[sig-network] Networking Granular Checks: Pods should function for intra-pod communication: http [Conformance] [NodeConformance]
+[sig-network] Networking Granular Checks: Pods should function for intra-pod communication: udp [Conformance] [NodeConformance]
+[sig-network] Networking Granular Checks: Pods should function for node-pod communication: http [LinuxOnly] [Conformance] [NodeConformance]
+[sig-network] Networking Granular Checks: Pods should function for node-pod communication: udp [LinuxOnly] [Conformance] [NodeConformance]
+[sig-network] Proxy version v1 A set of valid responses are returned for both pod and service Proxy [Conformance]
+[sig-network] Proxy version v1 A set of valid responses are returned for both pod and service ProxyWithPath [Conformance]
+[sig-network] Proxy version v1 should proxy through a service and a pod [Conformance]
+[sig-network] Service endpoints latency should not be very high [Conformance]
+[sig-network] ServiceCIDR and IPAddress API should support IPAddress API operations [Conformance]
+[sig-network] ServiceCIDR and IPAddress API should support ServiceCIDR API operations [Conformance]
+[sig-network] Services should be able to change the type from ClusterIP to ExternalName [Conformance]
+[sig-network] Services should be able to change the type from ExternalName to ClusterIP [Conformance]
+[sig-network] Services should be able to change the type from ExternalName to NodePort [Conformance]
+[sig-network] Services should be able to change the type from NodePort to ExternalName [Conformance]
+[sig-network] Services should be able to create a functioning NodePort service [Conformance]
+[sig-network] Services should be able to switch session affinity for NodePort service [LinuxOnly] [Conformance]
+[sig-network] Services should be able to switch session affinity for service with type clusterIP [LinuxOnly] [Conformance]
+[sig-network] Services should complete a service status lifecycle [Conformance]
+[sig-network] Services should delete a collection of services [Conformance]
+[sig-network] Services should find a service from listing all namespaces [Conformance]
+[sig-network] Services should have session affinity work for NodePort service [LinuxOnly] [Conformance]
+[sig-network] Services should have session affinity work for service with type clusterIP [LinuxOnly] [Conformance]
+[sig-network] Services should serve a basic endpoint from pods [Conformance]
+[sig-network] Services should serve endpoints on same port and different protocols [Conformance]
+[sig-network] Services should serve multiport endpoints from pods [Conformance]

--- a/e2e/testsets/sets/nftables/xtables-encap-aws-autohep.txt
+++ b/e2e/testsets/sets/nftables/xtables-encap-aws-autohep.txt
@@ -28,12 +28,12 @@
 [sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC read-only access should allow reading but deny writing for a read-only user [Conformance]
 [sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC resource-name exact match [RequiresCalicoAPIServer] should allow access to the named policy but deny access to others
 [sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC tier isolation should restrict a user to only their permitted tier [Conformance]
-[sig-calico] [Team:CORE] [Category:Policy] [RequiresGoldmane] staged network policy Test presence in flow logs StagedGlobalNetworkPolicy Validate name, tier, action [Conformance]
-[sig-calico] [Team:CORE] [Category:Policy] [RequiresGoldmane] staged network policy Test presence in flow logs StagedKubernetesNetworkPolicy Validate name, tier, action [Conformance]
-[sig-calico] [Team:CORE] [Category:Policy] [RequiresGoldmane] staged network policy Test presence in flow logs StagedNetworkPolicy Validate name, tier, action [Conformance]
-[sig-calico] [Team:CORE] [Category:Policy] [RequiresGoldmane] staged network policy enforcing staged-policies StagedGlobalNetworkPolicy should enforce a deny policy
-[sig-calico] [Team:CORE] [Category:Policy] [RequiresGoldmane] staged network policy enforcing staged-policies StagedKubernetesNetworkPolicy should enforce a deny policy
-[sig-calico] [Team:CORE] [Category:Policy] [RequiresGoldmane] staged network policy enforcing staged-policies StagedNetworkPolicy should enforce a deny policy
+[sig-calico] [Team:CORE] [Category:Policy] [RequiresGoldmane] [NoTierPrefix] staged network policy Test presence in flow logs StagedGlobalNetworkPolicy Validate name, tier, action [Conformance]
+[sig-calico] [Team:CORE] [Category:Policy] [RequiresGoldmane] [NoTierPrefix] staged network policy Test presence in flow logs StagedKubernetesNetworkPolicy Validate name, tier, action [Conformance]
+[sig-calico] [Team:CORE] [Category:Policy] [RequiresGoldmane] [NoTierPrefix] staged network policy Test presence in flow logs StagedNetworkPolicy Validate name, tier, action [Conformance]
+[sig-calico] [Team:CORE] [Category:Policy] [RequiresGoldmane] [NoTierPrefix] staged network policy enforcing staged-policies StagedGlobalNetworkPolicy should enforce a deny policy
+[sig-calico] [Team:CORE] [Category:Policy] [RequiresGoldmane] [NoTierPrefix] staged network policy enforcing staged-policies StagedKubernetesNetworkPolicy should enforce a deny policy
+[sig-calico] [Team:CORE] [Category:Policy] [RequiresGoldmane] [NoTierPrefix] staged network policy enforcing staged-policies StagedNetworkPolicy should enforce a deny policy
 [sig-calico] [Team:CORE] [Feature:BGPPeer] [RequiresBGP] [Category:Networking] BGP password should enforce BGP password authentication [Serial]
 [sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Packet Size Verification with different packet sizes using UDP and TCP host to nodeport, different nodes
 [sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Packet Size Verification with different packet sizes using UDP and TCP host to pod, different nodes
@@ -105,8 +105,8 @@
 [sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath xtables-only [RequiresXtables] egress-2N2 ApplyOnForward=true, egress [Serial]
 [sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath xtables-only [RequiresXtables] ingress-2N2 ApplyOnForward=false, ingress [Serial]
 [sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath xtables-only [RequiresXtables] ingress-2N2 ApplyOnForward=true, ingress [Serial]
-[sig-calico] [Team:CORE] [Feature:IPAM] [Category:Networking] IPAM GC should garbage-collect leaked IP addresses [Serial]
-[sig-calico] [Team:CORE] [Feature:IPAM] [Category:Networking] IPAM StrictAffinity should respect StrictAffinity when toggled [Serial]
+[sig-calico] [Team:CORE] [Feature:IPAM] [RequiresCalicoIPAM] [Category:Networking] IPAM GC should garbage-collect leaked IP addresses [Serial]
+[sig-calico] [Team:CORE] [Feature:IPAM] [RequiresCalicoIPAM] [Category:Networking] IPAM StrictAffinity should respect StrictAffinity when toggled [Serial]
 [sig-calico] [Team:CORE] [Feature:IPPool] [Category:Operator] operator IPPool management tests should create and delete IP pools [Serial]
 [sig-calico] [Team:CORE] [Feature:Istio] [Category:Networking] Istio OpenShift Platform Configuration should deploy Istio with correct OpenShift platform configuration [Serial]
 [sig-calico] [Team:CORE] [Feature:Istio] [Category:Networking] [RequiresOperator] Istio Ambient Mode should allow UDP traffic to bypass ztunnel while Calico enforces UDP policy [Serial]

--- a/e2e/testsets/sets/nftables/xtables-encap-aws-autohep.txt
+++ b/e2e/testsets/sets/nftables/xtables-encap-aws-autohep.txt
@@ -1,0 +1,218 @@
+[sig-calico] [Team:CORE] [Category:Networking] [Feature:HostPorts] HostPorts tests with host port resources active on :8080 should support Pod HostPorts [Conformance] [Serial]
+[sig-calico] [Team:CORE] [Category:Networking] [Feature:Pods] Pod Termination Grace Period should allow client to reach server while client is terminating [Conformance]
+[sig-calico] [Team:CORE] [Category:Networking] [Feature:Pods] Pod Termination Grace Period should allow pinging a server pod while it is terminating
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:AutoHEPs] auto host endpoint tests should create host endpoints for each node [Conformance] [Serial]
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:AutoHEPs] auto host endpoint tests with policies in place with egress policy should block one node 1 from reaching node 0 on port 9091 with egress policy [Serial]
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:AutoHEPs] auto host endpoint tests with policies in place with ingress policy should block one node 1 from entering node 0 on port 9090 with ingress policy [Serial]
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Host-Protection] host endpoint tests doNotTrack policy should deny connections to the specified port in a doNotTrack deny policy [Serial]
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Host-Protection] host endpoint tests should allow connections using a named port [Conformance] [Serial]
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Host-Protection] host endpoint tests should allow inbound connections with an allow-all [Serial]
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Host-Protection] host endpoint tests should block all inbound connections by default [Serial]
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-Policy] [RunsOnWindows] Tiered policy tests with a second tier can explicitly pass traffic
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-Policy] [RunsOnWindows] Tiered policy tests with a second tier should enforce a default deny
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-Policy] [RunsOnWindows] Tiered policy tests with a single tier taking precedence over the default tier can pass to the default tier, and allow traffic explicitly. [Conformance]
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] Tiered RBAC with tier-prefixed names should allow create and deny based on tier RBAC with prefixed names
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC GlobalNetworkPolicy should allow creation by a user with full tier RBAC
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC GlobalNetworkPolicy should deny creation by a user without tier access
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC NetworkPolicy should allow creation by a user with full tier RBAC [Conformance]
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC NetworkPolicy should allow deletion by a user with full tier RBAC
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC NetworkPolicy should allow update by a user with full tier RBAC
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC NetworkPolicy should deny creation by a user without tier GET access [Conformance]
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC NetworkPolicy should deny creation by a user without tier policy access
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC NetworkPolicy should deny update by a user without tier GET access
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC default tier should not allow deleting the default tier
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC default tier should not allow updating the default tier
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC list via tier RBAC [RequiresCalicoAPIServer] should allow listing policies in the permitted tier
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC list via tier RBAC [RequiresCalicoAPIServer] should deny listing when user lacks tier policy access
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC old-style vs new-style name disambiguation [RequiresCalicoAPIServer] should independently authorize bare and tier-prefixed policy names
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC read-only access should allow reading but deny writing for a read-only user [Conformance]
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC resource-name exact match [RequiresCalicoAPIServer] should allow access to the named policy but deny access to others
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC tier isolation should restrict a user to only their permitted tier [Conformance]
+[sig-calico] [Team:CORE] [Category:Policy] [RequiresGoldmane] staged network policy Test presence in flow logs StagedGlobalNetworkPolicy Validate name, tier, action [Conformance]
+[sig-calico] [Team:CORE] [Category:Policy] [RequiresGoldmane] staged network policy Test presence in flow logs StagedKubernetesNetworkPolicy Validate name, tier, action [Conformance]
+[sig-calico] [Team:CORE] [Category:Policy] [RequiresGoldmane] staged network policy Test presence in flow logs StagedNetworkPolicy Validate name, tier, action [Conformance]
+[sig-calico] [Team:CORE] [Category:Policy] [RequiresGoldmane] staged network policy enforcing staged-policies StagedGlobalNetworkPolicy should enforce a deny policy
+[sig-calico] [Team:CORE] [Category:Policy] [RequiresGoldmane] staged network policy enforcing staged-policies StagedKubernetesNetworkPolicy should enforce a deny policy
+[sig-calico] [Team:CORE] [Category:Policy] [RequiresGoldmane] staged network policy enforcing staged-policies StagedNetworkPolicy should enforce a deny policy
+[sig-calico] [Team:CORE] [Feature:BGPPeer] [RequiresBGP] [Category:Networking] BGP password should enforce BGP password authentication [Serial]
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Packet Size Verification with different packet sizes using UDP and TCP host to nodeport, different nodes
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Packet Size Verification with different packet sizes using UDP and TCP host to pod, different nodes
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Packet Size Verification with different packet sizes using UDP and TCP host to service, different nodes
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Packet Size Verification with different packet sizes using UDP and TCP pod to nodeport, different nodes
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Packet Size Verification with different packet sizes using UDP and TCP pod to nodeport, same node
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Packet Size Verification with different packet sizes using UDP and TCP pod to pod, different nodes
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Packet Size Verification with different packet sizes using UDP and TCP pod to pod, same node
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Packet Size Verification with different packet sizes using UDP and TCP pod to service, different nodes
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Packet Size Verification with different packet sizes using UDP and TCP pod to service, same node
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath ClusterIP access scenario-0C0: pod0 -> clusterIP -> pod0 (loopback)
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath ClusterIP access scenario-0C1: pod0 -> clusterIP -> pod1 (same node)
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath ClusterIP access scenario-0C2: pod0 -> clusterIP -> pod2 (cross node) [Conformance]
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath ExternalIP access scenario-0EC0: pod0 -> externalIP Cluster -> pod0
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath ExternalIP access scenario-0EC1: pod0 -> externalIP Cluster -> pod1
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath ExternalIP access scenario-0EC2: pod0 -> externalIP Cluster -> pod2 (other node) [Conformance]
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath ExternalIP access scenario-0EL0: pod0 -> externalIP local-only -> pod0
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath ExternalIP access scenario-0EL1: pod0 -> externalIP local-only -> pod1
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath Host-networked destination scenario-0H1: pod0 -> clusterIP -> host-networked pod1 (same node)
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath Host-networked destination scenario-0H2: pod0 -> clusterIP -> host-networked pod2 (other node)
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath NodePort access scenario-0L00: pod0 -> node0 NodePort local-only -> pod0
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath NodePort access scenario-0L01: pod0 -> node0 NodePort local-only -> pod1
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath NodePort access scenario-0L12: pod0 -> node1 NodePort local-only -> pod2
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath NodePort access scenario-0N00: pod0 -> node0 NodePort -> pod0
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath NodePort access scenario-0N01: pod0 -> node0 NodePort -> pod1 (same node)
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath NodePort access scenario-0N02: pod0 -> node0 NodePort -> pod2 (other node) [Conformance]
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath NodePort access scenario-0N10: pod0 -> node1 NodePort -> pod0
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath NodePort access scenario-0N11: pod0 -> node1 NodePort -> pod1 (hairpin)
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath NodePort access scenario-0N12: pod0 -> node1 NodePort -> pod2 (pod on other node)
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Ingress Datapath scenario-10: node1 hostNet=true -> node1NodePort
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Ingress Datapath scenario-11: node0 hostNet=false -> node1NodePort
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Ingress Datapath scenario-12: node0 hostNet=true -> node1NodePort
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Ingress Datapath scenario-1: svcNode hostNet=false -> clusterIP
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Ingress Datapath scenario-2: svcNode hostNet=true -> clusterIP
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Ingress Datapath scenario-3: node1 hostNet=false -> clusterIP [Conformance]
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Ingress Datapath scenario-4: node1 hostNet=true -> clusterIP
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Ingress Datapath scenario-5: svcNode hostNet=false -> svcNodePort
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Ingress Datapath scenario-6: svcNode hostNet=true -> svcNodePort
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Ingress Datapath scenario-7: node1 hostNet=false -> svcNodePort
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Ingress Datapath scenario-8: node1 hostNet=true -> svcNodePort
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Ingress Datapath scenario-9: node1 hostNet=false -> node1NodePort
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-0-2 ApplyOnForward=false, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-0-2 ApplyOnForward=true, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-0C2 ApplyOnForward=false, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-0C2 ApplyOnForward=true, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-0C3 ApplyOnForward=false, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-0C3 ApplyOnForward=true, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-0N2 ApplyOnForward=false, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-0N2 ApplyOnForward=true, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-0N3 ApplyOnForward=false, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-0N3 ApplyOnForward=true, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-1-2 ApplyOnForward=false, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-1-2 ApplyOnForward=true, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-1C2 ApplyOnForward=false, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-1C2 ApplyOnForward=true, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-1N2 ApplyOnForward=false, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-1N2 ApplyOnForward=true, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-2N1 ApplyOnForward=false, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-2N1 ApplyOnForward=true, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath ingress-2-1 ApplyOnForward=false, ingress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath ingress-2-1 ApplyOnForward=true, ingress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath ingress-2C0 ApplyOnForward=false, ingress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath ingress-2C0 ApplyOnForward=true, ingress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath ingress-2N1 ApplyOnForward=false, ingress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath ingress-2N1 ApplyOnForward=true, ingress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath ingress-3-0 ApplyOnForward=false, ingress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath ingress-3-0 ApplyOnForward=true, ingress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath xtables-only [RequiresXtables] egress-2N2 ApplyOnForward=false, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath xtables-only [RequiresXtables] egress-2N2 ApplyOnForward=true, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath xtables-only [RequiresXtables] ingress-2N2 ApplyOnForward=false, ingress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath xtables-only [RequiresXtables] ingress-2N2 ApplyOnForward=true, ingress [Serial]
+[sig-calico] [Team:CORE] [Feature:IPAM] [Category:Networking] IPAM GC should garbage-collect leaked IP addresses [Serial]
+[sig-calico] [Team:CORE] [Feature:IPAM] [Category:Networking] IPAM StrictAffinity should respect StrictAffinity when toggled [Serial]
+[sig-calico] [Team:CORE] [Feature:IPPool] [Category:Operator] operator IPPool management tests should create and delete IP pools [Serial]
+[sig-calico] [Team:CORE] [Feature:Istio] [Category:Networking] Istio OpenShift Platform Configuration should deploy Istio with correct OpenShift platform configuration [Serial]
+[sig-calico] [Team:CORE] [Feature:Istio] [Category:Networking] [RequiresOperator] Istio Ambient Mode should allow UDP traffic to bypass ztunnel while Calico enforces UDP policy [Serial]
+[sig-calico] [Team:CORE] [Feature:Istio] [Category:Networking] [RequiresOperator] Istio Ambient Mode should encrypt traffic with ambient mode and enforce Calico NetworkPolicy [Serial]
+[sig-calico] [Team:CORE] [Feature:MTU] [Category:Networking] Automatic MTU tests should select the correct MTU for the platform
+[sig-calico] [Team:CORE] [Feature:NetworkPolicy] [Category:Policy] [RunsOnWindows] Calico NetworkPolicy should correctly isolate namespaces [Conformance]
+[sig-calico] [Team:CORE] [Feature:NetworkPolicy] [Category:Policy] [RunsOnWindows] Calico NetworkPolicy should provide a default allow [Conformance]
+[sig-calico] [Team:CORE] [Feature:NetworkPolicy] [Category:Policy] [RunsOnWindows] Calico NetworkPolicy should support a 'deny egress' policy [Conformance]
+[sig-calico] [Team:CORE] [Feature:NetworkPolicy] [Category:Policy] [RunsOnWindows] Calico NetworkPolicy should support namespace selectors [Conformance]
+[sig-calico] [Team:CORE] [Feature:NetworkPolicy] [Category:Policy] [RunsOnWindows] Calico NetworkPolicy should support service account selectors [Conformance]
+[sig-calico] [Team:CORE] [Feature:NetworkPolicy] [Category:Policy] service network policy Calico service network policy test ServiceMatch policy client egress by pod-name, server ingress by service [Conformance]
+[sig-calico] [Team:CORE] [Feature:NetworkPolicy] [Category:Policy] service network policy Calico service network policy test ServiceMatch policy client egress by service, server ingress by pod-name [Conformance]
+[sig-calico] [Team:CORE] [Feature:NetworkPolicy] [Category:Policy] service network policy Calico service network policy test ServiceMatch policy client egress by service, server ingress by service [Conformance]
+[sig-calico] [Team:CORE] [Feature:OwnerReferences] [Category:Configuration] OwnerReference tests should delete a NetworkSet if its owner has been deleted
+[sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit bandwidth with QoS annotations
+[sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit packet rate with QoS annotations
+[sig-network] API Server should have Endpoints and EndpointSlices pointing to API Server [Conformance]
+[sig-network] API Server should provide secure master service [Conformance]
+[sig-network] DNS should provide /etc/hosts entries for the cluster [Conformance]
+[sig-network] DNS should provide DNS for ExternalName services [Conformance]
+[sig-network] DNS should provide DNS for pods for Hostname [Conformance]
+[sig-network] DNS should provide DNS for pods for Subdomain [Conformance]
+[sig-network] DNS should provide DNS for services [Conformance]
+[sig-network] DNS should provide DNS for the cluster [Conformance]
+[sig-network] DNS should resolve DNS of partial qualified names for services [LinuxOnly] [Conformance]
+[sig-network] DNS should support configurable pod DNS nameservers [Conformance]
+[sig-network] EndpointSlice should create Endpoints and EndpointSlices for Pods matching a Service [Conformance]
+[sig-network] EndpointSlice should create and delete EndpointSlices for a Service with a selector that matches no pods [Conformance]
+[sig-network] EndpointSlice should support a Service with multiple endpoint IPs specified in multiple EndpointSlices [Conformance]
+[sig-network] EndpointSlice should support a Service with multiple ports specified in multiple EndpointSlices [Conformance]
+[sig-network] EndpointSlice should support creating EndpointSlice API operations [Conformance]
+[sig-network] EndpointSliceMirroring should mirror a custom Endpoints resource through create update and delete [Conformance]
+[sig-network] Endpoints should test the lifecycle of an Endpoint [Conformance]
+[sig-network] EndpointsController should create Endpoints for Pods matching a Service [Conformance]
+[sig-network] EndpointsController should create and delete Endpoints for a Service with a selector that matches no pods [Conformance]
+[sig-network] HostPort validates that there is no conflict between pods with same hostPort but different hostIP and protocol [LinuxOnly] [Conformance]
+[sig-network] Ingress API should support creating Ingress API operations [Conformance]
+[sig-network] IngressClass API should support creating IngressClass API operations [Conformance]
+[sig-network] Netpol NetworkPolicy between server and client should allow egress access on one named port [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should allow egress access to server in CIDR block [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should allow ingress access from namespace on one named port [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should allow ingress access from updated namespace [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should allow ingress access from updated pod [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should allow ingress access on one named port [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should deny egress from all pods in a namespace [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should deny egress from pods based on PodSelector [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should deny ingress access to updated pod [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should deny ingress from pods on other namespaces [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce egress policy allowing traffic to a server in a different namespace based on PodSelector and NamespaceSelector [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce except clause while egress access to server in CIDR block [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce ingress policy allowing any port traffic to a server on a specific protocol [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce multiple egress policies with egress allow-all policy taking precedence [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce multiple ingress policies with ingress allow-all policy taking precedence [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce multiple, stacked policies with overlapping podSelectors [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce policies to check ingress and egress policies can be controlled independently based on PodSelector [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce policy based on Multiple PodSelectors and NamespaceSelectors [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce policy based on NamespaceSelector with MatchExpressions [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce policy based on NamespaceSelector with MatchExpressions using default ns label [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce policy based on PodSelector and NamespaceSelector [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce policy based on PodSelector or NamespaceSelector [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce policy based on PodSelector with MatchExpressions [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce policy based on Ports [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce policy based on any PodSelectors [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce policy to allow ingress traffic for a target [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce policy to allow ingress traffic from pods in all namespaces [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce policy to allow traffic based on NamespaceSelector with MatchLabels using default ns label [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce policy to allow traffic from pods within server namespace based on PodSelector [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce policy to allow traffic only from a different namespace, based on NamespaceSelector [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce policy to allow traffic only from a pod in a different namespace based on PodSelector and NamespaceSelector [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce updated policy [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should ensure an IP overlapping both IPBlock.CIDR and IPBlock.Except is allowed [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should not allow access by TCP when a policy specifies only UDP [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should not allow all ports if it cannot limit to the requested port [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should not mistakenly treat 'protocol: SCTP' as 'protocol: TCP', even if the plugin doesn't support SCTP [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should properly isolate pods that are selected by a policy allowing SCTP, even if the plugin doesn't support SCTP [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should stop enforcing policies after they are deleted [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should support a 'default-deny-all' policy [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should support a 'default-deny-ingress' policy [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should support allow-all policy [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should support denying of egress traffic on the client side (even if the server explicitly allows this traffic) [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should work with Ingress, Egress specified together [Feature:NetworkPolicy]
+[sig-network] Netpol [LinuxOnly] NetworkPolicy between server and client using UDP should enforce policy based on Ports [Feature:NetworkPolicy]
+[sig-network] Netpol [LinuxOnly] NetworkPolicy between server and client using UDP should enforce policy to allow traffic only from a pod in a different namespace based on PodSelector and NamespaceSelector [Feature:NetworkPolicy]
+[sig-network] Netpol [LinuxOnly] NetworkPolicy between server and client using UDP should support a 'default-deny-ingress' policy [Feature:NetworkPolicy]
+[sig-network] Networking Granular Checks: Pods should function for intra-pod communication: http [Conformance] [NodeConformance]
+[sig-network] Networking Granular Checks: Pods should function for intra-pod communication: udp [Conformance] [NodeConformance]
+[sig-network] Networking Granular Checks: Pods should function for node-pod communication: http [LinuxOnly] [Conformance] [NodeConformance]
+[sig-network] Networking Granular Checks: Pods should function for node-pod communication: udp [LinuxOnly] [Conformance] [NodeConformance]
+[sig-network] Proxy version v1 A set of valid responses are returned for both pod and service Proxy [Conformance]
+[sig-network] Proxy version v1 A set of valid responses are returned for both pod and service ProxyWithPath [Conformance]
+[sig-network] Proxy version v1 should proxy through a service and a pod [Conformance]
+[sig-network] Service endpoints latency should not be very high [Conformance]
+[sig-network] ServiceCIDR and IPAddress API should support IPAddress API operations [Conformance]
+[sig-network] ServiceCIDR and IPAddress API should support ServiceCIDR API operations [Conformance]
+[sig-network] Services should be able to change the type from ClusterIP to ExternalName [Conformance]
+[sig-network] Services should be able to change the type from ExternalName to ClusterIP [Conformance]
+[sig-network] Services should be able to change the type from ExternalName to NodePort [Conformance]
+[sig-network] Services should be able to change the type from NodePort to ExternalName [Conformance]
+[sig-network] Services should be able to create a functioning NodePort service [Conformance]
+[sig-network] Services should be able to switch session affinity for NodePort service [LinuxOnly] [Conformance]
+[sig-network] Services should be able to switch session affinity for service with type clusterIP [LinuxOnly] [Conformance]
+[sig-network] Services should complete a service status lifecycle [Conformance]
+[sig-network] Services should delete a collection of services [Conformance]
+[sig-network] Services should find a service from listing all namespaces [Conformance]
+[sig-network] Services should have session affinity work for NodePort service [LinuxOnly] [Conformance]
+[sig-network] Services should have session affinity work for service with type clusterIP [LinuxOnly] [Conformance]
+[sig-network] Services should serve a basic endpoint from pods [Conformance]
+[sig-network] Services should serve endpoints on same port and different protocols [Conformance]
+[sig-network] Services should serve multiport endpoints from pods [Conformance]

--- a/e2e/testsets/sets/nftables/xtables-encap-nobgp-v3crd-autohep.txt
+++ b/e2e/testsets/sets/nftables/xtables-encap-nobgp-v3crd-autohep.txt
@@ -24,12 +24,12 @@
 [sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC default tier should not allow updating the default tier
 [sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC read-only access should allow reading but deny writing for a read-only user [Conformance]
 [sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC tier isolation should restrict a user to only their permitted tier [Conformance]
-[sig-calico] [Team:CORE] [Category:Policy] [RequiresGoldmane] staged network policy Test presence in flow logs StagedGlobalNetworkPolicy Validate name, tier, action [Conformance]
-[sig-calico] [Team:CORE] [Category:Policy] [RequiresGoldmane] staged network policy Test presence in flow logs StagedKubernetesNetworkPolicy Validate name, tier, action [Conformance]
-[sig-calico] [Team:CORE] [Category:Policy] [RequiresGoldmane] staged network policy Test presence in flow logs StagedNetworkPolicy Validate name, tier, action [Conformance]
-[sig-calico] [Team:CORE] [Category:Policy] [RequiresGoldmane] staged network policy enforcing staged-policies StagedGlobalNetworkPolicy should enforce a deny policy
-[sig-calico] [Team:CORE] [Category:Policy] [RequiresGoldmane] staged network policy enforcing staged-policies StagedKubernetesNetworkPolicy should enforce a deny policy
-[sig-calico] [Team:CORE] [Category:Policy] [RequiresGoldmane] staged network policy enforcing staged-policies StagedNetworkPolicy should enforce a deny policy
+[sig-calico] [Team:CORE] [Category:Policy] [RequiresGoldmane] [NoTierPrefix] staged network policy Test presence in flow logs StagedGlobalNetworkPolicy Validate name, tier, action [Conformance]
+[sig-calico] [Team:CORE] [Category:Policy] [RequiresGoldmane] [NoTierPrefix] staged network policy Test presence in flow logs StagedKubernetesNetworkPolicy Validate name, tier, action [Conformance]
+[sig-calico] [Team:CORE] [Category:Policy] [RequiresGoldmane] [NoTierPrefix] staged network policy Test presence in flow logs StagedNetworkPolicy Validate name, tier, action [Conformance]
+[sig-calico] [Team:CORE] [Category:Policy] [RequiresGoldmane] [NoTierPrefix] staged network policy enforcing staged-policies StagedGlobalNetworkPolicy should enforce a deny policy
+[sig-calico] [Team:CORE] [Category:Policy] [RequiresGoldmane] [NoTierPrefix] staged network policy enforcing staged-policies StagedKubernetesNetworkPolicy should enforce a deny policy
+[sig-calico] [Team:CORE] [Category:Policy] [RequiresGoldmane] [NoTierPrefix] staged network policy enforcing staged-policies StagedNetworkPolicy should enforce a deny policy
 [sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Packet Size Verification with different packet sizes using UDP and TCP host to nodeport, different nodes
 [sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Packet Size Verification with different packet sizes using UDP and TCP host to pod, different nodes
 [sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Packet Size Verification with different packet sizes using UDP and TCP host to service, different nodes
@@ -100,8 +100,8 @@
 [sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath xtables-only [RequiresXtables] egress-2N2 ApplyOnForward=true, egress [Serial]
 [sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath xtables-only [RequiresXtables] ingress-2N2 ApplyOnForward=false, ingress [Serial]
 [sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath xtables-only [RequiresXtables] ingress-2N2 ApplyOnForward=true, ingress [Serial]
-[sig-calico] [Team:CORE] [Feature:IPAM] [Category:Networking] IPAM GC should garbage-collect leaked IP addresses [Serial]
-[sig-calico] [Team:CORE] [Feature:IPAM] [Category:Networking] IPAM StrictAffinity should respect StrictAffinity when toggled [Serial]
+[sig-calico] [Team:CORE] [Feature:IPAM] [RequiresCalicoIPAM] [Category:Networking] IPAM GC should garbage-collect leaked IP addresses [Serial]
+[sig-calico] [Team:CORE] [Feature:IPAM] [RequiresCalicoIPAM] [Category:Networking] IPAM StrictAffinity should respect StrictAffinity when toggled [Serial]
 [sig-calico] [Team:CORE] [Feature:IPPool] [Category:Operator] operator IPPool management tests should create and delete IP pools [Serial]
 [sig-calico] [Team:CORE] [Feature:Istio] [Category:Networking] Istio OpenShift Platform Configuration should deploy Istio with correct OpenShift platform configuration [Serial]
 [sig-calico] [Team:CORE] [Feature:Istio] [Category:Networking] [RequiresOperator] Istio Ambient Mode should allow UDP traffic to bypass ztunnel while Calico enforces UDP policy [Serial]

--- a/e2e/testsets/sets/nftables/xtables-encap-nobgp-v3crd-autohep.txt
+++ b/e2e/testsets/sets/nftables/xtables-encap-nobgp-v3crd-autohep.txt
@@ -1,0 +1,213 @@
+[sig-calico] [Team:CORE] [Category:Networking] [Feature:HostPorts] HostPorts tests with host port resources active on :8080 should support Pod HostPorts [Conformance] [Serial]
+[sig-calico] [Team:CORE] [Category:Networking] [Feature:Pods] Pod Termination Grace Period should allow client to reach server while client is terminating [Conformance]
+[sig-calico] [Team:CORE] [Category:Networking] [Feature:Pods] Pod Termination Grace Period should allow pinging a server pod while it is terminating
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:AutoHEPs] auto host endpoint tests should create host endpoints for each node [Conformance] [Serial]
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:AutoHEPs] auto host endpoint tests with policies in place with egress policy should block one node 1 from reaching node 0 on port 9091 with egress policy [Serial]
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:AutoHEPs] auto host endpoint tests with policies in place with ingress policy should block one node 1 from entering node 0 on port 9090 with ingress policy [Serial]
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Host-Protection] host endpoint tests doNotTrack policy should deny connections to the specified port in a doNotTrack deny policy [Serial]
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Host-Protection] host endpoint tests should allow connections using a named port [Conformance] [Serial]
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Host-Protection] host endpoint tests should allow inbound connections with an allow-all [Serial]
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Host-Protection] host endpoint tests should block all inbound connections by default [Serial]
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-Policy] [RunsOnWindows] Tiered policy tests with a second tier can explicitly pass traffic
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-Policy] [RunsOnWindows] Tiered policy tests with a second tier should enforce a default deny
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-Policy] [RunsOnWindows] Tiered policy tests with a single tier taking precedence over the default tier can pass to the default tier, and allow traffic explicitly. [Conformance]
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] Tiered RBAC with tier-prefixed names should allow create and deny based on tier RBAC with prefixed names
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC GlobalNetworkPolicy should allow creation by a user with full tier RBAC
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC GlobalNetworkPolicy should deny creation by a user without tier access
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC NetworkPolicy should allow creation by a user with full tier RBAC [Conformance]
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC NetworkPolicy should allow deletion by a user with full tier RBAC
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC NetworkPolicy should allow update by a user with full tier RBAC
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC NetworkPolicy should deny creation by a user without tier GET access [Conformance]
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC NetworkPolicy should deny creation by a user without tier policy access
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC NetworkPolicy should deny update by a user without tier GET access
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC default tier should not allow deleting the default tier
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC default tier should not allow updating the default tier
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC read-only access should allow reading but deny writing for a read-only user [Conformance]
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC tier isolation should restrict a user to only their permitted tier [Conformance]
+[sig-calico] [Team:CORE] [Category:Policy] [RequiresGoldmane] staged network policy Test presence in flow logs StagedGlobalNetworkPolicy Validate name, tier, action [Conformance]
+[sig-calico] [Team:CORE] [Category:Policy] [RequiresGoldmane] staged network policy Test presence in flow logs StagedKubernetesNetworkPolicy Validate name, tier, action [Conformance]
+[sig-calico] [Team:CORE] [Category:Policy] [RequiresGoldmane] staged network policy Test presence in flow logs StagedNetworkPolicy Validate name, tier, action [Conformance]
+[sig-calico] [Team:CORE] [Category:Policy] [RequiresGoldmane] staged network policy enforcing staged-policies StagedGlobalNetworkPolicy should enforce a deny policy
+[sig-calico] [Team:CORE] [Category:Policy] [RequiresGoldmane] staged network policy enforcing staged-policies StagedKubernetesNetworkPolicy should enforce a deny policy
+[sig-calico] [Team:CORE] [Category:Policy] [RequiresGoldmane] staged network policy enforcing staged-policies StagedNetworkPolicy should enforce a deny policy
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Packet Size Verification with different packet sizes using UDP and TCP host to nodeport, different nodes
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Packet Size Verification with different packet sizes using UDP and TCP host to pod, different nodes
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Packet Size Verification with different packet sizes using UDP and TCP host to service, different nodes
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Packet Size Verification with different packet sizes using UDP and TCP pod to nodeport, different nodes
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Packet Size Verification with different packet sizes using UDP and TCP pod to nodeport, same node
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Packet Size Verification with different packet sizes using UDP and TCP pod to pod, different nodes
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Packet Size Verification with different packet sizes using UDP and TCP pod to pod, same node
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Packet Size Verification with different packet sizes using UDP and TCP pod to service, different nodes
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Packet Size Verification with different packet sizes using UDP and TCP pod to service, same node
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath ClusterIP access scenario-0C0: pod0 -> clusterIP -> pod0 (loopback)
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath ClusterIP access scenario-0C1: pod0 -> clusterIP -> pod1 (same node)
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath ClusterIP access scenario-0C2: pod0 -> clusterIP -> pod2 (cross node) [Conformance]
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath ExternalIP access scenario-0EC0: pod0 -> externalIP Cluster -> pod0
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath ExternalIP access scenario-0EC1: pod0 -> externalIP Cluster -> pod1
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath ExternalIP access scenario-0EC2: pod0 -> externalIP Cluster -> pod2 (other node) [Conformance]
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath ExternalIP access scenario-0EL0: pod0 -> externalIP local-only -> pod0
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath ExternalIP access scenario-0EL1: pod0 -> externalIP local-only -> pod1
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath Host-networked destination scenario-0H1: pod0 -> clusterIP -> host-networked pod1 (same node)
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath Host-networked destination scenario-0H2: pod0 -> clusterIP -> host-networked pod2 (other node)
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath NodePort access scenario-0L00: pod0 -> node0 NodePort local-only -> pod0
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath NodePort access scenario-0L01: pod0 -> node0 NodePort local-only -> pod1
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath NodePort access scenario-0L12: pod0 -> node1 NodePort local-only -> pod2
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath NodePort access scenario-0N00: pod0 -> node0 NodePort -> pod0
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath NodePort access scenario-0N01: pod0 -> node0 NodePort -> pod1 (same node)
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath NodePort access scenario-0N02: pod0 -> node0 NodePort -> pod2 (other node) [Conformance]
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath NodePort access scenario-0N10: pod0 -> node1 NodePort -> pod0
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath NodePort access scenario-0N11: pod0 -> node1 NodePort -> pod1 (hairpin)
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath NodePort access scenario-0N12: pod0 -> node1 NodePort -> pod2 (pod on other node)
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Ingress Datapath scenario-10: node1 hostNet=true -> node1NodePort
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Ingress Datapath scenario-11: node0 hostNet=false -> node1NodePort
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Ingress Datapath scenario-12: node0 hostNet=true -> node1NodePort
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Ingress Datapath scenario-1: svcNode hostNet=false -> clusterIP
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Ingress Datapath scenario-2: svcNode hostNet=true -> clusterIP
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Ingress Datapath scenario-3: node1 hostNet=false -> clusterIP [Conformance]
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Ingress Datapath scenario-4: node1 hostNet=true -> clusterIP
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Ingress Datapath scenario-5: svcNode hostNet=false -> svcNodePort
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Ingress Datapath scenario-6: svcNode hostNet=true -> svcNodePort
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Ingress Datapath scenario-7: node1 hostNet=false -> svcNodePort
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Ingress Datapath scenario-8: node1 hostNet=true -> svcNodePort
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Ingress Datapath scenario-9: node1 hostNet=false -> node1NodePort
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-0-2 ApplyOnForward=false, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-0-2 ApplyOnForward=true, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-0C2 ApplyOnForward=false, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-0C2 ApplyOnForward=true, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-0C3 ApplyOnForward=false, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-0C3 ApplyOnForward=true, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-0N2 ApplyOnForward=false, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-0N2 ApplyOnForward=true, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-0N3 ApplyOnForward=false, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-0N3 ApplyOnForward=true, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-1-2 ApplyOnForward=false, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-1-2 ApplyOnForward=true, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-1C2 ApplyOnForward=false, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-1C2 ApplyOnForward=true, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-1N2 ApplyOnForward=false, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-1N2 ApplyOnForward=true, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-2N1 ApplyOnForward=false, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-2N1 ApplyOnForward=true, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath ingress-2-1 ApplyOnForward=false, ingress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath ingress-2-1 ApplyOnForward=true, ingress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath ingress-2C0 ApplyOnForward=false, ingress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath ingress-2C0 ApplyOnForward=true, ingress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath ingress-2N1 ApplyOnForward=false, ingress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath ingress-2N1 ApplyOnForward=true, ingress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath ingress-3-0 ApplyOnForward=false, ingress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath ingress-3-0 ApplyOnForward=true, ingress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath xtables-only [RequiresXtables] egress-2N2 ApplyOnForward=false, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath xtables-only [RequiresXtables] egress-2N2 ApplyOnForward=true, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath xtables-only [RequiresXtables] ingress-2N2 ApplyOnForward=false, ingress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath xtables-only [RequiresXtables] ingress-2N2 ApplyOnForward=true, ingress [Serial]
+[sig-calico] [Team:CORE] [Feature:IPAM] [Category:Networking] IPAM GC should garbage-collect leaked IP addresses [Serial]
+[sig-calico] [Team:CORE] [Feature:IPAM] [Category:Networking] IPAM StrictAffinity should respect StrictAffinity when toggled [Serial]
+[sig-calico] [Team:CORE] [Feature:IPPool] [Category:Operator] operator IPPool management tests should create and delete IP pools [Serial]
+[sig-calico] [Team:CORE] [Feature:Istio] [Category:Networking] Istio OpenShift Platform Configuration should deploy Istio with correct OpenShift platform configuration [Serial]
+[sig-calico] [Team:CORE] [Feature:Istio] [Category:Networking] [RequiresOperator] Istio Ambient Mode should allow UDP traffic to bypass ztunnel while Calico enforces UDP policy [Serial]
+[sig-calico] [Team:CORE] [Feature:Istio] [Category:Networking] [RequiresOperator] Istio Ambient Mode should encrypt traffic with ambient mode and enforce Calico NetworkPolicy [Serial]
+[sig-calico] [Team:CORE] [Feature:MTU] [Category:Networking] Automatic MTU tests should select the correct MTU for the platform
+[sig-calico] [Team:CORE] [Feature:NetworkPolicy] [Category:Policy] [RunsOnWindows] Calico NetworkPolicy should correctly isolate namespaces [Conformance]
+[sig-calico] [Team:CORE] [Feature:NetworkPolicy] [Category:Policy] [RunsOnWindows] Calico NetworkPolicy should provide a default allow [Conformance]
+[sig-calico] [Team:CORE] [Feature:NetworkPolicy] [Category:Policy] [RunsOnWindows] Calico NetworkPolicy should support a 'deny egress' policy [Conformance]
+[sig-calico] [Team:CORE] [Feature:NetworkPolicy] [Category:Policy] [RunsOnWindows] Calico NetworkPolicy should support namespace selectors [Conformance]
+[sig-calico] [Team:CORE] [Feature:NetworkPolicy] [Category:Policy] [RunsOnWindows] Calico NetworkPolicy should support service account selectors [Conformance]
+[sig-calico] [Team:CORE] [Feature:NetworkPolicy] [Category:Policy] service network policy Calico service network policy test ServiceMatch policy client egress by pod-name, server ingress by service [Conformance]
+[sig-calico] [Team:CORE] [Feature:NetworkPolicy] [Category:Policy] service network policy Calico service network policy test ServiceMatch policy client egress by service, server ingress by pod-name [Conformance]
+[sig-calico] [Team:CORE] [Feature:NetworkPolicy] [Category:Policy] service network policy Calico service network policy test ServiceMatch policy client egress by service, server ingress by service [Conformance]
+[sig-calico] [Team:CORE] [Feature:OwnerReferences] [Category:Configuration] OwnerReference tests should delete a NetworkSet if its owner has been deleted
+[sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit bandwidth with QoS annotations
+[sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit packet rate with QoS annotations
+[sig-network] API Server should have Endpoints and EndpointSlices pointing to API Server [Conformance]
+[sig-network] API Server should provide secure master service [Conformance]
+[sig-network] DNS should provide /etc/hosts entries for the cluster [Conformance]
+[sig-network] DNS should provide DNS for ExternalName services [Conformance]
+[sig-network] DNS should provide DNS for pods for Hostname [Conformance]
+[sig-network] DNS should provide DNS for pods for Subdomain [Conformance]
+[sig-network] DNS should provide DNS for services [Conformance]
+[sig-network] DNS should provide DNS for the cluster [Conformance]
+[sig-network] DNS should resolve DNS of partial qualified names for services [LinuxOnly] [Conformance]
+[sig-network] DNS should support configurable pod DNS nameservers [Conformance]
+[sig-network] EndpointSlice should create Endpoints and EndpointSlices for Pods matching a Service [Conformance]
+[sig-network] EndpointSlice should create and delete EndpointSlices for a Service with a selector that matches no pods [Conformance]
+[sig-network] EndpointSlice should support a Service with multiple endpoint IPs specified in multiple EndpointSlices [Conformance]
+[sig-network] EndpointSlice should support a Service with multiple ports specified in multiple EndpointSlices [Conformance]
+[sig-network] EndpointSlice should support creating EndpointSlice API operations [Conformance]
+[sig-network] EndpointSliceMirroring should mirror a custom Endpoints resource through create update and delete [Conformance]
+[sig-network] Endpoints should test the lifecycle of an Endpoint [Conformance]
+[sig-network] EndpointsController should create Endpoints for Pods matching a Service [Conformance]
+[sig-network] EndpointsController should create and delete Endpoints for a Service with a selector that matches no pods [Conformance]
+[sig-network] HostPort validates that there is no conflict between pods with same hostPort but different hostIP and protocol [LinuxOnly] [Conformance]
+[sig-network] Ingress API should support creating Ingress API operations [Conformance]
+[sig-network] IngressClass API should support creating IngressClass API operations [Conformance]
+[sig-network] Netpol NetworkPolicy between server and client should allow egress access on one named port [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should allow egress access to server in CIDR block [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should allow ingress access from namespace on one named port [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should allow ingress access from updated namespace [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should allow ingress access from updated pod [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should allow ingress access on one named port [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should deny egress from all pods in a namespace [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should deny egress from pods based on PodSelector [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should deny ingress access to updated pod [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should deny ingress from pods on other namespaces [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce egress policy allowing traffic to a server in a different namespace based on PodSelector and NamespaceSelector [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce except clause while egress access to server in CIDR block [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce ingress policy allowing any port traffic to a server on a specific protocol [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce multiple egress policies with egress allow-all policy taking precedence [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce multiple ingress policies with ingress allow-all policy taking precedence [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce multiple, stacked policies with overlapping podSelectors [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce policies to check ingress and egress policies can be controlled independently based on PodSelector [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce policy based on Multiple PodSelectors and NamespaceSelectors [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce policy based on NamespaceSelector with MatchExpressions [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce policy based on NamespaceSelector with MatchExpressions using default ns label [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce policy based on PodSelector and NamespaceSelector [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce policy based on PodSelector or NamespaceSelector [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce policy based on PodSelector with MatchExpressions [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce policy based on Ports [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce policy based on any PodSelectors [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce policy to allow ingress traffic for a target [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce policy to allow ingress traffic from pods in all namespaces [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce policy to allow traffic based on NamespaceSelector with MatchLabels using default ns label [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce policy to allow traffic from pods within server namespace based on PodSelector [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce policy to allow traffic only from a different namespace, based on NamespaceSelector [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce policy to allow traffic only from a pod in a different namespace based on PodSelector and NamespaceSelector [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce updated policy [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should ensure an IP overlapping both IPBlock.CIDR and IPBlock.Except is allowed [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should not allow access by TCP when a policy specifies only UDP [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should not allow all ports if it cannot limit to the requested port [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should not mistakenly treat 'protocol: SCTP' as 'protocol: TCP', even if the plugin doesn't support SCTP [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should properly isolate pods that are selected by a policy allowing SCTP, even if the plugin doesn't support SCTP [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should stop enforcing policies after they are deleted [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should support a 'default-deny-all' policy [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should support a 'default-deny-ingress' policy [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should support allow-all policy [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should support denying of egress traffic on the client side (even if the server explicitly allows this traffic) [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should work with Ingress, Egress specified together [Feature:NetworkPolicy]
+[sig-network] Netpol [LinuxOnly] NetworkPolicy between server and client using UDP should enforce policy based on Ports [Feature:NetworkPolicy]
+[sig-network] Netpol [LinuxOnly] NetworkPolicy between server and client using UDP should enforce policy to allow traffic only from a pod in a different namespace based on PodSelector and NamespaceSelector [Feature:NetworkPolicy]
+[sig-network] Netpol [LinuxOnly] NetworkPolicy between server and client using UDP should support a 'default-deny-ingress' policy [Feature:NetworkPolicy]
+[sig-network] Networking Granular Checks: Pods should function for intra-pod communication: http [Conformance] [NodeConformance]
+[sig-network] Networking Granular Checks: Pods should function for intra-pod communication: udp [Conformance] [NodeConformance]
+[sig-network] Networking Granular Checks: Pods should function for node-pod communication: http [LinuxOnly] [Conformance] [NodeConformance]
+[sig-network] Networking Granular Checks: Pods should function for node-pod communication: udp [LinuxOnly] [Conformance] [NodeConformance]
+[sig-network] Proxy version v1 A set of valid responses are returned for both pod and service Proxy [Conformance]
+[sig-network] Proxy version v1 A set of valid responses are returned for both pod and service ProxyWithPath [Conformance]
+[sig-network] Proxy version v1 should proxy through a service and a pod [Conformance]
+[sig-network] Service endpoints latency should not be very high [Conformance]
+[sig-network] ServiceCIDR and IPAddress API should support IPAddress API operations [Conformance]
+[sig-network] ServiceCIDR and IPAddress API should support ServiceCIDR API operations [Conformance]
+[sig-network] Services should be able to change the type from ClusterIP to ExternalName [Conformance]
+[sig-network] Services should be able to change the type from ExternalName to ClusterIP [Conformance]
+[sig-network] Services should be able to change the type from ExternalName to NodePort [Conformance]
+[sig-network] Services should be able to change the type from NodePort to ExternalName [Conformance]
+[sig-network] Services should be able to create a functioning NodePort service [Conformance]
+[sig-network] Services should be able to switch session affinity for NodePort service [LinuxOnly] [Conformance]
+[sig-network] Services should be able to switch session affinity for service with type clusterIP [LinuxOnly] [Conformance]
+[sig-network] Services should complete a service status lifecycle [Conformance]
+[sig-network] Services should delete a collection of services [Conformance]
+[sig-network] Services should find a service from listing all namespaces [Conformance]
+[sig-network] Services should have session affinity work for NodePort service [LinuxOnly] [Conformance]
+[sig-network] Services should have session affinity work for service with type clusterIP [LinuxOnly] [Conformance]
+[sig-network] Services should serve a basic endpoint from pods [Conformance]
+[sig-network] Services should serve endpoints on same port and different protocols [Conformance]
+[sig-network] Services should serve multiport endpoints from pods [Conformance]

--- a/e2e/testsets/sets/nftables/xtables-v3crd-aws-autohep.txt
+++ b/e2e/testsets/sets/nftables/xtables-v3crd-aws-autohep.txt
@@ -1,0 +1,218 @@
+[sig-calico] [Team:CORE] [Category:Networking] [Feature:HostPorts] HostPorts tests with host port resources active on :8080 should support Pod HostPorts [Conformance] [Serial]
+[sig-calico] [Team:CORE] [Category:Networking] [Feature:Pods] Pod Termination Grace Period should allow client to reach server while client is terminating [Conformance]
+[sig-calico] [Team:CORE] [Category:Networking] [Feature:Pods] Pod Termination Grace Period should allow pinging a server pod while it is terminating
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:AutoHEPs] auto host endpoint tests should create host endpoints for each node [Conformance] [Serial]
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:AutoHEPs] auto host endpoint tests with policies in place with egress policy should block one node 1 from reaching node 0 on port 9091 with egress policy [Serial]
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:AutoHEPs] auto host endpoint tests with policies in place with ingress policy should block one node 1 from entering node 0 on port 9090 with ingress policy [Serial]
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Host-Protection] host endpoint tests doNotTrack policy should deny connections to the specified port in a doNotTrack deny policy [Serial]
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Host-Protection] host endpoint tests should allow connections using a named port [Conformance] [Serial]
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Host-Protection] host endpoint tests should allow inbound connections with an allow-all [Serial]
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Host-Protection] host endpoint tests should block all inbound connections by default [Serial]
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-Policy] [RunsOnWindows] Tiered policy tests with a second tier can explicitly pass traffic
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-Policy] [RunsOnWindows] Tiered policy tests with a second tier should enforce a default deny
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-Policy] [RunsOnWindows] Tiered policy tests with a single tier taking precedence over the default tier can pass to the default tier, and allow traffic explicitly. [Conformance]
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] Tiered RBAC with tier-prefixed names should allow create and deny based on tier RBAC with prefixed names
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC GlobalNetworkPolicy should allow creation by a user with full tier RBAC
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC GlobalNetworkPolicy should deny creation by a user without tier access
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC NetworkPolicy should allow creation by a user with full tier RBAC [Conformance]
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC NetworkPolicy should allow deletion by a user with full tier RBAC
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC NetworkPolicy should allow update by a user with full tier RBAC
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC NetworkPolicy should deny creation by a user without tier GET access [Conformance]
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC NetworkPolicy should deny creation by a user without tier policy access
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC NetworkPolicy should deny update by a user without tier GET access
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC default tier should not allow deleting the default tier
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC default tier should not allow updating the default tier
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC read-only access should allow reading but deny writing for a read-only user [Conformance]
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC tier isolation should restrict a user to only their permitted tier [Conformance]
+[sig-calico] [Team:CORE] [Category:Policy] [RequiresGoldmane] staged network policy Test presence in flow logs StagedGlobalNetworkPolicy Validate name, tier, action [Conformance]
+[sig-calico] [Team:CORE] [Category:Policy] [RequiresGoldmane] staged network policy Test presence in flow logs StagedKubernetesNetworkPolicy Validate name, tier, action [Conformance]
+[sig-calico] [Team:CORE] [Category:Policy] [RequiresGoldmane] staged network policy Test presence in flow logs StagedNetworkPolicy Validate name, tier, action [Conformance]
+[sig-calico] [Team:CORE] [Category:Policy] [RequiresGoldmane] staged network policy enforcing staged-policies StagedGlobalNetworkPolicy should enforce a deny policy
+[sig-calico] [Team:CORE] [Category:Policy] [RequiresGoldmane] staged network policy enforcing staged-policies StagedKubernetesNetworkPolicy should enforce a deny policy
+[sig-calico] [Team:CORE] [Category:Policy] [RequiresGoldmane] staged network policy enforcing staged-policies StagedNetworkPolicy should enforce a deny policy
+[sig-calico] [Team:CORE] [Feature:BGPPeer] [RequiresBGP] [Category:Networking] BGP password should enforce BGP password authentication [Serial]
+[sig-calico] [Team:CORE] [Feature:BGPPeer] [RequiresBGP] [Category:Networking] [RequiresBGPMesh] BGP export tests should not export pools with export disabled [Serial]
+[sig-calico] [Team:CORE] [Feature:BGPPeer] [RequiresBGP] [Category:Networking] [RequiresBGPMesh] BGPPeer should support BGP peers [Serial]
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Packet Size Verification with different packet sizes using UDP and TCP host to nodeport, different nodes
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Packet Size Verification with different packet sizes using UDP and TCP host to pod, different nodes
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Packet Size Verification with different packet sizes using UDP and TCP host to service, different nodes
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Packet Size Verification with different packet sizes using UDP and TCP pod to nodeport, different nodes
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Packet Size Verification with different packet sizes using UDP and TCP pod to nodeport, same node
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Packet Size Verification with different packet sizes using UDP and TCP pod to pod, different nodes
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Packet Size Verification with different packet sizes using UDP and TCP pod to pod, same node
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Packet Size Verification with different packet sizes using UDP and TCP pod to service, different nodes
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Packet Size Verification with different packet sizes using UDP and TCP pod to service, same node
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath ClusterIP access scenario-0C0: pod0 -> clusterIP -> pod0 (loopback)
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath ClusterIP access scenario-0C1: pod0 -> clusterIP -> pod1 (same node)
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath ClusterIP access scenario-0C2: pod0 -> clusterIP -> pod2 (cross node) [Conformance]
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath ExternalIP access scenario-0EC0: pod0 -> externalIP Cluster -> pod0
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath ExternalIP access scenario-0EC1: pod0 -> externalIP Cluster -> pod1
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath ExternalIP access scenario-0EC2: pod0 -> externalIP Cluster -> pod2 (other node) [Conformance]
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath ExternalIP access scenario-0EL0: pod0 -> externalIP local-only -> pod0
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath ExternalIP access scenario-0EL1: pod0 -> externalIP local-only -> pod1
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath Host-networked destination scenario-0H1: pod0 -> clusterIP -> host-networked pod1 (same node)
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath Host-networked destination scenario-0H2: pod0 -> clusterIP -> host-networked pod2 (other node)
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath NodePort access scenario-0L00: pod0 -> node0 NodePort local-only -> pod0
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath NodePort access scenario-0L01: pod0 -> node0 NodePort local-only -> pod1
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath NodePort access scenario-0L12: pod0 -> node1 NodePort local-only -> pod2
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath NodePort access scenario-0N00: pod0 -> node0 NodePort -> pod0
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath NodePort access scenario-0N01: pod0 -> node0 NodePort -> pod1 (same node)
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath NodePort access scenario-0N02: pod0 -> node0 NodePort -> pod2 (other node) [Conformance]
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath NodePort access scenario-0N10: pod0 -> node1 NodePort -> pod0
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath NodePort access scenario-0N11: pod0 -> node1 NodePort -> pod1 (hairpin)
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath NodePort access scenario-0N12: pod0 -> node1 NodePort -> pod2 (pod on other node)
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Ingress Datapath scenario-10: node1 hostNet=true -> node1NodePort
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Ingress Datapath scenario-11: node0 hostNet=false -> node1NodePort
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Ingress Datapath scenario-12: node0 hostNet=true -> node1NodePort
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Ingress Datapath scenario-1: svcNode hostNet=false -> clusterIP
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Ingress Datapath scenario-2: svcNode hostNet=true -> clusterIP
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Ingress Datapath scenario-3: node1 hostNet=false -> clusterIP [Conformance]
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Ingress Datapath scenario-4: node1 hostNet=true -> clusterIP
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Ingress Datapath scenario-5: svcNode hostNet=false -> svcNodePort
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Ingress Datapath scenario-6: svcNode hostNet=true -> svcNodePort
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Ingress Datapath scenario-7: node1 hostNet=false -> svcNodePort
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Ingress Datapath scenario-8: node1 hostNet=true -> svcNodePort
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Ingress Datapath scenario-9: node1 hostNet=false -> node1NodePort
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-0-2 ApplyOnForward=false, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-0-2 ApplyOnForward=true, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-0C2 ApplyOnForward=false, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-0C2 ApplyOnForward=true, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-0C3 ApplyOnForward=false, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-0C3 ApplyOnForward=true, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-0N2 ApplyOnForward=false, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-0N2 ApplyOnForward=true, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-0N3 ApplyOnForward=false, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-0N3 ApplyOnForward=true, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-1-2 ApplyOnForward=false, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-1-2 ApplyOnForward=true, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-1C2 ApplyOnForward=false, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-1C2 ApplyOnForward=true, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-1N2 ApplyOnForward=false, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-1N2 ApplyOnForward=true, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-2N1 ApplyOnForward=false, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-2N1 ApplyOnForward=true, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath ingress-2-1 ApplyOnForward=false, ingress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath ingress-2-1 ApplyOnForward=true, ingress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath ingress-2C0 ApplyOnForward=false, ingress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath ingress-2C0 ApplyOnForward=true, ingress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath ingress-2N1 ApplyOnForward=false, ingress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath ingress-2N1 ApplyOnForward=true, ingress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath ingress-3-0 ApplyOnForward=false, ingress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath ingress-3-0 ApplyOnForward=true, ingress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath xtables-only [RequiresXtables] egress-2N2 ApplyOnForward=false, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath xtables-only [RequiresXtables] egress-2N2 ApplyOnForward=true, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath xtables-only [RequiresXtables] ingress-2N2 ApplyOnForward=false, ingress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath xtables-only [RequiresXtables] ingress-2N2 ApplyOnForward=true, ingress [Serial]
+[sig-calico] [Team:CORE] [Feature:IPAM] [Category:Networking] IPAM GC should garbage-collect leaked IP addresses [Serial]
+[sig-calico] [Team:CORE] [Feature:IPAM] [Category:Networking] IPAM StrictAffinity should respect StrictAffinity when toggled [Serial]
+[sig-calico] [Team:CORE] [Feature:IPIP] [Category:Networking] [NoEncap] IP-in-IP tests should assign an IPIP address to the tunl0 interface [Serial]
+[sig-calico] [Team:CORE] [Feature:IPIP] [Category:Networking] [NoEncap] IP-in-IP tests should support toggling IPIP on and off [Serial]
+[sig-calico] [Team:CORE] [Feature:IPPool] [Category:Operator] operator IPPool management tests should create and delete IP pools [Serial]
+[sig-calico] [Team:CORE] [Feature:Istio] [Category:Networking] Istio OpenShift Platform Configuration should deploy Istio with correct OpenShift platform configuration [Serial]
+[sig-calico] [Team:CORE] [Feature:Istio] [Category:Networking] [RequiresOperator] Istio Ambient Mode should allow UDP traffic to bypass ztunnel while Calico enforces UDP policy [Serial]
+[sig-calico] [Team:CORE] [Feature:Istio] [Category:Networking] [RequiresOperator] Istio Ambient Mode should encrypt traffic with ambient mode and enforce Calico NetworkPolicy [Serial]
+[sig-calico] [Team:CORE] [Feature:MTU] [Category:Networking] Automatic MTU tests should select the correct MTU for the platform
+[sig-calico] [Team:CORE] [Feature:NetworkPolicy] [Category:Policy] [RunsOnWindows] Calico NetworkPolicy should correctly isolate namespaces [Conformance]
+[sig-calico] [Team:CORE] [Feature:NetworkPolicy] [Category:Policy] [RunsOnWindows] Calico NetworkPolicy should provide a default allow [Conformance]
+[sig-calico] [Team:CORE] [Feature:NetworkPolicy] [Category:Policy] [RunsOnWindows] Calico NetworkPolicy should support a 'deny egress' policy [Conformance]
+[sig-calico] [Team:CORE] [Feature:NetworkPolicy] [Category:Policy] [RunsOnWindows] Calico NetworkPolicy should support namespace selectors [Conformance]
+[sig-calico] [Team:CORE] [Feature:NetworkPolicy] [Category:Policy] [RunsOnWindows] Calico NetworkPolicy should support service account selectors [Conformance]
+[sig-calico] [Team:CORE] [Feature:NetworkPolicy] [Category:Policy] service network policy Calico service network policy test ServiceMatch policy client egress by pod-name, server ingress by service [Conformance]
+[sig-calico] [Team:CORE] [Feature:NetworkPolicy] [Category:Policy] service network policy Calico service network policy test ServiceMatch policy client egress by service, server ingress by pod-name [Conformance]
+[sig-calico] [Team:CORE] [Feature:NetworkPolicy] [Category:Policy] service network policy Calico service network policy test ServiceMatch policy client egress by service, server ingress by service [Conformance]
+[sig-calico] [Team:CORE] [Feature:OwnerReferences] [Category:Configuration] OwnerReference tests should delete a NetworkSet if its owner has been deleted
+[sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit bandwidth with QoS annotations
+[sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit packet rate with QoS annotations
+[sig-network] API Server should have Endpoints and EndpointSlices pointing to API Server [Conformance]
+[sig-network] API Server should provide secure master service [Conformance]
+[sig-network] DNS should provide /etc/hosts entries for the cluster [Conformance]
+[sig-network] DNS should provide DNS for ExternalName services [Conformance]
+[sig-network] DNS should provide DNS for pods for Hostname [Conformance]
+[sig-network] DNS should provide DNS for pods for Subdomain [Conformance]
+[sig-network] DNS should provide DNS for services [Conformance]
+[sig-network] DNS should provide DNS for the cluster [Conformance]
+[sig-network] DNS should resolve DNS of partial qualified names for services [LinuxOnly] [Conformance]
+[sig-network] DNS should support configurable pod DNS nameservers [Conformance]
+[sig-network] EndpointSlice should create Endpoints and EndpointSlices for Pods matching a Service [Conformance]
+[sig-network] EndpointSlice should create and delete EndpointSlices for a Service with a selector that matches no pods [Conformance]
+[sig-network] EndpointSlice should support a Service with multiple endpoint IPs specified in multiple EndpointSlices [Conformance]
+[sig-network] EndpointSlice should support a Service with multiple ports specified in multiple EndpointSlices [Conformance]
+[sig-network] EndpointSlice should support creating EndpointSlice API operations [Conformance]
+[sig-network] EndpointSliceMirroring should mirror a custom Endpoints resource through create update and delete [Conformance]
+[sig-network] Endpoints should test the lifecycle of an Endpoint [Conformance]
+[sig-network] EndpointsController should create Endpoints for Pods matching a Service [Conformance]
+[sig-network] EndpointsController should create and delete Endpoints for a Service with a selector that matches no pods [Conformance]
+[sig-network] HostPort validates that there is no conflict between pods with same hostPort but different hostIP and protocol [LinuxOnly] [Conformance]
+[sig-network] Ingress API should support creating Ingress API operations [Conformance]
+[sig-network] IngressClass API should support creating IngressClass API operations [Conformance]
+[sig-network] Netpol NetworkPolicy between server and client should allow egress access on one named port [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should allow egress access to server in CIDR block [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should allow ingress access from namespace on one named port [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should allow ingress access from updated namespace [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should allow ingress access from updated pod [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should allow ingress access on one named port [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should deny egress from all pods in a namespace [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should deny egress from pods based on PodSelector [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should deny ingress access to updated pod [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should deny ingress from pods on other namespaces [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce egress policy allowing traffic to a server in a different namespace based on PodSelector and NamespaceSelector [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce except clause while egress access to server in CIDR block [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce ingress policy allowing any port traffic to a server on a specific protocol [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce multiple egress policies with egress allow-all policy taking precedence [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce multiple ingress policies with ingress allow-all policy taking precedence [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce multiple, stacked policies with overlapping podSelectors [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce policies to check ingress and egress policies can be controlled independently based on PodSelector [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce policy based on Multiple PodSelectors and NamespaceSelectors [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce policy based on NamespaceSelector with MatchExpressions [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce policy based on NamespaceSelector with MatchExpressions using default ns label [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce policy based on PodSelector and NamespaceSelector [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce policy based on PodSelector or NamespaceSelector [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce policy based on PodSelector with MatchExpressions [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce policy based on Ports [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce policy based on any PodSelectors [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce policy to allow ingress traffic for a target [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce policy to allow ingress traffic from pods in all namespaces [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce policy to allow traffic based on NamespaceSelector with MatchLabels using default ns label [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce policy to allow traffic from pods within server namespace based on PodSelector [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce policy to allow traffic only from a different namespace, based on NamespaceSelector [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce policy to allow traffic only from a pod in a different namespace based on PodSelector and NamespaceSelector [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce updated policy [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should ensure an IP overlapping both IPBlock.CIDR and IPBlock.Except is allowed [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should not allow access by TCP when a policy specifies only UDP [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should not allow all ports if it cannot limit to the requested port [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should not mistakenly treat 'protocol: SCTP' as 'protocol: TCP', even if the plugin doesn't support SCTP [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should properly isolate pods that are selected by a policy allowing SCTP, even if the plugin doesn't support SCTP [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should stop enforcing policies after they are deleted [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should support a 'default-deny-all' policy [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should support a 'default-deny-ingress' policy [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should support allow-all policy [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should support denying of egress traffic on the client side (even if the server explicitly allows this traffic) [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should work with Ingress, Egress specified together [Feature:NetworkPolicy]
+[sig-network] Netpol [LinuxOnly] NetworkPolicy between server and client using UDP should enforce policy based on Ports [Feature:NetworkPolicy]
+[sig-network] Netpol [LinuxOnly] NetworkPolicy between server and client using UDP should enforce policy to allow traffic only from a pod in a different namespace based on PodSelector and NamespaceSelector [Feature:NetworkPolicy]
+[sig-network] Netpol [LinuxOnly] NetworkPolicy between server and client using UDP should support a 'default-deny-ingress' policy [Feature:NetworkPolicy]
+[sig-network] Networking Granular Checks: Pods should function for intra-pod communication: http [Conformance] [NodeConformance]
+[sig-network] Networking Granular Checks: Pods should function for intra-pod communication: udp [Conformance] [NodeConformance]
+[sig-network] Networking Granular Checks: Pods should function for node-pod communication: http [LinuxOnly] [Conformance] [NodeConformance]
+[sig-network] Networking Granular Checks: Pods should function for node-pod communication: udp [LinuxOnly] [Conformance] [NodeConformance]
+[sig-network] Proxy version v1 A set of valid responses are returned for both pod and service Proxy [Conformance]
+[sig-network] Proxy version v1 A set of valid responses are returned for both pod and service ProxyWithPath [Conformance]
+[sig-network] Proxy version v1 should proxy through a service and a pod [Conformance]
+[sig-network] Service endpoints latency should not be very high [Conformance]
+[sig-network] ServiceCIDR and IPAddress API should support IPAddress API operations [Conformance]
+[sig-network] ServiceCIDR and IPAddress API should support ServiceCIDR API operations [Conformance]
+[sig-network] Services should be able to change the type from ClusterIP to ExternalName [Conformance]
+[sig-network] Services should be able to change the type from ExternalName to ClusterIP [Conformance]
+[sig-network] Services should be able to change the type from ExternalName to NodePort [Conformance]
+[sig-network] Services should be able to change the type from NodePort to ExternalName [Conformance]
+[sig-network] Services should be able to create a functioning NodePort service [Conformance]
+[sig-network] Services should be able to switch session affinity for NodePort service [LinuxOnly] [Conformance]
+[sig-network] Services should be able to switch session affinity for service with type clusterIP [LinuxOnly] [Conformance]
+[sig-network] Services should complete a service status lifecycle [Conformance]
+[sig-network] Services should delete a collection of services [Conformance]
+[sig-network] Services should find a service from listing all namespaces [Conformance]
+[sig-network] Services should have session affinity work for NodePort service [LinuxOnly] [Conformance]
+[sig-network] Services should have session affinity work for service with type clusterIP [LinuxOnly] [Conformance]
+[sig-network] Services should serve a basic endpoint from pods [Conformance]
+[sig-network] Services should serve endpoints on same port and different protocols [Conformance]
+[sig-network] Services should serve multiport endpoints from pods [Conformance]

--- a/e2e/testsets/sets/nftables/xtables-v3crd-aws-autohep.txt
+++ b/e2e/testsets/sets/nftables/xtables-v3crd-aws-autohep.txt
@@ -24,12 +24,12 @@
 [sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC default tier should not allow updating the default tier
 [sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC read-only access should allow reading but deny writing for a read-only user [Conformance]
 [sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC tier isolation should restrict a user to only their permitted tier [Conformance]
-[sig-calico] [Team:CORE] [Category:Policy] [RequiresGoldmane] staged network policy Test presence in flow logs StagedGlobalNetworkPolicy Validate name, tier, action [Conformance]
-[sig-calico] [Team:CORE] [Category:Policy] [RequiresGoldmane] staged network policy Test presence in flow logs StagedKubernetesNetworkPolicy Validate name, tier, action [Conformance]
-[sig-calico] [Team:CORE] [Category:Policy] [RequiresGoldmane] staged network policy Test presence in flow logs StagedNetworkPolicy Validate name, tier, action [Conformance]
-[sig-calico] [Team:CORE] [Category:Policy] [RequiresGoldmane] staged network policy enforcing staged-policies StagedGlobalNetworkPolicy should enforce a deny policy
-[sig-calico] [Team:CORE] [Category:Policy] [RequiresGoldmane] staged network policy enforcing staged-policies StagedKubernetesNetworkPolicy should enforce a deny policy
-[sig-calico] [Team:CORE] [Category:Policy] [RequiresGoldmane] staged network policy enforcing staged-policies StagedNetworkPolicy should enforce a deny policy
+[sig-calico] [Team:CORE] [Category:Policy] [RequiresGoldmane] [NoTierPrefix] staged network policy Test presence in flow logs StagedGlobalNetworkPolicy Validate name, tier, action [Conformance]
+[sig-calico] [Team:CORE] [Category:Policy] [RequiresGoldmane] [NoTierPrefix] staged network policy Test presence in flow logs StagedKubernetesNetworkPolicy Validate name, tier, action [Conformance]
+[sig-calico] [Team:CORE] [Category:Policy] [RequiresGoldmane] [NoTierPrefix] staged network policy Test presence in flow logs StagedNetworkPolicy Validate name, tier, action [Conformance]
+[sig-calico] [Team:CORE] [Category:Policy] [RequiresGoldmane] [NoTierPrefix] staged network policy enforcing staged-policies StagedGlobalNetworkPolicy should enforce a deny policy
+[sig-calico] [Team:CORE] [Category:Policy] [RequiresGoldmane] [NoTierPrefix] staged network policy enforcing staged-policies StagedKubernetesNetworkPolicy should enforce a deny policy
+[sig-calico] [Team:CORE] [Category:Policy] [RequiresGoldmane] [NoTierPrefix] staged network policy enforcing staged-policies StagedNetworkPolicy should enforce a deny policy
 [sig-calico] [Team:CORE] [Feature:BGPPeer] [RequiresBGP] [Category:Networking] BGP password should enforce BGP password authentication [Serial]
 [sig-calico] [Team:CORE] [Feature:BGPPeer] [RequiresBGP] [Category:Networking] [RequiresBGPMesh] BGP export tests should not export pools with export disabled [Serial]
 [sig-calico] [Team:CORE] [Feature:BGPPeer] [RequiresBGP] [Category:Networking] [RequiresBGPMesh] BGPPeer should support BGP peers [Serial]
@@ -103,8 +103,8 @@
 [sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath xtables-only [RequiresXtables] egress-2N2 ApplyOnForward=true, egress [Serial]
 [sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath xtables-only [RequiresXtables] ingress-2N2 ApplyOnForward=false, ingress [Serial]
 [sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath xtables-only [RequiresXtables] ingress-2N2 ApplyOnForward=true, ingress [Serial]
-[sig-calico] [Team:CORE] [Feature:IPAM] [Category:Networking] IPAM GC should garbage-collect leaked IP addresses [Serial]
-[sig-calico] [Team:CORE] [Feature:IPAM] [Category:Networking] IPAM StrictAffinity should respect StrictAffinity when toggled [Serial]
+[sig-calico] [Team:CORE] [Feature:IPAM] [RequiresCalicoIPAM] [Category:Networking] IPAM GC should garbage-collect leaked IP addresses [Serial]
+[sig-calico] [Team:CORE] [Feature:IPAM] [RequiresCalicoIPAM] [Category:Networking] IPAM StrictAffinity should respect StrictAffinity when toggled [Serial]
 [sig-calico] [Team:CORE] [Feature:IPIP] [Category:Networking] [NoEncap] IP-in-IP tests should assign an IPIP address to the tunl0 interface [Serial]
 [sig-calico] [Team:CORE] [Feature:IPIP] [Category:Networking] [NoEncap] IP-in-IP tests should support toggling IPIP on and off [Serial]
 [sig-calico] [Team:CORE] [Feature:IPPool] [Category:Operator] operator IPPool management tests should create and delete IP pools [Serial]


### PR DESCRIPTION
Moves the seven remaining nftables e2e lanes off ginkgo focus/skip and onto the YAML test-selection configs, and drops the pipeline-level focus/skip default now that no lane falls back to it. The configs were already authored, so this is wiring plus the regenerated test sets.

What changes in what runs:

- each lane picks up the 46 upstream Netpol policy specs, which the old focus regex missed because they carry neither the sig-calico nor the Conformance tag
- KubeVirt, external-node and Maglev specs drop out, since these clusters cannot run them
- two iptables test sets change as well - they were stale on master, and the regen corrects them

**Release note:**
```release-note
None
```
