### PR TITLE
Make the AZ_PROJECT comment concise

### DIFF
--- a/.argoci/scripts/global_prologue.sh
+++ b/.argoci/scripts/global_prologue.sh
@@ -101,11 +101,8 @@ else
   export TEST_TYPE=${TEST_TYPE:-k8s-e2e}
 fi
 export GOOGLE_PROJECT=${GOOGLE_PROJECT:-unique-caldron-775}
-# Despite the name this is an Azure *subscription name*, not a project or a
-# resource group: azr-aso/azr-capi select the subscription by matching it
-# against `az account list` output. The spelling is banzai-core's variable, so
-# it can't be renamed from here. banzai-core defaults it to the developer
-# subscription; azr-aks ignores it, which is why only the ASO/CAPI paths break.
+# banzai-core's name for the Azure *subscription name*: azr-aso/azr-capi
+# resolve the subscription id by matching it against `az account list`.
 export AZ_PROJECT=${AZ_PROJECT:-tigera-dev-ci}
 
 # GCP placement: gcp-openstack has its own defaults in banzai-core


### PR DESCRIPTION
## Description

Follow-up to review feedback on #13590 (and #13578): the five-line comment explaining `AZ_PROJECT` in the ArgoCI global prologue is more verbose than it needs to be. Trim it to the two facts that matter — it holds an Azure *subscription name*, and the azr-aso/azr-capi provisioners resolve the subscription id by matching it against `az account list`.

Comment-only change; no behavior difference. The same trimmed wording can be carried to release-v3.31/release-v3.32 on their next CI-config sync.

cc @coutinhop

## Release Note

```release-note
None required. Comment-only CI change.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)