### PR TITLE
[Release v3.33] Fix the calicoctl exec fallback client's creates and updates

### DIFF
--- a/calicoctl/calicoctl/resourcemgr/ipamconfiguration.go
+++ b/calicoctl/calicoctl/resourcemgr/ipamconfiguration.go
@@ -1,0 +1,73 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resourcemgr
+
+import (
+	"context"
+
+	api "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	client "github.com/projectcalico/calico/libcalico-go/lib/clientv3"
+	"github.com/projectcalico/calico/libcalico-go/lib/options"
+)
+
+func init() {
+	registerResource(
+		api.NewIPAMConfiguration(),
+		newIPAMConfigurationList(),
+		false,
+		[]string{"ipamconfiguration", "ipamconfigurations", "ipamconfig", "ipamconfigs"},
+		[]string{"NAME", "STRICTAFFINITY", "AUTOALLOCATEBLOCKS"},
+		[]string{"NAME", "STRICTAFFINITY", "AUTOALLOCATEBLOCKS", "MAXBLOCKSPERHOST"},
+		map[string]string{
+			"NAME":               "{{.ObjectMeta.Name}}",
+			"STRICTAFFINITY":     "{{.Spec.StrictAffinity}}",
+			"AUTOALLOCATEBLOCKS": "{{.Spec.AutoAllocateBlocks}}",
+			"MAXBLOCKSPERHOST":   "{{.Spec.MaxBlocksPerHost}}",
+		},
+		func(ctx context.Context, client client.Interface, resource ResourceObject) (ResourceObject, error) {
+			r := resource.(*api.IPAMConfiguration)
+			return client.IPAMConfiguration().Create(ctx, r, options.SetOptions{})
+		},
+		func(ctx context.Context, client client.Interface, resource ResourceObject) (ResourceObject, error) {
+			r := resource.(*api.IPAMConfiguration)
+			return client.IPAMConfiguration().Update(ctx, r, options.SetOptions{})
+		},
+		func(ctx context.Context, client client.Interface, resource ResourceObject) (ResourceObject, error) {
+			r := resource.(*api.IPAMConfiguration)
+			return client.IPAMConfiguration().Delete(ctx, r.Name, options.DeleteOptions{ResourceVersion: r.ResourceVersion})
+		},
+		func(ctx context.Context, client client.Interface, resource ResourceObject) (ResourceObject, error) {
+			r := resource.(*api.IPAMConfiguration)
+			return client.IPAMConfiguration().Get(ctx, r.Name, options.GetOptions{ResourceVersion: r.ResourceVersion})
+		},
+		func(ctx context.Context, client client.Interface, resource ResourceObject) (ResourceListObject, error) {
+			r := resource.(*api.IPAMConfiguration)
+			return client.IPAMConfiguration().List(ctx, options.ListOptions{ResourceVersion: r.ResourceVersion, Name: r.Name})
+		},
+	)
+}
+
+// newIPAMConfigurationList creates a new (zeroed) IPAMConfigurationList struct with the
+// TypeMetadata initialised to the current version.
+func newIPAMConfigurationList() *api.IPAMConfigurationList {
+	return &api.IPAMConfigurationList{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       api.KindIPAMConfigurationList,
+			APIVersion: api.GroupVersionCurrent,
+		},
+	}
+}

--- a/calicoctl/calicoctl/resourcemgr/nodestatus.go
+++ b/calicoctl/calicoctl/resourcemgr/nodestatus.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resourcemgr
+
+import (
+	"context"
+
+	api "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	client "github.com/projectcalico/calico/libcalico-go/lib/clientv3"
+	"github.com/projectcalico/calico/libcalico-go/lib/options"
+)
+
+func init() {
+	registerResource(
+		api.NewCalicoNodeStatus(),
+		newCalicoNodeStatusList(),
+		false,
+		[]string{"caliconodestatus", "caliconodestatuses", "nodestatus", "nodestatuses"},
+		[]string{"NAME", "NODE"},
+		[]string{"NAME", "NODE", "CLASSES"},
+		map[string]string{
+			"NAME":    "{{.ObjectMeta.Name}}",
+			"NODE":    "{{.Spec.Node}}",
+			"CLASSES": "{{join .Spec.Classes \",\"}}",
+		},
+		func(ctx context.Context, client client.Interface, resource ResourceObject) (ResourceObject, error) {
+			r := resource.(*api.CalicoNodeStatus)
+			return client.CalicoNodeStatus().Create(ctx, r, options.SetOptions{})
+		},
+		func(ctx context.Context, client client.Interface, resource ResourceObject) (ResourceObject, error) {
+			r := resource.(*api.CalicoNodeStatus)
+			return client.CalicoNodeStatus().Update(ctx, r, options.SetOptions{})
+		},
+		func(ctx context.Context, client client.Interface, resource ResourceObject) (ResourceObject, error) {
+			r := resource.(*api.CalicoNodeStatus)
+			return client.CalicoNodeStatus().Delete(ctx, r.Name, options.DeleteOptions{ResourceVersion: r.ResourceVersion})
+		},
+		func(ctx context.Context, client client.Interface, resource ResourceObject) (ResourceObject, error) {
+			r := resource.(*api.CalicoNodeStatus)
+			return client.CalicoNodeStatus().Get(ctx, r.Name, options.GetOptions{ResourceVersion: r.ResourceVersion})
+		},
+		func(ctx context.Context, client client.Interface, resource ResourceObject) (ResourceListObject, error) {
+			r := resource.(*api.CalicoNodeStatus)
+			return client.CalicoNodeStatus().List(ctx, options.ListOptions{ResourceVersion: r.ResourceVersion, Name: r.Name})
+		},
+	)
+}
+
+// newCalicoNodeStatusList creates a new (zeroed) CalicoNodeStatusList struct with the
+// TypeMetadata initialised to the current version.
+func newCalicoNodeStatusList() *api.CalicoNodeStatusList {
+	return &api.CalicoNodeStatusList{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       api.KindCalicoNodeStatusList,
+			APIVersion: api.GroupVersionCurrent,
+		},
+	}
+}

--- a/e2e/pkg/utils/client/calicoctl.go
+++ b/e2e/pkg/utils/client/calicoctl.go
@@ -1,7 +1,22 @@
+// Copyright (c) 2025-2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package client
 
 import (
 	"context"
+	"encoding/json"
 	"strings"
 
 	"github.com/sirupsen/logrus"
@@ -9,7 +24,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
-	"k8s.io/apimachinery/pkg/runtime/serializer/json"
 	"k8s.io/kubernetes/test/e2e/framework/kubectl"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -41,22 +55,7 @@ func (c *calicoctlExecClient) Create(ctx context.Context, obj client.Object, opt
 		return c.base.Create(ctx, obj, opts...)
 	}
 
-	// calicoctl requires typemeta to be set for create operations, so set it here.
-	kind, err := c.kindFromObject(obj)
-	if err != nil {
-		return err
-	}
-	obj.GetObjectKind().SetGroupVersionKind(schema.GroupVersionKind{
-		Group:   "projectcalico.org",
-		Version: "v3",
-		Kind:    kind,
-	})
-
-	// Create the stdin input for the calicoctl command.
-	serializer := json.NewSerializer(json.DefaultMetaFactory, c.scheme, c.scheme, false)
-
-	w := &strings.Builder{}
-	err = serializer.Encode(obj, w)
+	data, err := c.encode(obj)
 	if err != nil {
 		return err
 	}
@@ -65,11 +64,11 @@ func (c *calicoctlExecClient) Create(ctx context.Context, obj client.Object, opt
 	cmd := []string{"exec", "-i", c.name, "--", "calicoctl", "create", "-f", "-"}
 
 	logrus.WithFields(logrus.Fields{
-		"data": w.String(),
+		"data": data,
 	}).Info("Executing calicoctl create command")
 
 	// Execute the command in the specified pod.
-	_, err = kubectl.RunKubectlInput(c.namespace, w.String(), cmd...)
+	_, err = kubectl.RunKubectlInput(c.namespace, data, cmd...)
 	if err != nil {
 		return err
 	}
@@ -116,11 +115,8 @@ func (c *calicoctlExecClient) Update(ctx context.Context, obj client.Object, opt
 		return c.base.Update(ctx, obj, opts...)
 	}
 
-	// Create the stdin input for the calicoctl command.
-	serializer := json.NewSerializer(json.DefaultMetaFactory, c.scheme, c.scheme, false)
-
-	w := &strings.Builder{}
-	if err := serializer.Encode(obj, w); err != nil {
+	data, err := c.encode(obj)
+	if err != nil {
 		return err
 	}
 
@@ -128,7 +124,7 @@ func (c *calicoctlExecClient) Update(ctx context.Context, obj client.Object, opt
 	cmd := []string{"exec", "-i", c.name, "--", "calicoctl", "apply", "-f", "-"}
 
 	// Execute the command in the specified pod.
-	_, err := kubectl.RunKubectlInput(c.namespace, w.String(), cmd...)
+	_, err = kubectl.RunKubectlInput(c.namespace, data, cmd...)
 	if err != nil {
 		return err
 	}
@@ -222,6 +218,42 @@ func (c *calicoctlExecClient) kindFromObject(obj runtime.Object) (string, error)
 
 	// If the kind is a list, return the kind without "List" suffix.
 	return strings.TrimSuffix(kinds[0].Kind, "List"), nil
+}
+
+// datastoreOwnedMetadata are the metadata fields calicoctl will not accept on a
+// create or an apply.
+var datastoreOwnedMetadata = []string{"creationTimestamp", "generation", "managedFields", "resourceVersion", "selfLink", "uid"}
+
+// encode renders obj as JSON for calicoctl's stdin. The datastore owns the status and
+// parts of the metadata, and calicoctl rejects the whole object if they are present.
+func (c *calicoctlExecClient) encode(obj client.Object) (string, error) {
+	// calicoctl requires typemeta to be set, so set it here.
+	kind, err := c.kindFromObject(obj)
+	if err != nil {
+		return "", err
+	}
+	obj.GetObjectKind().SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "projectcalico.org",
+		Version: "v3",
+		Kind:    kind,
+	})
+
+	u, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
+	if err != nil {
+		return "", err
+	}
+	delete(u, "status")
+	if metadata, ok := u["metadata"].(map[string]any); ok {
+		for _, field := range datastoreOwnedMetadata {
+			delete(metadata, field)
+		}
+	}
+
+	data, err := json.Marshal(u)
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
 }
 
 func (c *calicoctlExecClient) isV3Request(obj runtime.Object) (bool, error) {

--- a/e2e/pkg/utils/client/calicoctl_test.go
+++ b/e2e/pkg/utils/client/calicoctl_test.go
@@ -1,0 +1,119 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"encoding/json"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	v3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/projectcalico/calico/calicoctl/calicoctl/resourcemgr"
+)
+
+const testsDir = "../../tests"
+
+func TestEncodeDropsDatastoreOwnedFields(t *testing.T) {
+	RegisterTestingT(t)
+
+	scheme, err := newScheme()
+	Expect(err).NotTo(HaveOccurred())
+	c := &calicoctlExecClient{scheme: scheme}
+
+	data, err := c.encode(&v3.Tier{ObjectMeta: metav1.ObjectMeta{Name: "test-tier", ResourceVersion: "1234"}})
+	Expect(err).NotTo(HaveOccurred())
+
+	obj := map[string]any{}
+	Expect(json.Unmarshal([]byte(data), &obj)).NotTo(HaveOccurred())
+	Expect(obj).To(HaveKeyWithValue("kind", "Tier"))
+	Expect(obj).To(HaveKeyWithValue("apiVersion", "projectcalico.org/v3"))
+	Expect(obj).NotTo(HaveKey("status"))
+	Expect(obj["metadata"]).To(HaveKeyWithValue("name", "test-tier"))
+	Expect(obj["metadata"]).NotTo(HaveKey("creationTimestamp"))
+	Expect(obj["metadata"]).NotTo(HaveKey("resourceVersion"))
+}
+
+// The exec client runs on clusters with no v3 API, so every kind the e2e tests reach
+// for has to be one calicoctl can create, get, and delete.
+func TestEveryKindTheTestsUseIsKnownToCalicoctl(t *testing.T) {
+	RegisterTestingT(t)
+
+	scheme, err := newScheme()
+	Expect(err).NotTo(HaveOccurred())
+
+	kinds := v3KindsUsedByTests(t, scheme)
+	Expect(kinds).NotTo(BeEmpty(), "no v3 kind found under "+testsDir+", so this guard checks nothing")
+
+	valid := resourcemgr.ValidResources()
+	for _, kind := range kinds {
+		if !slices.Contains(valid, kind) {
+			t.Errorf("the e2e tests use %s but calicoctl has no resource manager for it", kind)
+		}
+	}
+}
+
+// v3KindsUsedByTests returns the projectcalico.org/v3 kinds the e2e tests name, ignoring
+// the v3 types that are not resources of their own.
+func v3KindsUsedByTests(t *testing.T, scheme interface {
+	Recognizes(schema.GroupVersionKind) bool
+},
+) []string {
+	t.Helper()
+
+	var kinds []string
+	err := filepath.WalkDir(testsDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() || !strings.HasSuffix(path, ".go") {
+			return err
+		}
+		file, err := parser.ParseFile(token.NewFileSet(), path, nil, 0)
+		if err != nil {
+			return err
+		}
+		ast.Inspect(file, func(n ast.Node) bool {
+			sel, ok := n.(*ast.SelectorExpr)
+			if !ok {
+				return true
+			}
+			if pkg, ok := sel.X.(*ast.Ident); !ok || pkg.Name != "v3" {
+				return true
+			}
+			gvk := schema.GroupVersionKind{Group: "projectcalico.org", Version: "v3", Kind: sel.Sel.Name}
+			if !scheme.Recognizes(gvk) {
+				return true
+			}
+			// The exec client asks calicoctl for the kind itself, list or not.
+			kind := strings.TrimSuffix(gvk.Kind, "List")
+			if !slices.Contains(kinds, kind) {
+				kinds = append(kinds, kind)
+			}
+			return true
+		})
+		return nil
+	})
+	Expect(err).NotTo(HaveOccurred())
+
+	slices.Sort(kinds)
+	return kinds
+}


### PR DESCRIPTION
Cherry-pick of https://github.com/projectcalico/calico/pull/13589 onto release-v3.33.

The exec fallback client shipped the datastore-owned status and metadata on every create, and calicoctl had no resource manager for IPAMConfiguration or CalicoNodeStatus, so a get or an apply came back with "resource type is not supported". Scheduled e2e on this branch runs the in-repo binary downloaded from the hashrelease, so the same failures show up here.

Related: [CORE-13388](https://tigera.atlassian.net/browse/CORE-13388)


[CORE-13388]: https://tigera.atlassian.net/browse/CORE-13388?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ