### PR TITLE
Add an AI-assisted contribution policy

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -176,6 +176,15 @@ Per-area sub-designs carry area-specific test conventions on top of this rule
 
 Every PR needs one docs label (`docs-pr-required`, `docs-completed`, or `docs-not-required`) and one release note label (`release-note-required` or `release-note-not-required`). Optional: `cherry-pick-candidate` (bug fix backports), `needs-operator-pr` (requires operator change).
 
+## AI-assisted contribution policy
+
+[`AI_POLICY.md`](../AI_POLICY.md) at the repo root governs contributions written with AI assistance. The parts that affect what you produce:
+
+- The PR description discloses the assistance - the PR template has an **AI assistance** line for it.
+- Never add an AI co-author or `Assisted-By:` trailer to a commit.
+- The human author has to be able to explain the change without you, so leave the code and the PR description in a state they can defend.
+- Don't reply to review comments on their behalf.
+
 ## Additional Resources
 
 - **Developer Guide:** `DEVELOPER_GUIDE.md`

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,7 +7,7 @@ why it should be merged, testing done, and links to related issues. -->
 TBD
 ```
 
-<!-- If AI tools helped write this change, say so here. -->
-**AI assistance:** None.
+<!-- Replace TBD: say what AI tools helped write this change, or "None". -->
+**AI assistance:** TBD
 
 By opening this PR you take responsibility for every line in it, and you agree to explain the change yourself during review rather than routing review comments back through an agent. See [AI_POLICY.md](../AI_POLICY.md).

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,3 +6,8 @@ why it should be merged, testing done, and links to related issues. -->
 ```release-note
 TBD
 ```
+
+<!-- If AI tools helped write this change, say so here. -->
+**AI assistance:** None.
+
+By opening this PR you take responsibility for every line in it, and you agree to explain the change yourself during review rather than routing review comments back through an agent. See [AI_POLICY.md](../AI_POLICY.md).

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -242,6 +242,15 @@ make image                   # Build all images (slow)
 
 Every PR needs one docs label (`docs-pr-required`, `docs-completed`, or `docs-not-required`) and one release note label (`release-note-required` or `release-note-not-required`). Optional: `cherry-pick-candidate` (bug fix backports), `needs-operator-pr` (requires operator change).
 
+## AI-assisted contribution policy
+
+[`AI_POLICY.md`](../AI_POLICY.md) at the repo root governs contributions written with AI assistance. The parts that affect what you produce:
+
+- The PR description discloses the assistance - the PR template has an **AI assistance** line for it.
+- Never add an AI co-author or `Assisted-By:` trailer to a commit.
+- The human author has to be able to explain the change without you, so leave the code and the PR description in a state they can defend.
+- Don't reply to review comments on their behalf.
+
 ## Documentation map
 
 Calico's docs are split by purpose. Architecture lives in

--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -1,0 +1,36 @@
+# Using AI tools to contribute to Calico
+
+AI tools are welcome here. Plenty of us use them. This policy sets the floor for using them on contributions to this repository - code, docs, issues, and reviews alike. It is deliberately short, and it borrows heavily from the Kubernetes project's [approach to the same problem](https://kubernetes.io/blog/2026/06/26/open-source-maintainership-in-the-age-of-ai/).
+
+## You are responsible for your change
+
+The person who opens a pull request owns every line in it, whether they typed it or an agent did. "That's what the AI generated" is not an answer to review feedback.
+
+## Say when AI helped
+
+Note it in the PR description. One line is enough:
+
+> This PR was written in part with the assistance of generative AI.
+
+Don't credit AI tools as commit co-authors (`Co-Authored-By:`, `Assisted-By:`, and similar trailers). Our CLA is an agreement between humans, and a co-author who can't sign it will block your PR.
+
+## Reviews happen between humans
+
+Reviewers are here to talk to you, not to your agent. You need to be able to explain what your change does and why, in your own words. If you can't, expect the reviewer to close the PR.
+
+Using an agent to help draft a reply is fine. Handing over the review thread to one is not.
+
+## Understand it before you push
+
+Working code isn't the bar - understood code is. Before you open the PR:
+
+- read the whole diff yourself, including the parts you didn't write
+- run the tests that cover the change, and add tests for new behavior
+- confirm generated files came out of `make generate` rather than being hand-edited
+- check that the change fits the design docs for the components it touches, and update them if it doesn't
+
+Agents are especially prone to inventing plausible-looking tests that assert nothing, and to "fixing" a test by loosening its assertion. Read your test diffs closely.
+
+## Automated review bots
+
+Comments from review bots are advisory. A human maintainer still approves and merges, and you're free to disagree with a bot and say why.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,10 @@ for both you and your reviewer!
 Simple bug fixes can just be raised as a pull request. Make sure you describe the bug in the pull request description,
 and please try to reproduce the bug in a unit test. This will help ensure the bug stays fixed!
 
+### Did AI tools help write it?
+
+That's fine, and it doesn't change the process below. It does mean you should read [AI_POLICY.md](AI_POLICY.md) first: you are responsible for every line you submit, you need to disclose the assistance in the PR description, and you need to be able to explain the change yourself during review.
+
 ### Writing, testing, and building the code
 
 For more detailed information on the development process for Calico, see the [developer guide](DEVELOPER_GUIDE.md).

--- a/charts/CLAUDE.md
+++ b/charts/CLAUDE.md
@@ -18,3 +18,7 @@ between charts, adding or removing a manual step, renaming a chart, and changing
 a documented values key or example command.
 
 See [`.github/instructions/helm-charts.instructions.md`](../.github/instructions/helm-charts.instructions.md).
+
+## AI-assisted contribution policy
+
+Contributions written with AI assistance follow [`AI_POLICY.md`](../AI_POLICY.md): disclose the assistance in the PR description, no AI co-author trailers, and leave the change in a state the human author can explain themselves.

--- a/felix/CLAUDE.md
+++ b/felix/CLAUDE.md
@@ -103,3 +103,7 @@ Felix parameters are declared in `config/config_params.go` with types and valida
 ## Design and review criteria
 
 Architecture, invariants, and review criteria live in the design index [`felix/DESIGN.md`](./DESIGN.md) and the per-topic sub-designs under [`felix/design/`](./design/). Path-scoped Copilot rules that reference each sub-design live under [`.github/instructions/`](../.github/instructions/). Do not look here for dataplane invariants, calc-graph internals, or rule-generation rules — look in the matching sub-design.
+
+## AI-assisted contribution policy
+
+Contributions written with AI assistance follow [`AI_POLICY.md`](../AI_POLICY.md): disclose the assistance in the PR description, no AI co-author trailers, and leave the change in a state the human author can explain themselves.

--- a/goldmane/CLAUDE.md
+++ b/goldmane/CLAUDE.md
@@ -201,3 +201,7 @@ Architecture and invariants live in
 [`goldmane/DESIGN.md`](./DESIGN.md). Do not look here for gRPC
 service shapes, BucketRing semantics, Prometheus metric meanings,
 or env var contracts — look there.
+
+## AI-assisted contribution policy
+
+Contributions written with AI assistance follow [`AI_POLICY.md`](../AI_POLICY.md): disclose the assistance in the PR description, no AI co-author trailers, and leave the change in a state the human author can explain themselves.


### PR DESCRIPTION
We're seeing a lot of AI-generated PRs, and right now the project doesn't say anything about what we expect from them. This adds a short `AI_POLICY.md` at the repo root as a starting point, modeled on the [Kubernetes policy](https://kubernetes.io/blog/2026/06/26/open-source-maintainership-in-the-age-of-ai/).

The part I care most about: reviewers expect to engage with humans. If you can't explain a change you submitted, the PR gets closed. The rest is disclosure in the PR description, no AI co-author trailers (they can't sign the CLA), and read your own diff before pushing.

Linked from `CONTRIBUTING.md`, summarized in the PR template with a new **AI assistance** field, and pointed at from the in-repo agent instruction files (`.claude/CLAUDE.md`, `.github/copilot-instructions.md`, and the per-component `CLAUDE.md` files).

Happy to argue about any of the wording - I'd rather land something short now and tighten it than keep having this conversation per-PR.

(OH and by the way, I used Claude to help write this) 

```release-note
None
```
