### PR TITLE
[DE-4474] release: publish version-matched e2e binaries for official releases

### DIFF
--- a/.argoci/cron/e2e-upgrade.yaml
+++ b/.argoci/cron/e2e-upgrade.yaml
@@ -15,6 +15,7 @@ globalPrologue: |
   export TEST_TYPE="${TEST_TYPE:-k8s-e2e}"
   export UPLEVEL_PRE_RELEASE="${UPLEVEL_PRE_RELEASE:-true}"
   export UPLEVEL_PRODUCT="${UPLEVEL_PRODUCT:-calico}"
+  export UPLEVEL_RELEASE_STREAM="${UPLEVEL_RELEASE_STREAM:-master}"
   export USE_HASH_RELEASE="${USE_HASH_RELEASE:-false}"
   export USE_PRIVATE_REGISTRY="${USE_PRIVATE_REGISTRY:-true}"
   source .argoci/scripts/global_prologue.sh

--- a/.argoci/scripts/phases/run_tests.sh
+++ b/.argoci/scripts/phases/run_tests.sh
@@ -34,7 +34,17 @@ elif [[ "${TEST_TYPE}" == "k8s-e2e" ]]; then
   # Upgrade runs set RELEASE_STREAM to the downlevel version they install first,
   # but the tests run against the uplevel one.
   E2E_STREAM=${UPLEVEL_RELEASE_STREAM:-${RELEASE_STREAM}}
-  HASHREL_URL=$(curl --retry 9 --retry-all-errors -fsS "https://latest-os.hashrelease.tools.tigera.net/${E2E_STREAM}.txt")
+  if [[ -z "${E2E_STREAM}" ]]; then
+    echo "[ERROR] neither UPLEVEL_RELEASE_STREAM nor RELEASE_STREAM is set; cannot resolve an e2e binary"
+    exit 1
+  fi
+  E2E_STREAM_URL="https://latest-os.hashrelease.tools.tigera.net/${E2E_STREAM}.txt"
+  # Assign inside `if` so the diagnostic below runs: this script is sourced under
+  # `set -e`, where a bare command substitution would exit here instead.
+  if ! HASHREL_URL=$(curl --retry 9 --retry-all-errors -fsS "${E2E_STREAM_URL}"); then
+    echo "[ERROR] no hashrelease published for stream ${E2E_STREAM} at ${E2E_STREAM_URL}"
+    exit 1
+  fi
   echo "[INFO] hashrelease URL (stream ${E2E_STREAM}): ${HASHREL_URL}"
   ARCH=$(uname -m); [[ "$ARCH" == "x86_64" ]] && ARCH=amd64; [[ "$ARCH" == "aarch64" ]] && ARCH=arm64
   E2E_BINARY_URL="${HASHREL_URL}/files/e2e/e2e-linux-${ARCH}.test"

--- a/.argoci/scripts/phases/run_tests.sh
+++ b/.argoci/scripts/phases/run_tests.sh
@@ -13,7 +13,7 @@
 # Required for local builds:
 #   E2E_TEST_CONFIG
 # Required for hashrelease downloads:
-#   RELEASE_STREAM
+#   RELEASE_STREAM (or UPLEVEL_RELEASE_STREAM, which takes precedence)
 #
 # Sourced from body_*.sh. Exits with the test exit code.
 
@@ -31,11 +31,20 @@ if [[ -n "${RUN_LOCAL_TESTS:-}" ]]; then
 elif [[ "${TEST_TYPE}" == "k8s-e2e" ]]; then
   # Scheduled CI: download the pre-built e2e binary from the hashrelease.
   echo "[INFO] downloading e2e binary from hashrelease..."
-  HASHREL_URL=$(curl --retry 9 --retry-all-errors -fsS "https://latest-os.hashrelease.tools.tigera.net/${RELEASE_STREAM}.txt")
-  echo "[INFO] hashrelease URL: ${HASHREL_URL}"
+  # Upgrade runs set RELEASE_STREAM to the downlevel version they install first,
+  # but the tests run against the uplevel one.
+  E2E_STREAM=${UPLEVEL_RELEASE_STREAM:-${RELEASE_STREAM}}
+  HASHREL_URL=$(curl --retry 9 --retry-all-errors -fsS "https://latest-os.hashrelease.tools.tigera.net/${E2E_STREAM}.txt")
+  echo "[INFO] hashrelease URL (stream ${E2E_STREAM}): ${HASHREL_URL}"
   ARCH=$(uname -m); [[ "$ARCH" == "x86_64" ]] && ARCH=amd64; [[ "$ARCH" == "aarch64" ]] && ARCH=arm64
+  E2E_BINARY_URL="${HASHREL_URL}/files/e2e/e2e-linux-${ARCH}.test"
   mkdir -p "${CI_HOME}/${CI_GIT_DIR}/e2e/bin/k8s"
-  curl --retry 9 --retry-all-errors -fsSL "${HASHREL_URL}/files/e2e/e2e-linux-${ARCH}.test" -o "${CI_HOME}/${CI_GIT_DIR}/e2e/bin/k8s/e2e.test"
+  # Fail loudly rather than falling back to a floating image, which would run a
+  # suite built from another branch (and, for k8s-e2e:stable, another repo).
+  if ! curl --retry 9 --retry-all-errors -fsSL "${E2E_BINARY_URL}" -o "${CI_HOME}/${CI_GIT_DIR}/e2e/bin/k8s/e2e.test"; then
+    echo "[ERROR] no e2e binary published for stream ${E2E_STREAM} at ${E2E_BINARY_URL}"
+    exit 1
+  fi
   chmod +x "${CI_HOME}/${CI_GIT_DIR}/e2e/bin/k8s/e2e.test"
   echo "[INFO] downloaded e2e binary to ${CI_HOME}/${CI_GIT_DIR}/e2e/bin/k8s/e2e.test"
   E2E_BINARY=/go/src/github.com/projectcalico/calico/e2e/bin/k8s/e2e.test

--- a/.semaphore/end-to-end/pipelines/upgrade.yml
+++ b/.semaphore/end-to-end/pipelines/upgrade.yml
@@ -37,6 +37,8 @@ global_job_config:
       value: calico
     - name: UPLEVEL_PRE_RELEASE
       value: "true"
+    - name: UPLEVEL_RELEASE_STREAM # the version under test after the upgrade
+      value: master
     - name: CALICOCTL_INSTALL_TYPE
       value: "container"
     - name: FUNCTIONAL_AREA

--- a/.semaphore/end-to-end/scripts/phases/run_tests.sh
+++ b/.semaphore/end-to-end/scripts/phases/run_tests.sh
@@ -14,7 +14,7 @@
 # Required for local builds:
 #   E2E_TEST_CONFIG
 # Required for hashrelease downloads:
-#   RELEASE_STREAM
+#   RELEASE_STREAM (or UPLEVEL_RELEASE_STREAM, which takes precedence)
 #
 # Sourced from body_*.sh. Exits with the test exit code.
 
@@ -32,11 +32,20 @@ if [[ -n "${RUN_LOCAL_TESTS:-}" ]]; then
 elif [[ "${TEST_TYPE}" == "k8s-e2e" ]]; then
   # Scheduled CI: download the pre-built e2e binary from the hashrelease.
   echo "[INFO] downloading e2e binary from hashrelease..."
-  HASHREL_URL=$(curl --retry 9 --retry-all-errors -fsS "https://latest-os.hashrelease.tools.tigera.net/${RELEASE_STREAM}.txt")
-  echo "[INFO] hashrelease URL: ${HASHREL_URL}"
+  # Upgrade runs set RELEASE_STREAM to the downlevel version they install first,
+  # but the tests run against the uplevel one.
+  E2E_STREAM=${UPLEVEL_RELEASE_STREAM:-${RELEASE_STREAM}}
+  HASHREL_URL=$(curl --retry 9 --retry-all-errors -fsS "https://latest-os.hashrelease.tools.tigera.net/${E2E_STREAM}.txt")
+  echo "[INFO] hashrelease URL (stream ${E2E_STREAM}): ${HASHREL_URL}"
   ARCH=$(uname -m); [[ "$ARCH" == "x86_64" ]] && ARCH=amd64; [[ "$ARCH" == "aarch64" ]] && ARCH=arm64
+  E2E_BINARY_URL="${HASHREL_URL}/files/e2e/e2e-linux-${ARCH}.test"
   mkdir -p "${HOME}/calico/e2e/bin/k8s"
-  curl --retry 9 --retry-all-errors -fsSL "${HASHREL_URL}/files/e2e/e2e-linux-${ARCH}.test" -o "${HOME}/calico/e2e/bin/k8s/e2e.test"
+  # Fail loudly rather than falling back to a floating image, which would run a
+  # suite built from another branch (and, for k8s-e2e:stable, another repo).
+  if ! curl --retry 9 --retry-all-errors -fsSL "${E2E_BINARY_URL}" -o "${HOME}/calico/e2e/bin/k8s/e2e.test"; then
+    echo "[ERROR] no e2e binary published for stream ${E2E_STREAM} at ${E2E_BINARY_URL}"
+    exit 1
+  fi
   chmod +x "${HOME}/calico/e2e/bin/k8s/e2e.test"
   echo "[INFO] downloaded e2e binary to ${HOME}/calico/e2e/bin/k8s/e2e.test"
   E2E_BINARY=/go/src/github.com/projectcalico/calico/e2e/bin/k8s/e2e.test

--- a/.semaphore/end-to-end/scripts/phases/run_tests.sh
+++ b/.semaphore/end-to-end/scripts/phases/run_tests.sh
@@ -35,7 +35,17 @@ elif [[ "${TEST_TYPE}" == "k8s-e2e" ]]; then
   # Upgrade runs set RELEASE_STREAM to the downlevel version they install first,
   # but the tests run against the uplevel one.
   E2E_STREAM=${UPLEVEL_RELEASE_STREAM:-${RELEASE_STREAM}}
-  HASHREL_URL=$(curl --retry 9 --retry-all-errors -fsS "https://latest-os.hashrelease.tools.tigera.net/${E2E_STREAM}.txt")
+  if [[ -z "${E2E_STREAM}" ]]; then
+    echo "[ERROR] neither UPLEVEL_RELEASE_STREAM nor RELEASE_STREAM is set; cannot resolve an e2e binary"
+    exit 1
+  fi
+  E2E_STREAM_URL="https://latest-os.hashrelease.tools.tigera.net/${E2E_STREAM}.txt"
+  # Assign inside `if` so the diagnostic below runs: this script is sourced under
+  # `set -e`, where a bare command substitution would exit here instead.
+  if ! HASHREL_URL=$(curl --retry 9 --retry-all-errors -fsS "${E2E_STREAM_URL}"); then
+    echo "[ERROR] no hashrelease published for stream ${E2E_STREAM} at ${E2E_STREAM_URL}"
+    exit 1
+  fi
   echo "[INFO] hashrelease URL (stream ${E2E_STREAM}): ${HASHREL_URL}"
   ARCH=$(uname -m); [[ "$ARCH" == "x86_64" ]] && ARCH=amd64; [[ "$ARCH" == "aarch64" ]] && ARCH=arm64
   E2E_BINARY_URL="${HASHREL_URL}/files/e2e/e2e-linux-${ARCH}.test"

--- a/release/cmd/flags.go
+++ b/release/cmd/flags.go
@@ -515,9 +515,10 @@ var (
 			helmIndexFlag(envHelmIndexLegacy, envBuildHelmIndex, envReleaseHelmIndex),
 			tarballFlag,
 			windowsArchiveFlag(envBuildWindowsArchive, envReleaseWindowsArchive),
+			e2eBinariesFlag,
 		}
 		if hashrelease {
-			f = append(f, e2eBinariesFlag, releaseNotesFlag)
+			f = append(f, releaseNotesFlag)
 		}
 		return f
 	}

--- a/release/cmd/flags.go
+++ b/release/cmd/flags.go
@@ -532,6 +532,7 @@ var (
 		}
 		return append(f,
 			helmIndexFlag(envHelmIndexLegacy, envPublishHelmIndex, envReleaseHelmIndex),
+			e2eBinariesFlag,
 			gitRefFlag,
 			githubReleaseFlag)
 	}
@@ -611,7 +612,7 @@ var (
 	e2eBinariesFlag = &cli.BoolWithInverseFlag{
 		Name:     "e2e-binaries",
 		Category: stepControlCategory,
-		Usage:    "Build multi-arch e2e test binaries",
+		Usage:    "Include multi-arch e2e test binaries",
 		Sources:  cli.EnvVars(envBuildE2EBinaries, envReleaseE2EBinaries),
 		Value:    true,
 	}

--- a/release/cmd/release.go
+++ b/release/cmd/release.go
@@ -117,6 +117,7 @@ func releaseSubCommands(cfg *Config) []*cli.Command {
 					calico.WithHelmCharts(c.Bool(helmChartsFlagName)),
 					calico.WithManifests(c.Bool(manifestsFlag.Name)),
 					calico.WithBinaries(c.Bool(binariesFlag.Name)),
+					calico.WithE2EBinaries(c.Bool(e2eBinariesFlag.Name)),
 					calico.WithOCPBundle(c.Bool(ocpBundleFlag.Name)),
 					calico.WithTarball(c.Bool(tarballFlag.Name)),
 					calico.WithWindowsArchive(c.Bool(windowsArchiveFlagName)),

--- a/release/cmd/release.go
+++ b/release/cmd/release.go
@@ -159,6 +159,7 @@ func releaseSubCommands(cfg *Config) []*cli.Command {
 					calico.WithImages(c.Bool(imagesFlagName)),
 					calico.WithHelmCharts(c.Bool(helmChartsFlagName)),
 					calico.WithHelmIndex(c.Bool(helmIndexFlagName)),
+					calico.WithE2EBinaries(c.Bool(e2eBinariesFlag.Name)),
 					calico.WithGitRef(c.Bool(gitRefFlag.Name)),
 					calico.WithGithubRelease(c.Bool(githubReleaseFlag.Name)),
 					calico.WithValidation(c.Bool(validationFlag.Name)),

--- a/release/pkg/manager/calico/manager.go
+++ b/release/pkg/manager/calico/manager.go
@@ -780,6 +780,11 @@ func (r *CalicoManager) PublishRelease() error {
 		if err := r.updateHelmChartIndex(); err != nil {
 			return fmt.Errorf("update helm chart index: %s", err)
 		}
+
+		// Publish the e2e test binaries for individual download.
+		if err := r.publishE2EBinaries(); err != nil {
+			return fmt.Errorf("publish e2e binaries: %s", err)
+		}
 	}
 
 	return nil
@@ -1207,6 +1212,14 @@ func (r *CalicoManager) buildReleaseTar() error {
 			// Felix binaries.
 			"felix/bin/calico-bpf": binDir,
 		}
+		// Per-arch e2e test binaries, when the build produced them. Sourced from
+		// the staged copy rather than e2e/bin/k8s so the archive and the S3
+		// publish ship the same files.
+		if e2eStaged := filepath.Join(r.uploadDir(), "files", "e2e"); r.e2eBinaries {
+			if _, err := os.Stat(e2eStaged); err == nil {
+				binaries[e2eStaged+"/"] = filepath.Join(binDir, "e2e")
+			}
+		}
 		// -al (archive + hard-link) keeps staging disk usage flat and preserves symlinks
 		for src, dst := range binaries {
 			if _, err := r.runner.RunInDir(r.repoRoot, "cp", []string{"-al", src, dst}, nil); err != nil {
@@ -1248,17 +1261,6 @@ func e2eArchitectures(configured []string) []string {
 	return arches
 }
 
-// e2eStagingDir is where buildE2EBinaries puts the per-arch binaries.
-// Hashreleases serve a directory tree, so they go under files/e2e/. A release
-// attaches them to a GitHub release, whose assets are flat and which ghr
-// populates from the top level of the upload directory.
-func (r *CalicoManager) e2eStagingDir() string {
-	if r.isHashRelease {
-		return filepath.Join(r.uploadDir(), "files", "e2e")
-	}
-	return r.uploadDir()
-}
-
 func (r *CalicoManager) buildE2EBinaries() error {
 	arches := e2eArchitectures(r.architectures)
 	if len(arches) == 0 {
@@ -1277,8 +1279,10 @@ func (r *CalicoManager) buildE2EBinaries() error {
 	}
 
 	// Hard-link the built binaries into the output directory to avoid
-	// duplicating ~1 GB of cross-compiled test binaries on disk.
-	e2eOutputDir := r.e2eStagingDir()
+	// duplicating ~1 GB of cross-compiled test binaries on disk. files/e2e/ is
+	// the layout the hashrelease server serves and that publishArtifactsToS3
+	// mirrors for a release.
+	e2eOutputDir := filepath.Join(r.uploadDir(), "files", "e2e")
 	if err := os.MkdirAll(e2eOutputDir, 0o755); err != nil {
 		return fmt.Errorf("failed to create e2e output dir: %w", err)
 	}
@@ -1440,7 +1444,7 @@ Attached to this release are the following artifacts:
 - {helm_chart}: Calico Helm 3 chart (also hosted at oci://quay.io/calico/charts/tigera-operator).
 - {helm_v1_crd_chart}: Calico crd.projectcalico.org/v1 CRD chart.
 - {helm_v3_crd_chart}: Calico projectcalico.org/v3 CRD chart (tech-preview).
-- ocp.tgz: Manifest bundle for OpenShift.{e2e_binaries}
+- ocp.tgz: Manifest bundle for OpenShift.
 
 Additional links:
 
@@ -1449,17 +1453,6 @@ Additional links:
 `
 	ver := version.New(r.calicoVersion)
 	sv := ver.Semver()
-	// Advertise the e2e binaries based on what the build staged, not on
-	// r.e2eBinaries: that flag belongs to the build step and is never passed to
-	// publish, so it always reads as its default here.
-	e2eBinariesNote := ""
-	staged, err := filepath.Glob(filepath.Join(r.uploadDir(), "e2e-linux-*.test"))
-	if err != nil {
-		return fmt.Errorf("looking for staged e2e binaries: %w", err)
-	}
-	if len(staged) > 0 {
-		e2eBinariesNote = "\n- `e2e-linux-<arch>.test`: Version-matched Kubernetes e2e test binaries, one per architecture."
-	}
 	formatters := []string{
 		// Alternating placeholder / filler. We can't use backticks in the multiline string above,
 		// so we replace anything that needs to be backticked into it here.
@@ -1471,7 +1464,6 @@ Additional links:
 		"{helm_chart}", fmt.Sprintf("`%s-%s.tgz`", utils.TigeraOperatorChart, r.calicoVersion),
 		"{helm_v1_crd_chart}", fmt.Sprintf("`%s-%s.tgz`", utils.ProjectCalicoV1CRDsChart, r.calicoVersion),
 		"{helm_v3_crd_chart}", fmt.Sprintf("`%s-%s.tgz`", utils.ProjectCalicoV3CRDsChart, r.calicoVersion),
-		"{e2e_binaries}", e2eBinariesNote,
 	}
 	replacer := strings.NewReplacer(formatters...)
 	releaseNote := replacer.Replace(releaseNoteTemplate)
@@ -1647,6 +1639,33 @@ func (r *CalicoManager) updateHelmChartIndex() error {
 	}
 	if err := r.s3Cp(filepath.Join(filepath.Dir(r.uploadDir()), fmt.Sprintf("charts-%s", r.helmChartVersion()), helmIndexFileName), fmt.Sprintf("s3://%s/charts/", r.s3Bucket), s3ACLPublicRead...); err != nil {
 		return fmt.Errorf("update helm index: %w", err)
+	}
+	return nil
+}
+
+// publishE2EBinaries uploads the per-arch e2e test binaries so a consumer can
+// fetch one directly instead of unpacking the release archive. The layout
+// matches Enterprise (<version>/files/e2e/), so both products resolve a binary
+// the same way.
+//
+// Keyed off what the build staged rather than r.e2eBinaries: the e2e-binaries
+// flag belongs to the build step and is never passed to publish.
+func (r *CalicoManager) publishE2EBinaries() error {
+	e2eDir := filepath.Join(r.uploadDir(), "files", "e2e")
+	staged, err := filepath.Glob(filepath.Join(e2eDir, "e2e-linux-*.test"))
+	if err != nil {
+		return fmt.Errorf("looking for staged e2e binaries: %w", err)
+	}
+	if len(staged) == 0 {
+		logrus.Info("Skipping publishing e2e test binaries (none staged)")
+		return nil
+	}
+	if r.s3Bucket == "" {
+		return fmt.Errorf("no S3 bucket specified for publishing e2e binaries")
+	}
+	dest := fmt.Sprintf("s3://%s/%s/files/e2e/", r.s3Bucket, r.calicoVersion)
+	if err := r.s3Cp(e2eDir+"/", dest, s3ACLPublicRead...); err != nil {
+		return fmt.Errorf("publish e2e binaries: %w", err)
 	}
 	return nil
 }

--- a/release/pkg/manager/calico/manager.go
+++ b/release/pkg/manager/calico/manager.go
@@ -982,6 +982,15 @@ func (r *CalicoManager) publishPrereqs() error {
 			errStack = errors.Join(errStack, fmt.Errorf("no S3 bucket specified for pushing helm index"))
 		}
 	}
+	// The e2e binaries go to S3 late in the publish, so check the bucket up front
+	// rather than after the images and charts are already out.
+	if !r.isHashRelease && r.s3Bucket == "" {
+		if staged, err := r.stagedE2EBinaries(); err != nil {
+			errStack = errors.Join(errStack, err)
+		} else if len(staged) > 0 {
+			errStack = errors.Join(errStack, fmt.Errorf("no S3 bucket specified for publishing e2e binaries"))
+		}
+	}
 	if dirty, err := utils.GitIsDirty(r.repoRoot); dirty || err != nil {
 		errStack = errors.Join(errStack, fmt.Errorf("there are uncommitted changes in the repository, please commit or stash them before publishing the release"))
 	}
@@ -1198,27 +1207,32 @@ func (r *CalicoManager) buildReleaseTar() error {
 		}
 	}
 
-	// Add in release binaries that we ship.
+	// Add in release binaries that we ship. Sources are repo-relative (cp runs
+	// in repoRoot) except the e2e binaries, which come from the output directory.
+	binDir := filepath.Join(releaseBase, "bin")
+	binaries := map[string]string{}
 	if r.binaries {
-		binDir := filepath.Join(releaseBase, "bin")
+		// Calicoctl binaries.
+		binaries["calicoctl/bin/"] = filepath.Join(binDir, "calicoctl")
+
+		// Felix binaries.
+		binaries["felix/bin/calico-bpf"] = binDir
+	}
+	// Per-arch e2e test binaries, taken from the staged copy so the archive and
+	// the S3 publish ship the same files. Independent of r.binaries: the two are
+	// separate flags.
+	if r.e2eBinaries {
+		staged, err := r.stagedE2EBinaries()
+		if err != nil {
+			return err
+		}
+		if len(staged) > 0 {
+			binaries[r.e2eBinariesDir()+"/"] = filepath.Join(binDir, "e2e")
+		}
+	}
+	if len(binaries) > 0 {
 		if err := os.MkdirAll(binDir, os.ModePerm); err != nil {
-			return fmt.Errorf("failed to create images dir: %s", err)
-		}
-
-		binaries := map[string]string{
-			// Calicoctl binaries.
-			"calicoctl/bin/": filepath.Join(binDir, "calicoctl"),
-
-			// Felix binaries.
-			"felix/bin/calico-bpf": binDir,
-		}
-		// Per-arch e2e test binaries, when the build produced them. Sourced from
-		// the staged copy rather than e2e/bin/k8s so the archive and the S3
-		// publish ship the same files.
-		if e2eStaged := filepath.Join(r.uploadDir(), "files", "e2e"); r.e2eBinaries {
-			if _, err := os.Stat(e2eStaged); err == nil {
-				binaries[e2eStaged+"/"] = filepath.Join(binDir, "e2e")
-			}
+			return fmt.Errorf("failed to create bin dir: %s", err)
 		}
 		// -al (archive + hard-link) keeps staging disk usage flat and preserves symlinks
 		for src, dst := range binaries {
@@ -1261,6 +1275,24 @@ func e2eArchitectures(configured []string) []string {
 	return arches
 }
 
+// e2eBinariesDir is the single owner of where the per-arch e2e test binaries
+// live in the output directory. files/e2e/ is the layout the hashrelease server
+// serves, and publishE2EBinaries mirrors it under the release version on S3.
+func (r *CalicoManager) e2eBinariesDir() string {
+	return filepath.Join(r.uploadDir(), "files", "e2e")
+}
+
+// stagedE2EBinaries lists the e2e binaries the build produced. Callers on the
+// publish side key off this rather than r.e2eBinaries, because the e2e-binaries
+// flag belongs to the build step and is never passed to publish.
+func (r *CalicoManager) stagedE2EBinaries() ([]string, error) {
+	staged, err := filepath.Glob(filepath.Join(r.e2eBinariesDir(), "e2e-linux-*.test"))
+	if err != nil {
+		return nil, fmt.Errorf("looking for staged e2e binaries: %w", err)
+	}
+	return staged, nil
+}
+
 func (r *CalicoManager) buildE2EBinaries() error {
 	arches := e2eArchitectures(r.architectures)
 	if len(arches) == 0 {
@@ -1279,10 +1311,8 @@ func (r *CalicoManager) buildE2EBinaries() error {
 	}
 
 	// Hard-link the built binaries into the output directory to avoid
-	// duplicating ~1 GB of cross-compiled test binaries on disk. files/e2e/ is
-	// the layout the hashrelease server serves and that publishArtifactsToS3
-	// mirrors for a release.
-	e2eOutputDir := filepath.Join(r.uploadDir(), "files", "e2e")
+	// duplicating ~1 GB of cross-compiled test binaries on disk.
+	e2eOutputDir := r.e2eBinariesDir()
 	if err := os.MkdirAll(e2eOutputDir, 0o755); err != nil {
 		return fmt.Errorf("failed to create e2e output dir: %w", err)
 	}
@@ -1647,27 +1677,22 @@ func (r *CalicoManager) updateHelmChartIndex() error {
 // fetch one directly instead of unpacking the release archive. The layout
 // matches Enterprise (<version>/files/e2e/), so both products resolve a binary
 // the same way.
-//
-// Keyed off what the build staged rather than r.e2eBinaries: the e2e-binaries
-// flag belongs to the build step and is never passed to publish.
 func (r *CalicoManager) publishE2EBinaries() error {
-	e2eDir := filepath.Join(r.uploadDir(), "files", "e2e")
-	staged, err := filepath.Glob(filepath.Join(e2eDir, "e2e-linux-*.test"))
+	staged, err := r.stagedE2EBinaries()
 	if err != nil {
-		return fmt.Errorf("looking for staged e2e binaries: %w", err)
+		return err
 	}
 	if len(staged) == 0 {
 		logrus.Info("Skipping publishing e2e test binaries (none staged)")
 		return nil
 	}
+	// publishPrereqs catches this too; repeated here for a --no-validate run,
+	// which would otherwise upload to "s3:///".
 	if r.s3Bucket == "" {
-		return fmt.Errorf("no S3 bucket specified for publishing e2e binaries")
+		return fmt.Errorf("no S3 bucket specified")
 	}
 	dest := fmt.Sprintf("s3://%s/%s/files/e2e/", r.s3Bucket, r.calicoVersion)
-	if err := r.s3Cp(e2eDir+"/", dest, s3ACLPublicRead...); err != nil {
-		return fmt.Errorf("publish e2e binaries: %w", err)
-	}
-	return nil
+	return r.s3Cp(r.e2eBinariesDir()+"/", dest, s3ACLPublicRead...)
 }
 
 func (r *CalicoManager) assertReleaseNotesPresent(ver string) error {

--- a/release/pkg/manager/calico/manager.go
+++ b/release/pkg/manager/calico/manager.go
@@ -1029,9 +1029,6 @@ func (r *CalicoManager) collectGithubArtifacts() error {
 	if err := r.collectOCPBundle(); err != nil {
 		return err
 	}
-	if err := r.collectE2EBinaries(); err != nil {
-		return err
-	}
 
 	// Generate a SHA256SUMS file containing the checksums for each artifact
 	// that we attach to the release. These can be confirmed by end users via the following command:
@@ -1112,45 +1109,6 @@ func (r *CalicoManager) collectOCPBundle() error {
 	uploadDir := r.uploadDir()
 	if _, err := r.runner.RunInDir(r.repoRoot, "cp", []string{"bin/ocp.tgz", uploadDir}, nil); err != nil {
 		return fmt.Errorf("failed to copy OCP bundle: %w", err)
-	}
-	return nil
-}
-
-// collectE2EBinaries flattens the staged e2e test binaries into the upload
-// directory. buildE2EBinaries stages them under files/e2e/ for the hashrelease
-// server, but GitHub release assets are flat and ghr does not recurse into
-// subdirectories, so a release needs a copy at the top level. Hard links keep
-// the duplicate free.
-func (r *CalicoManager) collectE2EBinaries() error {
-	if !r.e2eBinaries || r.isHashRelease {
-		return nil
-	}
-	uploadDir := r.uploadDir()
-	e2eDir := filepath.Join(uploadDir, "files", "e2e")
-	entries, err := os.ReadDir(e2eDir)
-	if err != nil {
-		return fmt.Errorf("reading staged e2e binaries: %w", err)
-	}
-	linked := 0
-	for _, entry := range entries {
-		if !strings.HasPrefix(entry.Name(), "e2e-linux-") {
-			continue
-		}
-		dst := filepath.Join(uploadDir, entry.Name())
-		// Replace any leftover from an earlier build of the same version, so a
-		// rerun behaves like the sibling collect steps, which copy over.
-		if err := os.Remove(dst); err != nil && !errors.Is(err, os.ErrNotExist) {
-			return fmt.Errorf("replacing e2e binary %s: %w", entry.Name(), err)
-		}
-		if err := os.Link(filepath.Join(e2eDir, entry.Name()), dst); err != nil {
-			return fmt.Errorf("linking e2e binary %s: %w", entry.Name(), err)
-		}
-		linked++
-	}
-	// An empty staging dir means the build produced nothing; shipping a release
-	// with --e2e-binaries enabled and no e2e assets should not pass silently.
-	if linked == 0 {
-		return fmt.Errorf("no e2e test binaries staged in %s", e2eDir)
 	}
 	return nil
 }
@@ -1290,6 +1248,17 @@ func e2eArchitectures(configured []string) []string {
 	return arches
 }
 
+// e2eStagingDir is where buildE2EBinaries puts the per-arch binaries.
+// Hashreleases serve a directory tree, so they go under files/e2e/. A release
+// attaches them to a GitHub release, whose assets are flat and which ghr
+// populates from the top level of the upload directory.
+func (r *CalicoManager) e2eStagingDir() string {
+	if r.isHashRelease {
+		return filepath.Join(r.uploadDir(), "files", "e2e")
+	}
+	return r.uploadDir()
+}
+
 func (r *CalicoManager) buildE2EBinaries() error {
 	arches := e2eArchitectures(r.architectures)
 	if len(arches) == 0 {
@@ -1307,31 +1276,38 @@ func (r *CalicoManager) buildE2EBinaries() error {
 		return fmt.Errorf("failed to build e2e binaries: %w", err)
 	}
 
-	// Hard-link the built binaries into the hashrelease output directory
-	// to avoid duplicating ~1 GB of cross-compiled test binaries on disk.
-	e2eOutputDir := filepath.Join(r.uploadDir(), "files", "e2e")
+	// Hard-link the built binaries into the output directory to avoid
+	// duplicating ~1 GB of cross-compiled test binaries on disk.
+	e2eOutputDir := r.e2eStagingDir()
 	if err := os.MkdirAll(e2eOutputDir, 0o755); err != nil {
 		return fmt.Errorf("failed to create e2e output dir: %w", err)
 	}
-	entries, err := os.ReadDir(filepath.Join(e2eDir, "bin", "k8s"))
+	binDir := filepath.Join(e2eDir, "bin", "k8s")
+	entries, err := os.ReadDir(binDir)
 	if err != nil {
 		return fmt.Errorf("reading e2e bin directory: %w", err)
 	}
+	staged := 0
 	for _, entry := range entries {
 		if !strings.HasPrefix(entry.Name(), "e2e-linux-") {
 			continue
 		}
-		src := filepath.Join(e2eDir, "bin", "k8s", entry.Name())
 		dst := filepath.Join(e2eOutputDir, entry.Name())
 		// Replace a leftover link from an earlier build of the same version;
 		// os.Link fails outright on an existing destination.
 		if err := os.Remove(dst); err != nil && !errors.Is(err, os.ErrNotExist) {
 			return fmt.Errorf("replacing e2e binary %s: %w", entry.Name(), err)
 		}
-		if err := os.Link(src, dst); err != nil {
+		if err := os.Link(filepath.Join(binDir, entry.Name()), dst); err != nil {
 			return fmt.Errorf("linking e2e binary %s: %w", entry.Name(), err)
 		}
 		logrus.Infof("Staged e2e binary: %s", entry.Name())
+		staged++
+	}
+	// Nothing staged means the build produced no binaries; a release must not
+	// ship with --e2e-binaries enabled and no e2e assets.
+	if staged == 0 {
+		return fmt.Errorf("no e2e test binaries were produced in %s", binDir)
 	}
 	return nil
 }
@@ -1473,9 +1449,15 @@ Additional links:
 `
 	ver := version.New(r.calicoVersion)
 	sv := ver.Semver()
-	// Only advertise the e2e binaries when the build actually produced them.
+	// Advertise the e2e binaries based on what the build staged, not on
+	// r.e2eBinaries: that flag belongs to the build step and is never passed to
+	// publish, so it always reads as its default here.
 	e2eBinariesNote := ""
-	if r.e2eBinaries {
+	staged, err := filepath.Glob(filepath.Join(r.uploadDir(), "e2e-linux-*.test"))
+	if err != nil {
+		return fmt.Errorf("looking for staged e2e binaries: %w", err)
+	}
+	if len(staged) > 0 {
 		e2eBinariesNote = "\n- `e2e-linux-<arch>.test`: Version-matched Kubernetes e2e test binaries, one per architecture."
 	}
 	formatters := []string{
@@ -1510,8 +1492,7 @@ Additional links:
 		r.calicoVersion,
 		r.uploadDir(),
 	}
-	_, err := r.runner.RunInDir(r.repoRoot, "./bin/ghr", args, nil)
-	if err != nil {
+	if _, err := r.runner.RunInDir(r.repoRoot, "./bin/ghr", args, nil); err != nil {
 		return fmt.Errorf("failed to publish github release: %w", err)
 	}
 	return nil
@@ -1927,6 +1908,11 @@ func derivedBranchEdits(derived, stream string) []branch.Edit {
 		{File: "test-tools/mocknode/mock-node.yaml", Pattern: `([a-zA-Z .]+)([a-zA-Z.]+/mock-node:)[^[:space:]]+`, Replacement: fmt.Sprintf(`${1}${2}%s`, derived)},
 		{File: "process/testing/aso/export-env.sh", Pattern: `export RELEASE_STREAM="\$\{RELEASE_STREAM:=master\}"`, Replacement: fmt.Sprintf(`export RELEASE_STREAM="${RELEASE_STREAM:=%s}"`, stream)},
 		{File: "process/testing/aso/install-calico.sh", Pattern: `: \$\{RELEASE_STREAM:="master"\} # Default to master`, Replacement: fmt.Sprintf(`: ${RELEASE_STREAM:="%s"} # Default to %s`, stream, stream)},
+		// The upgrade lanes test the branch's own stream after upgrading, so the
+		// uplevel has to follow the cut. Required: left at master, a fresh branch
+		// would silently run master's e2e suite against its own build.
+		{File: ".argoci/cron/e2e-upgrade.yaml", Pattern: `export UPLEVEL_RELEASE_STREAM="\$\{UPLEVEL_RELEASE_STREAM:-master\}"`, Replacement: fmt.Sprintf(`export UPLEVEL_RELEASE_STREAM="${UPLEVEL_RELEASE_STREAM:-%s}"`, stream), Required: true},
+		{File: ".semaphore/end-to-end/pipelines/upgrade.yml", Pattern: `(- name: UPLEVEL_RELEASE_STREAM.*\n[[:space:]]+value: )master`, Replacement: fmt.Sprintf(`${1}%s`, stream), Required: true},
 	}
 }
 

--- a/release/pkg/manager/calico/manager.go
+++ b/release/pkg/manager/calico/manager.go
@@ -1131,13 +1131,26 @@ func (r *CalicoManager) collectE2EBinaries() error {
 	if err != nil {
 		return fmt.Errorf("reading staged e2e binaries: %w", err)
 	}
+	linked := 0
 	for _, entry := range entries {
 		if !strings.HasPrefix(entry.Name(), "e2e-linux-") {
 			continue
 		}
-		if err := os.Link(filepath.Join(e2eDir, entry.Name()), filepath.Join(uploadDir, entry.Name())); err != nil {
+		dst := filepath.Join(uploadDir, entry.Name())
+		// Replace any leftover from an earlier build of the same version, so a
+		// rerun behaves like the sibling collect steps, which copy over.
+		if err := os.Remove(dst); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("replacing e2e binary %s: %w", entry.Name(), err)
+		}
+		if err := os.Link(filepath.Join(e2eDir, entry.Name()), dst); err != nil {
 			return fmt.Errorf("linking e2e binary %s: %w", entry.Name(), err)
 		}
+		linked++
+	}
+	// An empty staging dir means the build produced nothing; shipping a release
+	// with --e2e-binaries enabled and no e2e assets should not pass silently.
+	if linked == 0 {
+		return fmt.Errorf("no e2e test binaries staged in %s", e2eDir)
 	}
 	return nil
 }
@@ -1310,6 +1323,11 @@ func (r *CalicoManager) buildE2EBinaries() error {
 		}
 		src := filepath.Join(e2eDir, "bin", "k8s", entry.Name())
 		dst := filepath.Join(e2eOutputDir, entry.Name())
+		// Replace a leftover link from an earlier build of the same version;
+		// os.Link fails outright on an existing destination.
+		if err := os.Remove(dst); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("replacing e2e binary %s: %w", entry.Name(), err)
+		}
 		if err := os.Link(src, dst); err != nil {
 			return fmt.Errorf("linking e2e binary %s: %w", entry.Name(), err)
 		}
@@ -1446,8 +1464,7 @@ Attached to this release are the following artifacts:
 - {helm_chart}: Calico Helm 3 chart (also hosted at oci://quay.io/calico/charts/tigera-operator).
 - {helm_v1_crd_chart}: Calico crd.projectcalico.org/v1 CRD chart.
 - {helm_v3_crd_chart}: Calico projectcalico.org/v3 CRD chart (tech-preview).
-- ocp.tgz: Manifest bundle for OpenShift.
-- {e2e_binaries}: Version-matched Kubernetes e2e test binaries, one per architecture.
+- ocp.tgz: Manifest bundle for OpenShift.{e2e_binaries}
 
 Additional links:
 
@@ -1456,6 +1473,11 @@ Additional links:
 `
 	ver := version.New(r.calicoVersion)
 	sv := ver.Semver()
+	// Only advertise the e2e binaries when the build actually produced them.
+	e2eBinariesNote := ""
+	if r.e2eBinaries {
+		e2eBinariesNote = "\n- `e2e-linux-<arch>.test`: Version-matched Kubernetes e2e test binaries, one per architecture."
+	}
 	formatters := []string{
 		// Alternating placeholder / filler. We can't use backticks in the multiline string above,
 		// so we replace anything that needs to be backticked into it here.
@@ -1467,7 +1489,7 @@ Additional links:
 		"{helm_chart}", fmt.Sprintf("`%s-%s.tgz`", utils.TigeraOperatorChart, r.calicoVersion),
 		"{helm_v1_crd_chart}", fmt.Sprintf("`%s-%s.tgz`", utils.ProjectCalicoV1CRDsChart, r.calicoVersion),
 		"{helm_v3_crd_chart}", fmt.Sprintf("`%s-%s.tgz`", utils.ProjectCalicoV3CRDsChart, r.calicoVersion),
-		"{e2e_binaries}", "`e2e-linux-<arch>.test`",
+		"{e2e_binaries}", e2eBinariesNote,
 	}
 	replacer := strings.NewReplacer(formatters...)
 	releaseNote := replacer.Replace(releaseNoteTemplate)

--- a/release/pkg/manager/calico/manager.go
+++ b/release/pkg/manager/calico/manager.go
@@ -345,19 +345,19 @@ func (r *CalicoManager) Build() error {
 		} else {
 			logrus.Info("Skipping building windows archive")
 		}
-
-		// Build multi-arch e2e test binaries and copy them into the output directory.
-		if r.e2eBinaries {
-			if err = r.buildE2EBinaries(); err != nil {
-				return err
-			}
-		} else {
-			logrus.Info("Skipping building e2e test binaries")
-		}
 	} else {
 		if err = r.buildOCPBundle(); err != nil {
 			return err
 		}
+	}
+
+	// Build multi-arch e2e test binaries and copy them into the output directory.
+	if r.e2eBinaries {
+		if err = r.buildE2EBinaries(); err != nil {
+			return err
+		}
+	} else {
+		logrus.Info("Skipping building e2e test binaries")
 	}
 
 	// Build and add in the complete release tarball.
@@ -1029,6 +1029,9 @@ func (r *CalicoManager) collectGithubArtifacts() error {
 	if err := r.collectOCPBundle(); err != nil {
 		return err
 	}
+	if err := r.collectE2EBinaries(); err != nil {
+		return err
+	}
 
 	// Generate a SHA256SUMS file containing the checksums for each artifact
 	// that we attach to the release. These can be confirmed by end users via the following command:
@@ -1109,6 +1112,32 @@ func (r *CalicoManager) collectOCPBundle() error {
 	uploadDir := r.uploadDir()
 	if _, err := r.runner.RunInDir(r.repoRoot, "cp", []string{"bin/ocp.tgz", uploadDir}, nil); err != nil {
 		return fmt.Errorf("failed to copy OCP bundle: %w", err)
+	}
+	return nil
+}
+
+// collectE2EBinaries flattens the staged e2e test binaries into the upload
+// directory. buildE2EBinaries stages them under files/e2e/ for the hashrelease
+// server, but GitHub release assets are flat and ghr does not recurse into
+// subdirectories, so a release needs a copy at the top level. Hard links keep
+// the duplicate free.
+func (r *CalicoManager) collectE2EBinaries() error {
+	if !r.e2eBinaries || r.isHashRelease {
+		return nil
+	}
+	uploadDir := r.uploadDir()
+	e2eDir := filepath.Join(uploadDir, "files", "e2e")
+	entries, err := os.ReadDir(e2eDir)
+	if err != nil {
+		return fmt.Errorf("reading staged e2e binaries: %w", err)
+	}
+	for _, entry := range entries {
+		if !strings.HasPrefix(entry.Name(), "e2e-linux-") {
+			continue
+		}
+		if err := os.Link(filepath.Join(e2eDir, entry.Name()), filepath.Join(uploadDir, entry.Name())); err != nil {
+			return fmt.Errorf("linking e2e binary %s: %w", entry.Name(), err)
+		}
 	}
 	return nil
 }
@@ -1418,6 +1447,7 @@ Attached to this release are the following artifacts:
 - {helm_v1_crd_chart}: Calico crd.projectcalico.org/v1 CRD chart.
 - {helm_v3_crd_chart}: Calico projectcalico.org/v3 CRD chart (tech-preview).
 - ocp.tgz: Manifest bundle for OpenShift.
+- {e2e_binaries}: Version-matched Kubernetes e2e test binaries, one per architecture.
 
 Additional links:
 
@@ -1437,6 +1467,7 @@ Additional links:
 		"{helm_chart}", fmt.Sprintf("`%s-%s.tgz`", utils.TigeraOperatorChart, r.calicoVersion),
 		"{helm_v1_crd_chart}", fmt.Sprintf("`%s-%s.tgz`", utils.ProjectCalicoV1CRDsChart, r.calicoVersion),
 		"{helm_v3_crd_chart}", fmt.Sprintf("`%s-%s.tgz`", utils.ProjectCalicoV3CRDsChart, r.calicoVersion),
+		"{e2e_binaries}", "`e2e-linux-<arch>.test`",
 	}
 	replacer := strings.NewReplacer(formatters...)
 	releaseNote := replacer.Replace(releaseNoteTemplate)

--- a/release/pkg/manager/calico/manager.go
+++ b/release/pkg/manager/calico/manager.go
@@ -358,6 +358,9 @@ func (r *CalicoManager) Build() error {
 		}
 	} else {
 		logrus.Info("Skipping building e2e test binaries")
+		if err = r.clearStagedE2EBinaries(); err != nil {
+			return err
+		}
 	}
 
 	// Build and add in the complete release tarball.
@@ -781,9 +784,11 @@ func (r *CalicoManager) PublishRelease() error {
 			return fmt.Errorf("update helm chart index: %s", err)
 		}
 
-		// Publish the e2e test binaries for individual download.
+		// Publish the e2e test binaries for individual download. Logged and
+		// ignored like the ISS scan above: the test binaries also ship inside the
+		// release archive, so failing to upload them should not halt a release.
 		if err := r.publishE2EBinaries(); err != nil {
-			return fmt.Errorf("publish e2e binaries: %s", err)
+			logrus.WithError(err).Error("Failed to publish e2e test binaries")
 		}
 	}
 
@@ -980,15 +985,6 @@ func (r *CalicoManager) publishPrereqs() error {
 		}
 		if !r.isHashRelease && r.s3Bucket == "" {
 			errStack = errors.Join(errStack, fmt.Errorf("no S3 bucket specified for pushing helm index"))
-		}
-	}
-	// The e2e binaries go to S3 late in the publish, so check the bucket up front
-	// rather than after the images and charts are already out.
-	if !r.isHashRelease && r.s3Bucket == "" {
-		if staged, err := r.stagedE2EBinaries(); err != nil {
-			errStack = errors.Join(errStack, err)
-		} else if len(staged) > 0 {
-			errStack = errors.Join(errStack, fmt.Errorf("no S3 bucket specified for publishing e2e binaries"))
 		}
 	}
 	if dirty, err := utils.GitIsDirty(r.repoRoot); dirty || err != nil {
@@ -1282,15 +1278,24 @@ func (r *CalicoManager) e2eBinariesDir() string {
 	return filepath.Join(r.uploadDir(), "files", "e2e")
 }
 
-// stagedE2EBinaries lists the e2e binaries the build produced. Callers on the
-// publish side key off this rather than r.e2eBinaries, because the e2e-binaries
-// flag belongs to the build step and is never passed to publish.
+// stagedE2EBinaries lists the e2e binaries the build produced, so the archive and
+// the publish can no-op when there are none.
 func (r *CalicoManager) stagedE2EBinaries() ([]string, error) {
 	staged, err := filepath.Glob(filepath.Join(r.e2eBinariesDir(), "e2e-linux-*.test"))
 	if err != nil {
 		return nil, fmt.Errorf("looking for staged e2e binaries: %w", err)
 	}
 	return staged, nil
+}
+
+// clearStagedE2EBinaries drops the staging directory. The output directory
+// survives between runs, so without this a --no-e2e-binaries build would leave an
+// earlier run's binaries for the archive and the publish to find.
+func (r *CalicoManager) clearStagedE2EBinaries() error {
+	if err := os.RemoveAll(r.e2eBinariesDir()); err != nil {
+		return fmt.Errorf("removing staged e2e binaries: %w", err)
+	}
+	return nil
 }
 
 func (r *CalicoManager) buildE2EBinaries() error {
@@ -1678,6 +1683,10 @@ func (r *CalicoManager) updateHelmChartIndex() error {
 // matches Enterprise (<version>/files/e2e/), so both products resolve a binary
 // the same way.
 func (r *CalicoManager) publishE2EBinaries() error {
+	if !r.e2eBinaries {
+		logrus.Info("Skipping publishing e2e test binaries")
+		return nil
+	}
 	staged, err := r.stagedE2EBinaries()
 	if err != nil {
 		return err
@@ -1686,10 +1695,11 @@ func (r *CalicoManager) publishE2EBinaries() error {
 		logrus.Info("Skipping publishing e2e test binaries (none staged)")
 		return nil
 	}
-	// publishPrereqs catches this too; repeated here for a --no-validate run,
-	// which would otherwise upload to "s3:///".
+	// Nothing to upload to, and this step is best-effort, so warn rather than
+	// fail a release that is otherwise complete.
 	if r.s3Bucket == "" {
-		return fmt.Errorf("no S3 bucket specified")
+		logrus.Warn("Skipping publishing e2e test binaries (no S3 bucket specified)")
+		return nil
 	}
 	dest := fmt.Sprintf("s3://%s/%s/files/e2e/", r.s3Bucket, r.calicoVersion)
 	return r.s3Cp(r.e2eBinariesDir()+"/", dest, s3ACLPublicRead...)

--- a/release/pkg/manager/calico/manager.go
+++ b/release/pkg/manager/calico/manager.go
@@ -1315,6 +1315,13 @@ func (r *CalicoManager) buildE2EBinaries() error {
 		return fmt.Errorf("failed to build e2e binaries: %w", err)
 	}
 
+	// Clear the staging directory so it describes this build alone. The output
+	// directory survives between runs, so anything left there — an arch dropped
+	// from the set, or a previous run's wider set — would otherwise ship in the
+	// archive and upload to S3 alongside the current binaries.
+	if err := r.clearStagedE2EBinaries(); err != nil {
+		return err
+	}
 	// Hard-link the built binaries into the output directory to avoid
 	// duplicating ~1 GB of cross-compiled test binaries on disk.
 	e2eOutputDir := r.e2eBinariesDir()
@@ -1332,11 +1339,6 @@ func (r *CalicoManager) buildE2EBinaries() error {
 			continue
 		}
 		dst := filepath.Join(e2eOutputDir, entry.Name())
-		// Replace a leftover link from an earlier build of the same version;
-		// os.Link fails outright on an existing destination.
-		if err := os.Remove(dst); err != nil && !errors.Is(err, os.ErrNotExist) {
-			return fmt.Errorf("replacing e2e binary %s: %w", entry.Name(), err)
-		}
 		if err := os.Link(filepath.Join(binDir, entry.Name()), dst); err != nil {
 			return fmt.Errorf("linking e2e binary %s: %w", entry.Name(), err)
 		}

--- a/release/pkg/manager/calico/manager_test.go
+++ b/release/pkg/manager/calico/manager_test.go
@@ -784,30 +784,37 @@ func TestPublishE2EBinaries(t *testing.T) {
 	const bucket = "example-bucket"
 
 	tests := []struct {
-		name     string
-		staged   []string
-		bucket   string
-		wantS3   bool
-		wantErr  bool
-		wantDest string
+		name        string
+		e2eBinaries bool
+		staged      []string
+		bucket      string
+		wantS3      bool
+		wantDest    string
 	}{
 		{
-			name:     "staged binaries go to <version>/files/e2e/",
-			staged:   []string{"e2e-linux-amd64.test", "e2e-linux-arm64.test"},
-			bucket:   bucket,
-			wantS3:   true,
-			wantDest: "s3://" + bucket + "/v3.30.0/files/e2e/",
+			name:        "staged binaries go to <version>/files/e2e/",
+			e2eBinaries: true,
+			staged:      []string{"e2e-linux-amd64.test", "e2e-linux-arm64.test"},
+			bucket:      bucket,
+			wantS3:      true,
+			wantDest:    "s3://" + bucket + "/v3.30.0/files/e2e/",
 		},
 		{
-			name:   "nothing staged is a no-op",
+			name:        "nothing staged is a no-op",
+			e2eBinaries: true,
+			bucket:      bucket,
+		},
+		{
+			name:   "the flag off skips staged binaries",
+			staged: []string{"e2e-linux-amd64.test"},
 			bucket: bucket,
 		},
 		{
-			// The flag is not passed to publish, so a missing bucket must fail
-			// rather than silently skip a release that did stage binaries.
-			name:    "staged binaries without a bucket error",
-			staged:  []string{"e2e-linux-amd64.test"},
-			wantErr: true,
+			// Best-effort step: an incomplete upload target must not fail a
+			// release that is otherwise done.
+			name:        "no bucket warns rather than failing",
+			e2eBinaries: true,
+			staged:      []string{"e2e-linux-amd64.test"},
 		},
 	}
 
@@ -825,17 +832,12 @@ func TestPublishE2EBinaries(t *testing.T) {
 
 			r := &CalicoManager{
 				runner:        f,
+				e2eBinaries:   tt.e2eBinaries,
 				calicoVersion: "v3.30.0",
 				s3Bucket:      tt.bucket,
 				outputDir:     outputDir,
 			}
-			err := r.publishE2EBinaries()
-			if tt.wantErr {
-				require.Error(t, err)
-				require.False(t, f.ran("aws"), "no upload should be attempted (calls: %v)", f.calls)
-				return
-			}
-			require.NoError(t, err)
+			require.NoError(t, r.publishE2EBinaries())
 			require.Equal(t, tt.wantS3, f.ran("aws"), "calls: %v", f.calls)
 			if tt.wantS3 {
 				var dest string
@@ -848,4 +850,23 @@ func TestPublishE2EBinaries(t *testing.T) {
 			}
 		})
 	}
+}
+
+// A --no-e2e-binaries build must not leave an earlier run's binaries in the
+// output directory, which survives between runs.
+func TestClearStagedE2EBinaries(t *testing.T) {
+	outputDir := t.TempDir()
+	r := &CalicoManager{outputDir: outputDir}
+	e2eDir := filepath.Join(outputDir, "files", "e2e")
+	require.NoError(t, os.MkdirAll(e2eDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(e2eDir, "e2e-linux-amd64.test"), []byte("stale"), 0o755))
+
+	require.NoError(t, r.clearStagedE2EBinaries())
+
+	staged, err := r.stagedE2EBinaries()
+	require.NoError(t, err)
+	require.Empty(t, staged)
+
+	// Idempotent: a build that never staged anything must not error.
+	require.NoError(t, r.clearStagedE2EBinaries())
 }

--- a/release/pkg/manager/calico/manager_test.go
+++ b/release/pkg/manager/calico/manager_test.go
@@ -893,6 +893,13 @@ func TestBuildE2EBinariesStaging(t *testing.T) {
 			wantStaged:  1,
 		},
 		{
+			// A narrower arch set must not ship the wider set's leftovers.
+			name:        "an arch dropped from the set is not left staged",
+			produced:    []string{"e2e-linux-amd64.test"},
+			preexisting: []string{"e2e-linux-amd64.test", "e2e-linux-arm64.test"},
+			wantStaged:  1,
+		},
+		{
 			name:    "a build that produced nothing errors",
 			wantErr: true,
 		},

--- a/release/pkg/manager/calico/manager_test.go
+++ b/release/pkg/manager/calico/manager_test.go
@@ -727,56 +727,84 @@ func TestBuildE2EBinariesUsesARCHES(t *testing.T) {
 	}
 }
 
-func TestCollectE2EBinaries(t *testing.T) {
+// The e2e binaries ship inside the release archive and are published to S3 for
+// individual download; they are deliberately not flat GitHub release assets.
+func TestBuildReleaseTarIncludesE2EBinaries(t *testing.T) {
 	tests := []struct {
-		name          string
-		e2eBinaries   bool
-		isHashRelease bool
-		staged        []string
-		preexisting   []string
-		want          []string
-		wantErr       bool
+		name        string
+		e2eBinaries bool
+		staged      bool
+		wantInTar   bool
+	}{
+		{name: "staged binaries are added to bin/e2e", e2eBinaries: true, staged: true, wantInTar: true},
+		{name: "nothing staged adds nothing", e2eBinaries: true, staged: false},
+		{name: "disabled adds nothing", e2eBinaries: false, staged: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			outputDir := filepath.Join(t.TempDir(), "upload")
+			require.NoError(t, os.MkdirAll(outputDir, 0o755))
+			if tt.staged {
+				e2eDir := filepath.Join(outputDir, "files", "e2e")
+				require.NoError(t, os.MkdirAll(e2eDir, 0o755))
+				require.NoError(t, os.WriteFile(filepath.Join(e2eDir, "e2e-linux-amd64.test"), []byte("x"), 0o755))
+			}
+
+			f := newFakeRunner()
+			f.on("cp", "", nil)
+			f.on("tar", "", nil)
+
+			r := &CalicoManager{
+				runner:        f,
+				tarball:       true,
+				binaries:      true,
+				e2eBinaries:   tt.e2eBinaries,
+				calicoVersion: "v3.30.0",
+				outputDir:     outputDir,
+				repoRoot:      t.TempDir(),
+			}
+			require.NoError(t, r.buildReleaseTar())
+
+			var copiedE2E bool
+			for _, c := range f.calls {
+				if strings.HasPrefix(c, "cp ") && strings.Contains(c, filepath.Join("bin", "e2e")) {
+					copiedE2E = true
+				}
+			}
+			require.Equal(t, tt.wantInTar, copiedE2E, "calls: %v", f.calls)
+		})
+	}
+}
+
+func TestPublishE2EBinaries(t *testing.T) {
+	const bucket = "example-bucket"
+
+	tests := []struct {
+		name     string
+		staged   []string
+		bucket   string
+		wantS3   bool
+		wantErr  bool
+		wantDest string
 	}{
 		{
-			name:        "release flattens the staged binaries",
-			e2eBinaries: true,
-			staged:      []string{"e2e-linux-amd64.test", "e2e-linux-arm64.test"},
-			want:        []string{"e2e-linux-amd64.test", "e2e-linux-arm64.test"},
+			name:     "staged binaries go to <version>/files/e2e/",
+			staged:   []string{"e2e-linux-amd64.test", "e2e-linux-arm64.test"},
+			bucket:   bucket,
+			wantS3:   true,
+			wantDest: "s3://" + bucket + "/v3.30.0/files/e2e/",
 		},
 		{
-			name:        "unrelated staged files are left behind",
-			e2eBinaries: true,
-			staged:      []string{"e2e-linux-amd64.test", "notes.txt"},
-			want:        []string{"e2e-linux-amd64.test"},
+			name:   "nothing staged is a no-op",
+			bucket: bucket,
 		},
 		{
-			name:        "a rerun relinks over the previous build",
-			e2eBinaries: true,
-			staged:      []string{"e2e-linux-amd64.test"},
-			preexisting: []string{"e2e-linux-amd64.test"},
-			want:        []string{"e2e-linux-amd64.test"},
-		},
-		{
-			name:        "staging with no binaries errors",
-			e2eBinaries: true,
-			staged:      []string{"notes.txt"},
-			wantErr:     true,
-		},
-		{
-			name:        "empty staging errors",
-			e2eBinaries: true,
-			wantErr:     true,
-		},
-		{
-			name:          "hashrelease keeps only the files/e2e layout",
-			e2eBinaries:   true,
-			isHashRelease: true,
-			staged:        []string{"e2e-linux-amd64.test"},
-		},
-		{
-			name:        "disabled does nothing",
-			e2eBinaries: false,
-			staged:      []string{"e2e-linux-amd64.test"},
+			// The flag is not passed to publish, so a missing bucket must fail
+			// rather than silently skip a release that did stage binaries.
+			name:    "staged binaries without a bucket error",
+			staged:  []string{"e2e-linux-amd64.test"},
+			wantErr: true,
 		},
 	}
 
@@ -788,131 +816,33 @@ func TestCollectE2EBinaries(t *testing.T) {
 			for _, name := range tt.staged {
 				require.NoError(t, os.WriteFile(filepath.Join(e2eDir, name), []byte(name), 0o755))
 			}
-			for _, name := range tt.preexisting {
-				require.NoError(t, os.WriteFile(filepath.Join(outputDir, name), []byte("stale"), 0o755))
-			}
-
-			r := &CalicoManager{
-				e2eBinaries:   tt.e2eBinaries,
-				isHashRelease: tt.isHashRelease,
-				outputDir:     outputDir,
-			}
-			err := r.collectE2EBinaries()
-			if tt.wantErr {
-				require.Error(t, err)
-				return
-			}
-			require.NoError(t, err)
-
-			entries, err := os.ReadDir(outputDir)
-			require.NoError(t, err)
-			var got []string
-			for _, entry := range entries {
-				if !entry.IsDir() {
-					got = append(got, entry.Name())
-				}
-			}
-			require.ElementsMatch(t, tt.want, got)
-
-			// A collected binary must carry the staged content, not a stale leftover.
-			for _, name := range tt.want {
-				content, err := os.ReadFile(filepath.Join(outputDir, name))
-				require.NoError(t, err)
-				require.Equal(t, name, string(content))
-			}
-		})
-	}
-}
-
-// A missing files/e2e directory means the build never staged anything, which
-// would otherwise ship a release with no e2e binaries and no warning.
-func TestCollectE2EBinariesUnstagedErrors(t *testing.T) {
-	r := &CalicoManager{e2eBinaries: true, outputDir: t.TempDir()}
-	require.Error(t, r.collectE2EBinaries())
-}
-
-// The staging layout is the whole reason a release and a hashrelease differ:
-// ghr populates GitHub release assets from the top level of the upload dir and
-// does not recurse, while the hashrelease server serves the directory tree.
-func TestE2EStagingDir(t *testing.T) {
-	tests := []struct {
-		name          string
-		isHashRelease bool
-		want          string
-	}{
-		{name: "release stages flat for ghr", want: "out"},
-		{name: "hashrelease stages under files/e2e", isHashRelease: true, want: filepath.Join("out", "files", "e2e")},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			r := &CalicoManager{outputDir: "out", isHashRelease: tt.isHashRelease}
-			require.Equal(t, tt.want, r.e2eStagingDir())
-		})
-	}
-}
-
-// The e2e-binaries flag belongs to the build step and is never passed to
-// publish, so the release note has to key off what was actually staged.
-func TestPublishGithubReleaseE2ENote(t *testing.T) {
-	const bullet = "e2e-linux-<arch>.test"
-
-	tests := []struct {
-		name        string
-		staged      []string
-		e2eBinaries bool
-		wantNote    bool
-	}{
-		{
-			name:        "staged binaries are listed",
-			staged:      []string{"e2e-linux-amd64.test", "e2e-linux-arm64.test"},
-			e2eBinaries: true,
-			wantNote:    true,
-		},
-		{
-			name:        "nothing staged is not listed even with the flag defaulted on",
-			e2eBinaries: true,
-			wantNote:    false,
-		},
-		{
-			name:        "staged binaries are listed even with the flag off",
-			staged:      []string{"e2e-linux-amd64.test"},
-			e2eBinaries: false,
-			wantNote:    true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			outputDir := t.TempDir()
-			for _, name := range tt.staged {
-				require.NoError(t, os.WriteFile(filepath.Join(outputDir, name), []byte(name), 0o755))
-			}
 
 			f := newFakeRunner()
-			f.on("./bin/gh release view", "release not found", fmt.Errorf("release not found"))
-			f.on("./bin/ghr", "", nil)
+			f.on("aws", "", nil)
 
 			r := &CalicoManager{
 				runner:        f,
-				githubRelease: true,
-				e2eBinaries:   tt.e2eBinaries,
 				calicoVersion: "v3.30.0",
-				githubOrg:     "projectcalico",
-				repo:          "calico",
+				s3Bucket:      tt.bucket,
 				outputDir:     outputDir,
 			}
-			require.NoError(t, r.publishGithubRelease())
-
-			var ghr string
-			for _, c := range f.calls {
-				if strings.HasPrefix(c, "./bin/ghr") {
-					ghr = c
-				}
+			err := r.publishE2EBinaries()
+			if tt.wantErr {
+				require.Error(t, err)
+				require.False(t, f.ran("aws"), "no upload should be attempted (calls: %v)", f.calls)
+				return
 			}
-			require.NotEmpty(t, ghr, "ghr was not invoked (calls: %v)", f.calls)
-			require.Equal(t, tt.wantNote, strings.Contains(ghr, bullet),
-				"release note mentions %q = %v, want %v", bullet, strings.Contains(ghr, bullet), tt.wantNote)
+			require.NoError(t, err)
+			require.Equal(t, tt.wantS3, f.ran("aws"), "calls: %v", f.calls)
+			if tt.wantS3 {
+				var dest string
+				for _, c := range f.calls {
+					if strings.HasPrefix(c, "aws") {
+						dest = c
+					}
+				}
+				require.Contains(t, dest, tt.wantDest)
+			}
 		})
 	}
 }

--- a/release/pkg/manager/calico/manager_test.go
+++ b/release/pkg/manager/calico/manager_test.go
@@ -870,3 +870,76 @@ func TestClearStagedE2EBinaries(t *testing.T) {
 	// Idempotent: a build that never staged anything must not error.
 	require.NoError(t, r.clearStagedE2EBinaries())
 }
+
+// The zero-output guard and the relink-on-rerun fix both used to live in the
+// collect step; they moved here when that step went away, so keep them covered.
+func TestBuildE2EBinariesStaging(t *testing.T) {
+	tests := []struct {
+		name        string
+		produced    []string
+		preexisting []string
+		wantErr     bool
+		wantStaged  int
+	}{
+		{
+			name:       "produced binaries are staged",
+			produced:   []string{"e2e-linux-amd64.test", "e2e-linux-arm64.test"},
+			wantStaged: 2,
+		},
+		{
+			name:        "a rerun relinks over the previous build",
+			produced:    []string{"e2e-linux-amd64.test"},
+			preexisting: []string{"e2e-linux-amd64.test"},
+			wantStaged:  1,
+		},
+		{
+			name:    "a build that produced nothing errors",
+			wantErr: true,
+		},
+		{
+			name:     "only unrelated output errors",
+			produced: []string{"README"},
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repoRoot, outputDir := t.TempDir(), t.TempDir()
+			buildOut := filepath.Join(repoRoot, "e2e", "bin", "k8s")
+			require.NoError(t, os.MkdirAll(buildOut, 0o755))
+			for _, name := range tt.produced {
+				require.NoError(t, os.WriteFile(filepath.Join(buildOut, name), []byte(name), 0o755))
+			}
+
+			r := &CalicoManager{
+				runner:        newFakeRunner().on("make", "", nil),
+				repoRoot:      repoRoot,
+				outputDir:     outputDir,
+				calicoVersion: "v3.30.0",
+				architectures: []string{"amd64", "arm64"},
+			}
+			for _, name := range tt.preexisting {
+				require.NoError(t, os.MkdirAll(r.e2eBinariesDir(), 0o755))
+				require.NoError(t, os.WriteFile(filepath.Join(r.e2eBinariesDir(), name), []byte("stale"), 0o755))
+			}
+
+			err := r.buildE2EBinaries()
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			staged, err := r.stagedE2EBinaries()
+			require.NoError(t, err)
+			require.Len(t, staged, tt.wantStaged)
+			// A rerun must land the new build, not leave the stale file behind.
+			for _, name := range tt.produced {
+				content, err := os.ReadFile(filepath.Join(r.e2eBinariesDir(), name))
+				require.NoError(t, err)
+				require.Equal(t, name, string(content))
+			}
+		})
+	}
+}

--- a/release/pkg/manager/calico/manager_test.go
+++ b/release/pkg/manager/calico/manager_test.go
@@ -733,7 +733,9 @@ func TestCollectE2EBinaries(t *testing.T) {
 		e2eBinaries   bool
 		isHashRelease bool
 		staged        []string
+		preexisting   []string
 		want          []string
+		wantErr       bool
 	}{
 		{
 			name:        "release flattens the staged binaries",
@@ -746,6 +748,24 @@ func TestCollectE2EBinaries(t *testing.T) {
 			e2eBinaries: true,
 			staged:      []string{"e2e-linux-amd64.test", "notes.txt"},
 			want:        []string{"e2e-linux-amd64.test"},
+		},
+		{
+			name:        "a rerun relinks over the previous build",
+			e2eBinaries: true,
+			staged:      []string{"e2e-linux-amd64.test"},
+			preexisting: []string{"e2e-linux-amd64.test"},
+			want:        []string{"e2e-linux-amd64.test"},
+		},
+		{
+			name:        "staging with no binaries errors",
+			e2eBinaries: true,
+			staged:      []string{"notes.txt"},
+			wantErr:     true,
+		},
+		{
+			name:        "empty staging errors",
+			e2eBinaries: true,
+			wantErr:     true,
 		},
 		{
 			name:          "hashrelease keeps only the files/e2e layout",
@@ -768,13 +788,21 @@ func TestCollectE2EBinaries(t *testing.T) {
 			for _, name := range tt.staged {
 				require.NoError(t, os.WriteFile(filepath.Join(e2eDir, name), []byte(name), 0o755))
 			}
+			for _, name := range tt.preexisting {
+				require.NoError(t, os.WriteFile(filepath.Join(outputDir, name), []byte("stale"), 0o755))
+			}
 
 			r := &CalicoManager{
 				e2eBinaries:   tt.e2eBinaries,
 				isHashRelease: tt.isHashRelease,
 				outputDir:     outputDir,
 			}
-			require.NoError(t, r.collectE2EBinaries())
+			err := r.collectE2EBinaries()
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
 
 			entries, err := os.ReadDir(outputDir)
 			require.NoError(t, err)
@@ -785,6 +813,13 @@ func TestCollectE2EBinaries(t *testing.T) {
 				}
 			}
 			require.ElementsMatch(t, tt.want, got)
+
+			// A collected binary must carry the staged content, not a stale leftover.
+			for _, name := range tt.want {
+				content, err := os.ReadFile(filepath.Join(outputDir, name))
+				require.NoError(t, err)
+				require.Equal(t, name, string(content))
+			}
 		})
 	}
 }

--- a/release/pkg/manager/calico/manager_test.go
+++ b/release/pkg/manager/calico/manager_test.go
@@ -733,12 +733,15 @@ func TestBuildReleaseTarIncludesE2EBinaries(t *testing.T) {
 	tests := []struct {
 		name        string
 		e2eBinaries bool
+		binaries    bool
 		staged      bool
 		wantInTar   bool
 	}{
-		{name: "staged binaries are added to bin/e2e", e2eBinaries: true, staged: true, wantInTar: true},
-		{name: "nothing staged adds nothing", e2eBinaries: true, staged: false},
-		{name: "disabled adds nothing", e2eBinaries: false, staged: true},
+		{name: "staged binaries are added to bin/e2e", e2eBinaries: true, binaries: true, staged: true, wantInTar: true},
+		{name: "nothing staged adds nothing", e2eBinaries: true, binaries: true, staged: false},
+		{name: "disabled adds nothing", e2eBinaries: false, binaries: true, staged: true},
+		// The two flags are independent, so --no-binaries must not drop them.
+		{name: "included even without the other binaries", e2eBinaries: true, binaries: false, staged: true, wantInTar: true},
 	}
 
 	for _, tt := range tests {
@@ -758,7 +761,7 @@ func TestBuildReleaseTarIncludesE2EBinaries(t *testing.T) {
 			r := &CalicoManager{
 				runner:        f,
 				tarball:       true,
-				binaries:      true,
+				binaries:      tt.binaries,
 				e2eBinaries:   tt.e2eBinaries,
 				calicoVersion: "v3.30.0",
 				outputDir:     outputDir,

--- a/release/pkg/manager/calico/manager_test.go
+++ b/release/pkg/manager/calico/manager_test.go
@@ -830,3 +830,89 @@ func TestCollectE2EBinariesUnstagedErrors(t *testing.T) {
 	r := &CalicoManager{e2eBinaries: true, outputDir: t.TempDir()}
 	require.Error(t, r.collectE2EBinaries())
 }
+
+// The staging layout is the whole reason a release and a hashrelease differ:
+// ghr populates GitHub release assets from the top level of the upload dir and
+// does not recurse, while the hashrelease server serves the directory tree.
+func TestE2EStagingDir(t *testing.T) {
+	tests := []struct {
+		name          string
+		isHashRelease bool
+		want          string
+	}{
+		{name: "release stages flat for ghr", want: "out"},
+		{name: "hashrelease stages under files/e2e", isHashRelease: true, want: filepath.Join("out", "files", "e2e")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &CalicoManager{outputDir: "out", isHashRelease: tt.isHashRelease}
+			require.Equal(t, tt.want, r.e2eStagingDir())
+		})
+	}
+}
+
+// The e2e-binaries flag belongs to the build step and is never passed to
+// publish, so the release note has to key off what was actually staged.
+func TestPublishGithubReleaseE2ENote(t *testing.T) {
+	const bullet = "e2e-linux-<arch>.test"
+
+	tests := []struct {
+		name        string
+		staged      []string
+		e2eBinaries bool
+		wantNote    bool
+	}{
+		{
+			name:        "staged binaries are listed",
+			staged:      []string{"e2e-linux-amd64.test", "e2e-linux-arm64.test"},
+			e2eBinaries: true,
+			wantNote:    true,
+		},
+		{
+			name:        "nothing staged is not listed even with the flag defaulted on",
+			e2eBinaries: true,
+			wantNote:    false,
+		},
+		{
+			name:        "staged binaries are listed even with the flag off",
+			staged:      []string{"e2e-linux-amd64.test"},
+			e2eBinaries: false,
+			wantNote:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			outputDir := t.TempDir()
+			for _, name := range tt.staged {
+				require.NoError(t, os.WriteFile(filepath.Join(outputDir, name), []byte(name), 0o755))
+			}
+
+			f := newFakeRunner()
+			f.on("./bin/gh release view", "release not found", fmt.Errorf("release not found"))
+			f.on("./bin/ghr", "", nil)
+
+			r := &CalicoManager{
+				runner:        f,
+				githubRelease: true,
+				e2eBinaries:   tt.e2eBinaries,
+				calicoVersion: "v3.30.0",
+				githubOrg:     "projectcalico",
+				repo:          "calico",
+				outputDir:     outputDir,
+			}
+			require.NoError(t, r.publishGithubRelease())
+
+			var ghr string
+			for _, c := range f.calls {
+				if strings.HasPrefix(c, "./bin/ghr") {
+					ghr = c
+				}
+			}
+			require.NotEmpty(t, ghr, "ghr was not invoked (calls: %v)", f.calls)
+			require.Equal(t, tt.wantNote, strings.Contains(ghr, bullet),
+				"release note mentions %q = %v, want %v", bullet, strings.Contains(ghr, bullet), tt.wantNote)
+		})
+	}
+}

--- a/release/pkg/manager/calico/manager_test.go
+++ b/release/pkg/manager/calico/manager_test.go
@@ -871,6 +871,33 @@ func TestClearStagedE2EBinaries(t *testing.T) {
 	require.NoError(t, r.clearStagedE2EBinaries())
 }
 
+// clearStagedE2EBinaries removes a directory, so pin its blast radius: only
+// files/e2e/ goes, never a sibling artifact or the upload directory itself.
+func TestClearStagedE2EBinariesScope(t *testing.T) {
+	outputDir := t.TempDir()
+	r := &CalicoManager{outputDir: outputDir}
+
+	keep := map[string]string{
+		"release-v3.30.0.tgz":            filepath.Join(outputDir, "release-v3.30.0.tgz"),
+		"files/other/thing.txt":          filepath.Join(outputDir, "files", "other", "thing.txt"),
+		"manifests/tigera-operator.yaml": filepath.Join(outputDir, "manifests", "tigera-operator.yaml"),
+	}
+	for _, path := range keep {
+		require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+		require.NoError(t, os.WriteFile(path, []byte("keep"), 0o644))
+	}
+	require.NoError(t, os.MkdirAll(r.e2eBinariesDir(), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(r.e2eBinariesDir(), "e2e-linux-amd64.test"), []byte("go"), 0o755))
+
+	require.NoError(t, r.clearStagedE2EBinaries())
+
+	require.NoDirExists(t, r.e2eBinariesDir())
+	for name, path := range keep {
+		require.FileExists(t, path, "%s must survive", name)
+	}
+	require.DirExists(t, outputDir)
+}
+
 // The zero-output guard and the relink-on-rerun fix both used to live in the
 // collect step; they moved here when that step went away, so keep them covered.
 func TestBuildE2EBinariesStaging(t *testing.T) {

--- a/release/pkg/manager/calico/manager_test.go
+++ b/release/pkg/manager/calico/manager_test.go
@@ -726,3 +726,72 @@ func TestBuildE2EBinariesUsesARCHES(t *testing.T) {
 			"e2e build-all should not set VALIDARCHES (lib.Makefile ignores it): %s", e)
 	}
 }
+
+func TestCollectE2EBinaries(t *testing.T) {
+	tests := []struct {
+		name          string
+		e2eBinaries   bool
+		isHashRelease bool
+		staged        []string
+		want          []string
+	}{
+		{
+			name:        "release flattens the staged binaries",
+			e2eBinaries: true,
+			staged:      []string{"e2e-linux-amd64.test", "e2e-linux-arm64.test"},
+			want:        []string{"e2e-linux-amd64.test", "e2e-linux-arm64.test"},
+		},
+		{
+			name:        "unrelated staged files are left behind",
+			e2eBinaries: true,
+			staged:      []string{"e2e-linux-amd64.test", "notes.txt"},
+			want:        []string{"e2e-linux-amd64.test"},
+		},
+		{
+			name:          "hashrelease keeps only the files/e2e layout",
+			e2eBinaries:   true,
+			isHashRelease: true,
+			staged:        []string{"e2e-linux-amd64.test"},
+		},
+		{
+			name:        "disabled does nothing",
+			e2eBinaries: false,
+			staged:      []string{"e2e-linux-amd64.test"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			outputDir := t.TempDir()
+			e2eDir := filepath.Join(outputDir, "files", "e2e")
+			require.NoError(t, os.MkdirAll(e2eDir, 0o755))
+			for _, name := range tt.staged {
+				require.NoError(t, os.WriteFile(filepath.Join(e2eDir, name), []byte(name), 0o755))
+			}
+
+			r := &CalicoManager{
+				e2eBinaries:   tt.e2eBinaries,
+				isHashRelease: tt.isHashRelease,
+				outputDir:     outputDir,
+			}
+			require.NoError(t, r.collectE2EBinaries())
+
+			entries, err := os.ReadDir(outputDir)
+			require.NoError(t, err)
+			var got []string
+			for _, entry := range entries {
+				if !entry.IsDir() {
+					got = append(got, entry.Name())
+				}
+			}
+			require.ElementsMatch(t, tt.want, got)
+		})
+	}
+}
+
+// A missing files/e2e directory means the build never staged anything, which
+// would otherwise ship a release with no e2e binaries and no warning.
+func TestCollectE2EBinariesUnstagedErrors(t *testing.T) {
+	r := &CalicoManager{e2eBinaries: true, outputDir: t.TempDir()}
+	require.Error(t, r.collectE2EBinaries())
+}


### PR DESCRIPTION
## Description

Official releases published no e2e test binaries. Hashreleases have carried them
since #12884, and CI downloads them from there, but a released version had
nothing to fetch — so anything testing a GA tag fell back to a floating image
built from a different branch.

Three things kept them off the release path:

- `Build()` called `buildE2EBinaries()` inside its `if r.isHashRelease` branch.
- `buildStepFlags()` only offered `--e2e-binaries` to the hashrelease command, and
  `release build` never passed `WithE2EBinaries`, so the manager field went unread
  on that path.
- `collectGithubArtifacts()` never collected `files/e2e/`.

A release now ships them two ways:

- **In the release archive**, at `bin/e2e/`, beside the `bin/calicoctl/` and
  `bin/calico-bpf` copies already there.
- **On S3**, at `<version>/files/e2e/`, so a consumer can fetch a single binary
  without unpacking the archive. `publishE2EBinaries()` mirrors
  `updateHelmChartIndex()`, the existing S3 publish in this tool — same `s3Cp`,
  `$S3_BUCKET` and `s3ACLPublicRead`.

`buildE2EBinaries()` stages into `files/e2e/` for both a release and a
hashrelease, and `e2eBinariesDir()` / `stagedE2EBinaries()` own that location and
the "what did the build produce" query. `--e2e-binaries` is wired to both
`release build` and `release publish`, so the archive and the upload agree on
whether the binaries are in play; opting out also clears the staging directory,
which the output directory would otherwise carry over between runs.

The upload is best-effort. A failure is logged and ignored the way the ISS scan
in the same function already is, since the binaries also ship inside the archive
— a failed upload should not halt an otherwise complete release.

The S3 layout deliberately matches Enterprise (tigera/calico-private#13082), which
means banzai-core needs no change: its runner already appends
`files/e2e/e2e-linux-<arch>.test` to a base URL, so OSS resolves exactly like
calient GA does today.

### Upgrade runs fetched the wrong stream

Upgrade pipelines set `RELEASE_STREAM` to the downlevel version they install
first, but the tests run against the uplevel one. `run_tests.sh` downloaded from
`RELEASE_STREAM`, so a master upgrade run fetched the **v3.29** suite. v3.29
publishes no e2e binary, so the download 404'd and the step died on a bare `curl`
failure with no diagnostic.

Both runners now prefer `UPLEVEL_RELEASE_STREAM`, which the upgrade pipelines set
explicitly, and name the stream and URL when the artifact is missing. The failure
stays fatal on purpose: falling back to a floating image silently runs a suite
built from another branch, and in the case of `k8s-e2e:stable`, from another
repository. v3.32 already fixed this in #13517; this brings master in line.

A branch cut now rewrites `UPLEVEL_RELEASE_STREAM` in both upgrade pipelines, as a
`Required` edit — left at `master`, a freshly cut branch would run master's e2e
suite against its own build.

## Sizing

Since #13758 landed, the e2e build is restricted to the arches runners actually
consume, so this ships `amd64` and `arm64` only — `e2eArchitectures()` intersects
the configured set with `{amd64, arm64}`.

The archive is gzipped, so the increase is smaller than the raw binaries suggest:
one binary is 183 MB raw and 71 MB gzipped, so two arches add roughly **142 MB**,
taking `release-v3.31.1.tgz` from 1,070 MB to about 1,212 MB (~13%).

Release build time also grows by a two-arch e2e cross-compile.

## Reachability — needs a companion docs PR

The bucket is `calico-public`, per `tigera/docs` `netlify.toml`:

```toml
from = "/calico/charts/*"
to = "https://calico-public.s3.amazonaws.com/charts/:splat"
status = 200
```

Two things follow, and only the first was obvious to me at first:

1. The uploaded object **is** fetchable on the bucket's own host —
   `https://calico-public.s3.amazonaws.com/<version>/files/e2e/e2e-linux-<arch>.test`.
   (`.../charts/index.yaml` returns `200` there, byte-identical to the docs path.)
2. It is **not** fetchable at the OSS public face. That `status = 200` rule is a
   per-prefix proxy, and `/calico/charts/*` is the only `/calico/*` S3 rule there
   is. Enterprise differs structurally: `downloads.tigera.io/ee` maps to its
   bucket root, so EE artifacts need no per-prefix rule.

So serving these the way every other OSS artifact is served needs a rule in
`tigera/docs`, raised as a draft in tigera/docs#3007:

```toml
# Version-matched e2e test binaries for Calico Open Source (proxied from S3)
[[redirects]]
   from = "/calico/:version/files/e2e/*"
   to = "https://calico-public.s3.amazonaws.com/:version/files/e2e/:splat"
   status = 200
   headers = {X-From = "Netlify"}
```

That collides with nothing: docs versions are `latest` / `3.30`-style while release
versions carry a `v` prefix, and the rule has no `force`, so a real file always
wins over the proxy.

None of this changes the upload code — only which hostname a consumer points at.

## Testing

- `make -C release static-checks` reports `0 issues`; the release unit tests pass.
  (`make -C release ut` is not runnable from a git worktree — it bind-mounts the
  real `.git` read-only, which breaks master's own `git init` tests. A full clone,
  as CI uses, is unaffected.)
- New table tests cover the archive inclusion (staged / nothing staged / flag off
  / independent of `--no-binaries`), the S3 publish (destination path, no-op when
  nothing is staged, no-op with the flag off, warn-and-skip when no bucket is
  set), and that opting out clears the staging directory.
- `bin/release release build --help` and `release publish --help` both list
  `--[no-]e2e-binaries`;
  `hashrelease build --help` still lists it alongside `--[no-]release-notes`.
- `bash -n` on both `run_tests.sh` copies; both changed pipeline YAMLs parse. Both
  `Required` branch-cut regexes were checked against the merged tree with Go's
  `regexp`, rewriting correctly for a hypothetical `v3.34` cut.
- The publish path can't be exercised without cutting a release, so the first real
  check is the next patch release. The upgrade-stream fix is checkable on the next
  scheduled `e2e-upgrade` run.

**Release note:**
```release-note
Official releases now ship version-matched Kubernetes e2e test binaries in the release archive under bin/e2e/, and publish them to S3 for individual download.
```







