### PR TITLE
helm: add configurable containerSecurityContext for operator containers

### DIFF
--- a/charts/tigera-operator/README.md
+++ b/charts/tigera-operator/README.md
@@ -187,6 +187,17 @@ podAnnotations: {}
 # Custom labels for the tigera/operator pod itself
 podLabels: {}
 
+# Security context applied to all containers in the tigera-operator deployment.
+# By default no security context is set; override to harden the operator pod.
+# Example hardened config:
+#   containerSecurityContext:
+#     allowPrivilegeEscalation: false
+#     runAsNonRoot: true
+#     runAsUser: 10000
+#     runAsGroup: 10000
+#     readOnlyRootFilesystem: true
+containerSecurityContext: {}
+
 # Configuration for the tigera operator images to deploy.
 tigeraOperator:
   image: tigera/operator

--- a/charts/tigera-operator/templates/tigera-operator/02-tigera-operator.yaml
+++ b/charts/tigera-operator/templates/tigera-operator/02-tigera-operator.yaml
@@ -57,6 +57,10 @@ spec:
         - name: tigera-operator
           image: {{ template "tigera-operator.image" .Values.tigeraOperator}}
           imagePullPolicy: {{ .Values.tigeraOperator.imagePullPolicy | default "IfNotPresent" }}
+          {{- with .Values.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           command:
             - operator
           args:
@@ -106,6 +110,10 @@ spec:
         # Install CRDs first, so that APIs exist for calicoctl to use.
         - name: bootstrap-crds
           image: {{ template "tigera-operator.image" .Values.tigeraOperator}}
+          {{- with .Values.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           command:
             - operator
           args:
@@ -117,6 +125,10 @@ spec:
         # Install any v3 API resources provided in the calico-resources ConfigMap.
         - name: create-initial-resources
           image: {{.Values.calicoctl.image}}:{{.Values.calicoctl.tag}}
+          {{- with .Values.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           env:
             - name: DATASTORE_TYPE
               value: kubernetes

--- a/charts/tigera-operator/values.yaml
+++ b/charts/tigera-operator/values.yaml
@@ -117,6 +117,17 @@ zapDevel: false
 # Resource requests and limits for the tigera/operator pod.
 resources: {}
 
+# Security context applied to all containers in the tigera-operator deployment.
+# By default no security context is set; override to harden the operator pod.
+# Example hardened config:
+#   containerSecurityContext:
+#     allowPrivilegeEscalation: false
+#     runAsNonRoot: true
+#     runAsUser: 10000
+#     runAsGroup: 10000
+#     readOnlyRootFilesystem: true
+containerSecurityContext: {}
+
 # Common labels for all resources created by this chart
 additionalLabels: {}
 


### PR DESCRIPTION
## What this PR does

Adds a new `containerSecurityContext` Helm value (default: `{}`, backwards-compatible no-op) that is applied as `securityContext:` to all containers in the `tigera-operator` Deployment:

- The main `tigera-operator` container
- The OpenShift-specific `bootstrap-crds` init container
- The OpenShift-specific `create-initial-resources` init container

This allows users to harden the operator pod (e.g. `runAsNonRoot`, `readOnlyRootFilesystem`, dropping privilege escalation) without needing to fork the chart or apply a post-install patch.

## Why

Security-conscious users and enterprise environments often require all containers to have an explicit `securityContext`. Without this value, the only way to add one was to fork or patch the chart.

## Pattern precedent

This follows the same approach already merged for other components:
- #6499 — `calico-kube-controllers` runs as non-root
- #6524 — seccomp profile for `calico-kube-controllers` and `calico-typha`

## Testing

- Default (`containerSecurityContext: {}`) produces identical rendered output to the current chart — fully backwards-compatible.
- Setting a value (e.g. `runAsNonRoot: true`) injects the field into all three containers as expected.
- Verified with `helm template` locally.

**Release note:**
```release-note
Add `containerSecurityContext` Helm value to the tigera-operator chart, allowing users to configure a container-level security context for the operator and its init containers. Defaults to `{}` (no change in existing behaviour).
```