### PR TITLE
[release-v3.32] Fix azr-aso Windows e2e provisioning and drop BPF+Windows job

### DIFF
--- a/.argoci/cron/e2e-windows.yaml
+++ b/.argoci/cron/e2e-windows.yaml
@@ -21,23 +21,6 @@ defaults:
   secretBundles:
     - banzai-secrets
 steps:
-  - name: calico-windows-azr-aso-2022-stable-bpf-vxlan
-    services:
-      - docker
-      - http-cache-proxy
-    env:
-      - name: DATAPLANE
-        value: CalicoBPF
-      - name: ENCAPSULATION_TYPE
-        value: VXLAN
-      - name: K8S_VERSION
-        value: stable-1
-      - name: PROVISIONER
-        value: azr-aso
-      - name: WINDOWS_OS
-        value: "2022"
-    commands: |
-      .argoci/scripts/body_standard.sh
   - name: calico-windows-azr-aso-2022-stable-1-nftables-vxlan
     services:
       - docker

--- a/.argoci/scripts/global_prologue.sh
+++ b/.argoci/scripts/global_prologue.sh
@@ -47,6 +47,12 @@ if [[ "${PROVISIONER:-}" == azr-* ]]; then
     echo "[WARN] azr-* provisioner but az CLI or AZ_SP_ID missing; azure auth skipped"
   fi
 fi
+# Despite the name this is an Azure *subscription name*, not a project or a
+# resource group: azr-aso/azr-capi select the subscription by matching it
+# against `az account list` output. The spelling is banzai-core's variable, so
+# it can't be renamed from here. banzai-core defaults it to the developer
+# subscription; azr-aks ignores it, which is why only the ASO/CAPI paths break.
+export AZ_PROJECT=${AZ_PROJECT:-tigera-dev-ci}
 
 export DOCKER_AUTH_FILE="${DOCKER_AUTH_FILE:-${HOME}/.docker/config.json}"
 chmod 0600 "${HOME}"/.keys/* 2>/dev/null || true

--- a/.semaphore/end-to-end/pipelines/windows.yml
+++ b/.semaphore/end-to-end/pipelines/windows.yml
@@ -40,13 +40,12 @@ global_job_config:
 # Provisioners: azr-aso, azr-aks
 # Installer: operator
 # Windows OS: Windows Server 2022
-# k8s Versions: stable-1, stable
-# linux dataplane: bpf, iptables, nftables
+# k8s Versions: stable-1
+# linux dataplane: iptables, nftables
 # encapsulation: vxlan, no-encap
 # CNI: Calico, Azure CNI
 
 # Runs:
-# azr-aso, 2022, stable, bpf, vxlan
 # azr-aso, 2022, stable-1, nftables, vxlan
 # azr-aks, 2022, stable-1, iptables, no-encap, azure CNI
 
@@ -55,23 +54,6 @@ blocks:
     dependencies: []
     task:
       jobs:
-        - name: "azr-aso, 2022, stable, bpf, vxlan"
-          execution_time_limit:
-            hours: 5
-          commands:
-            - ~/calico/.semaphore/end-to-end/scripts/body_standard.sh
-          env_vars:
-            - name: PROVISIONER
-              value: azr-aso
-            - name: K8S_VERSION
-              value: stable-1
-            - name: DATAPLANE
-              value: CalicoBPF
-            - name: ENCAPSULATION_TYPE
-              value: VXLAN
-            - name: WINDOWS_OS
-              value: "2022"
-
         - name: "azr-aso, 2022, stable-1, nftables, vxlan"
           execution_time_limit:
             hours: 5


### PR DESCRIPTION
## Description

Ports two Windows e2e fixes to release-v3.32 that master already has and that were just verified on release-v3.31:

**1. `AZ_PROJECT=tigera-dev-ci` in the ArgoCI global prologue** (master's fix, verbatim). banzai-core's `azr-aso` provisioner resolves the Azure subscription id by matching `AZ_PROJECT` against subscription *names* in `az account list`; its default (`tigera-dev`, the developer subscription) is not visible to the CI service principal, so `AZURE_SUBSCRIPTION_ID` resolves empty and the run aborts at VMSS creation:

```
process/testing/aso/export-env.sh: line 5: AZURE_SUBSCRIPTION_ID: Environment variable empty or not defined.
```

release-v3.32's prologue lacks this export, so its azr-aso Windows jobs are expected to be failing at provisioning the same way release-v3.31's did before #13578 (which fixed it there — the subsequent v3.31 run provisioned and ran the full `[RunsOnWindows]` suite). azr-aks is unaffected because it acts on the active `az` session and never performs the name lookup.

**2. Remove the BPF+Windows job** from `.argoci/cron/e2e-windows.yaml` and `.semaphore/end-to-end/pipelines/windows.yml`: BPF+Windows is not officially supported. This syncs the job matrix with master (which removed it in bf034b99be): nftables/vxlan on azr-aso and iptables/no-encap with Azure CNI on azr-aks. It also resolves the pre-existing job-name mismatch (the removed job was labeled `stable` but ran `stable-1`).

Related: #13569, #13578 (release-v3.31 equivalents).

## Release Note

```release-note
None required. CI-only change.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)