### PR TITLE
[Release v3.32] Fail instead of panicking when the external node has no addresses

### DIFF
--- a/e2e/pkg/utils/externalnode/client.go
+++ b/e2e/pkg/utils/externalnode/client.go
@@ -46,8 +46,14 @@ func NewClientManualConfig(ip, key, user string) *Client {
 	return &Client{extIP: ip, extKey: key, extUser: user}
 }
 
+// IP returns the external node's first internal address. The ssh probe that
+// discovers them can come back empty, which is a broken external node rather
+// than a test failure, so say which node had none.
 func (e *Client) IP() string {
-	return e.IPs()[0]
+	ips := e.IPs()
+	Expect(ips).NotTo(BeEmpty(), fmt.Sprintf(
+		"no internal IPs discovered on external node %s", e.extIP))
+	return ips[0]
 }
 
 func (e *Client) IPs() []string {

--- a/e2e/pkg/utils/externalnode/client_test.go
+++ b/e2e/pkg/utils/externalnode/client_test.go
@@ -1,0 +1,41 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+
+package externalnode
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/onsi/gomega"
+)
+
+// The ssh probe returns no addresses when the external node is unreachable, and
+// indexing that empty slice used to panic and take the whole Ginkgo node down.
+func TestIPWithNoDiscoveredAddressesFails(t *testing.T) {
+	gomega.RegisterTestingT(t)
+	c := &Client{extIP: "10.0.0.1", intIPs: []string{}}
+
+	err := gomega.InterceptGomegaFailure(func() {
+		c.IP()
+	})
+	if err == nil {
+		t.Fatal("expected IP() to fail when no internal IPs were discovered")
+	}
+	if !strings.Contains(err.Error(), "10.0.0.1") {
+		t.Errorf("failure message should name the external node, got: %s", err.Error())
+	}
+}
+
+func TestIPReturnsFirstDiscoveredAddress(t *testing.T) {
+	gomega.RegisterTestingT(t)
+	c := &Client{extIP: "10.0.0.1", intIPs: []string{"172.16.0.5", "172.16.0.6"}}
+
+	err := gomega.InterceptGomegaFailure(func() {
+		if got := c.IP(); got != "172.16.0.5" {
+			t.Errorf("IP() = %s, want 172.16.0.5", got)
+		}
+	})
+	if err != nil {
+		t.Fatalf("unexpected failure: %s", err)
+	}
+}


### PR DESCRIPTION
Cherry-pick of https://github.com/projectcalico/calico/pull/13584 onto release-v3.32.

The ssh probe that discovers the external node's internal addresses can come back empty, and the tests then panicked on the empty list rather than reporting which node had no addresses. Scheduled e2e on this branch runs the in-repo binary downloaded from the hashrelease, so the same panic shows up here.
 The new unit test does not execute on this branch, which has no `ut` target under e2e.

Related: [CORE-13393](https://tigera.atlassian.net/browse/CORE-13393)


[CORE-13393]: https://tigera.atlassian.net/browse/CORE-13393?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ