### PR TITLE
[release-v3.31] Set AZ_PROJECT to the CI subscription name for azr-aso e2es

### DIFF
--- a/.argoci/scripts/global_prologue.sh
+++ b/.argoci/scripts/global_prologue.sh
@@ -47,6 +47,12 @@ if [[ "${PROVISIONER:-}" == azr-* ]]; then
     echo "[WARN] azr-* provisioner but az CLI or AZ_SP_ID missing; azure auth skipped"
   fi
 fi
+# Despite the name this is an Azure *subscription name*, not a project or a
+# resource group: azr-aso/azr-capi select the subscription by matching it
+# against `az account list` output. The spelling is banzai-core's variable, so
+# it can't be renamed from here. banzai-core defaults it to the developer
+# subscription; azr-aks ignores it, which is why only the ASO/CAPI paths break.
+export AZ_PROJECT=${AZ_PROJECT:-tigera-dev-ci}
 
 export DOCKER_AUTH_FILE="${DOCKER_AUTH_FILE:-${HOME}/.docker/config.json}"
 chmod 0600 "${HOME}"/.keys/* 2>/dev/null || true


### PR DESCRIPTION
## Description

Follow-up to #13569. The first azr-aso Windows e2e run on this branch failed at Azure VMSS creation:

```
process/testing/aso/export-env.sh: line 5: AZURE_SUBSCRIPTION_ID: Environment variable empty or not defined.
make: *** [Makefile:49: .vmss-created] Error 1
```

banzai-core's `azr-aso` provisioner resolves the subscription id by matching `AZ_PROJECT` against subscription *names* in `az account list`. Its default (`tigera-dev`, the developer subscription) is not visible to the CI service principal, whose subscription is named `tigera-dev-ci` — so the lookup returns empty and the ASO tooling aborts before any VMs are created.

The azr-aks job in the same run passed (24m38s) because it acts on the active `az` session set by the prologue's `az account set --subscription` and never performs the name lookup — matching the comment master carries for this exact fix.

This ports master's `AZ_PROJECT=${AZ_PROJECT:-tigera-dev-ci}` default (with its comment) into the release-v3.31 ArgoCI global prologue.

Note: release-v3.32's ArgoCI prologue also lacks this export, so its azr-aso Windows jobs are expected to be failing the same way; an equivalent backport can follow.

## Release Note

```release-note
None required. CI-only change.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)