### PR TITLE
[v3.33] BPF QoS connlimit: fix connlimit slot permanently lost on spurious TCP RST; BPF QoS connlimit: gate egress connlimit check on EGRESS_CONN_LIMIT_CONFIGURED; BPF QoS connlimit: cover connlimit first SYN, IPv6 and dual-stack in unit tests

### DIFF
--- a/felix/bpf-gpl/conntrack.h
+++ b/felix/bpf-gpl/conntrack.h
@@ -1095,6 +1095,16 @@ static CALI_BPF_INLINE struct calico_ct_result calico_ct_lookup(struct cali_tc_c
 				 * likely established and the RST was spurious.
 				 */
 				tracking_v->rst_seen = 0;
+
+				/* The RST also decremented the connlimit counter and
+				 * claimed CONNLIMIT_DEC below. The recount has since
+				 * restored the slot, so that claim is stale: release it,
+				 * or this connection's real close finds the latch taken
+				 * and frees its slot only at recount speed. Atomic AND to
+				 * match the atomic OR that claims it -- a byte-wide RMW
+				 * on flags3 would race with a claim on another CPU.
+				 */
+				__sync_fetch_and_and(&v->type_flags_word, ~(__u32)CALI_CT_FLAG_CONNLIMIT_DEC);
 			}
 		}
 		ct_tcp_entry_update(ctx, tcp_header, src_to_dst, dst_to_src);

--- a/felix/bpf-gpl/tc.c
+++ b/felix/bpf-gpl/tc.c
@@ -1570,8 +1570,15 @@ int calico_tc_skb_new_flow_entrypoint(struct __sk_buff *skb)
 	/* Check egress connection limit for new TCP connections from WEP.
 	 * Atomically check the limit and increment the counter in the QoS map.
 	 * The Go-side CT scanner periodically recounts and corrects drift.
+	 *
+	 * Gated on EGRESS_CONN_LIMIT_CONFIGURED to match the CONNLIMIT_EGRESS
+	 * stamp below and the ingress check. Felix writes the cali_qos_conn
+	 * entry before the program is reattached with the new global, so
+	 * without this a connection opened in that window is counted but not
+	 * stamped, and nothing can decrement it until the next recount.
 	 */
 	if (CALI_F_FROM_WEP && state->ip_proto == IPPROTO_TCP &&
+			EGRESS_CONN_LIMIT_CONFIGURED &&
 			!(state->flags & CALI_ST_SUPPRESS_CT_STATE)) {
 		if (qos_connlimit_check_and_increment(ctx) < 0) {
 			CALI_DEBUG("Egress connection limit exceeded, rejecting with TCP RST");

--- a/felix/bpf/conntrack/connlimit_scanner.go
+++ b/felix/bpf/conntrack/connlimit_scanner.go
@@ -20,7 +20,6 @@ import (
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
 
-	ctv4 "github.com/projectcalico/calico/felix/bpf/conntrack/v4"
 	"github.com/projectcalico/calico/felix/bpf/maps"
 	"github.com/projectcalico/calico/felix/bpf/qos"
 )
@@ -134,15 +133,19 @@ func (s *ConnLimitScanner) Check(ctKey KeyInterface, ctVal ValueInterface, get E
 
 	data := ctVal.Data()
 
-	// Skip connections that are closing or closed (any FIN or RST),
-	// or already decremented by the BPF fast path. The CONNLIMIT_DEC
-	// flag is set when the BPF program decrements the counter on
-	// FIN/RST; if we counted these entries, the scanner's recount
-	// would overwrite the decremented value with a higher one.
+	// Skip connections that are closing or closed (any FIN or RST):
+	// the fast path decremented when it saw the close, or the cleanup
+	// path will when the entry expires, so counting them here would
+	// overwrite the decremented value with a higher one.
+	//
+	// Deliberately NOT skipped: entries carrying CONNLIMIT_DEC. The
+	// fast path claims that flag on any RST, including a spurious one
+	// both peers ignore, and rarely clears it again, so it sits on
+	// live connections. Since this recount is the only thing that can
+	// give a slot back, skipping on it made such an under-count
+	// effectively permanent. The FIN/RST skips above already prevent
+	// the double-count it was added for.
 	if data.FINsSeenDSR() || data.RSTSeen() {
-		return ScanVerdictOK, 0
-	}
-	if ctVal.Flags()&ctv4.FlagConnLimitDec != 0 {
 		return ScanVerdictOK, 0
 	}
 	// Only count fully established connections.

--- a/felix/bpf/conntrack/connlimit_scanner_test.go
+++ b/felix/bpf/conntrack/connlimit_scanner_test.go
@@ -72,16 +72,30 @@ func (f *fakeQoSMap) BatchUpdate(ks, vs [][]byte, flags uint64) (int, error) {
 // reads or writes.
 func (f *fakeQoSMap) seed(t *testing.T, ifindex uint32, direction uint16, maxConn, current uint32) {
 	t.Helper()
-	k := qos.NewKey(ifindex, direction, qos.IPFamilyV4).AsBytes()
-	v := qos.NewConnValue(maxConn, current).AsBytes()
-	f.contents[string(k)] = v[:]
+	f.seedFamily(t, ifindex, direction, qos.IPFamilyV4, maxConn, current)
 }
 
 func (f *fakeQoSMap) currentCount(t *testing.T, ifindex uint32, direction uint16) uint32 {
 	t.Helper()
-	bytes, err := f.Get(qos.NewKey(ifindex, direction, qos.IPFamilyV4).AsBytes())
+	return f.currentCountFamily(t, ifindex, direction, qos.IPFamilyV4)
+}
+
+// seedFamily is seed for an explicit IP family. v4 and v6 share one
+// cali_qos_conn map and are separated only by the family field of the key, so
+// tests that care about that separation must address the two entries
+// explicitly.
+func (f *fakeQoSMap) seedFamily(t *testing.T, ifindex uint32, direction, family uint16, maxConn, current uint32) {
+	t.Helper()
+	k := qos.NewKey(ifindex, direction, family).AsBytes()
+	v := qos.NewConnValue(maxConn, current).AsBytes()
+	f.contents[string(k)] = v[:]
+}
+
+func (f *fakeQoSMap) currentCountFamily(t *testing.T, ifindex uint32, direction, family uint16) uint32 {
+	t.Helper()
+	bytes, err := f.Get(qos.NewKey(ifindex, direction, family).AsBytes())
 	if err != nil {
-		t.Fatalf("fake Get for (%d,%d) failed: %v", ifindex, direction, err)
+		t.Fatalf("fake Get for (%d,%d,v%d) failed: %v", ifindex, direction, family, err)
 	}
 	return qos.ConnValueFromBytes(bytes).CurrentCount()
 }
@@ -112,6 +126,20 @@ func established(opener bool) Leg {
 // makeKey creates a TCP CT key for the given IPs and ports.
 func makeKey(ipA, ipB string, portA, portB uint16) Key {
 	return NewKey(6, net.ParseIP(ipA).To4(), portA, net.ParseIP(ipB).To4(), portB)
+}
+
+// makeKeyV6 creates a TCP CT key for the given IPv6 addresses and ports.
+func makeKeyV6(ipA, ipB string, portA, portB uint16) KeyV6 {
+	return NewKeyV6(6, net.ParseIP(ipA).To16(), portA, net.ParseIP(ipB).To16(), portB)
+}
+
+// makeEstablishedValueV6 is makeEstablishedValue for an IPv6 flow. Leg is
+// shared between families, so only the value constructor differs.
+func makeEstablishedValueV6() ValueV6 {
+	return NewValueV6Normal(time.Duration(0), 0,
+		established(true),  // A is opener
+		established(false), // B is responder
+	)
 }
 
 // makeEstablishedValue creates a NORMAL CT value with both legs established.
@@ -212,6 +240,51 @@ func TestConnLimitScannerCountsEgressConnection(t *testing.T) {
 	expected := connlimitKey{ifindex: 9, direction: 0}
 	if scanner.counts[expected] != 1 {
 		t.Errorf("expected egress count 1 for ifindex 9, got counts: %v", scanner.counts)
+	}
+}
+
+// TestConnLimitScannerV6WritesBackToItsOwnFamily verifies that a v6 scanner
+// counts a v6 flow and writes the result to the v6 cali_qos_conn entry,
+// leaving the v4 entry for the same (ifindex, direction) untouched.
+//
+// v4 and v6 share a single cali_qos_conn map, separated only by the family
+// field of the key, and each family runs its own scanner — NewConnLimitScanner
+// takes the family and prepareUpdate builds its write key from it. Getting
+// that wrong would send one stack's recount to the other stack's counter,
+// silently, and only on dual-stack clusters. The family dimension in the key
+// exists precisely to prevent that overwrite, so it is worth pinning: a test
+// that only ever exercises one family would pass even if the dimension were
+// dropped entirely.
+func TestConnLimitScannerV6WritesBackToItsOwnFamily(t *testing.T) {
+	podIP := "dead:beef::2"
+	remoteIP := "dead:beef::3"
+
+	fake := newFakeQoSMap()
+	// A dual-stack pod: same ifindex and direction, one entry per family. The
+	// v4 side is mid-flight with four connections of its own.
+	fake.seedFamily(t, 9, 1, qos.IPFamilyV4, 5, 4)
+	fake.seedFamily(t, 9, 1, qos.IPFamilyV6, 5, 0)
+
+	scanner := NewConnLimitScanner(fake, func() map[string]ConnLimitPodInfo {
+		return map[string]ConnLimitPodInfo{
+			string(net.ParseIP(podIP).To16()): podInfo(9, true, false),
+		}
+	}, qos.IPFamilyV6)
+
+	// Pod is AddrB (responder), remote is AddrA (opener), so this counts
+	// against the pod's ingress limit.
+	scanner.IterationStart()
+	verdict, _ := scanner.Check(makeKeyV6(remoteIP, podIP, 54321, 8080), makeEstablishedValueV6(), nil)
+	if verdict != ScanVerdictOK {
+		t.Fatalf("expected ScanVerdictOK, got %d", verdict)
+	}
+	scanner.IterationEnd()
+
+	if got := fake.currentCountFamily(t, 9, 1, qos.IPFamilyV6); got != 1 {
+		t.Errorf("v6 ingress counter: expected 1, got %d", got)
+	}
+	if got := fake.currentCountFamily(t, 9, 1, qos.IPFamilyV4); got != 4 {
+		t.Errorf("v4 counter must be untouched by a v6 scanner: expected 4, got %d", got)
 	}
 }
 

--- a/felix/bpf/conntrack/connlimit_scanner_test.go
+++ b/felix/bpf/conntrack/connlimit_scanner_test.go
@@ -418,7 +418,29 @@ func TestConnLimitScannerBothPodsLimited(t *testing.T) {
 	}
 }
 
-func TestConnLimitScannerSkipsConnLimitDec(t *testing.T) {
+// TestConnLimitScannerRecountsLiveConnectionAfterSpuriousRST verifies that a
+// live, established connection is included in the recount even though the BPF
+// fast path already decremented the counter for it and claimed
+// CALI_CT_FLAG_CONNLIMIT_DEC.
+//
+// The fast path decrements on any RST: conntrack.h reads tcp_header->rst
+// directly, nothing validates the sequence number, and the spurious-RST
+// reasoning alongside it can only reach a verdict two minutes later, in
+// hindsight. A spurious RST — out of window, ignored by both peers — therefore
+// decrements a connection that is still up. That much is recoverable on its
+// own, because the per-leg RST bits clear as soon as traffic resumes
+// (conntrack.h:571-576) and the entry becomes countable again.
+//
+// What was not recoverable was CONNLIMIT_DEC, which nothing ever clears. While
+// this scanner skipped entries carrying it, such a connection was excluded
+// from every future recount — and since the recount is the only mechanism that
+// can give a slot back, the under-count became permanent. N spurious RSTs
+// against N live connections parked current_count at 0 with all N still up,
+// letting the pod open N more.
+//
+// An established entry with no FIN and no RST is live, so it must be counted,
+// whatever CONNLIMIT_DEC says.
+func TestConnLimitScannerRecountsLiveConnectionAfterSpuriousRST(t *testing.T) {
 	podIP := "10.65.0.2"
 	remoteIP := "10.65.1.3"
 
@@ -430,11 +452,12 @@ func TestConnLimitScannerSkipsConnLimitDec(t *testing.T) {
 		},
 	}
 
-	// Established connection with CONNLIMIT_DEC flag set — the BPF fast
-	// path already decremented the counter for this connection. The scanner
-	// must skip it to avoid recounting and overwriting the decremented value.
+	// Pod is AddrB (responder), remote is AddrA (opener), so this counts
+	// against the pod's ingress limit. Both legs established, no FIN and no
+	// RST bit — the shape a busy connection presents once the transient RST
+	// marks have cleared — but CONNLIMIT_DEC is set from the earlier RST.
 	key := makeKey(remoteIP, podIP, 54321, 8080)
-	val := NewValueNormal(time.Duration(0), ctv4.FlagConnLimitDec,
+	val := NewValueNormal(time.Duration(0), ctv4.FlagConnLimitIn|ctv4.FlagConnLimitDec,
 		established(true),
 		established(false),
 	)
@@ -443,8 +466,11 @@ func TestConnLimitScannerSkipsConnLimitDec(t *testing.T) {
 	if verdict != ScanVerdictOK {
 		t.Fatalf("expected ScanVerdictOK, got %d", verdict)
 	}
-	if len(scanner.counts) != 0 {
-		t.Errorf("expected no counts for CONNLIMIT_DEC connection, got %v", scanner.counts)
+
+	expected := connlimitKey{ifindex: 9, direction: 1}
+	if scanner.counts[expected] != 1 {
+		t.Errorf("live established connection was excluded from the recount: "+
+			"expected ingress count 1 for ifindex 9, got counts: %v", scanner.counts)
 	}
 }
 

--- a/felix/bpf/ut/qos_test.go
+++ b/felix/bpf/ut/qos_test.go
@@ -15,10 +15,12 @@
 package ut_test
 
 import (
+	"encoding/binary"
 	"net"
 	"testing"
 	"time"
 
+	"github.com/gopacket/gopacket/layers"
 	. "github.com/onsi/gomega"
 
 	"github.com/projectcalico/calico/felix/bpf/conntrack"
@@ -755,4 +757,455 @@ func TestQoSConnLimitIngressRetransmissionOfAccepted(t *testing.T) {
 	// Counter must be unchanged at 1 — the "already counted" arm of the
 	// ingress check does NOT call qos_connlimit_check_and_increment.
 	Expect(readQoSCount()).To(Equal(uint32(1)))
+}
+
+// TestQoSConnLimitEgressSpuriousRSTSlotRestoredByRecount verifies that a
+// spurious RST on a live connection costs its egress connlimit slot only until
+// the next recount, rather than permanently.
+//
+// calico_ct_lookup decrements on any RST: conntrack.h tests tcp_header->rst
+// directly, with no sequence validation anywhere on the path (the entry is
+// stamped for any RST matching the 4-tuple, and ct_tcp_entry_update's seqno
+// checks cover only SYN+ACK and bare ACK). The spurious-RST reasoning nearby
+// can only reach a verdict two minutes later, in hindsight, so it cannot help
+// at the moment the RST arrives.
+//
+// That prompt decrement is deliberate and must stay: felix/fv asserts a
+// genuine RST close frees a slot within 5s, and routing RST closes to the
+// cleanup path instead made those cases wait for TCPResetSeen (40s).
+//
+// What made a spurious RST unrecoverable was CONNLIMIT_DEC. The helper claims
+// it before decrementing and nothing ever clears it, so while the scanner
+// skipped entries carrying it, a still-live connection was excluded from every
+// future recount — the one mechanism that can return a slot. The per-leg RST
+// bits, by contrast, clear themselves the moment traffic resumes, which is
+// what makes recovery possible at all.
+//
+// So this drives the packet path with an out-of-window RST — the shape a
+// peer's stack discards, leaving the connection up while the dataplane counts
+// it as a close — then continued traffic, and finally the real scanner, and
+// asserts the slot comes back.
+func TestQoSConnLimitEgressSpuriousRSTSlotRestoredByRecount(t *testing.T) {
+	RegisterTestingT(t)
+
+	bpfIfaceName = "HWrst"
+	defer func() { bpfIfaceName = "" }()
+
+	const (
+		// ifIndex must match the BPF UT's default skb ifindex so the
+		// workload RPF check (route iface vs skb iface) passes.
+		ifIndex               = 1
+		maxConnections        = 3
+		srcPort        uint16 = 12346 // local workload, the opener
+		dstPort        uint16 = 8055
+	)
+
+	// Routes: local workload source, remote workload destination (same shape
+	// as TestQoSConnLimitEgressRecycleNotDoubleCounted).
+	rtKey := routes.NewKey(srcV4CIDR).AsBytes()
+	rtVal := routes.NewValueWithIfIndex(routes.FlagsLocalWorkload|routes.FlagInIPAMPool, ifIndex).AsBytes()
+	Expect(rtMap.Update(rtKey, rtVal)).NotTo(HaveOccurred())
+	rtKey = routes.NewKey(dstV4CIDR).AsBytes()
+	rtVal = routes.NewValueWithIfIndex(routes.FlagsRemoteWorkload|routes.FlagInIPAMPool, ifIndex).AsBytes()
+	Expect(rtMap.Update(rtKey, rtVal)).NotTo(HaveOccurred())
+	defer resetRTMap(rtMap)
+
+	ctMap := conntrack.Map()
+	Expect(ctMap.EnsureExists()).NotTo(HaveOccurred())
+	defer resetCTMap(ctMap)
+	resetCTMap(ctMap)
+
+	// A fully-established egress connection that was counted against the
+	// egress limit on its first SYN (CONNLIMIT_EGRESS set, CONNLIMIT_DEC
+	// clear). No FIN and no RST on either leg. The opener leg carries the
+	// pod ifindex, which is where qos_connlimit_decrement_for_ct reads it.
+	//
+	// Approved must be set on both legs: from_wep is CALI_F_TO_HOST, so
+	// calico_ct_lookup checks src_to_dst->approved (conntrack.h:1041) and
+	// would otherwise return CALI_CT_INVALID for these non-SYN packets and
+	// drop them before they demonstrate anything.
+	legA := ctv4.Leg{SynSeen: true, AckSeen: true, Approved: true, Opener: true, Ifindex: ifIndex}
+	legB := ctv4.Leg{SynSeen: true, AckSeen: true, Approved: true}
+	k := ctv4.NewKey(6, srcIP, srcPort, dstIP, dstPort)
+	v := ctv4.NewValueNormal(time.Duration(0), ctv4.FlagConnLimitOut, legA, legB)
+	Expect(ctMap.Update(k.AsBytes(), v.AsBytes()[:])).NotTo(HaveOccurred())
+
+	// Egress connlimit map: max=3, current=1 — this one live connection.
+	defer resetQoSMap(qosConnMap)
+	resetQoSMap(qosConnMap)
+	qosKey := qos.NewKey(uint32(ifIndex), 0 /* egress */, qos.IPFamilyV4)
+	Expect(qosConnMap.Update(qosKey.AsBytes(),
+		qos.NewConnValue(maxConnections, 1).AsBytes())).
+		NotTo(HaveOccurred())
+
+	readQoSCount := func() uint32 {
+		b, err := qosConnMap.Get(qosKey.AsBytes())
+		Expect(err).NotTo(HaveOccurred())
+		return qos.ConnValueFromBytes(b).CurrentCount()
+	}
+
+	readCTVal := func() ctv4.ValueInterface {
+		b, err := ctMap.Get(k.AsBytes())
+		Expect(err).NotTo(HaveOccurred())
+		return ctv4.ValueFromBytes(b)
+	}
+
+	ip := *ipv4Default
+	ip.DstIP = dstIP
+
+	// An RST on the live connection's 5-tuple. Nothing in the BPF path
+	// checks its sequence number, which is what lets a peer's stack discard
+	// it (leaving the connection up) while the dataplane treats it as a
+	// close.
+	rstPkt, dataPkt := spuriousRSTThenTrafficPackets(&ip, srcPort, dstPort)
+
+	skbMark = 0
+	runBpfTest(t, "calico_from_workload_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+		res, err := bpfrun(rstPkt)
+		Expect(err).NotTo(HaveOccurred())
+		// The RST must actually reach the conntrack path — if it were
+		// dropped the counter would be untouched and this test would
+		// pass vacuously.
+		Expect(res.Retval).NotTo(Equal(resTC_ACT_SHOT))
+	}, withEgressQoSConnLimit())
+
+	// Guard, not the behaviour under test: a non-zero RST timestamp proves
+	// the RST branch at conntrack.h:1079 executed, so the assertions below
+	// are meaningful rather than vacuous.
+	Expect(readCTVal().RSTSeen()).NotTo(BeZero(),
+		"RST was not recorded on the CT entry; the packet never reached the RST path")
+
+	// The fast path releases the slot immediately. That promptness is
+	// required — felix/fv asserts a genuine RST close frees a slot within
+	// 5s — and is why the RST decrement stays. On a spurious RST it is an
+	// under-count, which the recount below is expected to repair.
+	Expect(readQoSCount()).To(Equal(uint32(0)),
+		"fast path should have decremented on the RST")
+
+	skbMark = 0
+	runBpfTest(t, "calico_from_workload_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+		res, err := bpfrun(dataPkt)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.Retval).NotTo(Equal(resTC_ACT_SHOT))
+	}, withEgressQoSConnLimit())
+
+	// The connection is demonstrably still live: traffic flowed after the
+	// RST, and the dataplane itself has withdrawn the per-leg RST marks.
+	Expect(readCTVal().Data().RSTSeen()).To(BeFalse(),
+		"per-leg rst_seen should have been cleared by the continued traffic")
+
+	// CONNLIMIT_DEC is still set and never will be cleared. The recount has
+	// to restore the slot in spite of it -- that is the whole fix.
+	Expect(readCTVal().Flags()&ctv4.FlagConnLimitDec).NotTo(Equal(uint32(0)),
+		"expected the fast path to have claimed CONNLIMIT_DEC")
+
+	// Run the real ConnLimitScanner over the real CT entry, exactly as the
+	// CT scan loop does. This is the seam the bug lived in: the packet path
+	// and the scanner were each locally reasonable, and only their
+	// composition was wrong, so assert the composition.
+	runConnLimitRecount(k, readCTVal(), srcIP, conntrack.ConnLimitPodInfo{
+		IfIndex: ifIndex, HasEgressLimit: true,
+	})
+
+	Expect(readQoSCount()).To(Equal(uint32(1)),
+		"recount did not restore the slot of a live connection after a spurious RST")
+}
+
+// TestQoSConnLimitSpuriousRSTReleasesStaleDecClaim verifies that once
+// calico_ct_lookup concludes an RST was spurious, it also releases the
+// CONNLIMIT_DEC claim that RST caused, so the connection's genuine close still
+// decrements on the fast path.
+//
+// A spurious RST decrements the counter and latches CONNLIMIT_DEC. The recount
+// restores the slot, but nothing released the latch, so when the connection
+// eventually closed for real qos_connlimit_decrement_for_ct bailed and the slot
+// came back only at recount speed (~30s) instead of immediately. The latch
+// describes a decrement that the recount has since rebased away, so it has to
+// be released at the same point the dataplane already decides the RST was
+// spurious — two minutes of continued traffic, where it clears v->rst_seen.
+//
+// The entry is staged in its post-recount state rather than replayed packet by
+// packet: established and approved, counted against the egress limit,
+// CONNLIMIT_DEC still latched from the earlier spurious RST, per-leg RST bits
+// already cleared by resumed traffic, and the peer's FIN seen. A single FIN
+// from the pod then has to do three things in one pass through
+// calico_ct_lookup: release the stale latch, complete the FIN exchange, and
+// decrement.
+func TestQoSConnLimitSpuriousRSTReleasesStaleDecClaim(t *testing.T) {
+	RegisterTestingT(t)
+
+	bpfIfaceName = "HWrstD"
+	defer func() { bpfIfaceName = "" }()
+
+	const (
+		ifIndex               = 1
+		maxConnections        = 3
+		srcPort        uint16 = 12347
+		dstPort        uint16 = 8055
+	)
+
+	rtKey := routes.NewKey(srcV4CIDR).AsBytes()
+	rtVal := routes.NewValueWithIfIndex(routes.FlagsLocalWorkload|routes.FlagInIPAMPool, ifIndex).AsBytes()
+	Expect(rtMap.Update(rtKey, rtVal)).NotTo(HaveOccurred())
+	rtKey = routes.NewKey(dstV4CIDR).AsBytes()
+	rtVal = routes.NewValueWithIfIndex(routes.FlagsRemoteWorkload|routes.FlagInIPAMPool, ifIndex).AsBytes()
+	Expect(rtMap.Update(rtKey, rtVal)).NotTo(HaveOccurred())
+	defer resetRTMap(rtMap)
+
+	ctMap := conntrack.Map()
+	Expect(ctMap.EnsureExists()).NotTo(HaveOccurred())
+	defer resetCTMap(ctMap)
+	resetCTMap(ctMap)
+
+	// The pod is the opener; the peer has already sent its FIN, so the pod's
+	// FIN below completes the exchange. CONNLIMIT_DEC is latched from the
+	// spurious RST; the per-leg RST bits are not set, because traffic resumed
+	// and conntrack.h:571-576 cleared them.
+	legA := ctv4.Leg{SynSeen: true, AckSeen: true, Approved: true, Opener: true, Ifindex: ifIndex}
+	legB := ctv4.Leg{SynSeen: true, AckSeen: true, Approved: true, FinSeen: true}
+	k := ctv4.NewKey(6, srcIP, srcPort, dstIP, dstPort)
+	v := ctv4.NewValueNormal(time.Duration(0),
+		ctv4.FlagConnLimitOut|ctv4.FlagConnLimitDec, legA, legB)
+
+	// Backdate the value's RST timestamp so the two-minute window has already
+	// elapsed. bpf_ktime_get_ns() counts from boot, so 1ns is effectively
+	// "at boot" — any host that has been up longer than 2 minutes satisfies
+	// the check, and the assertion on RSTSeen below catches it if not.
+	vb := v.AsBytes()
+	binary.LittleEndian.PutUint64(vb[ctv4.VoRSTSeen:ctv4.VoRSTSeen+8], 1)
+	Expect(ctMap.Update(k.AsBytes(), vb[:])).NotTo(HaveOccurred())
+
+	// The recount has already restored this connection's slot.
+	defer resetQoSMap(qosConnMap)
+	resetQoSMap(qosConnMap)
+	qosKey := qos.NewKey(uint32(ifIndex), 0 /* egress */, qos.IPFamilyV4)
+	Expect(qosConnMap.Update(qosKey.AsBytes(),
+		qos.NewConnValue(maxConnections, 1).AsBytes())).
+		NotTo(HaveOccurred())
+
+	readQoSCount := func() uint32 {
+		b, err := qosConnMap.Get(qosKey.AsBytes())
+		Expect(err).NotTo(HaveOccurred())
+		return qos.ConnValueFromBytes(b).CurrentCount()
+	}
+
+	readCTVal := func() ctv4.ValueInterface {
+		b, err := ctMap.Get(k.AsBytes())
+		Expect(err).NotTo(HaveOccurred())
+		return ctv4.ValueFromBytes(b)
+	}
+
+	ip := *ipv4Default
+	ip.DstIP = dstIP
+
+	// The pod's FIN, completing the bilateral close.
+	_, _, _, _, finPkt, err := testPacketV4(nil, &ip, &layers.TCP{
+		FIN:        true,
+		ACK:        true,
+		SrcPort:    layers.TCPPort(srcPort),
+		DstPort:    layers.TCPPort(dstPort),
+		DataOffset: 5,
+	}, nil)
+	Expect(err).NotTo(HaveOccurred())
+
+	skbMark = 0
+	runBpfTest(t, "calico_from_workload_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+		res, err := bpfrun(finPkt)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.Retval).NotTo(Equal(resTC_ACT_SHOT))
+	}, withEgressQoSConnLimit())
+
+	// Guard, not the behaviour under test: a cleared RST timestamp proves the
+	// two-minute branch actually ran. Without this a host up for less than
+	// 2 minutes would fail the real assertion below for the wrong reason.
+	Expect(readCTVal().RSTSeen()).To(BeZero(),
+		"two-minute spurious-RST branch did not run; the rest of this test proves nothing")
+
+	// The real close decremented on the fast path, despite the stale latch.
+	Expect(readQoSCount()).To(Equal(uint32(0)),
+		"stale CONNLIMIT_DEC claim suppressed the decrement on a genuine close")
+}
+
+// runConnLimitRecount drives the real ConnLimitScanner over a single CT entry
+// the way the conntrack scan loop does — IterationStart, one Check, then
+// IterationEnd, which is where the recounted value is written back to the
+// cali_qos_conn map. podIP is the limited pod's address; the scanner resolves
+// an entry to a pod by matching the CT key's addresses against its pod map.
+func runConnLimitRecount(k ctv4.Key, val ctv4.ValueInterface, podIP net.IP, info conntrack.ConnLimitPodInfo) {
+	scanner := conntrack.NewConnLimitScanner(qosConnMap,
+		func() map[string]conntrack.ConnLimitPodInfo {
+			return map[string]conntrack.ConnLimitPodInfo{
+				string(podIP.To4()): info,
+			}
+		}, qos.IPFamilyV4)
+
+	scanner.IterationStart()
+	scanner.Check(k, val, nil)
+	scanner.IterationEnd()
+}
+
+// TestQoSConnLimitIngressSpuriousRSTSlotRestoredByRecount is the ingress twin
+// of TestQoSConnLimitEgressSpuriousRSTSlotRestoredByRecount. The defect is
+// shared — the RST decrement is direction-agnostic — but the accounting is
+// not: the ingress arm of qos_connlimit_decrement_for_ct resolves the pod
+// ifindex from the *non-opener* leg and additionally gates on
+// CONNLIMIT_INGRESS_REJECTED, and the scanner picks the direction from the
+// opener bit, so egress passing is not evidence that ingress does.
+//
+// The threat model differs too. On egress the pod can defeat its own limit
+// knowing only its own 4-tuples; on ingress the RST arrives from outside, so a
+// third party needs the 4-tuple — but still not a valid sequence number, since
+// nothing in the BPF path validates one. The more common trigger here is not an
+// attacker at all but a genuinely spurious RST (a late reset for a recycled
+// tuple, or a middlebox), which is the case conntrack.h:1083-1091 already
+// concedes happens.
+func TestQoSConnLimitIngressSpuriousRSTSlotRestoredByRecount(t *testing.T) {
+	RegisterTestingT(t)
+
+	bpfIfaceName = "HWrstI"
+	defer func() { bpfIfaceName = "" }()
+
+	const (
+		ifIndex               = 1
+		maxConnections        = 3
+		srcPort        uint16 = 23458 // remote opener
+		dstPort        uint16 = 8055  // workload listening port
+	)
+
+	// Routes: same shape as the other ingress connlimit tests.
+	rtKey := routes.NewKey(srcV4CIDR).AsBytes()
+	rtVal := routes.NewValueWithIfIndex(routes.FlagsLocalWorkload|routes.FlagInIPAMPool, ifIndex).AsBytes()
+	Expect(rtMap.Update(rtKey, rtVal)).NotTo(HaveOccurred())
+	rtKey = routes.NewKey(dstV4CIDR).AsBytes()
+	rtVal = routes.NewValueWithIfIndex(routes.FlagsRemoteWorkload|routes.FlagInIPAMPool, ifIndex).AsBytes()
+	Expect(rtMap.Update(rtKey, rtVal)).NotTo(HaveOccurred())
+	defer resetRTMap(rtMap)
+
+	ctMap := conntrack.Map()
+	Expect(ctMap.EnsureExists()).NotTo(HaveOccurred())
+	defer resetCTMap(ctMap)
+	resetCTMap(ctMap)
+
+	// An established inbound connection counted against the ingress limit:
+	// CONNLIMIT_INGRESS set, CONNLIMIT_DEC clear, and crucially
+	// CONNLIMIT_INGRESS_REJECTED clear (with it set, the ingress arm of the
+	// decrement is skipped and this test could not distinguish the bug from
+	// correct behaviour).
+	//
+	// The remote is the opener on leg A, so the pod is the responder on leg B
+	// and leg B carries the pod ifindex — that is the leg the ingress arm of
+	// qos_connlimit_decrement_for_ct reads. Approved is needed on both legs
+	// for the same reason as the egress twin: to_wep is CALI_F_FROM_HOST and
+	// checks dst_to_src->approved (conntrack.h:1054), so unapproved non-SYN
+	// packets would be dropped as CALI_CT_INVALID.
+	legA := ctv4.Leg{SynSeen: true, AckSeen: true, Approved: true, Opener: true}
+	legB := ctv4.Leg{SynSeen: true, AckSeen: true, Approved: true, Ifindex: ifIndex}
+	k := ctv4.NewKey(6, srcIP, srcPort, dstIP, dstPort)
+	v := ctv4.NewValueNormal(time.Duration(0), ctv4.FlagConnLimitIn, legA, legB)
+	Expect(ctMap.Update(k.AsBytes(), v.AsBytes()[:])).NotTo(HaveOccurred())
+
+	// Ingress connlimit map: max=3, current=1 — this one live connection.
+	defer resetQoSMap(qosConnMap)
+	resetQoSMap(qosConnMap)
+	qosKey := qos.NewKey(uint32(ifIndex), 1 /* ingress */, qos.IPFamilyV4)
+	Expect(qosConnMap.Update(qosKey.AsBytes(),
+		qos.NewConnValue(maxConnections, 1).AsBytes())).
+		NotTo(HaveOccurred())
+
+	readQoSCount := func() uint32 {
+		b, err := qosConnMap.Get(qosKey.AsBytes())
+		Expect(err).NotTo(HaveOccurred())
+		return qos.ConnValueFromBytes(b).CurrentCount()
+	}
+
+	readCTVal := func() ctv4.ValueInterface {
+		b, err := ctMap.Get(k.AsBytes())
+		Expect(err).NotTo(HaveOccurred())
+		return ctv4.ValueFromBytes(b)
+	}
+
+	ip := *ipv4Default
+	ip.DstIP = dstIP
+
+	// Inbound RST on the live connection's 5-tuple, then inbound traffic
+	// that proves the connection survived it.
+	rstPkt, dataPkt := spuriousRSTThenTrafficPackets(&ip, srcPort, dstPort)
+
+	// Ingress program: skb already marked seen (the packet passed through
+	// from-hep earlier), matching the other ingress connlimit tests.
+	skbMark = tcdefs.MarkSeen
+	runBpfTest(t, "calico_to_workload_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+		res, err := bpfrun(rstPkt)
+		Expect(err).NotTo(HaveOccurred())
+		// The RST must actually reach the conntrack path — if it were
+		// dropped the counter would be untouched and this test would
+		// pass vacuously.
+		Expect(res.Retval).NotTo(Equal(resTC_ACT_SHOT))
+	}, withIngressQoSConnLimit())
+
+	// Guard, not the behaviour under test: proves the RST branch executed.
+	Expect(readCTVal().RSTSeen()).NotTo(BeZero(),
+		"RST was not recorded on the CT entry; the packet never reached the RST path")
+
+	// Prompt release on the fast path, as on egress.
+	Expect(readQoSCount()).To(Equal(uint32(0)),
+		"fast path should have decremented on the RST")
+
+	skbMark = tcdefs.MarkSeen
+	runBpfTest(t, "calico_to_workload_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+		res, err := bpfrun(dataPkt)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.Retval).NotTo(Equal(resTC_ACT_SHOT))
+	}, withIngressQoSConnLimit())
+
+	// The connection is demonstrably still live.
+	Expect(readCTVal().Data().RSTSeen()).To(BeFalse(),
+		"per-leg rst_seen should have been cleared by the continued traffic")
+
+	Expect(readCTVal().Flags()&ctv4.FlagConnLimitDec).NotTo(Equal(uint32(0)),
+		"expected the fast path to have claimed CONNLIMIT_DEC")
+
+	// The pod is the responder here, so it is the CT key's dst address.
+	runConnLimitRecount(k, readCTVal(), dstIP, conntrack.ConnLimitPodInfo{
+		IfIndex: ifIndex, HasIngressLimit: true,
+	})
+
+	Expect(readQoSCount()).To(Equal(uint32(1)),
+		"recount did not restore the slot of a live connection after a spurious RST")
+}
+
+// spuriousRSTThenTrafficPackets builds the two packets the spurious-RST tests
+// replay over a live connection, in order:
+//
+//   - an RST on the connection's 5-tuple, carrying no valid sequence number.
+//     Nothing in the BPF path validates one (conntrack.h:1079 stamps the entry
+//     for any RST matching the tuple, and ct_tcp_entry_update's seqno checks
+//     cover only SYN+ACK and bare ACK), which is what lets a real peer's stack
+//     discard this while the dataplane counts it as a close.
+//   - continued traffic: a normal ACK-bearing data packet. With both legs
+//     already ACKed this takes the "Normal packet" arm of ct_tcp_entry_update
+//     and clears the per-leg rst_seen bits (conntrack.h:571-576), so the
+//     dataplane itself withdraws its own close signal.
+//
+// Both directions use the same builder: which leg the RST lands on is decided
+// by the CT entry's opener bit and the program under test, not by the packet.
+func spuriousRSTThenTrafficPackets(ip *layers.IPv4, srcPort, dstPort uint16) (rstPkt, dataPkt []byte) {
+	_, _, _, _, rstPkt, err := testPacketV4(nil, ip, &layers.TCP{
+		RST:        true,
+		SrcPort:    layers.TCPPort(srcPort),
+		DstPort:    layers.TCPPort(dstPort),
+		DataOffset: 5,
+	}, nil)
+	Expect(err).NotTo(HaveOccurred())
+
+	_, _, _, _, dataPkt, err = testPacketV4(nil, ip, &layers.TCP{
+		ACK:        true,
+		PSH:        true,
+		SrcPort:    layers.TCPPort(srcPort),
+		DstPort:    layers.TCPPort(dstPort),
+		DataOffset: 5,
+	}, []byte("hello"))
+	Expect(err).NotTo(HaveOccurred())
+
+	return rstPkt, dataPkt
 }

--- a/felix/bpf/ut/qos_test.go
+++ b/felix/bpf/ut/qos_test.go
@@ -759,6 +759,430 @@ func TestQoSConnLimitIngressRetransmissionOfAccepted(t *testing.T) {
 	Expect(readQoSCount()).To(Equal(uint32(1)))
 }
 
+// TestQoSConnLimitIngressFirstSYN covers the plain first-SYN admission
+// decision at to-wep, both outcomes. The sibling tests in this file all cover
+// retransmission and recycle cases; this is the base case they build on.
+//
+// "First SYN" here means the first SYN seen at *this* hook, not the first in
+// the system: the ingress block in tc.c is gated on is_tcp_syn(), which reads
+// CT_RES_SYN, and calico_ct_lookup only sets that on a lookup hit. The
+// source-side program (from-wep or from-hep) has therefore already created the
+// CT entry by the time the SYN reaches to-wep. What distinguishes a first SYN
+// is that the entry carries neither CONNLIMIT_INGRESS nor
+// CONNLIMIT_INGRESS_REJECTED yet.
+func TestQoSConnLimitIngressFirstSYN(t *testing.T) {
+	RegisterTestingT(t)
+
+	bpfIfaceName = "HWfsi"
+	defer func() { bpfIfaceName = "" }()
+
+	const (
+		ifIndex               = 1
+		maxConnections        = 3
+		srcPort        uint16 = 23460 // remote opener
+		dstPort        uint16 = 8055  // workload listening port
+	)
+
+	rtKey := routes.NewKey(srcV4CIDR).AsBytes()
+	rtVal := routes.NewValueWithIfIndex(routes.FlagsLocalWorkload|routes.FlagInIPAMPool, ifIndex).AsBytes()
+	Expect(rtMap.Update(rtKey, rtVal)).NotTo(HaveOccurred())
+	rtKey = routes.NewKey(dstV4CIDR).AsBytes()
+	rtVal = routes.NewValueWithIfIndex(routes.FlagsRemoteWorkload|routes.FlagInIPAMPool, ifIndex).AsBytes()
+	Expect(rtMap.Update(rtKey, rtVal)).NotTo(HaveOccurred())
+	defer resetRTMap(rtMap)
+
+	ctMap := conntrack.Map()
+	Expect(ctMap.EnsureExists()).NotTo(HaveOccurred())
+	defer resetCTMap(ctMap)
+
+	k := ctv4.NewKey(6, srcIP, srcPort, dstIP, dstPort)
+	qosKey := qos.NewKey(uint32(ifIndex), 1 /* ingress */, qos.IPFamilyV4)
+
+	readQoSCount := func() uint32 {
+		b, err := qosConnMap.Get(qosKey.AsBytes())
+		Expect(err).NotTo(HaveOccurred())
+		return qos.ConnValueFromBytes(b).CurrentCount()
+	}
+
+	readCTFlags := func() uint32 {
+		b, err := ctMap.Get(k.AsBytes())
+		Expect(err).NotTo(HaveOccurred())
+		return ctv4.ValueFromBytes(b).Flags()
+	}
+
+	// The CT entry the source-side program created: opener has sent its SYN,
+	// the responder has not replied, and no connlimit flag has been set yet.
+	// current is the counter value this sub-case starts from.
+	seed := func(current uint32) {
+		resetCTMap(ctMap)
+		resetQoSMap(qosConnMap)
+
+		legA := ctv4.Leg{SynSeen: true, Opener: true}
+		legB := ctv4.Leg{Ifindex: ifIndex}
+		v := ctv4.NewValueNormal(time.Duration(0), 0 /* no connlimit flags */, legA, legB)
+		Expect(ctMap.Update(k.AsBytes(), v.AsBytes()[:])).NotTo(HaveOccurred())
+
+		Expect(qosConnMap.Update(qosKey.AsBytes(),
+			qos.NewConnValue(maxConnections, current).AsBytes())).NotTo(HaveOccurred())
+	}
+
+	_, _, _, _, synPkt, err := testPacketTCPV4WithPayload(dstIP, srcPort, dstPort, true /* syn */, nil)
+	Expect(err).NotTo(HaveOccurred())
+
+	t.Run("under the limit: counted and admitted", func(t *testing.T) {
+		RegisterTestingT(t)
+		seed(1)
+		defer resetQoSMap(qosConnMap)
+
+		skbMark = tcdefs.MarkSeen
+		runBpfTest(t, "calico_to_workload_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+			res, err := bpfrun(synPkt)
+			Expect(err).NotTo(HaveOccurred())
+			// Admitted: no TCP_RST tail call, packet proceeds normally.
+			Expect(res.Retval).To(Equal(resTC_ACT_UNSPEC))
+		}, withIngressQoSConnLimit())
+
+		Expect(readQoSCount()).To(Equal(uint32(2)), "first SYN was not counted")
+		Expect(readCTFlags()&ctv4.FlagConnLimitIn).To(Equal(ctv4.FlagConnLimitIn),
+			"admitted SYN must stamp CONNLIMIT_INGRESS, or nothing can decrement it on close")
+		Expect(readCTFlags() & ctv4.FlagConnLimitInRej).To(Equal(uint32(0)))
+	})
+
+	t.Run("at the limit: rejected and not counted", func(t *testing.T) {
+		RegisterTestingT(t)
+		seed(maxConnections)
+		defer resetQoSMap(qosConnMap)
+
+		skbMark = tcdefs.MarkSeen
+		runBpfTest(t, "calico_to_workload_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+			res, err := bpfrun(synPkt)
+			Expect(err).NotTo(HaveOccurred())
+			// Reject path tail-calls PROG_INDEX_TCP_RST, which builds the RST
+			// and forwards it; the final return is TC_ACT_UNSPEC.
+			Expect(res.Retval).To(Equal(resTC_ACT_UNSPEC))
+		}, withIngressQoSConnLimit())
+
+		// The failed check must not increment.
+		Expect(readQoSCount()).To(Equal(uint32(maxConnections)))
+		// Guard against a vacuous pass: REJECTED proves the check ran and
+		// failed, rather than the SYN never reaching the block.
+		Expect(readCTFlags()&ctv4.FlagConnLimitInRej).To(Equal(ctv4.FlagConnLimitInRej),
+			"rejected SYN must stamp CONNLIMIT_INGRESS_REJECTED")
+		Expect(readCTFlags() & ctv4.FlagConnLimitIn).To(Equal(uint32(0)))
+	})
+}
+
+// TestQoSConnLimitEgressFirstSYN covers the plain first-SYN admission decision
+// at from-wep, both outcomes.
+//
+// The egress path differs from ingress in more than direction: the check sits
+// in a different block (tc.c, after policy rather than at to-wep), there is no
+// pre-existing CT entry — this is a genuinely new flow — and CONNLIMIT_EGRESS
+// is applied through ct_ctx_nat->flags as the entry is created rather than
+// stamped onto an existing one. So ingress passing is not evidence that egress
+// does.
+func TestQoSConnLimitEgressFirstSYN(t *testing.T) {
+	RegisterTestingT(t)
+
+	bpfIfaceName = "HWfse"
+	defer func() { bpfIfaceName = "" }()
+
+	const (
+		ifIndex               = 1
+		maxConnections        = 3
+		srcPort        uint16 = 12349
+		dstPort        uint16 = 8055
+	)
+
+	rtKey := routes.NewKey(srcV4CIDR).AsBytes()
+	rtVal := routes.NewValueWithIfIndex(routes.FlagsLocalWorkload|routes.FlagInIPAMPool, ifIndex).AsBytes()
+	Expect(rtMap.Update(rtKey, rtVal)).NotTo(HaveOccurred())
+	rtKey = routes.NewKey(dstV4CIDR).AsBytes()
+	rtVal = routes.NewValueWithIfIndex(routes.FlagsRemoteWorkload|routes.FlagInIPAMPool, ifIndex).AsBytes()
+	Expect(rtMap.Update(rtKey, rtVal)).NotTo(HaveOccurred())
+	defer resetRTMap(rtMap)
+
+	ctMap := conntrack.Map()
+	Expect(ctMap.EnsureExists()).NotTo(HaveOccurred())
+	defer resetCTMap(ctMap)
+
+	k := ctv4.NewKey(6, srcIP, srcPort, dstIP, dstPort)
+	qosKey := qos.NewKey(uint32(ifIndex), 0 /* egress */, qos.IPFamilyV4)
+
+	readQoSCount := func() uint32 {
+		b, err := qosConnMap.Get(qosKey.AsBytes())
+		Expect(err).NotTo(HaveOccurred())
+		return qos.ConnValueFromBytes(b).CurrentCount()
+	}
+
+	// No CT entry: a genuinely new outbound flow.
+	seed := func(current uint32) {
+		resetCTMap(ctMap)
+		resetQoSMap(qosConnMap)
+		Expect(qosConnMap.Update(qosKey.AsBytes(),
+			qos.NewConnValue(maxConnections, current).AsBytes())).NotTo(HaveOccurred())
+	}
+
+	_, _, _, _, synPkt, err := testPacketTCPV4WithPayload(dstIP, srcPort, dstPort, true /* syn */, nil)
+	Expect(err).NotTo(HaveOccurred())
+
+	t.Run("under the limit: counted and admitted", func(t *testing.T) {
+		RegisterTestingT(t)
+		seed(1)
+		defer resetQoSMap(qosConnMap)
+
+		skbMark = 0
+		runBpfTest(t, "calico_from_workload_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+			res, err := bpfrun(synPkt)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(res.Retval).To(Equal(resTC_ACT_REDIRECT))
+		}, withEgressQoSConnLimit())
+
+		Expect(readQoSCount()).To(Equal(uint32(2)), "first SYN was not counted")
+
+		// The new CT entry must carry CONNLIMIT_EGRESS, or the close and
+		// cleanup paths cannot decrement it.
+		b, err := ctMap.Get(k.AsBytes())
+		Expect(err).NotTo(HaveOccurred(), "no CT entry was created for the admitted flow")
+		Expect(ctv4.ValueFromBytes(b).Flags()&ctv4.FlagConnLimitOut).
+			To(Equal(ctv4.FlagConnLimitOut), "admitted flow must be stamped CONNLIMIT_EGRESS")
+	})
+
+	t.Run("at the limit: rejected and not counted", func(t *testing.T) {
+		RegisterTestingT(t)
+		seed(maxConnections)
+		defer resetQoSMap(qosConnMap)
+
+		skbMark = 0
+		runBpfTest(t, "calico_from_workload_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+			res, err := bpfrun(synPkt)
+			Expect(err).NotTo(HaveOccurred())
+			// Note the return code does NOT distinguish reject from admit on
+			// egress: the reject path tail-calls PROG_INDEX_TCP_RST, which
+			// builds the RST and redirects it back to the workload, so both
+			// outcomes return TC_ACT_REDIRECT. Do not use it as the signal
+			// that the limit fired.
+			Expect(res.Retval).To(Equal(resTC_ACT_REDIRECT))
+		}, withEgressQoSConnLimit())
+
+		Expect(readQoSCount()).To(Equal(uint32(maxConnections)))
+
+		// This is the discriminator instead. The check sits ahead of the CT
+		// create, and a rejected SYN goes straight to deny, so the flow
+		// leaves no conntrack state — whereas the admitted case above ends
+		// with an entry stamped CONNLIMIT_EGRESS. Without this the assertion
+		// on the counter would pass just as happily if the SYN had never
+		// reached the check at all.
+		_, err := ctMap.Get(k.AsBytes())
+		Expect(err).To(HaveOccurred(),
+			"rejected SYN must not create a CT entry")
+	})
+}
+
+// TestQoSConnLimitV6FirstSYN is the IPv6 counterpart of the first-SYN tests
+// above. The v4 and v6 dataplanes are the same C source compiled twice
+// (IPVER6), so the admission *logic* cannot differ between them; what can
+// differ is whether the v6 programs reach the check at all and which
+// cali_qos_conn entry they address, since family is part of that map's key.
+// Those are what this covers, which is why it does not port every v4 case —
+// the retransmission and recycle paths are family-agnostic and already
+// covered.
+func TestQoSConnLimitV6FirstSYN(t *testing.T) {
+	RegisterTestingT(t)
+
+	hostIP = node1ipV6
+	defer func() { hostIP = node1ip }()
+
+	bpfIfaceName = "HWfs6"
+	defer func() { bpfIfaceName = "" }()
+
+	const (
+		ifIndex               = 1
+		maxConnections        = 3
+		srcPort        uint16 = 23461
+		dstPort        uint16 = 8055
+	)
+
+	rtKey := routes.NewKeyV6(srcV6CIDR).AsBytes()
+	rtVal := routes.NewValueV6WithIfIndex(routes.FlagsLocalWorkload|routes.FlagInIPAMPool, ifIndex).AsBytes()
+	Expect(rtMapV6.Update(rtKey, rtVal)).NotTo(HaveOccurred())
+	rtKey = routes.NewKeyV6(dstV6CIDR).AsBytes()
+	rtVal = routes.NewValueV6WithIfIndex(routes.FlagsRemoteWorkload|routes.FlagInIPAMPool, ifIndex).AsBytes()
+	Expect(rtMapV6.Update(rtKey, rtVal)).NotTo(HaveOccurred())
+	defer resetRTMap(rtMapV6)
+
+	ctMap := conntrack.MapV6()
+	Expect(ctMap.EnsureExists()).NotTo(HaveOccurred())
+	defer resetCTMap(ctMap)
+
+	k := conntrack.NewKeyV6(6, srcIPv6, srcPort, dstIPv6, dstPort)
+	// Family is part of the cali_qos_conn key: a v6 program must address the
+	// family=6 entry, not the v4 one.
+	ingressKey := qos.NewKey(uint32(ifIndex), 1, qos.IPFamilyV6)
+	egressKey := qos.NewKey(uint32(ifIndex), 0, qos.IPFamilyV6)
+
+	readCount := func(qk qos.Key) uint32 {
+		b, err := qosConnMap.Get(qk.AsBytes())
+		Expect(err).NotTo(HaveOccurred())
+		return qos.ConnValueFromBytes(b).CurrentCount()
+	}
+
+	readCTFlags := func() uint32 {
+		b, err := ctMap.Get(k.AsBytes())
+		Expect(err).NotTo(HaveOccurred())
+		return ctv4.ValueV6FromBytes(b).Flags()
+	}
+
+	_, _, _, _, synPkt, err := testPacketTCPV6WithPayload(dstIPv6, srcPort, dstPort, true /* syn */, nil)
+	Expect(err).NotTo(HaveOccurred())
+
+	t.Run("ingress under the limit: counted and admitted", func(t *testing.T) {
+		RegisterTestingT(t)
+		resetCTMap(ctMap)
+		resetQoSMap(qosConnMap)
+		defer resetQoSMap(qosConnMap)
+
+		// The CT entry the source-side program created, not yet counted.
+		legA := ctv4.Leg{SynSeen: true, Opener: true}
+		legB := ctv4.Leg{Ifindex: ifIndex}
+		v := conntrack.NewValueV6Normal(time.Duration(0), 0, legA, legB)
+		Expect(ctMap.Update(k.AsBytes(), v.AsBytes()[:])).NotTo(HaveOccurred())
+		Expect(qosConnMap.Update(ingressKey.AsBytes(),
+			qos.NewConnValue(maxConnections, 1).AsBytes())).NotTo(HaveOccurred())
+
+		skbMark = tcdefs.MarkSeen
+		runBpfTest(t, "calico_to_workload_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+			res, err := bpfrun(synPkt)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(res.Retval).To(Equal(resTC_ACT_UNSPEC))
+		}, withIngressQoSConnLimit(), withIPv6())
+
+		Expect(readCount(ingressKey)).To(Equal(uint32(2)), "v6 first SYN was not counted")
+		Expect(readCTFlags() & ctv4.FlagConnLimitIn).To(Equal(ctv4.FlagConnLimitIn))
+	})
+
+	t.Run("ingress at the limit: rejected and not counted", func(t *testing.T) {
+		RegisterTestingT(t)
+		resetCTMap(ctMap)
+		resetQoSMap(qosConnMap)
+		defer resetQoSMap(qosConnMap)
+
+		legA := ctv4.Leg{SynSeen: true, Opener: true}
+		legB := ctv4.Leg{Ifindex: ifIndex}
+		v := conntrack.NewValueV6Normal(time.Duration(0), 0, legA, legB)
+		Expect(ctMap.Update(k.AsBytes(), v.AsBytes()[:])).NotTo(HaveOccurred())
+		Expect(qosConnMap.Update(ingressKey.AsBytes(),
+			qos.NewConnValue(maxConnections, maxConnections).AsBytes())).NotTo(HaveOccurred())
+
+		skbMark = tcdefs.MarkSeen
+		runBpfTest(t, "calico_to_workload_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+			res, err := bpfrun(synPkt)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(res.Retval).To(Equal(resTC_ACT_UNSPEC))
+		}, withIngressQoSConnLimit(), withIPv6())
+
+		Expect(readCount(ingressKey)).To(Equal(uint32(maxConnections)))
+		// REJECTED proves the check ran and failed, rather than the SYN never
+		// reaching the block — the counter alone cannot tell those apart.
+		Expect(readCTFlags() & ctv4.FlagConnLimitInRej).To(Equal(ctv4.FlagConnLimitInRej))
+	})
+
+	t.Run("egress under the limit: counted and admitted", func(t *testing.T) {
+		RegisterTestingT(t)
+		resetCTMap(ctMap)
+		resetQoSMap(qosConnMap)
+		defer resetQoSMap(qosConnMap)
+
+		// No CT entry: a genuinely new outbound v6 flow.
+		Expect(qosConnMap.Update(egressKey.AsBytes(),
+			qos.NewConnValue(maxConnections, 1).AsBytes())).NotTo(HaveOccurred())
+
+		skbMark = 0
+		runBpfTest(t, "calico_from_workload_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+			res, err := bpfrun(synPkt)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(res.Retval).To(Equal(resTC_ACT_REDIRECT))
+		}, withEgressQoSConnLimit(), withIPv6())
+
+		Expect(readCount(egressKey)).To(Equal(uint32(2)), "v6 first SYN was not counted")
+		Expect(readCTFlags()&ctv4.FlagConnLimitOut).To(Equal(ctv4.FlagConnLimitOut),
+			"admitted v6 flow must be stamped CONNLIMIT_EGRESS")
+	})
+}
+
+// TestQoSConnLimitV6DualStackCountersAreIndependent verifies that a v6
+// connection increments the family=6 counter and leaves the family=4 counter
+// for the same interface and direction untouched.
+//
+// There is one cali_qos_conn map for both families; they are separated only by
+// the family field of the key, which the C side fills from the compile-time
+// IPVER6 and the Go side from the scanner's configured family. This is the
+// invariant that separation exists for, and it is the one thing a v4-only or
+// v6-only test cannot catch: either would pass unchanged if the family
+// dimension were dropped from the key altogether, because each would simply
+// find the single remaining entry.
+func TestQoSConnLimitV6DualStackCountersAreIndependent(t *testing.T) {
+	RegisterTestingT(t)
+
+	hostIP = node1ipV6
+	defer func() { hostIP = node1ip }()
+
+	bpfIfaceName = "HWds6"
+	defer func() { bpfIfaceName = "" }()
+
+	const (
+		ifIndex               = 1
+		maxConnections        = 3
+		srcPort        uint16 = 12350
+		dstPort        uint16 = 8055
+	)
+
+	rtKey := routes.NewKeyV6(srcV6CIDR).AsBytes()
+	rtVal := routes.NewValueV6WithIfIndex(routes.FlagsLocalWorkload|routes.FlagInIPAMPool, ifIndex).AsBytes()
+	Expect(rtMapV6.Update(rtKey, rtVal)).NotTo(HaveOccurred())
+	rtKey = routes.NewKeyV6(dstV6CIDR).AsBytes()
+	rtVal = routes.NewValueV6WithIfIndex(routes.FlagsRemoteWorkload|routes.FlagInIPAMPool, ifIndex).AsBytes()
+	Expect(rtMapV6.Update(rtKey, rtVal)).NotTo(HaveOccurred())
+	defer resetRTMap(rtMapV6)
+
+	ctMap := conntrack.MapV6()
+	Expect(ctMap.EnsureExists()).NotTo(HaveOccurred())
+	defer resetCTMap(ctMap)
+	resetCTMap(ctMap)
+
+	// A dual-stack pod: one egress entry per family on the same ifindex. The
+	// v4 side is mid-flight with two connections of its own.
+	defer resetQoSMap(qosConnMap)
+	resetQoSMap(qosConnMap)
+	v4Key := qos.NewKey(uint32(ifIndex), 0, qos.IPFamilyV4)
+	v6Key := qos.NewKey(uint32(ifIndex), 0, qos.IPFamilyV6)
+	Expect(qosConnMap.Update(v4Key.AsBytes(),
+		qos.NewConnValue(maxConnections, 2).AsBytes())).NotTo(HaveOccurred())
+	Expect(qosConnMap.Update(v6Key.AsBytes(),
+		qos.NewConnValue(maxConnections, 0).AsBytes())).NotTo(HaveOccurred())
+
+	readCount := func(qk qos.Key) uint32 {
+		b, err := qosConnMap.Get(qk.AsBytes())
+		Expect(err).NotTo(HaveOccurred())
+		return qos.ConnValueFromBytes(b).CurrentCount()
+	}
+
+	_, _, _, _, synPkt, err := testPacketTCPV6WithPayload(dstIPv6, srcPort, dstPort, true /* syn */, nil)
+	Expect(err).NotTo(HaveOccurred())
+
+	skbMark = 0
+	runBpfTest(t, "calico_from_workload_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+		res, err := bpfrun(synPkt)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.Retval).To(Equal(resTC_ACT_REDIRECT))
+	}, withEgressQoSConnLimit(), withIPv6())
+
+	Expect(readCount(v6Key)).To(Equal(uint32(1)),
+		"the v6 connection should have been counted against the v6 entry")
+	Expect(readCount(v4Key)).To(Equal(uint32(2)),
+		"a v6 connection must not touch the v4 counter for the same interface")
+}
+
 // TestQoSConnLimitEgressSpuriousRSTSlotRestoredByRecount verifies that a
 // spurious RST on a live connection costs its egress connlimit slot only until
 // the next recount, rather than permanently.
@@ -1315,428 +1739,4 @@ func TestQoSConnLimitEgressGatedOnConfiguredFlag(t *testing.T) {
 				"the connection is counted but the CT stamp is gated, "+
 				"so nothing can decrement it")
 	})
-}
-
-// TestQoSConnLimitIngressFirstSYN covers the plain first-SYN admission
-// decision at to-wep, both outcomes. The sibling tests in this file all cover
-// retransmission and recycle cases; this is the base case they build on.
-//
-// "First SYN" here means the first SYN seen at *this* hook, not the first in
-// the system: the ingress block in tc.c is gated on is_tcp_syn(), which reads
-// CT_RES_SYN, and calico_ct_lookup only sets that on a lookup hit. The
-// source-side program (from-wep or from-hep) has therefore already created the
-// CT entry by the time the SYN reaches to-wep. What distinguishes a first SYN
-// is that the entry carries neither CONNLIMIT_INGRESS nor
-// CONNLIMIT_INGRESS_REJECTED yet.
-func TestQoSConnLimitIngressFirstSYN(t *testing.T) {
-	RegisterTestingT(t)
-
-	bpfIfaceName = "HWfsi"
-	defer func() { bpfIfaceName = "" }()
-
-	const (
-		ifIndex               = 1
-		maxConnections        = 3
-		srcPort        uint16 = 23460 // remote opener
-		dstPort        uint16 = 8055  // workload listening port
-	)
-
-	rtKey := routes.NewKey(srcV4CIDR).AsBytes()
-	rtVal := routes.NewValueWithIfIndex(routes.FlagsLocalWorkload|routes.FlagInIPAMPool, ifIndex).AsBytes()
-	Expect(rtMap.Update(rtKey, rtVal)).NotTo(HaveOccurred())
-	rtKey = routes.NewKey(dstV4CIDR).AsBytes()
-	rtVal = routes.NewValueWithIfIndex(routes.FlagsRemoteWorkload|routes.FlagInIPAMPool, ifIndex).AsBytes()
-	Expect(rtMap.Update(rtKey, rtVal)).NotTo(HaveOccurred())
-	defer resetRTMap(rtMap)
-
-	ctMap := conntrack.Map()
-	Expect(ctMap.EnsureExists()).NotTo(HaveOccurred())
-	defer resetCTMap(ctMap)
-
-	k := ctv4.NewKey(6, srcIP, srcPort, dstIP, dstPort)
-	qosKey := qos.NewKey(uint32(ifIndex), 1 /* ingress */, qos.IPFamilyV4)
-
-	readQoSCount := func() uint32 {
-		b, err := qosConnMap.Get(qosKey.AsBytes())
-		Expect(err).NotTo(HaveOccurred())
-		return qos.ConnValueFromBytes(b).CurrentCount()
-	}
-
-	readCTFlags := func() uint32 {
-		b, err := ctMap.Get(k.AsBytes())
-		Expect(err).NotTo(HaveOccurred())
-		return ctv4.ValueFromBytes(b).Flags()
-	}
-
-	// The CT entry the source-side program created: opener has sent its SYN,
-	// the responder has not replied, and no connlimit flag has been set yet.
-	// current is the counter value this sub-case starts from.
-	seed := func(current uint32) {
-		resetCTMap(ctMap)
-		resetQoSMap(qosConnMap)
-
-		legA := ctv4.Leg{SynSeen: true, Opener: true}
-		legB := ctv4.Leg{Ifindex: ifIndex}
-		v := ctv4.NewValueNormal(time.Duration(0), 0 /* no connlimit flags */, legA, legB)
-		Expect(ctMap.Update(k.AsBytes(), v.AsBytes()[:])).NotTo(HaveOccurred())
-
-		Expect(qosConnMap.Update(qosKey.AsBytes(),
-			qos.NewConnValue(maxConnections, current).AsBytes())).NotTo(HaveOccurred())
-	}
-
-	_, _, _, _, synPkt, err := testPacketTCPV4WithPayload(dstIP, srcPort, dstPort, true /* syn */, nil)
-	Expect(err).NotTo(HaveOccurred())
-
-	t.Run("under the limit: counted and admitted", func(t *testing.T) {
-		RegisterTestingT(t)
-		seed(1)
-		defer resetQoSMap(qosConnMap)
-
-		skbMark = tcdefs.MarkSeen
-		runBpfTest(t, "calico_to_workload_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
-			res, err := bpfrun(synPkt)
-			Expect(err).NotTo(HaveOccurred())
-			// Admitted: no TCP_RST tail call, packet proceeds normally.
-			Expect(res.Retval).To(Equal(resTC_ACT_UNSPEC))
-		}, withIngressQoSConnLimit())
-
-		Expect(readQoSCount()).To(Equal(uint32(2)), "first SYN was not counted")
-		Expect(readCTFlags()&ctv4.FlagConnLimitIn).To(Equal(ctv4.FlagConnLimitIn),
-			"admitted SYN must stamp CONNLIMIT_INGRESS, or nothing can decrement it on close")
-		Expect(readCTFlags() & ctv4.FlagConnLimitInRej).To(Equal(uint32(0)))
-	})
-
-	t.Run("at the limit: rejected and not counted", func(t *testing.T) {
-		RegisterTestingT(t)
-		seed(maxConnections)
-		defer resetQoSMap(qosConnMap)
-
-		skbMark = tcdefs.MarkSeen
-		runBpfTest(t, "calico_to_workload_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
-			res, err := bpfrun(synPkt)
-			Expect(err).NotTo(HaveOccurred())
-			// Reject path tail-calls PROG_INDEX_TCP_RST, which builds the RST
-			// and forwards it; the final return is TC_ACT_UNSPEC.
-			Expect(res.Retval).To(Equal(resTC_ACT_UNSPEC))
-		}, withIngressQoSConnLimit())
-
-		// The failed check must not increment.
-		Expect(readQoSCount()).To(Equal(uint32(maxConnections)))
-		// Guard against a vacuous pass: REJECTED proves the check ran and
-		// failed, rather than the SYN never reaching the block.
-		Expect(readCTFlags()&ctv4.FlagConnLimitInRej).To(Equal(ctv4.FlagConnLimitInRej),
-			"rejected SYN must stamp CONNLIMIT_INGRESS_REJECTED")
-		Expect(readCTFlags() & ctv4.FlagConnLimitIn).To(Equal(uint32(0)))
-	})
-}
-
-// TestQoSConnLimitEgressFirstSYN covers the plain first-SYN admission decision
-// at from-wep, both outcomes.
-//
-// The egress path differs from ingress in more than direction: the check sits
-// in a different block (tc.c, after policy rather than at to-wep), there is no
-// pre-existing CT entry — this is a genuinely new flow — and CONNLIMIT_EGRESS
-// is applied through ct_ctx_nat->flags as the entry is created rather than
-// stamped onto an existing one. So ingress passing is not evidence that egress
-// does.
-func TestQoSConnLimitEgressFirstSYN(t *testing.T) {
-	RegisterTestingT(t)
-
-	bpfIfaceName = "HWfse"
-	defer func() { bpfIfaceName = "" }()
-
-	const (
-		ifIndex               = 1
-		maxConnections        = 3
-		srcPort        uint16 = 12349
-		dstPort        uint16 = 8055
-	)
-
-	rtKey := routes.NewKey(srcV4CIDR).AsBytes()
-	rtVal := routes.NewValueWithIfIndex(routes.FlagsLocalWorkload|routes.FlagInIPAMPool, ifIndex).AsBytes()
-	Expect(rtMap.Update(rtKey, rtVal)).NotTo(HaveOccurred())
-	rtKey = routes.NewKey(dstV4CIDR).AsBytes()
-	rtVal = routes.NewValueWithIfIndex(routes.FlagsRemoteWorkload|routes.FlagInIPAMPool, ifIndex).AsBytes()
-	Expect(rtMap.Update(rtKey, rtVal)).NotTo(HaveOccurred())
-	defer resetRTMap(rtMap)
-
-	ctMap := conntrack.Map()
-	Expect(ctMap.EnsureExists()).NotTo(HaveOccurred())
-	defer resetCTMap(ctMap)
-
-	k := ctv4.NewKey(6, srcIP, srcPort, dstIP, dstPort)
-	qosKey := qos.NewKey(uint32(ifIndex), 0 /* egress */, qos.IPFamilyV4)
-
-	readQoSCount := func() uint32 {
-		b, err := qosConnMap.Get(qosKey.AsBytes())
-		Expect(err).NotTo(HaveOccurred())
-		return qos.ConnValueFromBytes(b).CurrentCount()
-	}
-
-	// No CT entry: a genuinely new outbound flow.
-	seed := func(current uint32) {
-		resetCTMap(ctMap)
-		resetQoSMap(qosConnMap)
-		Expect(qosConnMap.Update(qosKey.AsBytes(),
-			qos.NewConnValue(maxConnections, current).AsBytes())).NotTo(HaveOccurred())
-	}
-
-	_, _, _, _, synPkt, err := testPacketTCPV4WithPayload(dstIP, srcPort, dstPort, true /* syn */, nil)
-	Expect(err).NotTo(HaveOccurred())
-
-	t.Run("under the limit: counted and admitted", func(t *testing.T) {
-		RegisterTestingT(t)
-		seed(1)
-		defer resetQoSMap(qosConnMap)
-
-		skbMark = 0
-		runBpfTest(t, "calico_from_workload_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
-			res, err := bpfrun(synPkt)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(res.Retval).To(Equal(resTC_ACT_REDIRECT))
-		}, withEgressQoSConnLimit())
-
-		Expect(readQoSCount()).To(Equal(uint32(2)), "first SYN was not counted")
-
-		// The new CT entry must carry CONNLIMIT_EGRESS, or the close and
-		// cleanup paths cannot decrement it.
-		b, err := ctMap.Get(k.AsBytes())
-		Expect(err).NotTo(HaveOccurred(), "no CT entry was created for the admitted flow")
-		Expect(ctv4.ValueFromBytes(b).Flags()&ctv4.FlagConnLimitOut).
-			To(Equal(ctv4.FlagConnLimitOut), "admitted flow must be stamped CONNLIMIT_EGRESS")
-	})
-
-	t.Run("at the limit: rejected and not counted", func(t *testing.T) {
-		RegisterTestingT(t)
-		seed(maxConnections)
-		defer resetQoSMap(qosConnMap)
-
-		skbMark = 0
-		runBpfTest(t, "calico_from_workload_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
-			res, err := bpfrun(synPkt)
-			Expect(err).NotTo(HaveOccurred())
-			// Note the return code does NOT distinguish reject from admit on
-			// egress: the reject path tail-calls PROG_INDEX_TCP_RST, which
-			// builds the RST and redirects it back to the workload, so both
-			// outcomes return TC_ACT_REDIRECT. Do not use it as the signal
-			// that the limit fired.
-			Expect(res.Retval).To(Equal(resTC_ACT_REDIRECT))
-		}, withEgressQoSConnLimit())
-
-		Expect(readQoSCount()).To(Equal(uint32(maxConnections)))
-
-		// This is the discriminator instead. The check sits ahead of the CT
-		// create, and a rejected SYN goes straight to deny, so the flow
-		// leaves no conntrack state — whereas the admitted case above ends
-		// with an entry stamped CONNLIMIT_EGRESS. Without this the assertion
-		// on the counter would pass just as happily if the SYN had never
-		// reached the check at all.
-		_, err := ctMap.Get(k.AsBytes())
-		Expect(err).To(HaveOccurred(),
-			"rejected SYN must not create a CT entry")
-	})
-}
-
-// TestQoSConnLimitV6FirstSYN is the IPv6 counterpart of the first-SYN tests
-// above. The v4 and v6 dataplanes are the same C source compiled twice
-// (IPVER6), so the admission *logic* cannot differ between them; what can
-// differ is whether the v6 programs reach the check at all and which
-// cali_qos_conn entry they address, since family is part of that map's key.
-// Those are what this covers, which is why it does not port every v4 case —
-// the retransmission and recycle paths are family-agnostic and already
-// covered.
-func TestQoSConnLimitV6FirstSYN(t *testing.T) {
-	RegisterTestingT(t)
-
-	hostIP = node1ipV6
-	defer func() { hostIP = node1ip }()
-
-	bpfIfaceName = "HWfs6"
-	defer func() { bpfIfaceName = "" }()
-
-	const (
-		ifIndex               = 1
-		maxConnections        = 3
-		srcPort        uint16 = 23461
-		dstPort        uint16 = 8055
-	)
-
-	rtKey := routes.NewKeyV6(srcV6CIDR).AsBytes()
-	rtVal := routes.NewValueV6WithIfIndex(routes.FlagsLocalWorkload|routes.FlagInIPAMPool, ifIndex).AsBytes()
-	Expect(rtMapV6.Update(rtKey, rtVal)).NotTo(HaveOccurred())
-	rtKey = routes.NewKeyV6(dstV6CIDR).AsBytes()
-	rtVal = routes.NewValueV6WithIfIndex(routes.FlagsRemoteWorkload|routes.FlagInIPAMPool, ifIndex).AsBytes()
-	Expect(rtMapV6.Update(rtKey, rtVal)).NotTo(HaveOccurred())
-	defer resetRTMap(rtMapV6)
-
-	ctMap := conntrack.MapV6()
-	Expect(ctMap.EnsureExists()).NotTo(HaveOccurred())
-	defer resetCTMap(ctMap)
-
-	k := conntrack.NewKeyV6(6, srcIPv6, srcPort, dstIPv6, dstPort)
-	// Family is part of the cali_qos_conn key: a v6 program must address the
-	// family=6 entry, not the v4 one.
-	ingressKey := qos.NewKey(uint32(ifIndex), 1, qos.IPFamilyV6)
-	egressKey := qos.NewKey(uint32(ifIndex), 0, qos.IPFamilyV6)
-
-	readCount := func(qk qos.Key) uint32 {
-		b, err := qosConnMap.Get(qk.AsBytes())
-		Expect(err).NotTo(HaveOccurred())
-		return qos.ConnValueFromBytes(b).CurrentCount()
-	}
-
-	readCTFlags := func() uint32 {
-		b, err := ctMap.Get(k.AsBytes())
-		Expect(err).NotTo(HaveOccurred())
-		return ctv4.ValueV6FromBytes(b).Flags()
-	}
-
-	_, _, _, _, synPkt, err := testPacketTCPV6WithPayload(dstIPv6, srcPort, dstPort, true /* syn */, nil)
-	Expect(err).NotTo(HaveOccurred())
-
-	t.Run("ingress under the limit: counted and admitted", func(t *testing.T) {
-		RegisterTestingT(t)
-		resetCTMap(ctMap)
-		resetQoSMap(qosConnMap)
-		defer resetQoSMap(qosConnMap)
-
-		// The CT entry the source-side program created, not yet counted.
-		legA := ctv4.Leg{SynSeen: true, Opener: true}
-		legB := ctv4.Leg{Ifindex: ifIndex}
-		v := conntrack.NewValueV6Normal(time.Duration(0), 0, legA, legB)
-		Expect(ctMap.Update(k.AsBytes(), v.AsBytes()[:])).NotTo(HaveOccurred())
-		Expect(qosConnMap.Update(ingressKey.AsBytes(),
-			qos.NewConnValue(maxConnections, 1).AsBytes())).NotTo(HaveOccurred())
-
-		skbMark = tcdefs.MarkSeen
-		runBpfTest(t, "calico_to_workload_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
-			res, err := bpfrun(synPkt)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(res.Retval).To(Equal(resTC_ACT_UNSPEC))
-		}, withIngressQoSConnLimit(), withIPv6())
-
-		Expect(readCount(ingressKey)).To(Equal(uint32(2)), "v6 first SYN was not counted")
-		Expect(readCTFlags() & ctv4.FlagConnLimitIn).To(Equal(ctv4.FlagConnLimitIn))
-	})
-
-	t.Run("ingress at the limit: rejected and not counted", func(t *testing.T) {
-		RegisterTestingT(t)
-		resetCTMap(ctMap)
-		resetQoSMap(qosConnMap)
-		defer resetQoSMap(qosConnMap)
-
-		legA := ctv4.Leg{SynSeen: true, Opener: true}
-		legB := ctv4.Leg{Ifindex: ifIndex}
-		v := conntrack.NewValueV6Normal(time.Duration(0), 0, legA, legB)
-		Expect(ctMap.Update(k.AsBytes(), v.AsBytes()[:])).NotTo(HaveOccurred())
-		Expect(qosConnMap.Update(ingressKey.AsBytes(),
-			qos.NewConnValue(maxConnections, maxConnections).AsBytes())).NotTo(HaveOccurred())
-
-		skbMark = tcdefs.MarkSeen
-		runBpfTest(t, "calico_to_workload_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
-			res, err := bpfrun(synPkt)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(res.Retval).To(Equal(resTC_ACT_UNSPEC))
-		}, withIngressQoSConnLimit(), withIPv6())
-
-		Expect(readCount(ingressKey)).To(Equal(uint32(maxConnections)))
-		// REJECTED proves the check ran and failed, rather than the SYN never
-		// reaching the block — the counter alone cannot tell those apart.
-		Expect(readCTFlags() & ctv4.FlagConnLimitInRej).To(Equal(ctv4.FlagConnLimitInRej))
-	})
-
-	t.Run("egress under the limit: counted and admitted", func(t *testing.T) {
-		RegisterTestingT(t)
-		resetCTMap(ctMap)
-		resetQoSMap(qosConnMap)
-		defer resetQoSMap(qosConnMap)
-
-		// No CT entry: a genuinely new outbound v6 flow.
-		Expect(qosConnMap.Update(egressKey.AsBytes(),
-			qos.NewConnValue(maxConnections, 1).AsBytes())).NotTo(HaveOccurred())
-
-		skbMark = 0
-		runBpfTest(t, "calico_from_workload_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
-			res, err := bpfrun(synPkt)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(res.Retval).To(Equal(resTC_ACT_REDIRECT))
-		}, withEgressQoSConnLimit(), withIPv6())
-
-		Expect(readCount(egressKey)).To(Equal(uint32(2)), "v6 first SYN was not counted")
-		Expect(readCTFlags()&ctv4.FlagConnLimitOut).To(Equal(ctv4.FlagConnLimitOut),
-			"admitted v6 flow must be stamped CONNLIMIT_EGRESS")
-	})
-}
-
-// TestQoSConnLimitV6DualStackCountersAreIndependent verifies that a v6
-// connection increments the family=6 counter and leaves the family=4 counter
-// for the same interface and direction untouched.
-//
-// There is one cali_qos_conn map for both families; they are separated only by
-// the family field of the key, which the C side fills from the compile-time
-// IPVER6 and the Go side from the scanner's configured family. This is the
-// invariant that separation exists for, and it is the one thing a v4-only or
-// v6-only test cannot catch: either would pass unchanged if the family
-// dimension were dropped from the key altogether, because each would simply
-// find the single remaining entry.
-func TestQoSConnLimitV6DualStackCountersAreIndependent(t *testing.T) {
-	RegisterTestingT(t)
-
-	hostIP = node1ipV6
-	defer func() { hostIP = node1ip }()
-
-	bpfIfaceName = "HWds6"
-	defer func() { bpfIfaceName = "" }()
-
-	const (
-		ifIndex               = 1
-		maxConnections        = 3
-		srcPort        uint16 = 12350
-		dstPort        uint16 = 8055
-	)
-
-	rtKey := routes.NewKeyV6(srcV6CIDR).AsBytes()
-	rtVal := routes.NewValueV6WithIfIndex(routes.FlagsLocalWorkload|routes.FlagInIPAMPool, ifIndex).AsBytes()
-	Expect(rtMapV6.Update(rtKey, rtVal)).NotTo(HaveOccurred())
-	rtKey = routes.NewKeyV6(dstV6CIDR).AsBytes()
-	rtVal = routes.NewValueV6WithIfIndex(routes.FlagsRemoteWorkload|routes.FlagInIPAMPool, ifIndex).AsBytes()
-	Expect(rtMapV6.Update(rtKey, rtVal)).NotTo(HaveOccurred())
-	defer resetRTMap(rtMapV6)
-
-	ctMap := conntrack.MapV6()
-	Expect(ctMap.EnsureExists()).NotTo(HaveOccurred())
-	defer resetCTMap(ctMap)
-	resetCTMap(ctMap)
-
-	// A dual-stack pod: one egress entry per family on the same ifindex. The
-	// v4 side is mid-flight with two connections of its own.
-	defer resetQoSMap(qosConnMap)
-	resetQoSMap(qosConnMap)
-	v4Key := qos.NewKey(uint32(ifIndex), 0, qos.IPFamilyV4)
-	v6Key := qos.NewKey(uint32(ifIndex), 0, qos.IPFamilyV6)
-	Expect(qosConnMap.Update(v4Key.AsBytes(),
-		qos.NewConnValue(maxConnections, 2).AsBytes())).NotTo(HaveOccurred())
-	Expect(qosConnMap.Update(v6Key.AsBytes(),
-		qos.NewConnValue(maxConnections, 0).AsBytes())).NotTo(HaveOccurred())
-
-	readCount := func(qk qos.Key) uint32 {
-		b, err := qosConnMap.Get(qk.AsBytes())
-		Expect(err).NotTo(HaveOccurred())
-		return qos.ConnValueFromBytes(b).CurrentCount()
-	}
-
-	_, _, _, _, synPkt, err := testPacketTCPV6WithPayload(dstIPv6, srcPort, dstPort, true /* syn */, nil)
-	Expect(err).NotTo(HaveOccurred())
-
-	skbMark = 0
-	runBpfTest(t, "calico_from_workload_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
-		res, err := bpfrun(synPkt)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(res.Retval).To(Equal(resTC_ACT_REDIRECT))
-	}, withEgressQoSConnLimit(), withIPv6())
-
-	Expect(readCount(v6Key)).To(Equal(uint32(1)),
-		"the v6 connection should have been counted against the v6 entry")
-	Expect(readCount(v4Key)).To(Equal(uint32(2)),
-		"a v6 connection must not touch the v4 counter for the same interface")
 }

--- a/felix/bpf/ut/qos_test.go
+++ b/felix/bpf/ut/qos_test.go
@@ -1209,3 +1209,110 @@ func spuriousRSTThenTrafficPackets(ip *layers.IPv4, srcPort, dstPort uint16) (rs
 
 	return rstPkt, dataPkt
 }
+
+// TestQoSConnLimitEgressGatedOnConfiguredFlag verifies that the egress
+// connection-limit check is gated on EGRESS_CONN_LIMIT_CONFIGURED, matching
+// the ingress check and the egress CT stamp.
+//
+// The egress check ran on every from-WEP TCP SYN and fired whenever a
+// cali_qos_conn entry with max_connections > 0 existed, while the stamp that
+// marks the CT entry CONNLIMIT_EGRESS was gated on the global. Felix writes
+// the map entry and sets ap.EgressConnLimitConfigured in the same pass
+// (bpf_ep_mgr.go), but the program only picks the global up when it is
+// reattached, so a connection opened in that window was counted without being
+// flagged — and qos_connlimit_decrement_for_ct returns early for an entry
+// carrying neither CONNLIMIT_INGRESS nor _EGRESS, so neither the close path
+// nor the cleanup path could decrement it.
+//
+// ConnLimitScanner rebases current_count on pod identity rather than on those
+// flags, so the drift was transient rather than a leak. The asymmetry is still
+// worth removing: gating both on the global closes the window and skips the
+// map lookup entirely for endpoints with no egress limit, which is what the
+// design doc already describes — "the per-direction ... flags gate the BPF
+// connlimit code path entirely when no limit is configured for that attach
+// point".
+func TestQoSConnLimitEgressGatedOnConfiguredFlag(t *testing.T) {
+	RegisterTestingT(t)
+
+	bpfIfaceName = "HWegg"
+	defer func() { bpfIfaceName = "" }()
+
+	const (
+		// ifIndex must match the BPF UT's default skb ifindex so the
+		// workload RPF check passes.
+		ifIndex               = 1
+		maxConnections        = 3
+		srcPort        uint16 = 12348
+		dstPort        uint16 = 8055
+	)
+
+	rtKey := routes.NewKey(srcV4CIDR).AsBytes()
+	rtVal := routes.NewValueWithIfIndex(routes.FlagsLocalWorkload|routes.FlagInIPAMPool, ifIndex).AsBytes()
+	Expect(rtMap.Update(rtKey, rtVal)).NotTo(HaveOccurred())
+	rtKey = routes.NewKey(dstV4CIDR).AsBytes()
+	rtVal = routes.NewValueWithIfIndex(routes.FlagsRemoteWorkload|routes.FlagInIPAMPool, ifIndex).AsBytes()
+	Expect(rtMap.Update(rtKey, rtVal)).NotTo(HaveOccurred())
+	defer resetRTMap(rtMap)
+
+	ctMap := conntrack.Map()
+	Expect(ctMap.EnsureExists()).NotTo(HaveOccurred())
+	defer resetCTMap(ctMap)
+
+	qosKey := qos.NewKey(uint32(ifIndex), 0 /* egress */, qos.IPFamilyV4)
+
+	readQoSCount := func() uint32 {
+		b, err := qosConnMap.Get(qosKey.AsBytes())
+		Expect(err).NotTo(HaveOccurred())
+		return qos.ConnValueFromBytes(b).CurrentCount()
+	}
+
+	// A configured limit with the counter at zero -- the map entry Felix has
+	// already written. Whether it is enforced is what the two cases differ on.
+	seed := func() {
+		resetCTMap(ctMap)
+		resetQoSMap(qosConnMap)
+		Expect(qosConnMap.Update(qosKey.AsBytes(),
+			qos.NewConnValue(maxConnections, 0).AsBytes())).NotTo(HaveOccurred())
+	}
+
+	_, _, _, _, synPkt, err := testPacketTCPV4WithPayload(dstIP, srcPort, dstPort, true /* syn */, nil)
+	Expect(err).NotTo(HaveOccurred())
+
+	// Positive control. Without it the case below would pass for any reason
+	// the SYN failed to reach the check at all.
+	t.Run("global set: SYN is counted", func(t *testing.T) {
+		RegisterTestingT(t)
+		seed()
+		defer resetQoSMap(qosConnMap)
+
+		skbMark = 0
+		runBpfTest(t, "calico_from_workload_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+			res, err := bpfrun(synPkt)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(res.Retval).To(Equal(resTC_ACT_REDIRECT))
+		}, withEgressQoSConnLimit())
+
+		Expect(readQoSCount()).To(Equal(uint32(1)))
+	})
+
+	t.Run("global clear: SYN is not counted", func(t *testing.T) {
+		RegisterTestingT(t)
+		seed()
+		defer resetQoSMap(qosConnMap)
+
+		// No withEgressQoSConnLimit(): the program as it is attached before
+		// Felix reattaches it with the new global, while the map entry
+		// seeded above is already in place.
+		skbMark = 0
+		runBpfTest(t, "calico_from_workload_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+			res, err := bpfrun(synPkt)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(res.Retval).To(Equal(resTC_ACT_REDIRECT))
+		})
+
+		Expect(readQoSCount()).To(Equal(uint32(0)),
+			"egress connlimit check ran without EGRESS_CONN_LIMIT_CONFIGURED; "+
+				"the connection is counted but the CT stamp is gated, "+
+				"so nothing can decrement it")
+	})
+}

--- a/felix/bpf/ut/qos_test.go
+++ b/felix/bpf/ut/qos_test.go
@@ -1316,3 +1316,427 @@ func TestQoSConnLimitEgressGatedOnConfiguredFlag(t *testing.T) {
 				"so nothing can decrement it")
 	})
 }
+
+// TestQoSConnLimitIngressFirstSYN covers the plain first-SYN admission
+// decision at to-wep, both outcomes. The sibling tests in this file all cover
+// retransmission and recycle cases; this is the base case they build on.
+//
+// "First SYN" here means the first SYN seen at *this* hook, not the first in
+// the system: the ingress block in tc.c is gated on is_tcp_syn(), which reads
+// CT_RES_SYN, and calico_ct_lookup only sets that on a lookup hit. The
+// source-side program (from-wep or from-hep) has therefore already created the
+// CT entry by the time the SYN reaches to-wep. What distinguishes a first SYN
+// is that the entry carries neither CONNLIMIT_INGRESS nor
+// CONNLIMIT_INGRESS_REJECTED yet.
+func TestQoSConnLimitIngressFirstSYN(t *testing.T) {
+	RegisterTestingT(t)
+
+	bpfIfaceName = "HWfsi"
+	defer func() { bpfIfaceName = "" }()
+
+	const (
+		ifIndex               = 1
+		maxConnections        = 3
+		srcPort        uint16 = 23460 // remote opener
+		dstPort        uint16 = 8055  // workload listening port
+	)
+
+	rtKey := routes.NewKey(srcV4CIDR).AsBytes()
+	rtVal := routes.NewValueWithIfIndex(routes.FlagsLocalWorkload|routes.FlagInIPAMPool, ifIndex).AsBytes()
+	Expect(rtMap.Update(rtKey, rtVal)).NotTo(HaveOccurred())
+	rtKey = routes.NewKey(dstV4CIDR).AsBytes()
+	rtVal = routes.NewValueWithIfIndex(routes.FlagsRemoteWorkload|routes.FlagInIPAMPool, ifIndex).AsBytes()
+	Expect(rtMap.Update(rtKey, rtVal)).NotTo(HaveOccurred())
+	defer resetRTMap(rtMap)
+
+	ctMap := conntrack.Map()
+	Expect(ctMap.EnsureExists()).NotTo(HaveOccurred())
+	defer resetCTMap(ctMap)
+
+	k := ctv4.NewKey(6, srcIP, srcPort, dstIP, dstPort)
+	qosKey := qos.NewKey(uint32(ifIndex), 1 /* ingress */, qos.IPFamilyV4)
+
+	readQoSCount := func() uint32 {
+		b, err := qosConnMap.Get(qosKey.AsBytes())
+		Expect(err).NotTo(HaveOccurred())
+		return qos.ConnValueFromBytes(b).CurrentCount()
+	}
+
+	readCTFlags := func() uint32 {
+		b, err := ctMap.Get(k.AsBytes())
+		Expect(err).NotTo(HaveOccurred())
+		return ctv4.ValueFromBytes(b).Flags()
+	}
+
+	// The CT entry the source-side program created: opener has sent its SYN,
+	// the responder has not replied, and no connlimit flag has been set yet.
+	// current is the counter value this sub-case starts from.
+	seed := func(current uint32) {
+		resetCTMap(ctMap)
+		resetQoSMap(qosConnMap)
+
+		legA := ctv4.Leg{SynSeen: true, Opener: true}
+		legB := ctv4.Leg{Ifindex: ifIndex}
+		v := ctv4.NewValueNormal(time.Duration(0), 0 /* no connlimit flags */, legA, legB)
+		Expect(ctMap.Update(k.AsBytes(), v.AsBytes()[:])).NotTo(HaveOccurred())
+
+		Expect(qosConnMap.Update(qosKey.AsBytes(),
+			qos.NewConnValue(maxConnections, current).AsBytes())).NotTo(HaveOccurred())
+	}
+
+	_, _, _, _, synPkt, err := testPacketTCPV4WithPayload(dstIP, srcPort, dstPort, true /* syn */, nil)
+	Expect(err).NotTo(HaveOccurred())
+
+	t.Run("under the limit: counted and admitted", func(t *testing.T) {
+		RegisterTestingT(t)
+		seed(1)
+		defer resetQoSMap(qosConnMap)
+
+		skbMark = tcdefs.MarkSeen
+		runBpfTest(t, "calico_to_workload_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+			res, err := bpfrun(synPkt)
+			Expect(err).NotTo(HaveOccurred())
+			// Admitted: no TCP_RST tail call, packet proceeds normally.
+			Expect(res.Retval).To(Equal(resTC_ACT_UNSPEC))
+		}, withIngressQoSConnLimit())
+
+		Expect(readQoSCount()).To(Equal(uint32(2)), "first SYN was not counted")
+		Expect(readCTFlags()&ctv4.FlagConnLimitIn).To(Equal(ctv4.FlagConnLimitIn),
+			"admitted SYN must stamp CONNLIMIT_INGRESS, or nothing can decrement it on close")
+		Expect(readCTFlags() & ctv4.FlagConnLimitInRej).To(Equal(uint32(0)))
+	})
+
+	t.Run("at the limit: rejected and not counted", func(t *testing.T) {
+		RegisterTestingT(t)
+		seed(maxConnections)
+		defer resetQoSMap(qosConnMap)
+
+		skbMark = tcdefs.MarkSeen
+		runBpfTest(t, "calico_to_workload_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+			res, err := bpfrun(synPkt)
+			Expect(err).NotTo(HaveOccurred())
+			// Reject path tail-calls PROG_INDEX_TCP_RST, which builds the RST
+			// and forwards it; the final return is TC_ACT_UNSPEC.
+			Expect(res.Retval).To(Equal(resTC_ACT_UNSPEC))
+		}, withIngressQoSConnLimit())
+
+		// The failed check must not increment.
+		Expect(readQoSCount()).To(Equal(uint32(maxConnections)))
+		// Guard against a vacuous pass: REJECTED proves the check ran and
+		// failed, rather than the SYN never reaching the block.
+		Expect(readCTFlags()&ctv4.FlagConnLimitInRej).To(Equal(ctv4.FlagConnLimitInRej),
+			"rejected SYN must stamp CONNLIMIT_INGRESS_REJECTED")
+		Expect(readCTFlags() & ctv4.FlagConnLimitIn).To(Equal(uint32(0)))
+	})
+}
+
+// TestQoSConnLimitEgressFirstSYN covers the plain first-SYN admission decision
+// at from-wep, both outcomes.
+//
+// The egress path differs from ingress in more than direction: the check sits
+// in a different block (tc.c, after policy rather than at to-wep), there is no
+// pre-existing CT entry — this is a genuinely new flow — and CONNLIMIT_EGRESS
+// is applied through ct_ctx_nat->flags as the entry is created rather than
+// stamped onto an existing one. So ingress passing is not evidence that egress
+// does.
+func TestQoSConnLimitEgressFirstSYN(t *testing.T) {
+	RegisterTestingT(t)
+
+	bpfIfaceName = "HWfse"
+	defer func() { bpfIfaceName = "" }()
+
+	const (
+		ifIndex               = 1
+		maxConnections        = 3
+		srcPort        uint16 = 12349
+		dstPort        uint16 = 8055
+	)
+
+	rtKey := routes.NewKey(srcV4CIDR).AsBytes()
+	rtVal := routes.NewValueWithIfIndex(routes.FlagsLocalWorkload|routes.FlagInIPAMPool, ifIndex).AsBytes()
+	Expect(rtMap.Update(rtKey, rtVal)).NotTo(HaveOccurred())
+	rtKey = routes.NewKey(dstV4CIDR).AsBytes()
+	rtVal = routes.NewValueWithIfIndex(routes.FlagsRemoteWorkload|routes.FlagInIPAMPool, ifIndex).AsBytes()
+	Expect(rtMap.Update(rtKey, rtVal)).NotTo(HaveOccurred())
+	defer resetRTMap(rtMap)
+
+	ctMap := conntrack.Map()
+	Expect(ctMap.EnsureExists()).NotTo(HaveOccurred())
+	defer resetCTMap(ctMap)
+
+	k := ctv4.NewKey(6, srcIP, srcPort, dstIP, dstPort)
+	qosKey := qos.NewKey(uint32(ifIndex), 0 /* egress */, qos.IPFamilyV4)
+
+	readQoSCount := func() uint32 {
+		b, err := qosConnMap.Get(qosKey.AsBytes())
+		Expect(err).NotTo(HaveOccurred())
+		return qos.ConnValueFromBytes(b).CurrentCount()
+	}
+
+	// No CT entry: a genuinely new outbound flow.
+	seed := func(current uint32) {
+		resetCTMap(ctMap)
+		resetQoSMap(qosConnMap)
+		Expect(qosConnMap.Update(qosKey.AsBytes(),
+			qos.NewConnValue(maxConnections, current).AsBytes())).NotTo(HaveOccurred())
+	}
+
+	_, _, _, _, synPkt, err := testPacketTCPV4WithPayload(dstIP, srcPort, dstPort, true /* syn */, nil)
+	Expect(err).NotTo(HaveOccurred())
+
+	t.Run("under the limit: counted and admitted", func(t *testing.T) {
+		RegisterTestingT(t)
+		seed(1)
+		defer resetQoSMap(qosConnMap)
+
+		skbMark = 0
+		runBpfTest(t, "calico_from_workload_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+			res, err := bpfrun(synPkt)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(res.Retval).To(Equal(resTC_ACT_REDIRECT))
+		}, withEgressQoSConnLimit())
+
+		Expect(readQoSCount()).To(Equal(uint32(2)), "first SYN was not counted")
+
+		// The new CT entry must carry CONNLIMIT_EGRESS, or the close and
+		// cleanup paths cannot decrement it.
+		b, err := ctMap.Get(k.AsBytes())
+		Expect(err).NotTo(HaveOccurred(), "no CT entry was created for the admitted flow")
+		Expect(ctv4.ValueFromBytes(b).Flags()&ctv4.FlagConnLimitOut).
+			To(Equal(ctv4.FlagConnLimitOut), "admitted flow must be stamped CONNLIMIT_EGRESS")
+	})
+
+	t.Run("at the limit: rejected and not counted", func(t *testing.T) {
+		RegisterTestingT(t)
+		seed(maxConnections)
+		defer resetQoSMap(qosConnMap)
+
+		skbMark = 0
+		runBpfTest(t, "calico_from_workload_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+			res, err := bpfrun(synPkt)
+			Expect(err).NotTo(HaveOccurred())
+			// Note the return code does NOT distinguish reject from admit on
+			// egress: the reject path tail-calls PROG_INDEX_TCP_RST, which
+			// builds the RST and redirects it back to the workload, so both
+			// outcomes return TC_ACT_REDIRECT. Do not use it as the signal
+			// that the limit fired.
+			Expect(res.Retval).To(Equal(resTC_ACT_REDIRECT))
+		}, withEgressQoSConnLimit())
+
+		Expect(readQoSCount()).To(Equal(uint32(maxConnections)))
+
+		// This is the discriminator instead. The check sits ahead of the CT
+		// create, and a rejected SYN goes straight to deny, so the flow
+		// leaves no conntrack state — whereas the admitted case above ends
+		// with an entry stamped CONNLIMIT_EGRESS. Without this the assertion
+		// on the counter would pass just as happily if the SYN had never
+		// reached the check at all.
+		_, err := ctMap.Get(k.AsBytes())
+		Expect(err).To(HaveOccurred(),
+			"rejected SYN must not create a CT entry")
+	})
+}
+
+// TestQoSConnLimitV6FirstSYN is the IPv6 counterpart of the first-SYN tests
+// above. The v4 and v6 dataplanes are the same C source compiled twice
+// (IPVER6), so the admission *logic* cannot differ between them; what can
+// differ is whether the v6 programs reach the check at all and which
+// cali_qos_conn entry they address, since family is part of that map's key.
+// Those are what this covers, which is why it does not port every v4 case —
+// the retransmission and recycle paths are family-agnostic and already
+// covered.
+func TestQoSConnLimitV6FirstSYN(t *testing.T) {
+	RegisterTestingT(t)
+
+	hostIP = node1ipV6
+	defer func() { hostIP = node1ip }()
+
+	bpfIfaceName = "HWfs6"
+	defer func() { bpfIfaceName = "" }()
+
+	const (
+		ifIndex               = 1
+		maxConnections        = 3
+		srcPort        uint16 = 23461
+		dstPort        uint16 = 8055
+	)
+
+	rtKey := routes.NewKeyV6(srcV6CIDR).AsBytes()
+	rtVal := routes.NewValueV6WithIfIndex(routes.FlagsLocalWorkload|routes.FlagInIPAMPool, ifIndex).AsBytes()
+	Expect(rtMapV6.Update(rtKey, rtVal)).NotTo(HaveOccurred())
+	rtKey = routes.NewKeyV6(dstV6CIDR).AsBytes()
+	rtVal = routes.NewValueV6WithIfIndex(routes.FlagsRemoteWorkload|routes.FlagInIPAMPool, ifIndex).AsBytes()
+	Expect(rtMapV6.Update(rtKey, rtVal)).NotTo(HaveOccurred())
+	defer resetRTMap(rtMapV6)
+
+	ctMap := conntrack.MapV6()
+	Expect(ctMap.EnsureExists()).NotTo(HaveOccurred())
+	defer resetCTMap(ctMap)
+
+	k := conntrack.NewKeyV6(6, srcIPv6, srcPort, dstIPv6, dstPort)
+	// Family is part of the cali_qos_conn key: a v6 program must address the
+	// family=6 entry, not the v4 one.
+	ingressKey := qos.NewKey(uint32(ifIndex), 1, qos.IPFamilyV6)
+	egressKey := qos.NewKey(uint32(ifIndex), 0, qos.IPFamilyV6)
+
+	readCount := func(qk qos.Key) uint32 {
+		b, err := qosConnMap.Get(qk.AsBytes())
+		Expect(err).NotTo(HaveOccurred())
+		return qos.ConnValueFromBytes(b).CurrentCount()
+	}
+
+	readCTFlags := func() uint32 {
+		b, err := ctMap.Get(k.AsBytes())
+		Expect(err).NotTo(HaveOccurred())
+		return ctv4.ValueV6FromBytes(b).Flags()
+	}
+
+	_, _, _, _, synPkt, err := testPacketTCPV6WithPayload(dstIPv6, srcPort, dstPort, true /* syn */, nil)
+	Expect(err).NotTo(HaveOccurred())
+
+	t.Run("ingress under the limit: counted and admitted", func(t *testing.T) {
+		RegisterTestingT(t)
+		resetCTMap(ctMap)
+		resetQoSMap(qosConnMap)
+		defer resetQoSMap(qosConnMap)
+
+		// The CT entry the source-side program created, not yet counted.
+		legA := ctv4.Leg{SynSeen: true, Opener: true}
+		legB := ctv4.Leg{Ifindex: ifIndex}
+		v := conntrack.NewValueV6Normal(time.Duration(0), 0, legA, legB)
+		Expect(ctMap.Update(k.AsBytes(), v.AsBytes()[:])).NotTo(HaveOccurred())
+		Expect(qosConnMap.Update(ingressKey.AsBytes(),
+			qos.NewConnValue(maxConnections, 1).AsBytes())).NotTo(HaveOccurred())
+
+		skbMark = tcdefs.MarkSeen
+		runBpfTest(t, "calico_to_workload_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+			res, err := bpfrun(synPkt)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(res.Retval).To(Equal(resTC_ACT_UNSPEC))
+		}, withIngressQoSConnLimit(), withIPv6())
+
+		Expect(readCount(ingressKey)).To(Equal(uint32(2)), "v6 first SYN was not counted")
+		Expect(readCTFlags() & ctv4.FlagConnLimitIn).To(Equal(ctv4.FlagConnLimitIn))
+	})
+
+	t.Run("ingress at the limit: rejected and not counted", func(t *testing.T) {
+		RegisterTestingT(t)
+		resetCTMap(ctMap)
+		resetQoSMap(qosConnMap)
+		defer resetQoSMap(qosConnMap)
+
+		legA := ctv4.Leg{SynSeen: true, Opener: true}
+		legB := ctv4.Leg{Ifindex: ifIndex}
+		v := conntrack.NewValueV6Normal(time.Duration(0), 0, legA, legB)
+		Expect(ctMap.Update(k.AsBytes(), v.AsBytes()[:])).NotTo(HaveOccurred())
+		Expect(qosConnMap.Update(ingressKey.AsBytes(),
+			qos.NewConnValue(maxConnections, maxConnections).AsBytes())).NotTo(HaveOccurred())
+
+		skbMark = tcdefs.MarkSeen
+		runBpfTest(t, "calico_to_workload_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+			res, err := bpfrun(synPkt)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(res.Retval).To(Equal(resTC_ACT_UNSPEC))
+		}, withIngressQoSConnLimit(), withIPv6())
+
+		Expect(readCount(ingressKey)).To(Equal(uint32(maxConnections)))
+		// REJECTED proves the check ran and failed, rather than the SYN never
+		// reaching the block — the counter alone cannot tell those apart.
+		Expect(readCTFlags() & ctv4.FlagConnLimitInRej).To(Equal(ctv4.FlagConnLimitInRej))
+	})
+
+	t.Run("egress under the limit: counted and admitted", func(t *testing.T) {
+		RegisterTestingT(t)
+		resetCTMap(ctMap)
+		resetQoSMap(qosConnMap)
+		defer resetQoSMap(qosConnMap)
+
+		// No CT entry: a genuinely new outbound v6 flow.
+		Expect(qosConnMap.Update(egressKey.AsBytes(),
+			qos.NewConnValue(maxConnections, 1).AsBytes())).NotTo(HaveOccurred())
+
+		skbMark = 0
+		runBpfTest(t, "calico_from_workload_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+			res, err := bpfrun(synPkt)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(res.Retval).To(Equal(resTC_ACT_REDIRECT))
+		}, withEgressQoSConnLimit(), withIPv6())
+
+		Expect(readCount(egressKey)).To(Equal(uint32(2)), "v6 first SYN was not counted")
+		Expect(readCTFlags()&ctv4.FlagConnLimitOut).To(Equal(ctv4.FlagConnLimitOut),
+			"admitted v6 flow must be stamped CONNLIMIT_EGRESS")
+	})
+}
+
+// TestQoSConnLimitV6DualStackCountersAreIndependent verifies that a v6
+// connection increments the family=6 counter and leaves the family=4 counter
+// for the same interface and direction untouched.
+//
+// There is one cali_qos_conn map for both families; they are separated only by
+// the family field of the key, which the C side fills from the compile-time
+// IPVER6 and the Go side from the scanner's configured family. This is the
+// invariant that separation exists for, and it is the one thing a v4-only or
+// v6-only test cannot catch: either would pass unchanged if the family
+// dimension were dropped from the key altogether, because each would simply
+// find the single remaining entry.
+func TestQoSConnLimitV6DualStackCountersAreIndependent(t *testing.T) {
+	RegisterTestingT(t)
+
+	hostIP = node1ipV6
+	defer func() { hostIP = node1ip }()
+
+	bpfIfaceName = "HWds6"
+	defer func() { bpfIfaceName = "" }()
+
+	const (
+		ifIndex               = 1
+		maxConnections        = 3
+		srcPort        uint16 = 12350
+		dstPort        uint16 = 8055
+	)
+
+	rtKey := routes.NewKeyV6(srcV6CIDR).AsBytes()
+	rtVal := routes.NewValueV6WithIfIndex(routes.FlagsLocalWorkload|routes.FlagInIPAMPool, ifIndex).AsBytes()
+	Expect(rtMapV6.Update(rtKey, rtVal)).NotTo(HaveOccurred())
+	rtKey = routes.NewKeyV6(dstV6CIDR).AsBytes()
+	rtVal = routes.NewValueV6WithIfIndex(routes.FlagsRemoteWorkload|routes.FlagInIPAMPool, ifIndex).AsBytes()
+	Expect(rtMapV6.Update(rtKey, rtVal)).NotTo(HaveOccurred())
+	defer resetRTMap(rtMapV6)
+
+	ctMap := conntrack.MapV6()
+	Expect(ctMap.EnsureExists()).NotTo(HaveOccurred())
+	defer resetCTMap(ctMap)
+	resetCTMap(ctMap)
+
+	// A dual-stack pod: one egress entry per family on the same ifindex. The
+	// v4 side is mid-flight with two connections of its own.
+	defer resetQoSMap(qosConnMap)
+	resetQoSMap(qosConnMap)
+	v4Key := qos.NewKey(uint32(ifIndex), 0, qos.IPFamilyV4)
+	v6Key := qos.NewKey(uint32(ifIndex), 0, qos.IPFamilyV6)
+	Expect(qosConnMap.Update(v4Key.AsBytes(),
+		qos.NewConnValue(maxConnections, 2).AsBytes())).NotTo(HaveOccurred())
+	Expect(qosConnMap.Update(v6Key.AsBytes(),
+		qos.NewConnValue(maxConnections, 0).AsBytes())).NotTo(HaveOccurred())
+
+	readCount := func(qk qos.Key) uint32 {
+		b, err := qosConnMap.Get(qk.AsBytes())
+		Expect(err).NotTo(HaveOccurred())
+		return qos.ConnValueFromBytes(b).CurrentCount()
+	}
+
+	_, _, _, _, synPkt, err := testPacketTCPV6WithPayload(dstIPv6, srcPort, dstPort, true /* syn */, nil)
+	Expect(err).NotTo(HaveOccurred())
+
+	skbMark = 0
+	runBpfTest(t, "calico_from_workload_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+		res, err := bpfrun(synPkt)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.Retval).To(Equal(resTC_ACT_REDIRECT))
+	}, withEgressQoSConnLimit(), withIPv6())
+
+	Expect(readCount(v6Key)).To(Equal(uint32(1)),
+		"the v6 connection should have been counted against the v6 entry")
+	Expect(readCount(v4Key)).To(Equal(uint32(2)),
+		"a v6 connection must not touch the v4 counter for the same interface")
+}

--- a/felix/design/bpf-observability.md
+++ b/felix/design/bpf-observability.md
@@ -341,8 +341,35 @@ on connection close.
   (`felix/bpf/conntrack/connlimit_scanner.go`) recounts established
   TCP CT entries every ~30s and overwrites `current_count` in
   `cali_qos_conn` via `BPF_F_LOCK` batch updates. It corrects any
-  residual drift the fast/cleanup paths missed and skips entries
-  with `CONNLIMIT_DEC` already set so it doesn't double-count.
+  residual drift the fast/cleanup paths missed, and skips entries
+  carrying any FIN or RST bit so it doesn't double-count a close
+  those paths have already accounted for.
+
+  It deliberately does **not** skip entries carrying
+  `CONNLIMIT_DEC`. That flag is cleared only on the spurious-RST
+  path below, and never at all for an entry that no longer sees
+  traffic, so skipping on it excluded a connection from future
+  recounts — and since the recount is the only mechanism that can
+  return a slot, the exclusion was effectively permanent. Because
+  the fast path decrements on any
+  RST, including a spurious one that is out of window and ignored by
+  both peers, and because the per-leg RST bits clear as soon as
+  traffic resumes, that produced live, established entries the
+  scanner would never count again: N spurious RSTs against N live
+  connections parked `current_count` at 0 with all N still up. An
+  established entry with no FIN and no RST is live and is counted,
+  whatever `CONNLIMIT_DEC` says; the FIN/RST skips are what prevent
+  double-counting, since a genuinely closed entry keeps those bits
+  until it is purged.
+
+This is why the RST decrement stays on the fast path even though an
+RST is weak evidence of a close. Prompt release is a requirement —
+`felix/fv` asserts a genuine RST close frees a slot within 5s, and
+deferring RST closes to the cleanup path makes them wait for
+`TCPResetSeen` (40s). The recount makes the resulting under-count
+self-correcting instead of permanent, which is the property that
+matters: a spurious RST costs one scan cycle, not the connection's
+lifetime.
 
 The per-direction `INGRESS_CONN_LIMIT_CONFIGURED` /
 `EGRESS_CONN_LIMIT_CONFIGURED` flags gate the BPF connlimit code
@@ -390,8 +417,36 @@ global, `ISTIO_DSCP`; see Istio ambient mode integration for the integration.
 - Any change to connlimit decrement paths must preserve the
   `CONNLIMIT_DEC` idempotence flag — both the fast path (FIN/RST in
   `calico_ct_lookup`) and the cleanup path (BPF conntrack cleanup
-  scanner) set it before decrementing, and the Go scanner skips
-  entries that carry it. Without that, drift accumulates upward.
+  scanner) set it before decrementing. It is what stops the same
+  close being counted twice when both paths see one entry.
+- `CONNLIMIT_DEC` is an idempotence latch, **not** a statement that
+  the connection is gone. Do not gate the userspace recount on it,
+  and do not add any other long-lived "already handled" marker that
+  the recount honours. The recount is the only path that can return
+  a slot, so anything it skips unconditionally is leaked for the
+  life of the entry — and the fast path claims the latch on signals
+  a live connection can survive (any RST, unvalidated). Keep the
+  skip conditions to state that clears itself or dies with the
+  entry: the per-leg FIN/RST bits.
+- The latch describes a decrement that is only meaningful while the
+  counter still reflects it, and the recount rebases the counter
+  every ~30s. That is why `calico_ct_lookup` releases the latch at
+  the same point it concludes an RST was spurious — two minutes of
+  continued traffic, where it also clears `v->rst_seen`. Without
+  that release, a connection that survived a spurious RST would find
+  the latch already taken when it genuinely closed, and free its
+  slot at recount speed rather than immediately. Release it with an
+  atomic AND on `type_flags_word`, mirroring the claim: a byte-wide
+  `ct_value_clear_flags()` would race with a concurrent claim on
+  another CPU. Note this re-arms the latch for that entry, so a
+  connection can be decremented once per spurious RST rather than
+  once ever; the recount bounds the resulting under-count either
+  way.
+- When choosing between holding a slot too long and releasing one
+  too early, hold. Over-counting fails closed — a pod is briefly
+  refused a connection it could have had. Under-counting fails open:
+  the limit stops being a limit, and if the under-count is permanent
+  an unauthenticated packet defeats it outright.
 - ep_mgr writes to `cali_qos` / `cali_qos_conn` must skip the
   UpdateWithFlags when the configured fields match the existing
   entry. The dataplane owns the dynamic fields between configuration

--- a/felix/design/bpf-observability.md
+++ b/felix/design/bpf-observability.md
@@ -371,6 +371,13 @@ self-correcting instead of permanent, which is the property that
 matters: a spurious RST costs one scan cycle, not the connection's
 lifetime.
 
+Host-originated traffic — including from host-networked pods — is
+exempt from the ingress limit: it takes the `skip_policy` path in
+`tc.c` and the admission check is gated on `!policy_skipped`, so it is
+neither counted nor limited. Same in iptables/nftables, where the
+connlimit rule sits in `cali-tw-<iface>`, a chain host-origin traffic
+never reaches.
+
 The per-direction `INGRESS_CONN_LIMIT_CONFIGURED` /
 `EGRESS_CONN_LIMIT_CONFIGURED` flags gate the BPF connlimit code
 path entirely when no limit is configured for that attach point.


### PR DESCRIPTION
**Cherry-pick history**
- Pick onto **release-v3.33**:
  - projectcalico/calico#13457
  - projectcalico/calico#13461
  - projectcalico/calico#13471

---
**BPF QoS connlimit: fix connlimit slot permanently lost on spurious TCP RST** (projectcalico/calico#13457)
The BPF fast path decrements the per-pod connection-limit counter on any TCP RST: calico_ct_lookup() reads tcp_header->rst directly, and nothing validates the RST's sequence number. An out-of-window RST that both peers discard therefore released the slot of a connection that stayed up.

That loss was permanent. qos_connlimit_decrement_for_ct() claims CALI_CT_FLAG_CONNLIMIT_DEC before decrementing, nothing cleared it, and ConnLimitScanner skipped every entry carrying it. The per-leg rst_seen bits do clear once traffic resumes, so the connection went back to looking live while staying invisible to the recount -- the only mechanism that can give a slot back. N spurious RSTs against N live connections left current_count at 0 with all N still established, admitting N more. A pod could do this to its own egress limit with bits do clear once traffic resumes, so the connection went back to looking live while staying invisible to the recount -- the only mechanism that can give a slot back. N spurious RSTs against N live connections left current_count at 0 with all N still established, admitting N more. A pod could do this to its own egress limit with CAP_NET_RAW, which is in the default Kubernetes capability set.

Fix in two parts:

- ConnLimitScanner no longer skips entries carrying CONNLIMIT_DEC. An established entry with no FIN and no RST is live and is counted, whatever the flag says; the FIN/RST skips already prevent the double-count the DEC skip was added for. A spurious RST now costs one scan cycle instead of the connection's lifetime.

- calico_ct_lookup() releases CONNLIMIT_DEC where it already concludes an RST was spurious -- two minutes of continued traffic, alongside clearing v->rst_seen. Otherwise the connection's genuine close finds the latch taken and frees its slot at recount speed rather than immediately.

The RST decrement itself is deliberately kept: FV asserts a genuine RST close frees a slot within 5s, and deferring RST closes to the cleanup path makes them wait out TCPResetSeen (40s).

Tests: the scanner test that pinned the DEC skip is replaced by one asserting a live DEC-flagged entry is recounted, plus three BPF UTs that drive packets through the real programs and then the real ConnLimitScanner, asserting the slot goes 1->0->1.

<!-- Describe your changes, including the type of change (bug fix, feature, etc.),
why it should be merged, testing done, and links to related issues. -->

<!-- For any user-visible change, replace TBD with a one-line description. -->
**Release note:**
```release-note
TBD
```
---
**BPF QoS connlimit: gate egress connlimit check on EGRESS_CONN_LIMIT_CONFIGURED** (projectcalico/calico#13461)
The egress connection-limit check fired whenever a cali_qos_conn entry with max_connections > 0 existed, while the CONNLIMIT_EGRESS stamp on the CT entry was gated on the global. Felix writes the map entry and sets the AttachPoint flag in one pass, but the program only picks the global up on reattach, so a connection opened in that window was counted without being stamped -- and qos_connlimit_decrement_for_ct returns early for an entry carrying neither CONNLIMIT flag, so nothing could decrement it until ConnLimitScanner's next recount.

Gate the check on the global too, matching the stamp and the ingress check. This closes the window and skips the map lookup entirely for endpoints with no egress limit, which is the behaviour felix/design/bpf-observability.md already describes.

Adds a BPF UT covering both gate states, with the configured case as a positive control.

<!-- Describe your changes, including the type of change (bug fix, feature, etc.),
why it should be merged, testing done, and links to related issues. -->

<!-- For any user-visible change, replace TBD with a one-line description. -->
**Release note:**
```release-note
TBD
```
---
**BPF QoS connlimit: cover connlimit first SYN, IPv6 and dual-stack in unit tests** (projectcalico/calico#13471)
Reviewing the eBPF QoS max-connections coverage turned up two gaps. The BPF unit tests exercised only the retransmission and recycle paths -- the plain first-SYN admission decision had no UT in either direction, only FV. And nothing exercised IPv6 at any level, despite the feature being family-aware: cali_qos_conn is keyed by family and the C is the plain first-SYN admission decision had no UT in either direction, only FV. And nothing exercised IPv6 at any level, despite the feature being family-aware: cali_qos_conn is keyed by family and the C is compiled twice via IPVER6, so v4 and v6 are separate code paths with independent counters.

Adds to felix/bpf/ut/qos_test.go:
- TestQoSConnLimit{Ingress,Egress}FirstSYN, both outcomes each.
- TestQoSConnLimitV6FirstSYN, the v6 counterpart.
- TestQoSConnLimitV6DualStackCountersAreIndependent.

Adds to felix/bpf/conntrack/connlimit_scanner_test.go:
- TestConnLimitScannerV6WritesBackToItsOwnFamily, plus family-aware helpers on the fake QoS map (the existing ones now delegate, so no call site changed).

The two dual-stack tests are the ones that could not be written as a port of an existing case: they seed both families for one interface and assert the untouched family stays untouched. A single-family test would pass unchanged even if the family dimension were dropped from the key, since it would simply find the one remaining entry.

The retransmission and recycle paths are deliberately not ported to v6 -- that logic is the same source compiled twice and cannot differ by family.

Also documents in felix/design/bpf-observability.md that host-originated traffic is exempt from the ingress connection limit, and that iptables and nftables behave the same way by a different mechanism: BPF via the skip_policy path, the others by returning from the OUTPUT chain before the cali-tw dispatch. That was previously undocumented and reads as a cross-dataplane divergence when found in only one of them.

Tests and documentation only; no dataplane behaviour change.

<!-- Describe your changes, including the type of change (bug fix, feature, etc.),
why it should be merged, testing done, and links to related issues. -->

<!-- For any user-visible change, replace TBD with a one-line description. -->
**Release note:**
```release-note
TBD
```

