### PR TITLE
Cover ClusterNetworkPolicy in the felix syncer FV

### DIFF
--- a/libcalico-go/lib/backend/syncersv1/felixsyncer/felixsyncer_e2e_test.go
+++ b/libcalico-go/lib/backend/syncersv1/felixsyncer/felixsyncer_e2e_test.go
@@ -25,6 +25,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
+	clusternetpol "sigs.k8s.io/network-policy-api/apis/v1alpha2"
+	netpolicyclient "sigs.k8s.io/network-policy-api/pkg/client/clientset/versioned/typed/apis/v1alpha2"
 
 	"github.com/projectcalico/calico/lib/std/uniquelabels"
 	"github.com/projectcalico/calico/libcalico-go/lib/apiconfig"
@@ -787,6 +789,85 @@ var _ = testutils.E2eDatastoreDescribe("Felix syncer tests (passive mode)", test
 		syncTester.ExpectValueMatches(
 			model.GlobalConfigKey{Name: "Variant"},
 			MatchRegexp("Calico"),
+		)
+	})
+})
+
+var _ = testutils.E2eDatastoreDescribe("Felix syncer tests (ClusterNetworkPolicy)", testutils.DatastoreK8s, func(config apiconfig.CalicoAPIConfig) {
+	const kcnpName = "felixsyncer-test-kcnp"
+
+	var be api.Client
+	var syncTester *testutils.SyncerTester
+	var kcnpClient *netpolicyclient.PolicyV1alpha2Client
+	var err error
+
+	BeforeEach(func() {
+		// Create the backend client to obtain a syncer interface.
+		be, err = backend.NewClient(config)
+		Expect(err).NotTo(HaveOccurred())
+		be.Clean()
+
+		// ClusterNetworkPolicies are upstream Kubernetes resources, so they are created
+		// through their own client rather than the Calico one.
+		cfg, err := clientcmd.BuildConfigFromFlags("", "/kubeconfig.yaml")
+		Expect(err).NotTo(HaveOccurred())
+		kcnpClient, err = netpolicyclient.NewForConfig(cfg)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Create a SyncerTester to receive the syncer callback events and to allow us
+		// to assert state.
+		syncTester = testutils.NewSyncerTester()
+	})
+
+	AfterEach(func() {
+		if kcnpClient != nil {
+			_ = kcnpClient.ClusterNetworkPolicies().Delete(context.Background(), kcnpName, metav1.DeleteOptions{})
+		}
+	})
+
+	It("should send ClusterNetworkPolicy updates over the syncer", func() {
+		syncer := felixsyncer.New(be, config.Spec, syncTester, true)
+		syncer.Start()
+		defer syncer.Stop()
+
+		syncTester.ExpectStatusUpdate(api.WaitForDatastore)
+		syncTester.ExpectStatusUpdate(api.ResyncInProgress)
+		syncTester.ExpectStatusUpdate(api.InSync)
+
+		By("Creating a ClusterNetworkPolicy in the admin tier")
+		_, err = kcnpClient.ClusterNetworkPolicies().Create(
+			context.Background(),
+			&clusternetpol.ClusterNetworkPolicy{
+				ObjectMeta: metav1.ObjectMeta{Name: kcnpName},
+				Spec: clusternetpol.ClusterNetworkPolicySpec{
+					Priority: 100,
+					Tier:     clusternetpol.AdminTier,
+					Subject: clusternetpol.ClusterNetworkPolicySubject{
+						Namespaces: &metav1.LabelSelector{},
+					},
+					Ingress: []clusternetpol.ClusterNetworkPolicyIngressRule{{
+						Name:   "deny-all-ingress",
+						Action: clusternetpol.ClusterNetworkPolicyRuleActionDeny,
+						From: []clusternetpol.ClusterNetworkPolicyIngressPeer{{
+							Namespaces: &metav1.LabelSelector{},
+						}},
+					}},
+				},
+			},
+			metav1.CreateOptions{},
+		)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Checking the policy is sent over the syncer in the kube-admin tier")
+		syncTester.ExpectValueMatches(
+			model.PolicyKey{Name: kcnpName, Kind: model.KindKubernetesClusterNetworkPolicy},
+			WithTransform(func(v any) string {
+				policy, ok := v.(*model.Policy)
+				if !ok {
+					return ""
+				}
+				return policy.Tier
+			}, Equal(names.KubeAdminTierName)),
 		)
 	})
 })


### PR DESCRIPTION
Nothing asserted that a `ClusterNetworkPolicy` actually reaches Felix over the felix syncer.

The registration is a single `watchersyncer.ResourceType` entry, and `felixsyncer.New` does not expose its resource types, so a dropped or misconfigured watcher is invisible below FV level — the syncer still reaches in-sync and the policy simply never arrives. That failure mode is silent by construction: `watchersyncer.NewMultiClient` skips a resource whose `ClientID` has no matching client with nothing but a `Debug` log.

The new spec starts the syncer, creates an admin-tier `ClusterNetworkPolicy` through the upstream client, and expects it over the syncer in the `kube-admin` tier. The CRD is already installed into the FV kind cluster (`lib.Makefile`), so no test infrastructure changes are needed.

### Testing

This spec was developed against a downstream fork of this file, where it passes as part of the full `felixsyncer` package (93/93 specs across both datastores). It also demonstrably catches the failure it is written for: in that fork, dropping the `ClientID` from the `ClusterNetworkPolicy` resource type makes it fail (`Timed out after 6.001s`), and restoring it makes it pass.

Against this tree it is compile-verified only (`go vet`); the port adjusts for the 4-argument `felixsyncer.New` and the absence of a validation-filter wrapper. I have not run the FV here — relying on CI for that. The one claim CI will be first to exercise is that the CNP CRD is present in the FV cluster, which I read from the Makefile rather than from a run.

Picked from https://github.com/tigera/calico-private/pull/13404

**Release note:**
```release-note
NONE
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)