### PR TITLE
[v3.33][DE-4474] release: publish version-matched e2e binaries for official releases

### DIFF
--- a/.argoci/cron/e2e-upgrade.yaml
+++ b/.argoci/cron/e2e-upgrade.yaml
@@ -16,6 +16,7 @@ globalPrologue: |
   export TEST_TYPE="${TEST_TYPE:-k8s-e2e}"
   export UPLEVEL_PRE_RELEASE="${UPLEVEL_PRE_RELEASE:-true}"
   export UPLEVEL_PRODUCT="${UPLEVEL_PRODUCT:-calico}"
+  export UPLEVEL_RELEASE_STREAM="${UPLEVEL_RELEASE_STREAM:-v3.33}"
   export USE_HASH_RELEASE="${USE_HASH_RELEASE:-false}"
   export USE_PRIVATE_REGISTRY="${USE_PRIVATE_REGISTRY:-true}"
   source .argoci/scripts/global_prologue.sh

--- a/.argoci/scripts/phases/run_tests.sh
+++ b/.argoci/scripts/phases/run_tests.sh
@@ -35,7 +35,17 @@ elif [[ "${TEST_TYPE}" == "k8s-e2e" ]]; then
   # Upgrade runs set RELEASE_STREAM to the downlevel version they install first,
   # but the tests run against the uplevel one.
   E2E_STREAM=${UPLEVEL_RELEASE_STREAM:-${RELEASE_STREAM}}
-  HASHREL_URL=$(curl --retry 9 --retry-all-errors -fsS "https://latest-os.hashrelease.tools.tigera.net/${E2E_STREAM}.txt")
+  if [[ -z "${E2E_STREAM}" ]]; then
+    echo "[ERROR] neither UPLEVEL_RELEASE_STREAM nor RELEASE_STREAM is set; cannot resolve an e2e binary"
+    exit 1
+  fi
+  E2E_STREAM_URL="https://latest-os.hashrelease.tools.tigera.net/${E2E_STREAM}.txt"
+  # Assign inside `if` so the diagnostic below runs: this script is sourced under
+  # `set -e`, where a bare command substitution would exit here instead.
+  if ! HASHREL_URL=$(curl --retry 9 --retry-all-errors -fsS "${E2E_STREAM_URL}"); then
+    echo "[ERROR] no hashrelease published for stream ${E2E_STREAM} at ${E2E_STREAM_URL}"
+    exit 1
+  fi
   echo "[INFO] hashrelease URL (stream ${E2E_STREAM}): ${HASHREL_URL}"
   ARCH=$(uname -m); [[ "$ARCH" == "x86_64" ]] && ARCH=amd64; [[ "$ARCH" == "aarch64" ]] && ARCH=arm64
   E2E_BINARY_URL="${HASHREL_URL}/files/e2e/e2e-linux-${ARCH}.test"

--- a/.argoci/scripts/phases/run_tests.sh
+++ b/.argoci/scripts/phases/run_tests.sh
@@ -14,7 +14,7 @@
 # Required for local builds:
 #   E2E_TEST_CONFIG or K8S_E2E_FLAGS
 # Required for hashrelease downloads:
-#   RELEASE_STREAM
+#   RELEASE_STREAM (or UPLEVEL_RELEASE_STREAM, which takes precedence)
 #
 # Sourced from body_*.sh. Exits with the test exit code.
 
@@ -32,11 +32,20 @@ if [[ -n "${RUN_LOCAL_TESTS:-}" ]]; then
 elif [[ "${TEST_TYPE}" == "k8s-e2e" ]]; then
   # Scheduled CI: download the pre-built e2e binary from the hashrelease.
   echo "[INFO] downloading e2e binary from hashrelease..."
-  HASHREL_URL=$(curl --retry 9 --retry-all-errors -fsS "https://latest-os.hashrelease.tools.tigera.net/${RELEASE_STREAM}.txt")
-  echo "[INFO] hashrelease URL: ${HASHREL_URL}"
+  # Upgrade runs set RELEASE_STREAM to the downlevel version they install first,
+  # but the tests run against the uplevel one.
+  E2E_STREAM=${UPLEVEL_RELEASE_STREAM:-${RELEASE_STREAM}}
+  HASHREL_URL=$(curl --retry 9 --retry-all-errors -fsS "https://latest-os.hashrelease.tools.tigera.net/${E2E_STREAM}.txt")
+  echo "[INFO] hashrelease URL (stream ${E2E_STREAM}): ${HASHREL_URL}"
   ARCH=$(uname -m); [[ "$ARCH" == "x86_64" ]] && ARCH=amd64; [[ "$ARCH" == "aarch64" ]] && ARCH=arm64
+  E2E_BINARY_URL="${HASHREL_URL}/files/e2e/e2e-linux-${ARCH}.test"
   mkdir -p "${CI_HOME}/${CI_GIT_DIR}/e2e/bin/k8s"
-  curl --retry 9 --retry-all-errors -fsSL "${HASHREL_URL}/files/e2e/e2e-linux-${ARCH}.test" -o "${CI_HOME}/${CI_GIT_DIR}/e2e/bin/k8s/e2e.test"
+  # Fail loudly rather than falling back to a floating image, which would run a
+  # suite built from another branch (and, for k8s-e2e:stable, another repo).
+  if ! curl --retry 9 --retry-all-errors -fsSL "${E2E_BINARY_URL}" -o "${CI_HOME}/${CI_GIT_DIR}/e2e/bin/k8s/e2e.test"; then
+    echo "[ERROR] no e2e binary published for stream ${E2E_STREAM} at ${E2E_BINARY_URL}"
+    exit 1
+  fi
   chmod +x "${CI_HOME}/${CI_GIT_DIR}/e2e/bin/k8s/e2e.test"
   echo "[INFO] downloaded e2e binary to ${CI_HOME}/${CI_GIT_DIR}/e2e/bin/k8s/e2e.test"
   E2E_BINARY=/go/src/github.com/projectcalico/calico/e2e/bin/k8s/e2e.test

--- a/.semaphore/end-to-end/pipelines/upgrade.yml
+++ b/.semaphore/end-to-end/pipelines/upgrade.yml
@@ -37,6 +37,8 @@ global_job_config:
       value: calico
     - name: UPLEVEL_PRE_RELEASE
       value: "true"
+    - name: UPLEVEL_RELEASE_STREAM # the version under test after the upgrade
+      value: v3.33
     - name: CALICOCTL_INSTALL_TYPE
       value: "container"
     - name: FUNCTIONAL_AREA

--- a/.semaphore/end-to-end/scripts/phases/run_tests.sh
+++ b/.semaphore/end-to-end/scripts/phases/run_tests.sh
@@ -14,7 +14,7 @@
 # Required for local builds:
 #   E2E_TEST_CONFIG or K8S_E2E_FLAGS
 # Required for hashrelease downloads:
-#   RELEASE_STREAM
+#   RELEASE_STREAM (or UPLEVEL_RELEASE_STREAM, which takes precedence)
 #
 # Sourced from body_*.sh. Exits with the test exit code.
 
@@ -32,11 +32,20 @@ if [[ -n "${RUN_LOCAL_TESTS:-}" ]]; then
 elif [[ "${TEST_TYPE}" == "k8s-e2e" ]]; then
   # Scheduled CI: download the pre-built e2e binary from the hashrelease.
   echo "[INFO] downloading e2e binary from hashrelease..."
-  HASHREL_URL=$(curl --retry 9 --retry-all-errors -fsS "https://latest-os.hashrelease.tools.tigera.net/${RELEASE_STREAM}.txt")
-  echo "[INFO] hashrelease URL: ${HASHREL_URL}"
+  # Upgrade runs set RELEASE_STREAM to the downlevel version they install first,
+  # but the tests run against the uplevel one.
+  E2E_STREAM=${UPLEVEL_RELEASE_STREAM:-${RELEASE_STREAM}}
+  HASHREL_URL=$(curl --retry 9 --retry-all-errors -fsS "https://latest-os.hashrelease.tools.tigera.net/${E2E_STREAM}.txt")
+  echo "[INFO] hashrelease URL (stream ${E2E_STREAM}): ${HASHREL_URL}"
   ARCH=$(uname -m); [[ "$ARCH" == "x86_64" ]] && ARCH=amd64; [[ "$ARCH" == "aarch64" ]] && ARCH=arm64
+  E2E_BINARY_URL="${HASHREL_URL}/files/e2e/e2e-linux-${ARCH}.test"
   mkdir -p "${HOME}/calico/e2e/bin/k8s"
-  curl --retry 9 --retry-all-errors -fsSL "${HASHREL_URL}/files/e2e/e2e-linux-${ARCH}.test" -o "${HOME}/calico/e2e/bin/k8s/e2e.test"
+  # Fail loudly rather than falling back to a floating image, which would run a
+  # suite built from another branch (and, for k8s-e2e:stable, another repo).
+  if ! curl --retry 9 --retry-all-errors -fsSL "${E2E_BINARY_URL}" -o "${HOME}/calico/e2e/bin/k8s/e2e.test"; then
+    echo "[ERROR] no e2e binary published for stream ${E2E_STREAM} at ${E2E_BINARY_URL}"
+    exit 1
+  fi
   chmod +x "${HOME}/calico/e2e/bin/k8s/e2e.test"
   echo "[INFO] downloaded e2e binary to ${HOME}/calico/e2e/bin/k8s/e2e.test"
   E2E_BINARY=/go/src/github.com/projectcalico/calico/e2e/bin/k8s/e2e.test

--- a/.semaphore/end-to-end/scripts/phases/run_tests.sh
+++ b/.semaphore/end-to-end/scripts/phases/run_tests.sh
@@ -35,7 +35,17 @@ elif [[ "${TEST_TYPE}" == "k8s-e2e" ]]; then
   # Upgrade runs set RELEASE_STREAM to the downlevel version they install first,
   # but the tests run against the uplevel one.
   E2E_STREAM=${UPLEVEL_RELEASE_STREAM:-${RELEASE_STREAM}}
-  HASHREL_URL=$(curl --retry 9 --retry-all-errors -fsS "https://latest-os.hashrelease.tools.tigera.net/${E2E_STREAM}.txt")
+  if [[ -z "${E2E_STREAM}" ]]; then
+    echo "[ERROR] neither UPLEVEL_RELEASE_STREAM nor RELEASE_STREAM is set; cannot resolve an e2e binary"
+    exit 1
+  fi
+  E2E_STREAM_URL="https://latest-os.hashrelease.tools.tigera.net/${E2E_STREAM}.txt"
+  # Assign inside `if` so the diagnostic below runs: this script is sourced under
+  # `set -e`, where a bare command substitution would exit here instead.
+  if ! HASHREL_URL=$(curl --retry 9 --retry-all-errors -fsS "${E2E_STREAM_URL}"); then
+    echo "[ERROR] no hashrelease published for stream ${E2E_STREAM} at ${E2E_STREAM_URL}"
+    exit 1
+  fi
   echo "[INFO] hashrelease URL (stream ${E2E_STREAM}): ${HASHREL_URL}"
   ARCH=$(uname -m); [[ "$ARCH" == "x86_64" ]] && ARCH=amd64; [[ "$ARCH" == "aarch64" ]] && ARCH=arm64
   E2E_BINARY_URL="${HASHREL_URL}/files/e2e/e2e-linux-${ARCH}.test"

--- a/release/cmd/flags.go
+++ b/release/cmd/flags.go
@@ -523,9 +523,10 @@ var (
 			helmIndexFlag(envHelmIndexLegacy, envBuildHelmIndex, envReleaseHelmIndex),
 			tarballFlag,
 			windowsArchiveFlag(envBuildWindowsArchive, envReleaseWindowsArchive),
+			e2eBinariesFlag,
 		}
 		if hashrelease {
-			f = append(f, e2eBinariesFlag, releaseNotesFlag)
+			f = append(f, releaseNotesFlag)
 		}
 		return f
 	}

--- a/release/cmd/release.go
+++ b/release/cmd/release.go
@@ -119,6 +119,7 @@ func releaseSubCommands(cfg *Config) []*cli.Command {
 					calico.WithHelmCharts(c.Bool(helmChartsFlagName)),
 					calico.WithManifests(c.Bool(manifestsFlag.Name)),
 					calico.WithBinaries(c.Bool(binariesFlag.Name)),
+					calico.WithE2EBinaries(c.Bool(e2eBinariesFlag.Name)),
 					calico.WithOCPBundle(c.Bool(ocpBundleFlag.Name)),
 					calico.WithTarball(c.Bool(tarballFlag.Name)),
 					calico.WithWindowsArchive(c.Bool(windowsArchiveFlagName)),

--- a/release/pkg/manager/calico/manager.go
+++ b/release/pkg/manager/calico/manager.go
@@ -1030,9 +1030,6 @@ func (r *CalicoManager) collectGithubArtifacts() error {
 	if err := r.collectOCPBundle(); err != nil {
 		return err
 	}
-	if err := r.collectE2EBinaries(); err != nil {
-		return err
-	}
 
 	// Generate a SHA256SUMS file containing the checksums for each artifact
 	// that we attach to the release. These can be confirmed by end users via the following command:
@@ -1113,45 +1110,6 @@ func (r *CalicoManager) collectOCPBundle() error {
 	uploadDir := r.uploadDir()
 	if _, err := r.runner.RunInDir(r.repoRoot, "cp", []string{"bin/ocp.tgz", uploadDir}, nil); err != nil {
 		return fmt.Errorf("failed to copy OCP bundle: %w", err)
-	}
-	return nil
-}
-
-// collectE2EBinaries flattens the staged e2e test binaries into the upload
-// directory. buildE2EBinaries stages them under files/e2e/ for the hashrelease
-// server, but GitHub release assets are flat and ghr does not recurse into
-// subdirectories, so a release needs a copy at the top level. Hard links keep
-// the duplicate free.
-func (r *CalicoManager) collectE2EBinaries() error {
-	if !r.e2eBinaries || r.isHashRelease {
-		return nil
-	}
-	uploadDir := r.uploadDir()
-	e2eDir := filepath.Join(uploadDir, "files", "e2e")
-	entries, err := os.ReadDir(e2eDir)
-	if err != nil {
-		return fmt.Errorf("reading staged e2e binaries: %w", err)
-	}
-	linked := 0
-	for _, entry := range entries {
-		if !strings.HasPrefix(entry.Name(), "e2e-linux-") {
-			continue
-		}
-		dst := filepath.Join(uploadDir, entry.Name())
-		// Replace any leftover from an earlier build of the same version, so a
-		// rerun behaves like the sibling collect steps, which copy over.
-		if err := os.Remove(dst); err != nil && !errors.Is(err, os.ErrNotExist) {
-			return fmt.Errorf("replacing e2e binary %s: %w", entry.Name(), err)
-		}
-		if err := os.Link(filepath.Join(e2eDir, entry.Name()), dst); err != nil {
-			return fmt.Errorf("linking e2e binary %s: %w", entry.Name(), err)
-		}
-		linked++
-	}
-	// An empty staging dir means the build produced nothing; shipping a release
-	// with --e2e-binaries enabled and no e2e assets should not pass silently.
-	if linked == 0 {
-		return fmt.Errorf("no e2e test binaries staged in %s", e2eDir)
 	}
 	return nil
 }
@@ -1271,6 +1229,17 @@ func (r *CalicoManager) buildReleaseTar() error {
 	return nil
 }
 
+// e2eStagingDir is where buildE2EBinaries puts the per-arch binaries.
+// Hashreleases serve a directory tree, so they go under files/e2e/. A release
+// attaches them to a GitHub release, whose assets are flat and which ghr
+// populates from the top level of the upload directory.
+func (r *CalicoManager) e2eStagingDir() string {
+	if r.isHashRelease {
+		return filepath.Join(r.uploadDir(), "files", "e2e")
+	}
+	return r.uploadDir()
+}
+
 func (r *CalicoManager) buildE2EBinaries() error {
 	logrus.Info("Building multi-arch e2e test binaries")
 	e2eDir := filepath.Join(r.repoRoot, "e2e")
@@ -1284,31 +1253,38 @@ func (r *CalicoManager) buildE2EBinaries() error {
 		return fmt.Errorf("failed to build e2e binaries: %w", err)
 	}
 
-	// Hard-link the built binaries into the hashrelease output directory
-	// to avoid duplicating ~1 GB of cross-compiled test binaries on disk.
-	e2eOutputDir := filepath.Join(r.uploadDir(), "files", "e2e")
+	// Hard-link the built binaries into the output directory to avoid
+	// duplicating ~1 GB of cross-compiled test binaries on disk.
+	e2eOutputDir := r.e2eStagingDir()
 	if err := os.MkdirAll(e2eOutputDir, 0o755); err != nil {
 		return fmt.Errorf("failed to create e2e output dir: %w", err)
 	}
-	entries, err := os.ReadDir(filepath.Join(e2eDir, "bin", "k8s"))
+	binDir := filepath.Join(e2eDir, "bin", "k8s")
+	entries, err := os.ReadDir(binDir)
 	if err != nil {
 		return fmt.Errorf("reading e2e bin directory: %w", err)
 	}
+	staged := 0
 	for _, entry := range entries {
 		if !strings.HasPrefix(entry.Name(), "e2e-linux-") {
 			continue
 		}
-		src := filepath.Join(e2eDir, "bin", "k8s", entry.Name())
 		dst := filepath.Join(e2eOutputDir, entry.Name())
 		// Replace a leftover link from an earlier build of the same version;
 		// os.Link fails outright on an existing destination.
 		if err := os.Remove(dst); err != nil && !errors.Is(err, os.ErrNotExist) {
 			return fmt.Errorf("replacing e2e binary %s: %w", entry.Name(), err)
 		}
-		if err := os.Link(src, dst); err != nil {
+		if err := os.Link(filepath.Join(binDir, entry.Name()), dst); err != nil {
 			return fmt.Errorf("linking e2e binary %s: %w", entry.Name(), err)
 		}
 		logrus.Infof("Staged e2e binary: %s", entry.Name())
+		staged++
+	}
+	// Nothing staged means the build produced no binaries; a release must not
+	// ship with --e2e-binaries enabled and no e2e assets.
+	if staged == 0 {
+		return fmt.Errorf("no e2e test binaries were produced in %s", binDir)
 	}
 	return nil
 }
@@ -1450,9 +1426,15 @@ Additional links:
 `
 	ver := version.New(r.calicoVersion)
 	sv := ver.Semver()
-	// Only advertise the e2e binaries when the build actually produced them.
+	// Advertise the e2e binaries based on what the build staged, not on
+	// r.e2eBinaries: that flag belongs to the build step and is never passed to
+	// publish, so it always reads as its default here.
 	e2eBinariesNote := ""
-	if r.e2eBinaries {
+	staged, err := filepath.Glob(filepath.Join(r.uploadDir(), "e2e-linux-*.test"))
+	if err != nil {
+		return fmt.Errorf("looking for staged e2e binaries: %w", err)
+	}
+	if len(staged) > 0 {
 		e2eBinariesNote = "\n- `e2e-linux-<arch>.test`: Version-matched Kubernetes e2e test binaries, one per architecture."
 	}
 	formatters := []string{
@@ -1487,8 +1469,7 @@ Additional links:
 		r.calicoVersion,
 		r.uploadDir(),
 	}
-	_, err := r.runner.RunInDir(r.repoRoot, "./bin/ghr", args, nil)
-	if err != nil {
+	if _, err := r.runner.RunInDir(r.repoRoot, "./bin/ghr", args, nil); err != nil {
 		return fmt.Errorf("failed to publish github release: %w", err)
 	}
 	return nil

--- a/release/pkg/manager/calico/manager.go
+++ b/release/pkg/manager/calico/manager.go
@@ -340,19 +340,19 @@ func (r *CalicoManager) Build() error {
 		} else {
 			logrus.Info("Skipping building windows archive")
 		}
-
-		// Build multi-arch e2e test binaries and copy them into the output directory.
-		if r.e2eBinaries {
-			if err = r.buildE2EBinaries(); err != nil {
-				return err
-			}
-		} else {
-			logrus.Info("Skipping building e2e test binaries")
-		}
 	} else {
 		if err = r.buildOCPBundle(); err != nil {
 			return err
 		}
+	}
+
+	// Build multi-arch e2e test binaries and copy them into the output directory.
+	if r.e2eBinaries {
+		if err = r.buildE2EBinaries(); err != nil {
+			return err
+		}
+	} else {
+		logrus.Info("Skipping building e2e test binaries")
 	}
 
 	// Build and add in the complete release tarball.
@@ -1030,6 +1030,9 @@ func (r *CalicoManager) collectGithubArtifacts() error {
 	if err := r.collectOCPBundle(); err != nil {
 		return err
 	}
+	if err := r.collectE2EBinaries(); err != nil {
+		return err
+	}
 
 	// Generate a SHA256SUMS file containing the checksums for each artifact
 	// that we attach to the release. These can be confirmed by end users via the following command:
@@ -1110,6 +1113,32 @@ func (r *CalicoManager) collectOCPBundle() error {
 	uploadDir := r.uploadDir()
 	if _, err := r.runner.RunInDir(r.repoRoot, "cp", []string{"bin/ocp.tgz", uploadDir}, nil); err != nil {
 		return fmt.Errorf("failed to copy OCP bundle: %w", err)
+	}
+	return nil
+}
+
+// collectE2EBinaries flattens the staged e2e test binaries into the upload
+// directory. buildE2EBinaries stages them under files/e2e/ for the hashrelease
+// server, but GitHub release assets are flat and ghr does not recurse into
+// subdirectories, so a release needs a copy at the top level. Hard links keep
+// the duplicate free.
+func (r *CalicoManager) collectE2EBinaries() error {
+	if !r.e2eBinaries || r.isHashRelease {
+		return nil
+	}
+	uploadDir := r.uploadDir()
+	e2eDir := filepath.Join(uploadDir, "files", "e2e")
+	entries, err := os.ReadDir(e2eDir)
+	if err != nil {
+		return fmt.Errorf("reading staged e2e binaries: %w", err)
+	}
+	for _, entry := range entries {
+		if !strings.HasPrefix(entry.Name(), "e2e-linux-") {
+			continue
+		}
+		if err := os.Link(filepath.Join(e2eDir, entry.Name()), filepath.Join(uploadDir, entry.Name())); err != nil {
+			return fmt.Errorf("linking e2e binary %s: %w", entry.Name(), err)
+		}
 	}
 	return nil
 }
@@ -1395,6 +1424,7 @@ Attached to this release are the following artifacts:
 - {helm_v1_crd_chart}: Calico crd.projectcalico.org/v1 CRD chart.
 - {helm_v3_crd_chart}: Calico projectcalico.org/v3 CRD chart (tech-preview).
 - ocp.tgz: Manifest bundle for OpenShift.
+- {e2e_binaries}: Version-matched Kubernetes e2e test binaries, one per architecture.
 
 Additional links:
 
@@ -1414,6 +1444,7 @@ Additional links:
 		"{helm_chart}", fmt.Sprintf("`%s-%s.tgz`", utils.TigeraOperatorChart, r.calicoVersion),
 		"{helm_v1_crd_chart}", fmt.Sprintf("`%s-%s.tgz`", utils.ProjectCalicoV1CRDsChart, r.calicoVersion),
 		"{helm_v3_crd_chart}", fmt.Sprintf("`%s-%s.tgz`", utils.ProjectCalicoV3CRDsChart, r.calicoVersion),
+		"{e2e_binaries}", "`e2e-linux-<arch>.test`",
 	}
 	replacer := strings.NewReplacer(formatters...)
 	releaseNote := replacer.Replace(releaseNoteTemplate)

--- a/release/pkg/manager/calico/manager.go
+++ b/release/pkg/manager/calico/manager.go
@@ -1132,13 +1132,26 @@ func (r *CalicoManager) collectE2EBinaries() error {
 	if err != nil {
 		return fmt.Errorf("reading staged e2e binaries: %w", err)
 	}
+	linked := 0
 	for _, entry := range entries {
 		if !strings.HasPrefix(entry.Name(), "e2e-linux-") {
 			continue
 		}
-		if err := os.Link(filepath.Join(e2eDir, entry.Name()), filepath.Join(uploadDir, entry.Name())); err != nil {
+		dst := filepath.Join(uploadDir, entry.Name())
+		// Replace any leftover from an earlier build of the same version, so a
+		// rerun behaves like the sibling collect steps, which copy over.
+		if err := os.Remove(dst); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("replacing e2e binary %s: %w", entry.Name(), err)
+		}
+		if err := os.Link(filepath.Join(e2eDir, entry.Name()), dst); err != nil {
 			return fmt.Errorf("linking e2e binary %s: %w", entry.Name(), err)
 		}
+		linked++
+	}
+	// An empty staging dir means the build produced nothing; shipping a release
+	// with --e2e-binaries enabled and no e2e assets should not pass silently.
+	if linked == 0 {
+		return fmt.Errorf("no e2e test binaries staged in %s", e2eDir)
 	}
 	return nil
 }
@@ -1287,6 +1300,11 @@ func (r *CalicoManager) buildE2EBinaries() error {
 		}
 		src := filepath.Join(e2eDir, "bin", "k8s", entry.Name())
 		dst := filepath.Join(e2eOutputDir, entry.Name())
+		// Replace a leftover link from an earlier build of the same version;
+		// os.Link fails outright on an existing destination.
+		if err := os.Remove(dst); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("replacing e2e binary %s: %w", entry.Name(), err)
+		}
 		if err := os.Link(src, dst); err != nil {
 			return fmt.Errorf("linking e2e binary %s: %w", entry.Name(), err)
 		}
@@ -1423,8 +1441,7 @@ Attached to this release are the following artifacts:
 - {helm_chart}: Calico Helm 3 chart (also hosted at oci://quay.io/calico/charts/tigera-operator).
 - {helm_v1_crd_chart}: Calico crd.projectcalico.org/v1 CRD chart.
 - {helm_v3_crd_chart}: Calico projectcalico.org/v3 CRD chart (tech-preview).
-- ocp.tgz: Manifest bundle for OpenShift.
-- {e2e_binaries}: Version-matched Kubernetes e2e test binaries, one per architecture.
+- ocp.tgz: Manifest bundle for OpenShift.{e2e_binaries}
 
 Additional links:
 
@@ -1433,6 +1450,11 @@ Additional links:
 `
 	ver := version.New(r.calicoVersion)
 	sv := ver.Semver()
+	// Only advertise the e2e binaries when the build actually produced them.
+	e2eBinariesNote := ""
+	if r.e2eBinaries {
+		e2eBinariesNote = "\n- `e2e-linux-<arch>.test`: Version-matched Kubernetes e2e test binaries, one per architecture."
+	}
 	formatters := []string{
 		// Alternating placeholder / filler. We can't use backticks in the multiline string above,
 		// so we replace anything that needs to be backticked into it here.
@@ -1444,7 +1466,7 @@ Additional links:
 		"{helm_chart}", fmt.Sprintf("`%s-%s.tgz`", utils.TigeraOperatorChart, r.calicoVersion),
 		"{helm_v1_crd_chart}", fmt.Sprintf("`%s-%s.tgz`", utils.ProjectCalicoV1CRDsChart, r.calicoVersion),
 		"{helm_v3_crd_chart}", fmt.Sprintf("`%s-%s.tgz`", utils.ProjectCalicoV3CRDsChart, r.calicoVersion),
-		"{e2e_binaries}", "`e2e-linux-<arch>.test`",
+		"{e2e_binaries}", e2eBinariesNote,
 	}
 	replacer := strings.NewReplacer(formatters...)
 	releaseNote := replacer.Replace(releaseNoteTemplate)

--- a/release/pkg/manager/calico/manager_test.go
+++ b/release/pkg/manager/calico/manager_test.go
@@ -467,106 +467,88 @@ func TestOwnerFromRemoteURL(t *testing.T) {
 	}
 }
 
-func TestCollectE2EBinaries(t *testing.T) {
+// The staging layout is the whole reason a release and a hashrelease differ:
+// ghr populates GitHub release assets from the top level of the upload dir and
+// does not recurse, while the hashrelease server serves the directory tree.
+func TestE2EStagingDir(t *testing.T) {
 	tests := []struct {
 		name          string
-		e2eBinaries   bool
 		isHashRelease bool
-		staged        []string
-		preexisting   []string
-		want          []string
-		wantErr       bool
+		want          string
+	}{
+		{name: "release stages flat for ghr", want: "out"},
+		{name: "hashrelease stages under files/e2e", isHashRelease: true, want: filepath.Join("out", "files", "e2e")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &CalicoManager{outputDir: "out", isHashRelease: tt.isHashRelease}
+			require.Equal(t, tt.want, r.e2eStagingDir())
+		})
+	}
+}
+
+// The e2e-binaries flag belongs to the build step and is never passed to
+// publish, so the release note has to key off what was actually staged.
+func TestPublishGithubReleaseE2ENote(t *testing.T) {
+	const bullet = "e2e-linux-<arch>.test"
+
+	tests := []struct {
+		name        string
+		staged      []string
+		e2eBinaries bool
+		wantNote    bool
 	}{
 		{
-			name:        "release flattens the staged binaries",
-			e2eBinaries: true,
+			name:        "staged binaries are listed",
 			staged:      []string{"e2e-linux-amd64.test", "e2e-linux-arm64.test"},
-			want:        []string{"e2e-linux-amd64.test", "e2e-linux-arm64.test"},
+			e2eBinaries: true,
+			wantNote:    true,
 		},
 		{
-			name:        "unrelated staged files are left behind",
+			name:        "nothing staged is not listed even with the flag defaulted on",
 			e2eBinaries: true,
-			staged:      []string{"e2e-linux-amd64.test", "notes.txt"},
-			want:        []string{"e2e-linux-amd64.test"},
+			wantNote:    false,
 		},
 		{
-			name:        "a rerun relinks over the previous build",
-			e2eBinaries: true,
+			name:        "staged binaries are listed even with the flag off",
 			staged:      []string{"e2e-linux-amd64.test"},
-			preexisting: []string{"e2e-linux-amd64.test"},
-			want:        []string{"e2e-linux-amd64.test"},
-		},
-		{
-			name:        "staging with no binaries errors",
-			e2eBinaries: true,
-			staged:      []string{"notes.txt"},
-			wantErr:     true,
-		},
-		{
-			name:        "empty staging errors",
-			e2eBinaries: true,
-			wantErr:     true,
-		},
-		{
-			name:          "hashrelease keeps only the files/e2e layout",
-			e2eBinaries:   true,
-			isHashRelease: true,
-			staged:        []string{"e2e-linux-amd64.test"},
-		},
-		{
-			name:        "disabled does nothing",
 			e2eBinaries: false,
-			staged:      []string{"e2e-linux-amd64.test"},
+			wantNote:    true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			outputDir := t.TempDir()
-			e2eDir := filepath.Join(outputDir, "files", "e2e")
-			require.NoError(t, os.MkdirAll(e2eDir, 0o755))
 			for _, name := range tt.staged {
-				require.NoError(t, os.WriteFile(filepath.Join(e2eDir, name), []byte(name), 0o755))
+				require.NoError(t, os.WriteFile(filepath.Join(outputDir, name), []byte(name), 0o755))
 			}
-			for _, name := range tt.preexisting {
-				require.NoError(t, os.WriteFile(filepath.Join(outputDir, name), []byte("stale"), 0o755))
-			}
+
+			f := newFakeRunner()
+			f.on("./bin/gh release view", "release not found", fmt.Errorf("release not found"))
+			f.on("./bin/ghr", "", nil)
 
 			r := &CalicoManager{
+				runner:        f,
+				githubRelease: true,
 				e2eBinaries:   tt.e2eBinaries,
-				isHashRelease: tt.isHashRelease,
+				calicoVersion: "v3.30.0",
+				githubOrg:     "projectcalico",
+				repo:          "calico",
 				outputDir:     outputDir,
 			}
-			err := r.collectE2EBinaries()
-			if tt.wantErr {
-				require.Error(t, err)
-				return
-			}
-			require.NoError(t, err)
+			require.NoError(t, r.publishGithubRelease())
 
-			entries, err := os.ReadDir(outputDir)
-			require.NoError(t, err)
-			var got []string
-			for _, entry := range entries {
-				if !entry.IsDir() {
-					got = append(got, entry.Name())
+			var ghr string
+			for _, c := range f.calls {
+				if strings.HasPrefix(c, "./bin/ghr") {
+					ghr = c
 				}
 			}
-			require.ElementsMatch(t, tt.want, got)
-
-			// A collected binary must carry the staged content, not a stale leftover.
-			for _, name := range tt.want {
-				content, err := os.ReadFile(filepath.Join(outputDir, name))
-				require.NoError(t, err)
-				require.Equal(t, name, string(content))
-			}
+			require.NotEmpty(t, ghr, "ghr was not invoked (calls: %v)", f.calls)
+			require.Equal(t, tt.wantNote, strings.Contains(ghr, bullet),
+				"release note mentions %q = %v, want %v", bullet, strings.Contains(ghr, bullet), tt.wantNote)
 		})
 	}
-}
-
-// A missing files/e2e directory means the build never staged anything, which
-// would otherwise ship a release with no e2e binaries and no warning.
-func TestCollectE2EBinariesUnstagedErrors(t *testing.T) {
-	r := &CalicoManager{e2eBinaries: true, outputDir: t.TempDir()}
-	require.Error(t, r.collectE2EBinaries())
 }

--- a/release/pkg/manager/calico/manager_test.go
+++ b/release/pkg/manager/calico/manager_test.go
@@ -16,8 +16,12 @@ package calico
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 // fakeResult is the canned response for a matched command.
@@ -461,4 +465,73 @@ func TestOwnerFromRemoteURL(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestCollectE2EBinaries(t *testing.T) {
+	tests := []struct {
+		name          string
+		e2eBinaries   bool
+		isHashRelease bool
+		staged        []string
+		want          []string
+	}{
+		{
+			name:        "release flattens the staged binaries",
+			e2eBinaries: true,
+			staged:      []string{"e2e-linux-amd64.test", "e2e-linux-arm64.test"},
+			want:        []string{"e2e-linux-amd64.test", "e2e-linux-arm64.test"},
+		},
+		{
+			name:        "unrelated staged files are left behind",
+			e2eBinaries: true,
+			staged:      []string{"e2e-linux-amd64.test", "notes.txt"},
+			want:        []string{"e2e-linux-amd64.test"},
+		},
+		{
+			name:          "hashrelease keeps only the files/e2e layout",
+			e2eBinaries:   true,
+			isHashRelease: true,
+			staged:        []string{"e2e-linux-amd64.test"},
+		},
+		{
+			name:        "disabled does nothing",
+			e2eBinaries: false,
+			staged:      []string{"e2e-linux-amd64.test"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			outputDir := t.TempDir()
+			e2eDir := filepath.Join(outputDir, "files", "e2e")
+			require.NoError(t, os.MkdirAll(e2eDir, 0o755))
+			for _, name := range tt.staged {
+				require.NoError(t, os.WriteFile(filepath.Join(e2eDir, name), []byte(name), 0o755))
+			}
+
+			r := &CalicoManager{
+				e2eBinaries:   tt.e2eBinaries,
+				isHashRelease: tt.isHashRelease,
+				outputDir:     outputDir,
+			}
+			require.NoError(t, r.collectE2EBinaries())
+
+			entries, err := os.ReadDir(outputDir)
+			require.NoError(t, err)
+			var got []string
+			for _, entry := range entries {
+				if !entry.IsDir() {
+					got = append(got, entry.Name())
+				}
+			}
+			require.ElementsMatch(t, tt.want, got)
+		})
+	}
+}
+
+// A missing files/e2e directory means the build never staged anything, which
+// would otherwise ship a release with no e2e binaries and no warning.
+func TestCollectE2EBinariesUnstagedErrors(t *testing.T) {
+	r := &CalicoManager{e2eBinaries: true, outputDir: t.TempDir()}
+	require.Error(t, r.collectE2EBinaries())
 }

--- a/release/pkg/manager/calico/manager_test.go
+++ b/release/pkg/manager/calico/manager_test.go
@@ -473,7 +473,9 @@ func TestCollectE2EBinaries(t *testing.T) {
 		e2eBinaries   bool
 		isHashRelease bool
 		staged        []string
+		preexisting   []string
 		want          []string
+		wantErr       bool
 	}{
 		{
 			name:        "release flattens the staged binaries",
@@ -486,6 +488,24 @@ func TestCollectE2EBinaries(t *testing.T) {
 			e2eBinaries: true,
 			staged:      []string{"e2e-linux-amd64.test", "notes.txt"},
 			want:        []string{"e2e-linux-amd64.test"},
+		},
+		{
+			name:        "a rerun relinks over the previous build",
+			e2eBinaries: true,
+			staged:      []string{"e2e-linux-amd64.test"},
+			preexisting: []string{"e2e-linux-amd64.test"},
+			want:        []string{"e2e-linux-amd64.test"},
+		},
+		{
+			name:        "staging with no binaries errors",
+			e2eBinaries: true,
+			staged:      []string{"notes.txt"},
+			wantErr:     true,
+		},
+		{
+			name:        "empty staging errors",
+			e2eBinaries: true,
+			wantErr:     true,
 		},
 		{
 			name:          "hashrelease keeps only the files/e2e layout",
@@ -508,13 +528,21 @@ func TestCollectE2EBinaries(t *testing.T) {
 			for _, name := range tt.staged {
 				require.NoError(t, os.WriteFile(filepath.Join(e2eDir, name), []byte(name), 0o755))
 			}
+			for _, name := range tt.preexisting {
+				require.NoError(t, os.WriteFile(filepath.Join(outputDir, name), []byte("stale"), 0o755))
+			}
 
 			r := &CalicoManager{
 				e2eBinaries:   tt.e2eBinaries,
 				isHashRelease: tt.isHashRelease,
 				outputDir:     outputDir,
 			}
-			require.NoError(t, r.collectE2EBinaries())
+			err := r.collectE2EBinaries()
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
 
 			entries, err := os.ReadDir(outputDir)
 			require.NoError(t, err)
@@ -525,6 +553,13 @@ func TestCollectE2EBinaries(t *testing.T) {
 				}
 			}
 			require.ElementsMatch(t, tt.want, got)
+
+			// A collected binary must carry the staged content, not a stale leftover.
+			for _, name := range tt.want {
+				content, err := os.ReadFile(filepath.Join(outputDir, name))
+				require.NoError(t, err)
+				require.Equal(t, name, string(content))
+			}
 		})
 	}
 }


### PR DESCRIPTION
> [!NOTE]
> **Stale pending a re-pick.** Master (#13566) has since changed approach on review
> feedback: the binaries now ship inside the release archive at `bin/e2e/` plus an
> S3 copy at `<version>/files/e2e/`, instead of flat GitHub release assets. This
> branch still carries the flat-asset version described below, and will be
> re-picked once #13566 settles. The sizing note below applies to the flat-asset
> approach only.

Backport of #13566 to `release-v3.33`.

## Description

Official releases on this branch publish no e2e test binaries. Hashreleases carry
them, and CI downloads them from there, but a released version has nothing to
fetch. `Build()` only built them for hashreleases, `release build` never received
`WithE2EBinaries`, and `collectGithubArtifacts()` never collected `files/e2e/`
(which `ghr` would skip anyway, since it does not recurse).

A release now attaches `e2e-linux-<arch>.test` as flat assets. `buildE2EBinaries()`
still stages under `files/e2e/` for the hashrelease server; `collectE2EBinaries()`
hard-links those into the upload directory for a release. `SHA256SUMS` is generated
after the collect calls, so the new assets are covered.

The second commit fixes upgrade runs fetching the wrong stream: the pipelines set
`RELEASE_STREAM` to the downlevel version they install first, so `run_tests.sh` was
downloading the v3.29 suite to test v3.33. v3.29 publishes no e2e binary, so it
404'd on a bare `curl` failure. Both runners now prefer `UPLEVEL_RELEASE_STREAM`,
set to `v3.33` here. v3.32 already fixed this in #13517.

### Backport notes

Two hand resolutions, both because this branch's `manager_test.go` is smaller than
master's:

- `TestCutPlanAdvancesMain` and `TestRequireOnMainBranch` came across with the
  pick but are master-only (branch-cut rework, #13529 — `cutPlan` and
  `requireOnMainBranch` don't exist here). Dropped.
- Added the `github.com/stretchr/testify/require` import, which master's test file
  already had.

`UPLEVEL_RELEASE_STREAM` is `v3.33` rather than master's `master`.

## Testing

- `make -C release ut` passes, including the new `collectE2EBinaries()` cases.
- `bin/release release build --help` lists `--[no-]e2e-binaries`.
- `bash -n` on both `run_tests.sh` copies; both changed pipeline YAMLs parse.
- `curl` confirms `v3.33.txt` resolves on the hashrelease server, so the
  upgrade-lane stream is valid.

**Release note:**
```release-note
Official releases now attach version-matched Kubernetes e2e test binaries (e2e-linux-<arch>.test) as release assets.
```


## Sizing — the main call for reviewers

The arch set follows `--arch`, which defaults to all four, so a release gains roughly **800 MB** across `amd64`, `arm64`, `ppc64le`, `s390x` (~191 MB each, measured from a current master hashrelease).

For context, `v3.31.1` already ships ~1.7 GB of assets: a 1,070 MB `release-v3.31.1.tgz` plus seven calicoctl binaries at 77-83 MB each. So this is proportionate rather than a step change, but it is a visible addition to every public release page and worth an explicit yes.

Two things you may want changed:

- **Trim to amd64+arm64** (~390 MB). Those are the only two CI can run — `run_tests.sh` maps `uname -m` to just those. The cost is a GA/hashrelease divergence, which is why I did not do it unilaterally.
- **Release build time** grows by a four-arch e2e cross-compile. `--no-e2e-binaries` opts out, and the release note bullet is conditional on it.

