### PR TITLE
[release-v3.31] Backport v3.32 Windows e2e pipeline (operator install on Azure)

### DIFF
--- a/.argoci/cron/e2e-windows.yaml
+++ b/.argoci/cron/e2e-windows.yaml
@@ -9,7 +9,8 @@ globalPrologue: |
   export ARGO_WORKFLOW_UID="{{workflow.uid}}"
   export CREATE_WINDOWS_NODES="${CREATE_WINDOWS_NODES-true}"
   export FUNCTIONAL_AREA="${FUNCTIONAL_AREA-windows.yml}"
-  export K8S_E2E_FLAGS="${K8S_E2E_FLAGS---ginkgo.focus=\[sig-calico\].*\[RunsOnWindows\]}"
+  export INSTALLER="${INSTALLER-operator}"
+  export K8S_E2E_FLAGS="${K8S_E2E_FLAGS---ginkgo.focus=(\[sig-calico\].*\[RunsOnWindows\]) --ginkgo.skip=(\[LinuxOnly\])}"
   export PRIVATE_REGISTRY="${PRIVATE_REGISTRY-quay.io/}"
   export USE_PRIVATE_REGISTRY="${USE_PRIVATE_REGISTRY-true}"
   source .argoci/scripts/global_prologue.sh
@@ -19,43 +20,7 @@ defaults:
   secretBundles:
     - banzai-secrets
 steps:
-  - name: calico-windows-aws-kubeadm-1809-stable-3-iptables-none
-    services:
-      - docker
-      - http-cache-proxy
-    env:
-      - name: DATAPLANE
-        value: CalicoIptables
-      - name: ENCAPSULATION_TYPE
-        value: None
-      - name: K8S_VERSION
-        value: stable-3
-      - name: PROVISIONER
-        value: aws-kubeadm
-      - name: VPC_SUBNETS
-        value: '["172.16.101.0/24"]'
-      - name: WINDOWS_OS_VERSION
-        value: "1809"
-    commands: |
-      .argoci/scripts/body_standard.sh
-  - name: calico-windows-gcp-kubeadm-2022-stable-bpf-vxlan
-    services:
-      - docker
-      - http-cache-proxy
-    env:
-      - name: DATAPLANE
-        value: CalicoBPF
-      - name: ENCAPSULATION_TYPE
-        value: VXLAN
-      - name: K8S_VERSION
-        value: stable
-      - name: PROVISIONER
-        value: gcp-kubeadm
-      - name: WINDOWS_OS_VERSION
-        value: "2022"
-    commands: |
-      .argoci/scripts/body_standard.sh
-  - name: calico-windows-gcp-rancher-2022-stable-1-nftables-vxlan
+  - name: calico-windows-azr-aso-2022-stable-1-nftables-vxlan
     services:
       - docker
       - http-cache-proxy
@@ -65,12 +30,29 @@ steps:
       - name: ENCAPSULATION_TYPE
         value: VXLAN
       - name: K8S_VERSION
-        value: v1.32.7
+        value: stable-1
       - name: PROVISIONER
-        value: gcp-rancher
-      - name: RKE_VERSION
-        value: v1.8.6
-      - name: WINDOWS_OS_VERSION
+        value: azr-aso
+      - name: WINDOWS_OS
+        value: "2022"
+    commands: |
+      .argoci/scripts/body_standard.sh
+  - name: calico-windows-azr-aks-2022-stable-1-iptables-no-encap-azure-cni
+    services:
+      - docker
+      - http-cache-proxy
+    env:
+      - name: DATAPLANE
+        value: CalicoIptables
+      - name: ENCAPSULATION_TYPE
+        value: None
+      - name: K8S_VERSION
+        value: stable-1
+      - name: PROVISIONER
+        value: azr-aks
+      - name: USE_VENDORED_CNI
+        value: "true"
+      - name: WINDOWS_OS
         value: "2022"
     commands: |
       .argoci/scripts/body_standard.sh

--- a/.semaphore/end-to-end/pipelines/windows.yml
+++ b/.semaphore/end-to-end/pipelines/windows.yml
@@ -24,88 +24,87 @@ global_job_config:
     - name: CREATE_WINDOWS_NODES
       value: "true"
     - name: K8S_E2E_FLAGS
-      value: --ginkgo.focus=\[sig-calico\].*\[RunsOnWindows\]
+      value: --ginkgo.focus=(\[sig-calico\].*\[RunsOnWindows\]) --ginkgo.skip=(\[LinuxOnly\])
     - name: FUNCTIONAL_AREA
       value: "windows.yml"
     - name: USE_PRIVATE_REGISTRY
       value: "true"
     - name: PRIVATE_REGISTRY
       value: "quay.io/"
+    - name: INSTALLER
+      value: "operator"
 
 # Dimensions
-# Provisioners: aws-kubeadm, gcp-kubeadm, rancher
+# Provisioners: azr-aso, azr-aks
 # Installer: operator
-# Windows OS: Windows Server 1809, Windows Server 2022
-# k8s Versions: stable-3, stable-1, stable
+# Windows OS: Windows Server 2022
+# k8s Versions: stable-1, stable
 # linux dataplane: bpf, iptables, nftables
-# encapsulation: vxlan, none
+# encapsulation: vxlan, no-encap
+# CNI: Calico, Azure CNI
 
 # Runs:
-# aws-kubeadm, 1809, stable-3, iptables, none
-# gcp-kubeadm, 2022, stable, bpf, vxlan
-# gcp-rancher, 2022, stable-1, nftables, none
+# azr-aso, 2022, stable, bpf, vxlan
+# azr-aso, 2022, stable-1, nftables, vxlan
+# azr-aks, 2022, stable-1, iptables, no-encap, azure CNI
 
 blocks:
   - name: Calico Windows
     dependencies: []
     task:
       jobs:
-        - name: aws-kubeadm, 1809, stable-3, iptables, none
+        - name: "azr-aso, 2022, stable, bpf, vxlan"
           execution_time_limit:
             hours: 5
           commands:
             - ~/calico/.semaphore/end-to-end/scripts/body_standard.sh
           env_vars:
             - name: PROVISIONER
-              value: aws-kubeadm
-            - name: WINDOWS_OS_VERSION
-              value: "1809"
+              value: azr-aso
             - name: K8S_VERSION
-              value: stable-3
-            - name: DATAPLANE
-              value: CalicoIptables
-            - name: ENCAPSULATION_TYPE
-              value: None
-            - name: VPC_SUBNETS
-              value: '["172.16.101.0/24"]' # single subnet because no encapsulation is being used
-
-        - name: gcp-kubeadm, 2022, stable, bpf, vxlan
-          execution_time_limit:
-            hours: 5
-          commands:
-            - ~/calico/.semaphore/end-to-end/scripts/body_standard.sh
-          env_vars:
-            - name: PROVISIONER
-              value: gcp-kubeadm
-            - name: WINDOWS_OS_VERSION
-              value: "2022"
-            - name: K8S_VERSION
-              value: stable
+              value: stable-1
             - name: DATAPLANE
               value: CalicoBPF
             - name: ENCAPSULATION_TYPE
               value: VXLAN
+            - name: WINDOWS_OS
+              value: "2022"
 
-        - name: gcp-rancher, 2022, stable-1, nftables, vxlan
+        - name: "azr-aso, 2022, stable-1, nftables, vxlan"
           execution_time_limit:
             hours: 5
           commands:
             - ~/calico/.semaphore/end-to-end/scripts/body_standard.sh
           env_vars:
             - name: PROVISIONER
-              value: gcp-rancher
-            - name: WINDOWS_OS_VERSION
-              value: "2022"
+              value: azr-aso
             - name: K8S_VERSION
               value: stable-1
             - name: DATAPLANE
               value: CalicoNftables
             - name: ENCAPSULATION_TYPE
               value: VXLAN
-            - name: RKE_VERSION # Don't just update these versions, need k8s and rke versions to match.
-              value: "v1.8.6" # https://github.com/rancher/rke/releases/tag/v1.8.6
+            - name: WINDOWS_OS
+              value: "2022"
+
+        - name: "azr-aks, 2022, stable-1, iptables, no encap, azure CNI"
+          execution_time_limit:
+            hours: 5
+          commands:
+            - ~/calico/.semaphore/end-to-end/scripts/body_standard.sh
+          env_vars:
+            - name: PROVISIONER
+              value: azr-aks
             - name: K8S_VERSION
-              value: "v1.32.7" # RKE 1.8.6 supports: v1.30.14-rancher1-1, v1.31.11-rancher1-1, v1.32.7-rancher1-1
+              value: stable-1
+            - name: DATAPLANE
+              value: CalicoIptables
+            - name: ENCAPSULATION_TYPE
+              value: "None"
+            - name: WINDOWS_OS
+              value: "2022"
+            - name: USE_VENDORED_CNI
+              value: "true"
 
 promotions:
   - name: Cleanup jobs

--- a/.semaphore/end-to-end/pipelines/windows.yml
+++ b/.semaphore/end-to-end/pipelines/windows.yml
@@ -38,13 +38,13 @@ global_job_config:
 # Provisioners: azr-aso, azr-aks
 # Installer: operator
 # Windows OS: Windows Server 2022
-# k8s Versions: stable-1, stable
+# k8s Versions: stable-1
 # linux dataplane: bpf, iptables, nftables
 # encapsulation: vxlan, no-encap
 # CNI: Calico, Azure CNI
 
 # Runs:
-# azr-aso, 2022, stable, bpf, vxlan
+# azr-aso, 2022, stable-1, bpf, vxlan
 # azr-aso, 2022, stable-1, nftables, vxlan
 # azr-aks, 2022, stable-1, iptables, no-encap, azure CNI
 
@@ -53,7 +53,7 @@ blocks:
     dependencies: []
     task:
       jobs:
-        - name: "azr-aso, 2022, stable, bpf, vxlan"
+        - name: "azr-aso, 2022, stable-1, bpf, vxlan"
           execution_time_limit:
             hours: 5
           commands:

--- a/.semaphore/end-to-end/pipelines/windows.yml
+++ b/.semaphore/end-to-end/pipelines/windows.yml
@@ -39,12 +39,11 @@ global_job_config:
 # Installer: operator
 # Windows OS: Windows Server 2022
 # k8s Versions: stable-1
-# linux dataplane: bpf, iptables, nftables
+# linux dataplane: iptables, nftables
 # encapsulation: vxlan, no-encap
 # CNI: Calico, Azure CNI
 
 # Runs:
-# azr-aso, 2022, stable-1, bpf, vxlan
 # azr-aso, 2022, stable-1, nftables, vxlan
 # azr-aks, 2022, stable-1, iptables, no-encap, azure CNI
 
@@ -53,23 +52,6 @@ blocks:
     dependencies: []
     task:
       jobs:
-        - name: "azr-aso, 2022, stable-1, bpf, vxlan"
-          execution_time_limit:
-            hours: 5
-          commands:
-            - ~/calico/.semaphore/end-to-end/scripts/body_standard.sh
-          env_vars:
-            - name: PROVISIONER
-              value: azr-aso
-            - name: K8S_VERSION
-              value: stable-1
-            - name: DATAPLANE
-              value: CalicoBPF
-            - name: ENCAPSULATION_TYPE
-              value: VXLAN
-            - name: WINDOWS_OS
-              value: "2022"
-
         - name: "azr-aso, 2022, stable-1, nftables, vxlan"
           execution_time_limit:
             hours: 5


### PR DESCRIPTION
## Description

The Windows e2e jobs on release-v3.31 still use the legacy manual installer flow (`INSTALLER` unset, defaulting to `manual`) on gcp-kubeadm/aws-kubeadm, where Windows nodes are provisioned via the old `create-nodes-old` zip install. That flow is broken: Windows nodes never join the cluster and all suites hang at provisioning for the full 45-minute wait, blocking the v3.31.7 release (both the Aug 15 and Aug 18 runs failed identically on gcp-kubeadm/BPF and aws-kubeadm/iptables).

This backports `windows.yml` from release-v3.32 (CORE-12132), which moved Windows e2es to operator-based hostprocess install on `azr-aso`/`azr-aks` provisioners.

Deviations from the v3.32 file, to keep this a windows.yml-only change with no script or e2e test code backports:

- keep machine type `c1-standard-1` (matches this branch's prologue, which gates pip3/gcloud/putty-tools setup on `c1-*` machines)
- drop `RUN_LOCAL_TESTS`, which this branch's `body_standard.sh` does not support; tests run via the standard `bz tests` path

Notes for reviewers:

- The Windows tests will run from this branch's e2e code, which lacks the Windows-gated conncheck fixes from CORE-12132 (longer image-pull timeouts, simplified TCP probe). Some `[RunsOnWindows]` cases may flake for already-fixed reasons; those can be cherry-picked separately if needed.
- With the manual-install pipeline removed from CI, the `node/windows-packaging/CalicoWindows/cni.conf.template` change in this patch release no longer has e2e coverage of the zip/manual install path.

## Related issues/PRs

Backport of the windows.yml portion of f6d4e50f46 (CORE-12132) plus follow-ups already on release-v3.32.

## Release Note

```release-note
None required. CI-only change.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)