### PR TITLE
Skip Egress Gateway specs in v3.31 scheduled e2e runs

### DIFF
--- a/.argoci/scripts/phases/run_tests.sh
+++ b/.argoci/scripts/phases/run_tests.sh
@@ -20,6 +20,13 @@ for _var in BZ_LOCAL_DIR BZ_LOGS_DIR HOME REPORT_DIR TEST_TYPE; do
   if [[ -z "${!_var}" ]]; then echo "[ERROR] ${_var} is required but not set"; exit 1; fi
 done
 
+# This branch runs the enterprise k8s-e2e suite, which compiles in Egress Gateway specs
+# that need an operator CRD Calico does not ship. Ginkgo ORs repeated --skip values.
+if [[ -n "${K8S_E2E_FLAGS:-}" ]]; then
+  K8S_E2E_FLAGS="${K8S_E2E_FLAGS} --ginkgo.skip=Feature:EgressGateway"
+  export K8S_E2E_FLAGS
+fi
+
 if [[ -n "${RUN_LOCAL_TESTS:-}" ]]; then
   # Build the e2e binary from the local source tree.
   echo "[INFO] building e2e binary from local source..."


### PR DESCRIPTION
Scheduled e2e on this branch defers to `bz tests`, which runs the enterprise k8s-e2e suite, and that suite compiles in Egress Gateway specs needing an operator custom resource Calico does not ship. All ten fail on a no-kind-match every run: 226 failed cases since 2026-08-13, still going. Rather than patch forty per-job skip regexes across the bpf, iptables, and nftables crons, the phase script appends one more `--ginkgo.skip` after the job environment resolves, and Ginkgo ORs repeated `--skip` values; master and release-v3.32 need no equivalent, since both already fetch the in-repo e2e binary from the hashrelease and it carries no Egress Gateway specs.

CORE-13390

**Release note:**
Related: [CORE-13390](https://tigera.atlassian.net/browse/CORE-13390)

```release-note
None
```


[CORE-13390]: https://tigera.atlassian.net/browse/CORE-13390?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ