### PR TITLE
Use the discovery-aware client in the KubeVirt e2e tests

### DIFF
--- a/e2e/pkg/tests/kubevirt/ip_persistence.go
+++ b/e2e/pkg/tests/kubevirt/ip_persistence.go
@@ -62,7 +62,7 @@ var _ = describe.CalicoDescribe(
 			utils.RequireNodeCount(f, 2)
 
 			var err error
-			cli, err = e2eclient.NewAPIClient(f.ClientConfig())
+			cli, err = e2eclient.New(f.ClientConfig())
 			Expect(err).NotTo(HaveOccurred(), "failed to build controller-runtime client")
 		})
 

--- a/e2e/pkg/tests/kubevirt/live_migration.go
+++ b/e2e/pkg/tests/kubevirt/live_migration.go
@@ -69,7 +69,7 @@ var _ = describe.CalicoDescribe(
 			utils.RequireNodeCount(f, 2)
 
 			var err error
-			cli, err = e2eclient.NewAPIClient(f.ClientConfig())
+			cli, err = e2eclient.New(f.ClientConfig())
 			Expect(err).NotTo(HaveOccurred(), "failed to build controller-runtime client")
 		})
 

--- a/e2e/pkg/tests/kubevirt/live_migration_mockvirt.go
+++ b/e2e/pkg/tests/kubevirt/live_migration_mockvirt.go
@@ -61,7 +61,7 @@ var _ = describe.CalicoDescribe(
 			utils.RequireNodeCount(f, 3)
 
 			var err error
-			cli, err = e2eclient.NewAPIClient(f.ClientConfig())
+			cli, err = e2eclient.New(f.ClientConfig())
 			Expect(err).NotTo(HaveOccurred(), "failed to build controller-runtime client")
 		})
 

--- a/e2e/pkg/tests/policy/tiered_rbac.go
+++ b/e2e/pkg/tests/policy/tiered_rbac.go
@@ -86,6 +86,8 @@ var _ = describe.CalicoDescribe(
 		)
 
 		// newImpersonatedClient creates a controller-runtime client that impersonates the given user.
+		// It must not fall back to calicoctl, which would run as its own service account and
+		// make every RBAC assertion here meaningless.
 		newImpersonatedClient := func(username string) ctrlclient.Client {
 			cfg := rest.CopyConfig(f.ClientConfig())
 			cfg.Impersonate = rest.ImpersonationConfig{

--- a/e2e/pkg/utils/client/client.go
+++ b/e2e/pkg/utils/client/client.go
@@ -67,7 +67,9 @@ func New(cfg *rest.Config) (client.Client, error) {
 	return NewCalicoctlExecClient(c)
 }
 
-// NewAPIClient returns a new controller-runtime client configured to use the projectcalico.org/v3 API group.
+// NewAPIClient returns a client that always talks to the aggregated apiserver, with no
+// discovery wait and no calicoctl fallback. Prefer New unless the request identity
+// matters, as it does for an impersonating client.
 func NewAPIClient(cfg *rest.Config) (client.Client, error) {
 	scheme, err := newScheme()
 	if err != nil {

--- a/e2e/pkg/utils/client/constructors_test.go
+++ b/e2e/pkg/utils/client/constructors_test.go
@@ -1,0 +1,106 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// An impersonated request has to reach the apiserver as itself, so the calicoctl
+// fallback would run as its own service account and void the RBAC assertions.
+var impersonationCallers = map[string]bool{
+	"tests/policy/tiered_rbac.go": true,
+}
+
+// TestNewAPIClientCallers keeps NewAPIClient out of the suites. It has no discovery wait
+// and no calicoctl fallback, so a rolling or absent calico-apiserver fails the test
+// instead of being waited out.
+func TestNewAPIClientCallers(t *testing.T) {
+	root, err := filepath.Abs("../..")
+	if err != nil {
+		t.Fatalf("resolve pkg root: %v", err)
+	}
+
+	fset := token.NewFileSet()
+	err = filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || !strings.HasSuffix(path, ".go") {
+			return nil
+		}
+
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		if impersonationCallers[filepath.ToSlash(rel)] {
+			return nil
+		}
+
+		f, err := parser.ParseFile(fset, path, nil, 0)
+		if err != nil {
+			return err
+		}
+		for _, line := range findAPIClientCalls(fset, f) {
+			t.Errorf("%s:%d calls NewAPIClient; use New so the suite waits for projectcalico.org/v3 and can fall back to calicoctl", filepath.ToSlash(rel), line)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk %s: %v", root, err)
+	}
+}
+
+func TestFindAPIClientCallsMatchesOnlyNewAPIClient(t *testing.T) {
+	for name, src := range map[string]string{
+		"NewAPIClient": "package p\nfunc f() { client.NewAPIClient(cfg) }\n",
+		"New":          "package p\nfunc f() { client.New(cfg) }\n",
+	} {
+		fset := token.NewFileSet()
+		f, err := parser.ParseFile(fset, name+".go", src, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", name, err)
+		}
+
+		got := len(findAPIClientCalls(fset, f))
+		want := 0
+		if name == "NewAPIClient" {
+			want = 1
+		}
+		if got != want {
+			t.Errorf("%s: got %d calls, want %d", name, got, want)
+		}
+	}
+}
+
+// findAPIClientCalls returns the lines of every package-qualified NewAPIClient call.
+func findAPIClientCalls(fset *token.FileSet, f *ast.File) []int {
+	var lines []int
+	ast.Inspect(f, func(n ast.Node) bool {
+		sel, ok := n.(*ast.SelectorExpr)
+		if ok && sel.Sel.Name == "NewAPIClient" {
+			lines = append(lines, fset.Position(sel.Pos()).Line)
+		}
+		return true
+	})
+	return lines
+}


### PR DESCRIPTION
The KubeVirt e2e specs built their Calico client with the constructor that talks straight to the aggregated apiserver, skipping the discovery wait and the calicoctl fallback, so an apiserver still rolling failed the spec instead of being waited out. Only the tiered RBAC specs need that constructor, since an impersonated request has to reach the apiserver as itself, and a unit test under `e2e/pkg/utils/client` walks the suite for callers and fails the build on any outside that list. The same change is going into the Enterprise fork, so the two e2e trees stay mergeable.

CORE-13387

**Release note:**
Related: [CORE-13387](https://tigera.atlassian.net/browse/CORE-13387)

```release-note
None
```


[CORE-13387]: https://tigera.atlassian.net/browse/CORE-13387?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ