### PR TITLE
[release-v3.32] fix: CTLB service affinity — keep unconnected-UDP entries alive, and honour sessionAffinity timeouts

### DIFF
--- a/felix/bpf-gpl/nat_lookup.h
+++ b/felix/bpf-gpl/nat_lookup.h
@@ -174,15 +174,23 @@ static CALI_BPF_INLINE struct calico_nat_dest* calico_nat_lookup(ipv46_addr_t *i
 	affkey.nat_key = nat_data;
 	affkey.client_ip = *ip_src;
 
-	CALI_DEBUG("NAT: backend affinity %d seconds", nat_lv1_val->affinity_timeo ? : affinity_always_timeo);
+	/* The service's own session affinity and the caller's enforced affinity (the
+	 * CTLB's, for unconnected UDP) can both apply. Honour whichever lasts
+	 * longer; picking the shorter would break the promise the other one made.
+	 */
+	int aff_timeo = nat_lv1_val->affinity_timeo;
+	if (affinity_always_timeo > aff_timeo) {
+		aff_timeo = affinity_always_timeo;
+	}
+
+	CALI_DEBUG("NAT: backend affinity %d seconds", aff_timeo);
 
 	struct calico_nat_affinity_val *affval;
 
 	now = bpf_ktime_get_ns();
 	affval = cali_nat_aff_lookup_elem(&affkey);
 	if (affval) {
-		int timeo = (affinity_always_timeo ? : nat_lv1_val->affinity_timeo);
-		if (now - affval->ts <= timeo  * 1000000000ULL) {
+		if (now - affval->ts <= aff_timeo * 1000000000ULL) {
 			CALI_DEBUG("NAT: using affinity backend " IP_FMT ":%d",
 					debug_ip(affval->nat_dest.addr), affval->nat_dest.port);
 			if (affinity_tmr_update) {

--- a/felix/bpf/proxy/ctlb_udp_affinity_test.go
+++ b/felix/bpf/proxy/ctlb_udp_affinity_test.go
@@ -1,0 +1,139 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package proxy_test
+
+import (
+	"net"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	k8sp "k8s.io/kubernetes/pkg/proxy"
+
+	"github.com/projectcalico/calico/felix/bpf"
+	"github.com/projectcalico/calico/felix/bpf/nat"
+	proxy "github.com/projectcalico/calico/felix/bpf/proxy"
+)
+
+// The connect-time load balancer keeps a backend affine to an *unconnected* UDP
+// socket for the "UDP not seen" timeout, whether or not the service asks for
+// session affinity, so that consecutive datagrams from one socket reach one
+// backend. The syncer's affinity map cleanup must leave those entries alone;
+// deleting them sends the next datagram to a fresh random backend.
+var _ = Describe("BPF Syncer CTLB UDP affinity cleanup", func() {
+	const ctlbUDPTimeo = 60 * time.Second
+
+	svcKey := k8sp.ServicePortName{
+		NamespacedName: types.NamespacedName{Namespace: "default", Name: "udp-service"},
+	}
+	clusterIP := net.IPv4(10, 0, 0, 1)
+	const svcPort = 1234
+	liveBackend := net.IPv4(10, 1, 0, 1)
+	const backendPort = 5555
+	clientIP := net.IPv4(5, 5, 5, 5)
+
+	var (
+		aff *mockAffinityMap
+		s   *proxy.Syncer
+	)
+
+	// newSyncer builds a syncer that has already programmed a single service with
+	// the given protocol and session affinity, and that believes the CTLB enforces
+	// UDP affinity for ctlbAffinityTimeo.
+	newSyncer := func(proto v1.Protocol, sticky bool, ctlbAffinityTimeo time.Duration) proxy.DPSyncerState {
+		aff = newMockAffinityMap()
+		var err error
+		s, err = proxy.NewSyncer(4, []net.IP{net.IPv4(192, 168, 0, 1)},
+			newMockNATMap(), newMockNATBackendMap(), newMockMaglevMap(), aff,
+			proxy.NewRTCache(), nil, maglevLUTSize, ctlbAffinityTimeo)
+		Expect(err).NotTo(HaveOccurred())
+
+		opts := []proxy.K8sServicePortOption{}
+		if sticky {
+			opts = append(opts, proxy.K8sSvcWithStickyClientIP(5))
+		}
+		state := proxy.DPSyncerState{
+			SvcMap: k8sp.ServicePortMap{
+				svcKey: proxy.NewK8sServicePort(clusterIP, svcPort, proto, opts...),
+			},
+			EpsMap: k8sp.EndpointsMap{
+				svcKey: []k8sp.Endpoint{
+					proxy.NewEndpointInfo(liveBackend.String(), backendPort,
+						proxy.EndpointInfoOptIsReady(true)),
+				},
+			},
+		}
+		Expect(s.Apply(state)).NotTo(HaveOccurred())
+		return state
+	}
+
+	// addAffEntry writes the affinity entry that the CTLB would have written for a
+	// datagram sent age ago to the given backend.
+	addAffEntry := func(proto v1.Protocol, backend net.IP, age time.Duration) {
+		err := aff.Update(
+			nat.NewAffinityKey(clientIP,
+				nat.NewNATKey(clusterIP, svcPort, proxy.ProtoV1ToIntPanic(proto)),
+			).AsBytes(),
+			nat.NewAffinityValue(
+				uint64(bpf.KTimeNanos())-uint64(age),
+				nat.NewNATBackendValue(backend, backendPort),
+			).AsBytes(),
+		)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(aff.m).To(HaveLen(1))
+	}
+
+	DescribeTable("cleanup of a UDP affinity entry",
+		func(sticky bool, ctlbAffinityTimeo time.Duration, age time.Duration, backend net.IP, expectKept bool) {
+			state := newSyncer(v1.ProtocolUDP, sticky, ctlbAffinityTimeo)
+			addAffEntry(v1.ProtocolUDP, backend, age)
+
+			Expect(s.Apply(state)).NotTo(HaveOccurred())
+
+			if expectKept {
+				Expect(aff.m).To(HaveLen(1), "affinity entry must survive cleanup")
+			} else {
+				Expect(aff.m).To(BeEmpty(), "affinity entry must be cleaned up")
+			}
+		},
+		// The regression: without session affinity the syncer used to know
+		// nothing about the entry and deleted it on the next sync.
+		Entry("fresh, no session affinity, CTLB does UDP: kept",
+			false, ctlbUDPTimeo, time.Second, liveBackend, true),
+		Entry("older than the CTLB timeout: cleaned up",
+			false, ctlbUDPTimeo, 2*ctlbUDPTimeo, liveBackend, false),
+		Entry("pointing at a backend that is gone: cleaned up",
+			false, ctlbUDPTimeo, time.Second, net.IPv4(10, 9, 9, 9), false),
+		// With no CTLB UDP affinity nothing should be creating these entries, so
+		// the syncer is right to reclaim them.
+		Entry("fresh, no session affinity, CTLB skips UDP: cleaned up",
+			false, time.Duration(0), time.Second, liveBackend, false),
+		// Session affinity's own (longer) timeout must still win.
+		Entry("fresh, session affinity, CTLB skips UDP: kept",
+			true, time.Duration(0), time.Second, liveBackend, true),
+	)
+
+	It("cleans up a TCP affinity entry for a service without session affinity", func() {
+		// The CTLB only enforces affinity for unconnected UDP, so a TCP entry on a
+		// service without session affinity is still stale.
+		state := newSyncer(v1.ProtocolTCP, false, ctlbUDPTimeo)
+		addAffEntry(v1.ProtocolTCP, liveBackend, time.Second)
+
+		Expect(s.Apply(state)).NotTo(HaveOccurred())
+		Expect(aff.m).To(BeEmpty())
+	})
+})

--- a/felix/bpf/proxy/kube-proxy.go
+++ b/felix/bpf/proxy/kube-proxy.go
@@ -17,6 +17,7 @@ package proxy
 import (
 	"net"
 	"sync"
+	"time"
 
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
@@ -65,6 +66,8 @@ type KubeProxy struct {
 	excludedCIDRs *ip.CIDRTrie
 
 	dsrEnabled bool
+
+	ctlbUDPAffinityTimeo time.Duration
 }
 
 // StartKubeProxy start a new kube-proxy if there was no error
@@ -160,7 +163,7 @@ func (kp *KubeProxy) run(hostIPs []net.IP, hostMetadata map[string]*proto.HostMe
 	}
 
 	syncer, err := NewSyncer(kp.ipFamily, withLocalNP, kp.frontendMap, kp.backendMap, kp.MaglevMap, kp.affinityMap,
-		kp.rt, kp.excludedCIDRs, kp.maglevLUTSize)
+		kp.rt, kp.excludedCIDRs, kp.maglevLUTSize, kp.ctlbUDPAffinityTimeo)
 	if err != nil {
 		return errors.WithMessage(err, "new bpf syncer")
 	}

--- a/felix/bpf/proxy/lb_src_range_test.go
+++ b/felix/bpf/proxy/lb_src_range_test.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	k8sp "k8s.io/kubernetes/pkg/proxy"
 
+	"github.com/projectcalico/calico/felix/bpf"
 	"github.com/projectcalico/calico/felix/bpf/nat"
 	"github.com/projectcalico/calico/felix/bpf/proxy"
 	"github.com/projectcalico/calico/felix/ip"
@@ -48,7 +49,7 @@ func testfn(makeIPs func(ips []net.IP) proxy.K8sServicePortOption) {
 	externalIP := makeIPs([]net.IP{net.IPv4(35, 0, 0, 2)})
 	twoExternalIPs := makeIPs([]net.IP{net.IPv4(35, 0, 0, 2), net.IPv4(45, 0, 1, 2)})
 
-	s, _ := proxy.NewSyncer(4, nodeIPs, svcs, eps, mglv, aff, rt, nil, maglevLUTSize)
+	s, _ := proxy.NewSyncer(4, nodeIPs, svcs, eps, mglv, aff, rt, nil, maglevLUTSize, 0)
 
 	svcKey := k8sp.ServicePortName{
 		NamespacedName: types.NamespacedName{
@@ -211,7 +212,7 @@ func testfn(makeIPs func(ips []net.IP) proxy.K8sServicePortOption) {
 				externalIP,
 				proxy.K8sSvcWithLBSourceRangeIPs([]*net.IPNet{&ipnet}),
 			)
-			s, _ = proxy.NewSyncer(4, nodeIPs, svcs, eps, mglv, aff, rt, nil, maglevLUTSize)
+			s, _ = proxy.NewSyncer(4, nodeIPs, svcs, eps, mglv, aff, rt, nil, maglevLUTSize, 0)
 			err := s.Apply(state)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(svcs.m).To(HaveLen(3))
@@ -224,7 +225,7 @@ func testfn(makeIPs func(ips []net.IP) proxy.K8sServicePortOption) {
 				v1.ProtocolTCP,
 				externalIP,
 			)
-			s, _ = proxy.NewSyncer(4, nodeIPs, svcs, eps, mglv, aff, rt, nil, maglevLUTSize)
+			s, _ = proxy.NewSyncer(4, nodeIPs, svcs, eps, mglv, aff, rt, nil, maglevLUTSize, 0)
 			err := s.Apply(state)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(svcs.m).To(HaveLen(2))
@@ -255,7 +256,7 @@ func test0000SourceRange() {
 
 	externalIP := net.IPv4(35, 0, 0, 2)
 
-	s, _ := proxy.NewSyncer(4, nodeIPs, svcs, eps, mglv, aff, rt, nil, maglevLUTSize)
+	s, _ := proxy.NewSyncer(4, nodeIPs, svcs, eps, mglv, aff, rt, nil, maglevLUTSize, 0)
 
 	svcKey := k8sp.ServicePortName{
 		NamespacedName: types.NamespacedName{
@@ -334,5 +335,80 @@ var _ = Describe("BPF Load Balancer source range", func() {
 
 	Context("With 0.0.0.0/0 source range", func() {
 		test0000SourceRange()
+	})
+})
+
+// A frontend with source ranges is written by writeLBSrcRangeSvcNATKeys() rather
+// than writeSvc(), so it is the other place that has to tell the affinity map
+// cleanup that the frontend may hold entries.
+var _ = Describe("BPF Load Balancer source range session affinity", func() {
+	svcKey := k8sp.ServicePortName{
+		NamespacedName: types.NamespacedName{Namespace: "default", Name: "sticky-service"},
+	}
+	clusterIP := net.IPv4(10, 0, 0, 2)
+	lbIP := net.IPv4(35, 0, 0, 2)
+	const svcPort = 2222
+	const backendPort = 5555
+	liveBackend := net.IPv4(10, 1, 0, 1)
+	clientIP := net.IPv4(35, 0, 1, 7)
+
+	var (
+		aff   *mockAffinityMap
+		s     *proxy.Syncer
+		state proxy.DPSyncerState
+	)
+
+	BeforeEach(func() {
+		aff = newMockAffinityMap()
+		var err error
+		s, err = proxy.NewSyncer(4, []net.IP{net.IPv4(192, 168, 0, 1)},
+			newMockNATMap(), newMockNATBackendMap(), newMockMaglevMap(), aff,
+			proxy.NewRTCache(), nil, maglevLUTSize, 0)
+		Expect(err).NotTo(HaveOccurred())
+
+		srcRange := ip.MustParseCIDROrIP("35.0.1.2/24").ToIPNet()
+		state = proxy.DPSyncerState{
+			SvcMap: k8sp.ServicePortMap{
+				svcKey: proxy.NewK8sServicePort(clusterIP, svcPort, v1.ProtocolTCP,
+					proxy.K8sSvcWithLoadBalancerIPs([]net.IP{lbIP}),
+					proxy.K8sSvcWithLBSourceRangeIPs([]*net.IPNet{&srcRange}),
+					proxy.K8sSvcWithStickyClientIP(60),
+				),
+			},
+			EpsMap: k8sp.EndpointsMap{
+				svcKey: []k8sp.Endpoint{
+					proxy.NewEndpointInfo(liveBackend.String(), backendPort,
+						proxy.EndpointInfoOptIsReady(true)),
+				},
+			},
+		}
+		Expect(s.Apply(state)).NotTo(HaveOccurred())
+	})
+
+	// addAffEntry writes the affinity entry that the TC programs would have written
+	// for a connection to the load balancer IP.
+	addAffEntry := func(backend net.IP) {
+		err := aff.Update(
+			nat.NewAffinityKey(clientIP,
+				nat.NewNATKey(lbIP, svcPort, proxy.ProtoV1ToIntPanic(v1.ProtocolTCP)),
+			).AsBytes(),
+			nat.NewAffinityValue(uint64(bpf.KTimeNanos()),
+				nat.NewNATBackendValue(backend, backendPort),
+			).AsBytes(),
+		)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(aff.m).To(HaveLen(1))
+	}
+
+	It("should keep a fresh affinity entry for a source-range frontend", func() {
+		addAffEntry(liveBackend)
+		Expect(s.Apply(state)).NotTo(HaveOccurred())
+		Expect(aff.m).To(HaveLen(1), "affinity entry must survive cleanup")
+	})
+
+	It("should still clean up an affinity entry whose backend is gone", func() {
+		addAffEntry(net.IPv4(10, 9, 9, 9))
+		Expect(s.Apply(state)).NotTo(HaveOccurred())
+		Expect(aff.m).To(BeEmpty())
 	})
 })

--- a/felix/bpf/proxy/options.go
+++ b/felix/bpf/proxy/options.go
@@ -133,6 +133,17 @@ func WithExcludedCIDRs(cidrs []string) Option {
 	})
 }
 
+// WithCTLBUDPAffinityTimeout tells the syncer how long the connect-time load
+// balancer keeps its affinity entries for unconnected UDP sockets alive, so that
+// the syncer's affinity map cleanup does not delete entries that the CTLB still
+// considers valid. Pass 0 when the CTLB does not handle UDP.
+func WithCTLBUDPAffinityTimeout(timeo time.Duration) Option {
+	return makeKubeProxyOption(func(kp *KubeProxy) error {
+		kp.ctlbUDPAffinityTimeo = timeo
+		return nil
+	})
+}
+
 func WithHealthCheck(hc Healthcheck) Option {
 	return makeOption(func(p *proxy) error {
 		if hc != nil {

--- a/felix/bpf/proxy/proxy_bench_test.go
+++ b/felix/bpf/proxy/proxy_bench_test.go
@@ -51,6 +51,7 @@ func benchmarkProxyUpdates(b *testing.B, svcN, epsN int) {
 			proxy.NewRTCache(),
 			nil,
 			maglevLUTSize,
+			0,
 		)
 		Expect(err).ShouldNot(HaveOccurred())
 

--- a/felix/bpf/proxy/syncer.go
+++ b/felix/bpf/proxy/syncer.go
@@ -136,6 +136,11 @@ type Syncer struct {
 
 	maglevLUTSize int
 
+	// ctlbUDPAffinityTimeo is the affinity timeout that the connect-time load
+	// balancer enforces for unconnected UDP sockets, or 0 if the CTLB does not
+	// handle UDP on this node.
+	ctlbUDPAffinityTimeo time.Duration
+
 	// active Maps contain all active svcs endpoints at the end of an iteration
 	activeSvcsMap map[ipPortProto]uint32
 	activeEpsMap  map[uint32]map[ipPort]struct{}
@@ -222,18 +227,20 @@ func NewSyncer(family int, nodePortIPs []net.IP,
 	affmap maps.Map, rt Routes,
 	excludedCIDRs *ip.CIDRTrie,
 	maglevLUTSize int,
+	ctlbUDPAffinityTimeo time.Duration,
 ) (*Syncer, error) {
 
 	s := &Syncer{
-		ipFamily:      family,
-		bpfAff:        affmap,
-		rt:            rt,
-		nodePortIPs:   uniqueIPs(nodePortIPs),
-		prevSvcMap:    make(map[svcKey]svcInfo),
-		prevEpsMap:    make(k8sp.EndpointsMap),
-		stop:          make(chan struct{}),
-		excludedCIDRs: excludedCIDRs,
-		maglevLUTSize: maglevLUTSize,
+		ipFamily:             family,
+		bpfAff:               affmap,
+		rt:                   rt,
+		nodePortIPs:          uniqueIPs(nodePortIPs),
+		prevSvcMap:           make(map[svcKey]svcInfo),
+		prevEpsMap:           make(k8sp.EndpointsMap),
+		stop:                 make(chan struct{}),
+		excludedCIDRs:        excludedCIDRs,
+		maglevLUTSize:        maglevLUTSize,
+		ctlbUDPAffinityTimeo: ctlbUDPAffinityTimeo,
 	}
 
 	switch family {
@@ -850,7 +857,7 @@ func (s *Syncer) updateService(skey svcKey, sinfo Service, id uint32, eps []k8sp
 	cnt := 0
 	local := 0
 
-	if sinfo.SessionAffinityType() == v1.ServiceAffinityClientIP {
+	if s.affinityCleanupTimeo(sinfo) > 0 {
 		// since we write the backend before we write the frontend, we need to
 		// preallocate the map for it
 		s.stickyEps[id] = make(map[nat.BackendValueInterface]struct{})
@@ -1024,6 +1031,11 @@ func (s *Syncer) writeLBSrcRangeSvcNATKeys(svc k8sp.ServicePort, svcID uint32, c
 		return err
 	}
 
+	// The BPF programs key affinity entries on the destination only, so an entry
+	// created for one of the source-range frontends above has the same affinity
+	// key as the zero-source-range frontend.
+	s.registerStickyFrontend(key, svcID, svc)
+
 	if _, ok := s.bpfSvcs.Desired().Get(key); !ok {
 		// There is no zero cidr source range entry, we need to add a blackhole
 		// entry to make sure that packets not matching any of the source ranges
@@ -1066,16 +1078,46 @@ func (s *Syncer) writeSvc(svc Service, svcID uint32, count, local int, flags uin
 	}
 	s.bpfSvcs.Desired().Set(key, val)
 
-	// we must have written the backends by now so the map exists
-	if s.stickyEps[svcID] != nil {
-		affkey := key.AffinityKeyCopy()
-		s.stickySvcs[affkey] = stickyFrontend{
-			id:    svcID,
-			timeo: time.Duration(affinityTimeo) * time.Second,
-		}
-	}
+	s.registerStickyFrontend(key, svcID, svc)
 
 	return nil
+}
+
+// registerStickyFrontend records that this frontend may hold affinity entries, so
+// that cleanupSticky() keeps them until they expire instead of reclaiming them as
+// orphans. Every writer of a frontend that carries a non-zero affinity timeout
+// must call this.
+func (s *Syncer) registerStickyFrontend(key nat.FrontendKeyInterface, svcID uint32, svc k8sp.ServicePort) {
+	// we must have written the backends by now so the map exists
+	if s.stickyEps[svcID] == nil {
+		return
+	}
+	s.stickySvcs[key.AffinityKeyCopy()] = stickyFrontend{
+		id:    svcID,
+		timeo: s.affinityCleanupTimeo(svc),
+	}
+}
+
+// affinityCleanupTimeo returns how long an affinity entry for this frontend may live
+// before cleanupSticky() treats it as expired. It is 0 for frontends that
+// should have no affinity entries at all.
+//
+// A service with ClientIP session affinity has entries created by both the TC
+// and the connect-time load balancer (CTLB) programs. On top of that, the CTLB
+// enforces affinity for *unconnected* UDP sockets on every UDP service, whether
+// or not the service asks for session affinity, so that consecutive datagrams
+// from one socket reach one backend. Those entries expire after
+// ctlbUDPAffinityTimeo. We take whichever timeout is longer so that we never
+// delete an entry that either program still considers valid.
+func (s *Syncer) affinityCleanupTimeo(svc k8sp.ServicePort) time.Duration {
+	timeo := time.Duration(0)
+	if svc.SessionAffinityType() == v1.ServiceAffinityClientIP {
+		timeo = time.Duration(svc.StickyMaxAgeSeconds()) * time.Second
+	}
+	if svc.Protocol() == v1.ProtocolUDP && s.ctlbUDPAffinityTimeo > timeo {
+		timeo = s.ctlbUDPAffinityTimeo
+	}
+	return timeo
 }
 
 // ProtoV1ToInt translates k8s v1.Protocol to its IANA number and returns

--- a/felix/bpf/proxy/syncer_bench_test.go
+++ b/felix/bpf/proxy/syncer_bench_test.go
@@ -175,6 +175,7 @@ func runBenchmarkServiceUpdate(b *testing.B, svcCnt, epCnt int, mockMaps bool, o
 			NewRTCache(),
 			nil,
 			maglevLUTSize,
+			0,
 		)
 		Expect(err).ShouldNot(HaveOccurred())
 	} else {
@@ -194,6 +195,7 @@ func runBenchmarkServiceUpdate(b *testing.B, svcCnt, epCnt int, mockMaps bool, o
 			NewRTCache(),
 			nil,
 			maglevLUTSize,
+			0,
 		)
 		Expect(err).ShouldNot(HaveOccurred())
 	}

--- a/felix/bpf/proxy/syncer_test.go
+++ b/felix/bpf/proxy/syncer_test.go
@@ -88,7 +88,7 @@ var _ = Describe("BPF Syncer", func() {
 
 		rt = proxy.NewRTCache()
 
-		s, _ = proxy.NewSyncer(4, nodeIPs, svcs, eps, mgEps, aff, rt, nil, maglevLUTSize)
+		s, _ = proxy.NewSyncer(4, nodeIPs, svcs, eps, mgEps, aff, rt, nil, maglevLUTSize, 0)
 
 		ep := proxy.NewEndpointInfo("10.1.0.1", 5555, proxy.EndpointInfoOptIsReady(true))
 		state = proxy.DPSyncerState{
@@ -512,7 +512,7 @@ var _ = Describe("BPF Syncer", func() {
 		}))
 
 		By("resyncing after creating a new syncer with the same result", makestep(func() {
-			s, _ = proxy.NewSyncer(4, nodeIPs, svcs, eps, mgEps, aff, rt, nil, maglevLUTSize)
+			s, _ = proxy.NewSyncer(4, nodeIPs, svcs, eps, mgEps, aff, rt, nil, maglevLUTSize, 0)
 			checkAfterResync()
 		}))
 
@@ -520,7 +520,7 @@ var _ = Describe("BPF Syncer", func() {
 			svcs.m[nat.NewNATKey(net.IPv4(5, 5, 5, 5), 1111, 6)] = nat.NewNATValue(0xdeadbeef, 2, 2, 0)
 			eps.m[nat.NewNATBackendKey(0xdeadbeef, 0)] = nat.NewNATBackendValue(net.IPv4(6, 6, 6, 6), 666)
 			eps.m[nat.NewNATBackendKey(0xdeadbeef, 1)] = nat.NewNATBackendValue(net.IPv4(7, 7, 7, 7), 777)
-			s, _ = proxy.NewSyncer(4, nodeIPs, svcs, eps, mgEps, aff, rt, nil, maglevLUTSize)
+			s, _ = proxy.NewSyncer(4, nodeIPs, svcs, eps, mgEps, aff, rt, nil, maglevLUTSize, 0)
 			checkAfterResync()
 		}))
 
@@ -668,7 +668,7 @@ var _ = Describe("BPF Syncer", func() {
 
 		By("inserting non-local eps for a NodePort - no route", makestep(func() {
 			// use the meta node IP for nodeports as well
-			s, _ = proxy.NewSyncer(4, append(nodeIPs, net.IPv4(255, 255, 255, 255)), svcs, eps, mgEps, aff, rt, nil, maglevLUTSize)
+			s, _ = proxy.NewSyncer(4, append(nodeIPs, net.IPv4(255, 255, 255, 255)), svcs, eps, mgEps, aff, rt, nil, maglevLUTSize, 0)
 			state.SvcMap[svcKey2] = proxy.NewK8sServicePort(
 				net.IPv4(10, 0, 0, 2),
 				2222,
@@ -821,7 +821,7 @@ var _ = Describe("BPF Syncer", func() {
 
 		By("inserting only non-local eps for a NodePort - multiple nodes & pods/node", makestep(func() {
 			// use the meta node IP for nodeports as well
-			s, _ = proxy.NewSyncer(4, append(nodeIPs, net.IPv4(255, 255, 255, 255)), svcs, eps, mgEps, aff, rt, nil, maglevLUTSize)
+			s, _ = proxy.NewSyncer(4, append(nodeIPs, net.IPv4(255, 255, 255, 255)), svcs, eps, mgEps, aff, rt, nil, maglevLUTSize, 0)
 			state.SvcMap[svcKey2] = proxy.NewK8sServicePort(
 				net.IPv4(10, 0, 0, 2),
 				2222,
@@ -901,7 +901,7 @@ var _ = Describe("BPF Syncer", func() {
 
 		By("restarting Syncer to check if NodePortRemotes are picked up correctly", makestep(func() {
 			// use the meta node IP for nodeports as well
-			s, _ = proxy.NewSyncer(4, append(nodeIPs, net.IPv4(255, 255, 255, 255)), svcs, eps, mgEps, aff, rt, nil, maglevLUTSize)
+			s, _ = proxy.NewSyncer(4, append(nodeIPs, net.IPv4(255, 255, 255, 255)), svcs, eps, mgEps, aff, rt, nil, maglevLUTSize, 0)
 			err := s.Apply(state)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -1275,7 +1275,7 @@ var _ = Describe("BPF Syncer", func() {
 			mgEps = newMockMaglevMap()
 			aff = newMockAffinityMap()
 			rt = proxy.NewRTCache()
-			s, _ = proxy.NewSyncer(4, nodeIPs, svcs, eps, mgEps, aff, rt, nil, maglevLUTSize)
+			s, _ = proxy.NewSyncer(4, nodeIPs, svcs, eps, mgEps, aff, rt, nil, maglevLUTSize, 0)
 		})
 
 		type testCase struct {
@@ -1443,7 +1443,7 @@ var _ = Describe("BPF Syncer API server NAT preservation", func() {
 		mgEps = newMockMaglevMap()
 		aff = newMockAffinityMap()
 		rt = proxy.NewRTCache()
-		s, _ = proxy.NewSyncer(4, nodeIPs, svcs, eps, mgEps, aff, rt, nil, maglevLUTSize)
+		s, _ = proxy.NewSyncer(4, nodeIPs, svcs, eps, mgEps, aff, rt, nil, maglevLUTSize, 0)
 	})
 
 	It("retains the API server backend across a transient loss of endpoints", func() {

--- a/felix/dataplane/linux/int_dataplane.go
+++ b/felix/dataplane/linux/int_dataplane.go
@@ -297,6 +297,26 @@ type Config struct {
 	NewNftablesDataplane nftables.NewNftablesDataplaneFn
 }
 
+// ctlbExcludesUDP returns whether the connect-time load balancer leaves UDP to
+// the TC programs.
+func (config *Config) ctlbExcludesUDP() bool {
+	return config.BPFConnTimeLB == string(apiv3.BPFConnectTimeLBTCP) &&
+		config.BPFHostNetworkedNAT == string(apiv3.BPFHostNetworkedNATEnabled)
+}
+
+// ctlbUDPAffinityTimeout returns how long the connect-time load balancer holds a
+// backend affine to an unconnected UDP socket, or 0 if the CTLB does not handle
+// UDP on this node. The CTLB uses this so that consecutive datagrams from one
+// socket reach one backend; the BPF kube-proxy needs the same value so that its
+// affinity map cleanup leaves those entries alone until they really have expired.
+func (config *Config) ctlbUDPAffinityTimeout() time.Duration {
+	if config.BPFConnTimeLB == string(apiv3.BPFConnectTimeLBDisabled) || config.ctlbExcludesUDP() {
+		return 0
+	}
+	// The BPF programs are given the timeout in whole seconds.
+	return config.BPFConntrackTimeouts.UDPTimeout.Truncate(time.Second)
+}
+
 type UpdateBatchResolver interface {
 	// Opportunity for a manager component to resolve state that depends jointly on the updates
 	// that it has seen since the preceding CompleteDeferredWork call.  Processing here can
@@ -1054,10 +1074,7 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 		}
 
 		if config.BPFConnTimeLB != string(apiv3.BPFConnectTimeLBDisabled) {
-			excludeUDP := false
-			if config.BPFConnTimeLB == string(apiv3.BPFConnectTimeLBTCP) && config.BPFHostNetworkedNAT == string(apiv3.BPFHostNetworkedNATEnabled) {
-				excludeUDP = true
-			}
+			excludeUDP := config.ctlbExcludesUDP()
 			logLevel := strings.ToLower(config.BPFLogLevel)
 			if config.BPFLogFilters != nil {
 				if logLevel != "off" && config.BPFCTLBLogFilter != "all" {
@@ -3026,6 +3043,7 @@ func startBPFDataplaneComponents(
 	bpfproxyOpts := []bpfproxy.Option{
 		bpfproxy.WithMinSyncPeriod(config.KubeProxyMinSyncPeriod),
 		bpfproxy.WithMaglevLUTSize(config.BPFMaglevLUTSize),
+		bpfproxy.WithCTLBUDPAffinityTimeout(config.ctlbUDPAffinityTimeout()),
 	}
 
 	if config.bpfProxyHealthCheck != nil {

--- a/felix/fv/bpf_test.go
+++ b/felix/fv/bpf_test.go
@@ -3294,66 +3294,76 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 								"Service endpoints didn't get created? Is controller-manager happy?")
 						})
 
+						affKV := func() (nat.AffinityKeyInterface, nat.AffinityValueInterface) {
+							if testOpts.ipv6 {
+								aff := dumpAffMapV6(tc.Felixes[0])
+								ExpectWithOffset(1, aff).To(HaveLen(1), "expected exactly one affinity entry")
+
+								// get the only key
+								for k, v := range aff {
+									return k, v
+								}
+							} else {
+								aff := dumpAffMap(tc.Felixes[0])
+								ExpectWithOffset(1, aff).To(HaveLen(1), "expected exactly one affinity entry")
+
+								// get the only key
+								for k, v := range aff {
+									return k, v
+								}
+							}
+
+							Fail("no value in aff map")
+							return nil, nil
+						}
+
+						affLen := func() int {
+							if testOpts.ipv6 {
+								return len(dumpAffMapV6(tc.Felixes[0]))
+							}
+							return len(dumpAffMap(tc.Felixes[0]))
+						}
+
+						family := 4
+						natFEKey := func(ip string, port uint16) nat.FrontendKeyInterface {
+							return nat.NewNATKeyIntf(net.ParseIP(ip), port, numericProto)
+						}
+						if testOpts.ipv6 {
+							family = 6
+							natFEKey = func(ip string, port uint16) nat.FrontendKeyInterface {
+								return nat.NewNATKeyV6Intf(net.ParseIP(ip), port, numericProto)
+							}
+						}
+
+						// waitForSvcProgrammed waits until felix-0 has the service's NAT
+						// frontend and its first backend. Syncing with the NAT tables stops
+						// us creating an extra affinity entry when the CTLB misses but the
+						// regular DNAT hits, the connection fails, and then the CTLB
+						// succeeds.
+						waitForSvcProgrammed := func(ip string, port uint16) {
+							natFtKey := natFEKey(ip, port)
+							EventuallyWithOffset(1, func() bool {
+								m, be, _ := dumpNATMapsAny(family, tc.Felixes[0])
+
+								v, ok := m[natFtKey]
+								if !ok || v.Count() == 0 {
+									return false
+								}
+
+								_, ok = be[nat.NewNATBackendKey(v.ID(), 0)]
+								return ok
+							}, 10*time.Second).Should(BeTrue(), "service was not programmed")
+						}
+
 						// Since the affinity map is shared by cgroup programs on
 						// all nodes, we must be careful to use only client(s) on a
 						// single node for the experiments.
 						It("should have connectivity from a workload to a service with multiple backends", func() {
-							affKV := func() (nat.AffinityKeyInterface, nat.AffinityValueInterface) {
-								if testOpts.ipv6 {
-									aff := dumpAffMapV6(tc.Felixes[0])
-									ExpectWithOffset(1, aff).To(HaveLen(1))
-
-									// get the only key
-									for k, v := range aff {
-										return k, v
-									}
-								} else {
-									aff := dumpAffMap(tc.Felixes[0])
-									ExpectWithOffset(1, aff).To(HaveLen(1))
-
-									// get the only key
-									for k, v := range aff {
-										return k, v
-									}
-								}
-
-								Fail("no value in aff map")
-								return nil, nil
-							}
-
 							ip := testSvc.Spec.ClusterIP
 							port := uint16(testSvc.Spec.Ports[0].Port)
 
 							if setAffinity {
-								// Sync with NAT tables to prevent creating extra entry when
-								// CTLB misses but regular DNAT hits, but connection fails and
-								// then CTLB succeeds.
-								var (
-									family   int
-									natFtKey nat.FrontendKeyInterface
-								)
-
-								if testOpts.ipv6 {
-									natFtKey = nat.NewNATKeyV6Intf(net.ParseIP(ip), port, numericProto)
-									family = 6
-								} else {
-									natFtKey = nat.NewNATKeyIntf(net.ParseIP(ip), port, numericProto)
-									family = 4
-								}
-
-								Eventually(func() bool {
-									m, be, _ := dumpNATMapsAny(family, tc.Felixes[0])
-
-									v, ok := m[natFtKey]
-									if !ok || v.Count() == 0 {
-										return false
-									}
-
-									beKey := nat.NewNATBackendKey(v.ID(), 0)
-
-									_, ok = be[beKey]
-									return ok
-								}, 5*time.Second).Should(BeTrue())
+								waitForSvcProgrammed(ip, port)
 							}
 
 							cc.ExpectSome(w[0][1], TargetIP(ip), port)
@@ -3367,6 +3377,39 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 
 							// This should happen consistently, but that may take quite some time.
 							Expect(val1.Backend()).To(Equal(v2.Backend()))
+
+							// The affinity entry must survive a kube-proxy sync. The
+							// syncer cleans the affinity map on every sync, and it only
+							// knows to keep an entry for a service it expects to have
+							// affinity - which, for unconnected UDP, includes services
+							// without session affinity because the CTLB enforces
+							// affinity for them too.
+							//
+							// Creating an unrelated service forces a sync; once felix
+							// has programmed it, the cleanup has definitely run.
+							By("keeping the affinity across a kube-proxy sync", func() {
+								syncSvcIP := "10.101.0.13"
+								if testOpts.ipv6 {
+									syncSvcIP = "dead:beef::abcd:0:0:13"
+								}
+								syncSvc := k8sService("test-service-sync", syncSvcIP, w[0][0], 80, 8055, 0, testOpts.protocol)
+								_, err := k8sClient.CoreV1().Services(testSvcNamespace).
+									Create(context.Background(), syncSvc, metav1.CreateOptions{})
+								Expect(err).NotTo(HaveOccurred())
+
+								syncSvcKey := natFEKey(syncSvcIP, 80)
+								Eventually(func() bool {
+									m, _, _ := dumpNATMapsAny(family, tc.Felixes[0])
+									_, ok := m[syncSvcKey]
+									return ok
+								}, "10s", "300ms").Should(BeTrue(), "kube-proxy did not sync the extra service")
+
+								Expect(affLen()).To(Equal(1),
+									"the kube-proxy sync deleted the affinity entry")
+								_, v3 := affKV()
+								Expect(v3.Backend()).To(Equal(val1.Backend()),
+									"the kube-proxy sync changed the affinity backend")
+							})
 
 							cc.ResetExpectations()
 
@@ -3446,6 +3489,47 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 								Not(Equal(mVal.Backend())),
 							))
 						})
+
+						// The CTLB enforces its own, short, affinity for unconnected UDP on
+						// every UDP service. A service that asks for session affinity has a
+						// much longer timeout of its own, and that is the one the user asked
+						// for, so it must win.
+						if setAffinity && testOpts.protocol == "udp" && testOpts.udpUnConnected && testOpts.connTimeEnabled {
+							It("should keep the affinity for longer than the CTLB's UDP timeout", func() {
+								ip := testSvc.Spec.ClusterIP
+								port := uint16(testSvc.Spec.Ports[0].Port)
+
+								// Shrink the CTLB's timeout so that the test can idle past it in
+								// a few seconds. The service keeps Kubernetes' default session
+								// affinity timeout of 3 hours.
+								By("restarting felix-0 with a 3s UDP conntrack timeout", func() {
+									tc.Felixes[0].SetEnv(map[string]string{"FELIX_BPFCONNTRACKTIMEOUTS": "UDPTimeout=3s"})
+									tc.Felixes[0].Restart()
+									waitForSvcProgrammed(ip, port)
+								})
+
+								// N.B. Client must be on felix-0 to be subject to ctlb!
+								cc.ExpectSome(w[0][1], TargetIP(ip), port)
+								cc.CheckConnectivity()
+								_, first := affKV()
+
+								// Each round idles for longer than the CTLB's UDP timeout. If the
+								// CTLB applied that timeout it would treat the entry as expired
+								// and re-pick at random, so with three backends a run of rounds
+								// all picking the same backend by luck is vanishingly unlikely.
+								for round := range 8 {
+									time.Sleep(4 * time.Second)
+									cc.CheckConnectivity()
+
+									Expect(affLen()).To(Equal(1),
+										fmt.Sprintf("round %d: affinity entry disappeared", round))
+									_, v := affKV()
+									Expect(v.Backend()).To(Equal(first.Backend()),
+										fmt.Sprintf("round %d: affinity backend changed after idling "+
+											"past the CTLB's UDP timeout", round))
+								}
+							})
+						}
 					}
 
 					Context("with affinity", func() {


### PR DESCRIPTION
Cherry-pick of #13399 onto `release-v3.32`.

### Cherry-pick details

Picked from OSS master merge commit `fb6e0cec9067`.

Two conflicts, both resolved by dropping content the branch does not have:

- `felix/design/bpf-services.md` — the file does not exist on `release-v3.32` (the `design/` layout landed on master after the branch cut), so the doc hunk is dropped. Nothing on this branch documents the affinity map.
- `felix/bpf/proxy/syncer_test.go` — conflicted only against master's `BPF Syncer NAT service ID conflicts` block (from #13388, not on this branch). That block is dropped; the eight existing `NewSyncer()` call sites take the new trailing `ctlbUDPAffinityTimeo` argument as on master.

Every other hunk is byte-identical to master's, verified by diffing the two patches.

### Validation

- `make go-vet` (`go vet --tags fvtests ./...`) — clean.
- `felix/bpf/proxy` UTs — see below.

```release-note
Fixed two eBPF dataplane service affinity bugs: consecutive datagrams from an unconnected UDP socket could be sent to different backends because Felix's affinity map cleanup deleted the connect-time load balancer's affinity entries; and a UDP service using sessionAffinity had its affinity timeout capped at the much shorter BPF UDP conntrack timeout on the connect-time load balancer path. Also fixed session affinity never working for a LoadBalancer or ExternalIP service that sets loadBalancerSourceRanges.
```