### PR TITLE
[v3.33] Backport four eBPF dataplane / flow-log fixes

### DIFF
--- a/felix/bpf-gpl/nat_lookup.h
+++ b/felix/bpf-gpl/nat_lookup.h
@@ -174,15 +174,23 @@ static CALI_BPF_INLINE struct calico_nat_dest* calico_nat_lookup(ipv46_addr_t *i
 	affkey.nat_key = nat_data;
 	affkey.client_ip = *ip_src;
 
-	CALI_DEBUG("NAT: backend affinity %d seconds", nat_lv1_val->affinity_timeo ? : affinity_always_timeo);
+	/* The service's own session affinity and the caller's enforced affinity (the
+	 * CTLB's, for unconnected UDP) can both apply. Honour whichever lasts
+	 * longer; picking the shorter would break the promise the other one made.
+	 */
+	int aff_timeo = nat_lv1_val->affinity_timeo;
+	if (affinity_always_timeo > aff_timeo) {
+		aff_timeo = affinity_always_timeo;
+	}
+
+	CALI_DEBUG("NAT: backend affinity %d seconds", aff_timeo);
 
 	struct calico_nat_affinity_val *affval;
 
 	now = bpf_ktime_get_ns();
 	affval = cali_nat_aff_lookup_elem(&affkey);
 	if (affval) {
-		int timeo = (affinity_always_timeo ? : nat_lv1_val->affinity_timeo);
-		if (now - affval->ts <= timeo  * 1000000000ULL) {
+		if (now - affval->ts <= aff_timeo * 1000000000ULL) {
 			CALI_DEBUG("NAT: using affinity backend " IP_FMT ":%d",
 					debug_ip(affval->nat_dest.addr), affval->nat_dest.port);
 			if (affinity_tmr_update) {

--- a/felix/bpf/proxy/ctlb_udp_affinity_test.go
+++ b/felix/bpf/proxy/ctlb_udp_affinity_test.go
@@ -1,0 +1,139 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package proxy_test
+
+import (
+	"net"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	k8sp "k8s.io/kubernetes/pkg/proxy"
+
+	"github.com/projectcalico/calico/felix/bpf"
+	"github.com/projectcalico/calico/felix/bpf/nat"
+	proxy "github.com/projectcalico/calico/felix/bpf/proxy"
+)
+
+// The connect-time load balancer keeps a backend affine to an *unconnected* UDP
+// socket for the "UDP not seen" timeout, whether or not the service asks for
+// session affinity, so that consecutive datagrams from one socket reach one
+// backend. The syncer's affinity map cleanup must leave those entries alone;
+// deleting them sends the next datagram to a fresh random backend.
+var _ = Describe("BPF Syncer CTLB UDP affinity cleanup", func() {
+	const ctlbUDPTimeo = 60 * time.Second
+
+	svcKey := k8sp.ServicePortName{
+		NamespacedName: types.NamespacedName{Namespace: "default", Name: "udp-service"},
+	}
+	clusterIP := net.IPv4(10, 0, 0, 1)
+	const svcPort = 1234
+	liveBackend := net.IPv4(10, 1, 0, 1)
+	const backendPort = 5555
+	clientIP := net.IPv4(5, 5, 5, 5)
+
+	var (
+		aff *mockAffinityMap
+		s   *proxy.Syncer
+	)
+
+	// newSyncer builds a syncer that has already programmed a single service with
+	// the given protocol and session affinity, and that believes the CTLB enforces
+	// UDP affinity for ctlbAffinityTimeo.
+	newSyncer := func(proto v1.Protocol, sticky bool, ctlbAffinityTimeo time.Duration) proxy.DPSyncerState {
+		aff = newMockAffinityMap()
+		var err error
+		s, err = proxy.NewSyncer(4, []net.IP{net.IPv4(192, 168, 0, 1)},
+			newMockNATMap(), newMockNATBackendMap(), newMockMaglevMap(), aff,
+			proxy.NewRTCache(), nil, maglevLUTSize, ctlbAffinityTimeo)
+		Expect(err).NotTo(HaveOccurred())
+
+		opts := []proxy.K8sServicePortOption{}
+		if sticky {
+			opts = append(opts, proxy.K8sSvcWithStickyClientIP(5))
+		}
+		state := proxy.DPSyncerState{
+			SvcMap: k8sp.ServicePortMap{
+				svcKey: proxy.NewK8sServicePort(clusterIP, svcPort, proto, opts...),
+			},
+			EpsMap: k8sp.EndpointsMap{
+				svcKey: []k8sp.Endpoint{
+					proxy.NewEndpointInfo(liveBackend.String(), backendPort,
+						proxy.EndpointInfoOptIsReady(true)),
+				},
+			},
+		}
+		Expect(s.Apply(state)).NotTo(HaveOccurred())
+		return state
+	}
+
+	// addAffEntry writes the affinity entry that the CTLB would have written for a
+	// datagram sent age ago to the given backend.
+	addAffEntry := func(proto v1.Protocol, backend net.IP, age time.Duration) {
+		err := aff.Update(
+			nat.NewAffinityKey(clientIP,
+				nat.NewNATKey(clusterIP, svcPort, proxy.ProtoV1ToIntPanic(proto)),
+			).AsBytes(),
+			nat.NewAffinityValue(
+				uint64(bpf.KTimeNanos())-uint64(age),
+				nat.NewNATBackendValue(backend, backendPort),
+			).AsBytes(),
+		)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(aff.m).To(HaveLen(1))
+	}
+
+	DescribeTable("cleanup of a UDP affinity entry",
+		func(sticky bool, ctlbAffinityTimeo time.Duration, age time.Duration, backend net.IP, expectKept bool) {
+			state := newSyncer(v1.ProtocolUDP, sticky, ctlbAffinityTimeo)
+			addAffEntry(v1.ProtocolUDP, backend, age)
+
+			Expect(s.Apply(state)).NotTo(HaveOccurred())
+
+			if expectKept {
+				Expect(aff.m).To(HaveLen(1), "affinity entry must survive cleanup")
+			} else {
+				Expect(aff.m).To(BeEmpty(), "affinity entry must be cleaned up")
+			}
+		},
+		// The regression: without session affinity the syncer used to know
+		// nothing about the entry and deleted it on the next sync.
+		Entry("fresh, no session affinity, CTLB does UDP: kept",
+			false, ctlbUDPTimeo, time.Second, liveBackend, true),
+		Entry("older than the CTLB timeout: cleaned up",
+			false, ctlbUDPTimeo, 2*ctlbUDPTimeo, liveBackend, false),
+		Entry("pointing at a backend that is gone: cleaned up",
+			false, ctlbUDPTimeo, time.Second, net.IPv4(10, 9, 9, 9), false),
+		// With no CTLB UDP affinity nothing should be creating these entries, so
+		// the syncer is right to reclaim them.
+		Entry("fresh, no session affinity, CTLB skips UDP: cleaned up",
+			false, time.Duration(0), time.Second, liveBackend, false),
+		// Session affinity's own (longer) timeout must still win.
+		Entry("fresh, session affinity, CTLB skips UDP: kept",
+			true, time.Duration(0), time.Second, liveBackend, true),
+	)
+
+	It("cleans up a TCP affinity entry for a service without session affinity", func() {
+		// The CTLB only enforces affinity for unconnected UDP, so a TCP entry on a
+		// service without session affinity is still stale.
+		state := newSyncer(v1.ProtocolTCP, false, ctlbUDPTimeo)
+		addAffEntry(v1.ProtocolTCP, liveBackend, time.Second)
+
+		Expect(s.Apply(state)).NotTo(HaveOccurred())
+		Expect(aff.m).To(BeEmpty())
+	})
+})

--- a/felix/bpf/proxy/kube-proxy.go
+++ b/felix/bpf/proxy/kube-proxy.go
@@ -17,6 +17,7 @@ package proxy
 import (
 	"net"
 	"sync"
+	"time"
 
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
@@ -65,6 +66,8 @@ type KubeProxy struct {
 	excludedCIDRs *ip.CIDRTrie
 
 	dsrEnabled bool
+
+	ctlbUDPAffinityTimeo time.Duration
 }
 
 // StartKubeProxy start a new kube-proxy if there was no error
@@ -160,7 +163,7 @@ func (kp *KubeProxy) run(hostIPs []net.IP, hostMetadata map[string]*proto.HostMe
 	}
 
 	syncer, err := NewSyncer(kp.ipFamily, withLocalNP, kp.frontendMap, kp.backendMap, kp.MaglevMap, kp.affinityMap,
-		kp.rt, kp.excludedCIDRs, kp.maglevLUTSize)
+		kp.rt, kp.excludedCIDRs, kp.maglevLUTSize, kp.ctlbUDPAffinityTimeo)
 	if err != nil {
 		return errors.WithMessage(err, "new bpf syncer")
 	}

--- a/felix/bpf/proxy/lb_src_range_test.go
+++ b/felix/bpf/proxy/lb_src_range_test.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	k8sp "k8s.io/kubernetes/pkg/proxy"
 
+	"github.com/projectcalico/calico/felix/bpf"
 	"github.com/projectcalico/calico/felix/bpf/nat"
 	"github.com/projectcalico/calico/felix/bpf/proxy"
 	"github.com/projectcalico/calico/felix/ip"
@@ -48,7 +49,7 @@ func testfn(makeIPs func(ips []net.IP) proxy.K8sServicePortOption) {
 	externalIP := makeIPs([]net.IP{net.IPv4(35, 0, 0, 2)})
 	twoExternalIPs := makeIPs([]net.IP{net.IPv4(35, 0, 0, 2), net.IPv4(45, 0, 1, 2)})
 
-	s, _ := proxy.NewSyncer(4, nodeIPs, svcs, eps, mglv, aff, rt, nil, maglevLUTSize)
+	s, _ := proxy.NewSyncer(4, nodeIPs, svcs, eps, mglv, aff, rt, nil, maglevLUTSize, 0)
 
 	svcKey := k8sp.ServicePortName{
 		NamespacedName: types.NamespacedName{
@@ -211,7 +212,7 @@ func testfn(makeIPs func(ips []net.IP) proxy.K8sServicePortOption) {
 				externalIP,
 				proxy.K8sSvcWithLBSourceRangeIPs([]*net.IPNet{&ipnet}),
 			)
-			s, _ = proxy.NewSyncer(4, nodeIPs, svcs, eps, mglv, aff, rt, nil, maglevLUTSize)
+			s, _ = proxy.NewSyncer(4, nodeIPs, svcs, eps, mglv, aff, rt, nil, maglevLUTSize, 0)
 			err := s.Apply(state)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(svcs.m).To(HaveLen(3))
@@ -224,7 +225,7 @@ func testfn(makeIPs func(ips []net.IP) proxy.K8sServicePortOption) {
 				v1.ProtocolTCP,
 				externalIP,
 			)
-			s, _ = proxy.NewSyncer(4, nodeIPs, svcs, eps, mglv, aff, rt, nil, maglevLUTSize)
+			s, _ = proxy.NewSyncer(4, nodeIPs, svcs, eps, mglv, aff, rt, nil, maglevLUTSize, 0)
 			err := s.Apply(state)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(svcs.m).To(HaveLen(2))
@@ -255,7 +256,7 @@ func test0000SourceRange() {
 
 	externalIP := net.IPv4(35, 0, 0, 2)
 
-	s, _ := proxy.NewSyncer(4, nodeIPs, svcs, eps, mglv, aff, rt, nil, maglevLUTSize)
+	s, _ := proxy.NewSyncer(4, nodeIPs, svcs, eps, mglv, aff, rt, nil, maglevLUTSize, 0)
 
 	svcKey := k8sp.ServicePortName{
 		NamespacedName: types.NamespacedName{
@@ -334,5 +335,80 @@ var _ = Describe("BPF Load Balancer source range", func() {
 
 	Context("With 0.0.0.0/0 source range", func() {
 		test0000SourceRange()
+	})
+})
+
+// A frontend with source ranges is written by writeLBSrcRangeSvcNATKeys() rather
+// than writeSvc(), so it is the other place that has to tell the affinity map
+// cleanup that the frontend may hold entries.
+var _ = Describe("BPF Load Balancer source range session affinity", func() {
+	svcKey := k8sp.ServicePortName{
+		NamespacedName: types.NamespacedName{Namespace: "default", Name: "sticky-service"},
+	}
+	clusterIP := net.IPv4(10, 0, 0, 2)
+	lbIP := net.IPv4(35, 0, 0, 2)
+	const svcPort = 2222
+	const backendPort = 5555
+	liveBackend := net.IPv4(10, 1, 0, 1)
+	clientIP := net.IPv4(35, 0, 1, 7)
+
+	var (
+		aff   *mockAffinityMap
+		s     *proxy.Syncer
+		state proxy.DPSyncerState
+	)
+
+	BeforeEach(func() {
+		aff = newMockAffinityMap()
+		var err error
+		s, err = proxy.NewSyncer(4, []net.IP{net.IPv4(192, 168, 0, 1)},
+			newMockNATMap(), newMockNATBackendMap(), newMockMaglevMap(), aff,
+			proxy.NewRTCache(), nil, maglevLUTSize, 0)
+		Expect(err).NotTo(HaveOccurred())
+
+		srcRange := ip.MustParseCIDROrIP("35.0.1.2/24").ToIPNet()
+		state = proxy.DPSyncerState{
+			SvcMap: k8sp.ServicePortMap{
+				svcKey: proxy.NewK8sServicePort(clusterIP, svcPort, v1.ProtocolTCP,
+					proxy.K8sSvcWithLoadBalancerIPs([]net.IP{lbIP}),
+					proxy.K8sSvcWithLBSourceRangeIPs([]*net.IPNet{&srcRange}),
+					proxy.K8sSvcWithStickyClientIP(60),
+				),
+			},
+			EpsMap: k8sp.EndpointsMap{
+				svcKey: []k8sp.Endpoint{
+					proxy.NewEndpointInfo(liveBackend.String(), backendPort,
+						proxy.EndpointInfoOptIsReady(true)),
+				},
+			},
+		}
+		Expect(s.Apply(state)).NotTo(HaveOccurred())
+	})
+
+	// addAffEntry writes the affinity entry that the TC programs would have written
+	// for a connection to the load balancer IP.
+	addAffEntry := func(backend net.IP) {
+		err := aff.Update(
+			nat.NewAffinityKey(clientIP,
+				nat.NewNATKey(lbIP, svcPort, proxy.ProtoV1ToIntPanic(v1.ProtocolTCP)),
+			).AsBytes(),
+			nat.NewAffinityValue(uint64(bpf.KTimeNanos()),
+				nat.NewNATBackendValue(backend, backendPort),
+			).AsBytes(),
+		)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(aff.m).To(HaveLen(1))
+	}
+
+	It("should keep a fresh affinity entry for a source-range frontend", func() {
+		addAffEntry(liveBackend)
+		Expect(s.Apply(state)).NotTo(HaveOccurred())
+		Expect(aff.m).To(HaveLen(1), "affinity entry must survive cleanup")
+	})
+
+	It("should still clean up an affinity entry whose backend is gone", func() {
+		addAffEntry(net.IPv4(10, 9, 9, 9))
+		Expect(s.Apply(state)).NotTo(HaveOccurred())
+		Expect(aff.m).To(BeEmpty())
 	})
 })

--- a/felix/bpf/proxy/options.go
+++ b/felix/bpf/proxy/options.go
@@ -133,6 +133,17 @@ func WithExcludedCIDRs(cidrs []string) Option {
 	})
 }
 
+// WithCTLBUDPAffinityTimeout tells the syncer how long the connect-time load
+// balancer keeps its affinity entries for unconnected UDP sockets alive, so that
+// the syncer's affinity map cleanup does not delete entries that the CTLB still
+// considers valid. Pass 0 when the CTLB does not handle UDP.
+func WithCTLBUDPAffinityTimeout(timeo time.Duration) Option {
+	return makeKubeProxyOption(func(kp *KubeProxy) error {
+		kp.ctlbUDPAffinityTimeo = timeo
+		return nil
+	})
+}
+
 func WithHealthCheck(hc Healthcheck) Option {
 	return makeOption(func(p *proxy) error {
 		if hc != nil {

--- a/felix/bpf/proxy/proxy_bench_test.go
+++ b/felix/bpf/proxy/proxy_bench_test.go
@@ -51,6 +51,7 @@ func benchmarkProxyUpdates(b *testing.B, svcN, epsN int) {
 			proxy.NewRTCache(),
 			nil,
 			maglevLUTSize,
+			0,
 		)
 		Expect(err).ShouldNot(HaveOccurred())
 

--- a/felix/bpf/proxy/syncer.go
+++ b/felix/bpf/proxy/syncer.go
@@ -136,6 +136,11 @@ type Syncer struct {
 
 	maglevLUTSize int
 
+	// ctlbUDPAffinityTimeo is the affinity timeout that the connect-time load
+	// balancer enforces for unconnected UDP sockets, or 0 if the CTLB does not
+	// handle UDP on this node.
+	ctlbUDPAffinityTimeo time.Duration
+
 	// active Maps contain all active svcs endpoints at the end of an iteration
 	activeSvcsMap map[ipPortProto]uint32
 	activeEpsMap  map[uint32]map[ipPort]struct{}
@@ -222,18 +227,20 @@ func NewSyncer(family int, nodePortIPs []net.IP,
 	affmap maps.Map, rt Routes,
 	excludedCIDRs *ip.CIDRTrie,
 	maglevLUTSize int,
+	ctlbUDPAffinityTimeo time.Duration,
 ) (*Syncer, error) {
 
 	s := &Syncer{
-		ipFamily:      family,
-		bpfAff:        affmap,
-		rt:            rt,
-		nodePortIPs:   uniqueIPs(nodePortIPs),
-		prevSvcMap:    make(map[svcKey]svcInfo),
-		prevEpsMap:    make(k8sp.EndpointsMap),
-		stop:          make(chan struct{}),
-		excludedCIDRs: excludedCIDRs,
-		maglevLUTSize: maglevLUTSize,
+		ipFamily:             family,
+		bpfAff:               affmap,
+		rt:                   rt,
+		nodePortIPs:          uniqueIPs(nodePortIPs),
+		prevSvcMap:           make(map[svcKey]svcInfo),
+		prevEpsMap:           make(k8sp.EndpointsMap),
+		stop:                 make(chan struct{}),
+		excludedCIDRs:        excludedCIDRs,
+		maglevLUTSize:        maglevLUTSize,
+		ctlbUDPAffinityTimeo: ctlbUDPAffinityTimeo,
 	}
 
 	switch family {
@@ -895,7 +902,7 @@ func (s *Syncer) updateService(skey svcKey, sinfo Service, id uint32, eps []k8sp
 	cnt := 0
 	local := 0
 
-	if sinfo.SessionAffinityType() == v1.ServiceAffinityClientIP {
+	if s.affinityCleanupTimeo(sinfo) > 0 {
 		// since we write the backend before we write the frontend, we need to
 		// preallocate the map for it
 		s.stickyEps[id] = make(map[nat.BackendValueInterface]struct{})
@@ -1069,6 +1076,11 @@ func (s *Syncer) writeLBSrcRangeSvcNATKeys(svc k8sp.ServicePort, svcID uint32, c
 		return err
 	}
 
+	// The BPF programs key affinity entries on the destination only, so an entry
+	// created for one of the source-range frontends above has the same affinity
+	// key as the zero-source-range frontend.
+	s.registerStickyFrontend(key, svcID, svc)
+
 	if _, ok := s.bpfSvcs.Desired().Get(key); !ok {
 		// There is no zero cidr source range entry, we need to add a blackhole
 		// entry to make sure that packets not matching any of the source ranges
@@ -1111,16 +1123,46 @@ func (s *Syncer) writeSvc(svc Service, svcID uint32, count, local int, flags uin
 	}
 	s.bpfSvcs.Desired().Set(key, val)
 
-	// we must have written the backends by now so the map exists
-	if s.stickyEps[svcID] != nil {
-		affkey := key.AffinityKeyCopy()
-		s.stickySvcs[affkey] = stickyFrontend{
-			id:    svcID,
-			timeo: time.Duration(affinityTimeo) * time.Second,
-		}
-	}
+	s.registerStickyFrontend(key, svcID, svc)
 
 	return nil
+}
+
+// registerStickyFrontend records that this frontend may hold affinity entries, so
+// that cleanupSticky() keeps them until they expire instead of reclaiming them as
+// orphans. Every writer of a frontend that carries a non-zero affinity timeout
+// must call this.
+func (s *Syncer) registerStickyFrontend(key nat.FrontendKeyInterface, svcID uint32, svc k8sp.ServicePort) {
+	// we must have written the backends by now so the map exists
+	if s.stickyEps[svcID] == nil {
+		return
+	}
+	s.stickySvcs[key.AffinityKeyCopy()] = stickyFrontend{
+		id:    svcID,
+		timeo: s.affinityCleanupTimeo(svc),
+	}
+}
+
+// affinityCleanupTimeo returns how long an affinity entry for this frontend may live
+// before cleanupSticky() treats it as expired. It is 0 for frontends that
+// should have no affinity entries at all.
+//
+// A service with ClientIP session affinity has entries created by both the TC
+// and the connect-time load balancer (CTLB) programs. On top of that, the CTLB
+// enforces affinity for *unconnected* UDP sockets on every UDP service, whether
+// or not the service asks for session affinity, so that consecutive datagrams
+// from one socket reach one backend. Those entries expire after
+// ctlbUDPAffinityTimeo. We take whichever timeout is longer so that we never
+// delete an entry that either program still considers valid.
+func (s *Syncer) affinityCleanupTimeo(svc k8sp.ServicePort) time.Duration {
+	timeo := time.Duration(0)
+	if svc.SessionAffinityType() == v1.ServiceAffinityClientIP {
+		timeo = time.Duration(svc.StickyMaxAgeSeconds()) * time.Second
+	}
+	if svc.Protocol() == v1.ProtocolUDP && s.ctlbUDPAffinityTimeo > timeo {
+		timeo = s.ctlbUDPAffinityTimeo
+	}
+	return timeo
 }
 
 // ProtoV1ToInt translates k8s v1.Protocol to its IANA number and returns

--- a/felix/bpf/proxy/syncer_bench_test.go
+++ b/felix/bpf/proxy/syncer_bench_test.go
@@ -175,6 +175,7 @@ func runBenchmarkServiceUpdate(b *testing.B, svcCnt, epCnt int, mockMaps bool, o
 			NewRTCache(),
 			nil,
 			maglevLUTSize,
+			0,
 		)
 		Expect(err).ShouldNot(HaveOccurred())
 	} else {
@@ -194,6 +195,7 @@ func runBenchmarkServiceUpdate(b *testing.B, svcCnt, epCnt int, mockMaps bool, o
 			NewRTCache(),
 			nil,
 			maglevLUTSize,
+			0,
 		)
 		Expect(err).ShouldNot(HaveOccurred())
 	}

--- a/felix/bpf/proxy/syncer_test.go
+++ b/felix/bpf/proxy/syncer_test.go
@@ -88,7 +88,7 @@ var _ = Describe("BPF Syncer", func() {
 
 		rt = proxy.NewRTCache()
 
-		s, _ = proxy.NewSyncer(4, nodeIPs, svcs, eps, mgEps, aff, rt, nil, maglevLUTSize)
+		s, _ = proxy.NewSyncer(4, nodeIPs, svcs, eps, mgEps, aff, rt, nil, maglevLUTSize, 0)
 
 		ep := proxy.NewEndpointInfo("10.1.0.1", 5555, proxy.EndpointInfoOptIsReady(true))
 		state = proxy.DPSyncerState{
@@ -512,7 +512,7 @@ var _ = Describe("BPF Syncer", func() {
 		}))
 
 		By("resyncing after creating a new syncer with the same result", makestep(func() {
-			s, _ = proxy.NewSyncer(4, nodeIPs, svcs, eps, mgEps, aff, rt, nil, maglevLUTSize)
+			s, _ = proxy.NewSyncer(4, nodeIPs, svcs, eps, mgEps, aff, rt, nil, maglevLUTSize, 0)
 			checkAfterResync()
 		}))
 
@@ -520,7 +520,7 @@ var _ = Describe("BPF Syncer", func() {
 			svcs.m[nat.NewNATKey(net.IPv4(5, 5, 5, 5), 1111, 6)] = nat.NewNATValue(0xdeadbeef, 2, 2, 0)
 			eps.m[nat.NewNATBackendKey(0xdeadbeef, 0)] = nat.NewNATBackendValue(net.IPv4(6, 6, 6, 6), 666)
 			eps.m[nat.NewNATBackendKey(0xdeadbeef, 1)] = nat.NewNATBackendValue(net.IPv4(7, 7, 7, 7), 777)
-			s, _ = proxy.NewSyncer(4, nodeIPs, svcs, eps, mgEps, aff, rt, nil, maglevLUTSize)
+			s, _ = proxy.NewSyncer(4, nodeIPs, svcs, eps, mgEps, aff, rt, nil, maglevLUTSize, 0)
 			checkAfterResync()
 		}))
 
@@ -668,7 +668,7 @@ var _ = Describe("BPF Syncer", func() {
 
 		By("inserting non-local eps for a NodePort - no route", makestep(func() {
 			// use the meta node IP for nodeports as well
-			s, _ = proxy.NewSyncer(4, append(nodeIPs, net.IPv4(255, 255, 255, 255)), svcs, eps, mgEps, aff, rt, nil, maglevLUTSize)
+			s, _ = proxy.NewSyncer(4, append(nodeIPs, net.IPv4(255, 255, 255, 255)), svcs, eps, mgEps, aff, rt, nil, maglevLUTSize, 0)
 			state.SvcMap[svcKey2] = proxy.NewK8sServicePort(
 				net.IPv4(10, 0, 0, 2),
 				2222,
@@ -821,7 +821,7 @@ var _ = Describe("BPF Syncer", func() {
 
 		By("inserting only non-local eps for a NodePort - multiple nodes & pods/node", makestep(func() {
 			// use the meta node IP for nodeports as well
-			s, _ = proxy.NewSyncer(4, append(nodeIPs, net.IPv4(255, 255, 255, 255)), svcs, eps, mgEps, aff, rt, nil, maglevLUTSize)
+			s, _ = proxy.NewSyncer(4, append(nodeIPs, net.IPv4(255, 255, 255, 255)), svcs, eps, mgEps, aff, rt, nil, maglevLUTSize, 0)
 			state.SvcMap[svcKey2] = proxy.NewK8sServicePort(
 				net.IPv4(10, 0, 0, 2),
 				2222,
@@ -901,7 +901,7 @@ var _ = Describe("BPF Syncer", func() {
 
 		By("restarting Syncer to check if NodePortRemotes are picked up correctly", makestep(func() {
 			// use the meta node IP for nodeports as well
-			s, _ = proxy.NewSyncer(4, append(nodeIPs, net.IPv4(255, 255, 255, 255)), svcs, eps, mgEps, aff, rt, nil, maglevLUTSize)
+			s, _ = proxy.NewSyncer(4, append(nodeIPs, net.IPv4(255, 255, 255, 255)), svcs, eps, mgEps, aff, rt, nil, maglevLUTSize, 0)
 			err := s.Apply(state)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -1275,7 +1275,7 @@ var _ = Describe("BPF Syncer", func() {
 			mgEps = newMockMaglevMap()
 			aff = newMockAffinityMap()
 			rt = proxy.NewRTCache()
-			s, _ = proxy.NewSyncer(4, nodeIPs, svcs, eps, mgEps, aff, rt, nil, maglevLUTSize)
+			s, _ = proxy.NewSyncer(4, nodeIPs, svcs, eps, mgEps, aff, rt, nil, maglevLUTSize, 0)
 		})
 
 		type testCase struct {
@@ -1443,7 +1443,7 @@ var _ = Describe("BPF Syncer API server NAT preservation", func() {
 		mgEps = newMockMaglevMap()
 		aff = newMockAffinityMap()
 		rt = proxy.NewRTCache()
-		s, _ = proxy.NewSyncer(4, nodeIPs, svcs, eps, mgEps, aff, rt, nil, maglevLUTSize)
+		s, _ = proxy.NewSyncer(4, nodeIPs, svcs, eps, mgEps, aff, rt, nil, maglevLUTSize, 0)
 	})
 
 	It("retains the API server backend across a transient loss of endpoints", func() {
@@ -1551,7 +1551,7 @@ var _ = Describe("BPF Syncer NAT service ID conflicts", func() {
 	}
 
 	newSyncer := func() *proxy.Syncer {
-		syncer, err := proxy.NewSyncer(4, nodeIPs, svcs, eps, mgEps, aff, rt, nil, maglevLUTSize)
+		syncer, err := proxy.NewSyncer(4, nodeIPs, svcs, eps, mgEps, aff, rt, nil, maglevLUTSize, 0)
 		Expect(err).NotTo(HaveOccurred())
 		return syncer
 	}

--- a/felix/collector/collector.go
+++ b/felix/collector/collector.go
@@ -597,7 +597,6 @@ func (c *collector) checkEpStats() {
 	minLastRuleUpdatedAt := monotime.Now() - c.config.InitialReportingDelay
 
 	now := monotime.Now()
-	minExpirationAt := now - c.config.AgeTimeout
 
 	// For each entry
 	// - report metrics.  Metrics reported through the ticker processing will wait for the initial reporting delay
@@ -605,33 +604,45 @@ func (c *collector) checkEpStats() {
 	//   the flow is terminated or has changed.
 	// - check age and expire the entry if needed.
 	for _, data := range c.epStats {
+		ageTimeout := c.config.AgeTimeout
 		if c.config.IsBPFDataplane {
-			switch data.Tuple.Proto {
-			case 6 /* TCP */ :
-				// We use reset because likely already cleaned it up as an expired
-				// connection if we haven't seen any update this long.
-				minExpirationAt = now - c.config.BPFConntrackTimeouts.TCPResetSeen
-			case 17 /* UDP */ :
-				minExpirationAt = now - c.config.BPFConntrackTimeouts.UDPTimeout
-			case 1 /* ICMP */, 58 /* ICMPv6 */ :
-				minExpirationAt = now - c.config.BPFConntrackTimeouts.ICMPTimeout
-			default:
-				minExpirationAt = now - c.config.BPFConntrackTimeouts.GenericTimeout
-			}
-			if minExpirationAt < 2*bpfconntrack.ScanPeriod {
-				minExpirationAt = now - 2*bpfconntrack.ScanPeriod
-			}
+			ageTimeout = bpfAgeTimeout(c.config.BPFConntrackTimeouts, data.Tuple.Proto)
 		}
 
 		if data.IsDirty() && (data.Reported || data.RuleUpdatedAt() < minLastRuleUpdatedAt) {
 			c.checkPreDNATTuple(data)
 			c.reportMetrics(data, true)
 		}
-		if data.UpdatedAt() < minExpirationAt {
+		if data.UpdatedAt() < now-ageTimeout {
 			c.expireMetrics(data)
 			c.deleteDataFromEpStats(data)
 		}
 	}
+}
+
+// bpfAgeTimeout returns how long the collector keeps an epStats entry after its last update when
+// running the BPF dataplane, based on the dataplane's conntrack timeout for the entry's protocol.
+//
+// The collector only touches an entry when the BPF conntrack scanner reports it, i.e. once per
+// ScanPeriod, so a timeout shorter than a couple of scan periods would expire flows that are still
+// alive.  Re-creating the entry afterwards re-credits the conntrack counters' absolute values as a
+// fresh delta, so premature expiry over-counts traffic as well as churning flow logs.  Hence the
+// floor.
+func bpfAgeTimeout(timeouts bpfconntrack.Timeouts, proto int) time.Duration {
+	var timeout time.Duration
+	switch proto {
+	case 6 /* TCP */ :
+		// We use reset because likely already cleaned it up as an expired
+		// connection if we haven't seen any update this long.
+		timeout = timeouts.TCPResetSeen
+	case 17 /* UDP */ :
+		timeout = timeouts.UDPTimeout
+	case 1 /* ICMP */, 58 /* ICMPv6 */ :
+		timeout = timeouts.ICMPTimeout
+	default:
+		timeout = timeouts.GenericTimeout
+	}
+	return max(timeout, 2*bpfconntrack.ScanPeriod)
 }
 
 func (c *collector) checkPreDNATTuple(data *Data) {

--- a/felix/collector/collector_test.go
+++ b/felix/collector/collector_test.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	"github.com/projectcalico/calico/app-policy/policystore"
+	bpfconntrack "github.com/projectcalico/calico/felix/bpf/conntrack/timeouts"
 	"github.com/projectcalico/calico/felix/calc"
 	clttypes "github.com/projectcalico/calico/felix/collector/types"
 	"github.com/projectcalico/calico/felix/collector/types/counter"
@@ -51,10 +52,11 @@ import (
 )
 
 const (
-	ipv4       = 0x800
-	proto_icmp = 1
-	proto_tcp  = 6
-	proto_udp  = 17
+	ipv4         = 0x800
+	proto_icmp   = 1
+	proto_tcp    = 6
+	proto_udp    = 17
+	proto_icmpv6 = 58
 )
 
 var (
@@ -4152,4 +4154,83 @@ func TestEqualFunction(t *testing.T) {
 			t.Errorf("Expected false, got true")
 		}
 	})
+}
+
+func TestBPFAgeTimeout(t *testing.T) {
+	timeouts := bpfconntrack.DefaultTimeouts()
+	floor := 2 * bpfconntrack.ScanPeriod
+
+	// The floor only bites for timeouts shorter than two scan periods, which is true of the default
+	// ICMP timeout. Guard the premise so this test fails loudly rather than silently passing if the
+	// defaults change.
+	if timeouts.ICMPTimeout >= floor {
+		t.Fatalf("default ICMPTimeout (%v) is no longer below the floor (%v); pick another protocol",
+			timeouts.ICMPTimeout, floor)
+	}
+
+	shortTimeouts := timeouts
+	shortTimeouts.TCPResetSeen = time.Second
+
+	for _, tc := range []struct {
+		name     string
+		timeouts bpfconntrack.Timeouts
+		proto    int
+		want     time.Duration
+	}{
+		{"TCP uses the reset timeout", timeouts, proto_tcp, timeouts.TCPResetSeen},
+		{"UDP uses the UDP timeout", timeouts, proto_udp, timeouts.UDPTimeout},
+		{"unknown protocols use the generic timeout", timeouts, 47 /* GRE */, timeouts.GenericTimeout},
+		{"ICMP is floored", timeouts, proto_icmp, floor},
+		{"ICMPv6 is floored", timeouts, proto_icmpv6, floor},
+		{"a configured sub-floor timeout is floored", shortTimeouts, proto_tcp, floor},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := bpfAgeTimeout(tc.timeouts, tc.proto); got != tc.want {
+				t.Errorf("bpfAgeTimeout(proto=%d) = %v, want %v", tc.proto, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestBPFAgeOutFloorKeepsLiveFlows checks the end of the floor's job: an entry whose dataplane
+// conntrack timeout is shorter than the scan period must survive the gap between scans. The
+// collector only touches an entry when the BPF conntrack scanner reports it, so expiring sooner
+// churns live flows and re-credits their absolute counters as a fresh delta on re-creation.
+func TestBPFAgeOutFloorKeepsLiveFlows(t *testing.T) {
+	floor := 2 * bpfconntrack.ScanPeriod
+
+	for _, tc := range []struct {
+		name            string
+		sinceLastUpdate time.Duration
+		wantPresent     bool
+	}{
+		{"past the ICMP timeout but inside the floor", floor - 5*time.Second, true},
+		{"past the floor", floor + 5*time.Second, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c := newCollector(newMockLookupsCache(map[[16]byte]calc.EndpointData{
+				localIp1:  localEd1,
+				remoteIp1: remoteEd1,
+			}, nil, nil, nil), &Config{
+				AgeTimeout:            10 * time.Second,
+				InitialReportingDelay: 5 * time.Second,
+				ExportingInterval:     time.Second,
+				FlowLogsFlushInterval: 100 * time.Second,
+				IsBPFDataplane:        true,
+				BPFConntrackTimeouts:  bpfconntrack.DefaultTimeouts(),
+			}).(*collector)
+
+			tpl := *tuple.New(remoteIp1, localIp1, proto_icmp, 0, 0)
+			data := NewData(tpl, remoteEd1, localEd1)
+			c.updateEpStatsCache(tpl, data)
+			data.updatedAt = monotime.Now() - tc.sinceLastUpdate
+
+			c.checkEpStats()
+
+			if _, present := c.epStats[tpl]; present != tc.wantPresent {
+				t.Errorf("entry last updated %v ago: present=%v, want %v",
+					tc.sinceLastUpdate, present, tc.wantPresent)
+			}
+		})
+	}
 }

--- a/felix/collector/rule_trace_change_test.go
+++ b/felix/collector/rule_trace_change_test.go
@@ -1,0 +1,274 @@
+//go:build !windows
+
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+import (
+	"testing"
+	"time"
+
+	v3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
+
+	"github.com/projectcalico/calico/felix/calc"
+	"github.com/projectcalico/calico/felix/collector/flowlog"
+	"github.com/projectcalico/calico/felix/collector/types"
+	"github.com/projectcalico/calico/felix/collector/types/metric"
+	"github.com/projectcalico/calico/felix/collector/types/tuple"
+	"github.com/projectcalico/calico/felix/rules"
+	"github.com/projectcalico/calico/libcalico-go/lib/backend/model"
+)
+
+// These tests verify that a flow whose rule trace verdict changes mid-flow is
+// always expired from the per-action flow log aggregators. A leaked active
+// reference is permanent: the aggregator re-exports the flow with zeroed
+// statistics on every flush until Felix restarts, and downstream Goldmane /
+// Whisker keep showing a phantom deny flow in every query window.
+
+// muCapture mirrors FlowLogReporter routing into per-action aggregators,
+// mimicking the goldmane dispatch pipeline.
+type muCapture struct {
+	t        *testing.T
+	updates  []metric.Update
+	denyAgg  *flowlog.Aggregator
+	allowAgg *flowlog.Aggregator
+}
+
+func (m *muCapture) Start() error { return nil }
+func (m *muCapture) Report(u any) error {
+	mu := u.(metric.Update)
+	m.updates = append(m.updates, mu)
+	if err := m.denyAgg.FeedUpdate(&mu); err != nil {
+		m.t.Errorf("denyAgg.FeedUpdate: %v", err)
+	}
+	if err := m.allowAgg.FeedUpdate(&mu); err != nil {
+		m.t.Errorf("allowAgg.FeedUpdate: %v", err)
+	}
+	return nil
+}
+
+const ageOutTimeout = 200 * time.Millisecond
+
+var (
+	zombieDstKey = model.WorkloadEndpointKey{
+		Hostname: "localhost", OrchestratorID: "orchestrator",
+		WorkloadID: "monitoring/grafana-1", EndpointID: "ep1",
+	}
+	zombieSrcKey = model.WorkloadEndpointKey{
+		OrchestratorID: "orchestrator",
+		WorkloadID:     "monitoring/prometheus-1", EndpointID: "ep1",
+	}
+	zombieSrcEp = &calc.RemoteEndpointData{
+		CommonEndpointData: calc.CalculateCommonEndpointData(zombieSrcKey, remoteWlEp1),
+	}
+
+	zombieEOTDenyHit = calc.NewRuleID(v3.KindGlobalNetworkPolicy, "default", "", "",
+		calc.RuleIndexTierDefaultAction, rules.RuleDirIngress, rules.RuleActionDeny) // IsEndOfTier => converted to TierDefaultActionRuleID
+	zombiePolicyAllow = calc.NewRuleID(v3.KindGlobalNetworkPolicy, "default", "policy1", "",
+		0, rules.RuleDirIngress, rules.RuleActionAllow)
+	zombieProfileAllow = calc.NewRuleID("", "", "kns.default", "",
+		0, rules.RuleDirIngress, rules.RuleActionAllow) // IsProfile => applied at ProfileMatchIndex
+	zombieUnknownPolicyAllow = calc.NewRuleID(v3.KindGlobalNetworkPolicy, "default", "policy-new", "",
+		0, rules.RuleDirIngress, rules.RuleActionAllow) // not in PolicyMatches => dropped
+)
+
+// realistic single-default-tier layout as produced by CreateLocalEndpointData:
+// all enforced policies and the EOT share index 0; profile match index is 1.
+func newZombieTestEp() *calc.LocalEndpointData {
+	eotDeny := calc.NewRuleID(v3.KindGlobalNetworkPolicy, "default", "policy2", "",
+		calc.RuleIndexTierDefaultAction, rules.RuleDirIngress, rules.RuleActionDeny)
+	md := &calc.MatchData{
+		PolicyMatches: map[calc.PolicyID]int{
+			{Name: "policy1", Kind: v3.KindGlobalNetworkPolicy}: 0,
+			{Name: "policy2", Kind: v3.KindGlobalNetworkPolicy}: 0,
+		},
+		TierData: map[string]*calc.TierData{
+			"default": {TierDefaultActionRuleID: eotDeny, EndOfTierMatchIndex: 0},
+		},
+		ProfileMatchIndex: 1,
+	}
+	return &calc.LocalEndpointData{
+		CommonEndpointData: calc.CalculateCommonEndpointData(zombieDstKey, localWlEp1),
+		Ingress:            md,
+		Egress:             md,
+	}
+}
+
+func newZombieTestCollector(t *testing.T) (*collector, *muCapture) {
+	t.Helper()
+	epMap := map[[16]byte]calc.EndpointData{
+		localIp1:  newZombieTestEp(),
+		remoteIp1: zombieSrcEp,
+	}
+	lm := newMockLookupsCache(epMap, map[[64]byte]*calc.RuleID{}, nil, nil)
+	conf := &Config{
+		AgeTimeout:            ageOutTimeout,
+		InitialReportingDelay: 0,
+		ExportingInterval:     time.Hour, // ticker not used; we call checkEpStats directly
+		FlowLogsFlushInterval: time.Hour,
+	}
+	c := newCollector(lm, conf).(*collector)
+	cap := &muCapture{
+		t:        t,
+		denyAgg:  flowlog.NewAggregator().IncludePolicies(true).ForAction(rules.RuleActionDeny),
+		allowAgg: flowlog.NewAggregator().IncludePolicies(true).ForAction(rules.RuleActionAllow),
+	}
+	c.RegisterMetricsReporter(cap)
+	return c, cap
+}
+
+func ingressHit(t tuple.Tuple, rid *calc.RuleID) types.PacketInfo {
+	return types.PacketInfo{
+		Tuple:     t,
+		Direction: rules.RuleDirIngress,
+		RuleHits:  []types.RuleHit{{RuleID: rid, Hits: 1, Bytes: 60}},
+	}
+}
+
+// assertDenyAggDrains flushes the deny aggregator and fails if anything is
+// exported after the expired flow's final record: a flow surviving flushes with
+// no incoming metric updates is a leaked reference that would be re-exported
+// forever.
+func assertDenyAggDrains(t *testing.T, cap *muCapture) {
+	t.Helper()
+	cap.denyAgg.GetAndCalibrate() // final report for the expired deny flow
+	for i := range 3 {
+		for _, fl := range cap.denyAgg.GetAndCalibrate() {
+			t.Errorf("leaked flow in deny aggregator on flush %d: action=%v reporter=%v pktsIn=%d numFlows=%d policies=%v",
+				i+2, fl.Action, fl.Reporter, fl.PacketsIn, fl.NumFlows, fl.FlowEnforcedPolicySet)
+		}
+	}
+}
+
+// Sleeping against the collector's real clock flakes on a loaded CI agent, so
+// these tests move a flow's timestamps instead. Reporting gates on
+// ruleUpdatedAt and expiry on updatedAt, so this must leave updatedAt alone or
+// the flow ages out before it is ever reported.
+func ripenForReport(d *Data) {
+	d.ruleUpdatedAt -= time.Second
+}
+
+func denyThenReport(t *testing.T, c *collector, tup tuple.Tuple) {
+	t.Helper()
+	c.applyPacketInfo(ingressHit(tup, zombieEOTDenyHit))
+	ripenForReport(c.epStats[tup])
+	c.checkEpStats() // report (InitialReportingDelay=0)
+	if data := c.epStats[tup]; data == nil || !data.Reported {
+		t.Fatalf("setup: deny flow not reported, data=%v", data)
+	}
+}
+
+func ageOut(t *testing.T, c *collector, tup tuple.Tuple) {
+	t.Helper()
+	data := c.epStats[tup]
+	data.updatedAt -= 2 * ageOutTimeout
+	data.ruleUpdatedAt -= 2 * ageOutTimeout
+	c.checkEpStats()
+	if _, ok := c.epStats[tup]; ok {
+		t.Fatalf("flow %v still in epStats after age timeout", tup)
+	}
+}
+
+// A plain deny that just ages out must drain.
+func TestDenyAggregatorDrains_PlainDeny(t *testing.T) {
+	c, cap := newZombieTestCollector(t)
+	tup := tuple.Make(remoteIp1, localIp1, proto_tcp, srcPort, dstPort)
+	denyThenReport(t, c, tup)
+	ageOut(t, c, tup)
+	assertDenyAggDrains(t, cap)
+}
+
+// A deny -> allow verdict flip at the SAME match index (allow rule added to an
+// existing policy) drains via RuleMatchIsDifferent.
+func TestDenyAggregatorDrains_SameIndexVerdictFlip(t *testing.T) {
+	c, cap := newZombieTestCollector(t)
+	tup := tuple.Make(remoteIp1, localIp1, proto_tcp, srcPort, dstPort)
+	denyThenReport(t, c, tup)
+	c.applyPacketInfo(ingressHit(tup, zombiePolicyAllow)) // same idx 0 -> conflict -> expire+replace
+	ripenForReport(c.epStats[tup])
+	c.checkEpStats() // report new allow state
+	ageOut(t, c, tup)
+	assertDenyAggDrains(t, cap)
+}
+
+// Deny verdict at EOT idx 0, then profile allow at idx 1 (an empty slot). The
+// verdict moves to a different match index, which must be treated as a rule
+// change so the reported deny flow is expired. Previously this leaked the
+// tuple in the deny aggregator forever.
+func TestDenyAggregatorDrains_VerdictMovesToEmptySlot(t *testing.T) {
+	c, cap := newZombieTestCollector(t)
+	tup := tuple.Make(remoteIp1, localIp1, proto_tcp, srcPort, dstPort)
+	denyThenReport(t, c, tup)
+	c.applyPacketInfo(ingressHit(tup, zombieProfileAllow)) // profile idx 1, empty slot
+	ripenForReport(c.epStats[tup])
+	c.checkEpStats()
+	ageOut(t, c, tup)
+	assertDenyAggDrains(t, cap)
+}
+
+// An allow hit from a policy the (stale) MatchData does not know is dropped;
+// the trace stays deny. Conntrack then marks the flow a connection; the flow
+// must still drain when the conntrack entry expires.
+func TestDenyAggregatorDrains_UnknownPolicyHitThenConntrack(t *testing.T) {
+	c, cap := newZombieTestCollector(t)
+	tup := tuple.Make(remoteIp1, localIp1, proto_tcp, srcPort, dstPort)
+	denyThenReport(t, c, tup)
+	c.applyPacketInfo(ingressHit(tup, zombieUnknownPolicyAllow)) // dropped: unknown PolicyID
+	// conntrack now sees the (allowed) connection.
+	data := c.getDataAndUpdateEndpoints(tup, false, false)
+	c.applyConntrackStatUpdate(data, 10, 1000, 8, 800, false)
+	ripenForReport(c.epStats[tup])
+	c.checkEpStats() // reports conn stats with stale deny trace
+	// conntrack entry expires later, which removes the flow on its own.
+	data = c.getDataAndUpdateEndpoints(tup, true, false)
+	c.applyConntrackStatUpdate(data, 12, 1200, 9, 900, true)
+	if _, ok := c.epStats[tup]; ok {
+		t.Fatalf("flow %v still in epStats after conntrack expiry", tup)
+	}
+	assertDenyAggDrains(t, cap)
+}
+
+// The endpoint's policy set changes (MatchData replaced, same key) and the
+// flow now matches the profile at the NEW ProfileMatchIndex.
+func TestDenyAggregatorDrains_MatchDataSwapProfileFlip(t *testing.T) {
+	c, cap := newZombieTestCollector(t)
+	tup := tuple.Make(remoteIp1, localIp1, proto_tcp, srcPort, dstPort)
+	denyThenReport(t, c, tup)
+
+	// Policies removed from endpoint: new MatchData with no tiers, profile idx 0.
+	noPolEp := &calc.LocalEndpointData{
+		CommonEndpointData: calc.CalculateCommonEndpointData(zombieDstKey, localWlEp1),
+		Ingress: &calc.MatchData{
+			PolicyMatches:     map[calc.PolicyID]int{},
+			TierData:          map[string]*calc.TierData{},
+			ProfileMatchIndex: 0,
+		},
+		Egress: &calc.MatchData{
+			PolicyMatches:     map[calc.PolicyID]int{},
+			TierData:          map[string]*calc.TierData{},
+			ProfileMatchIndex: 0,
+		},
+	}
+	c.luc.SetMockData(map[[16]byte]calc.EndpointData{
+		localIp1:  noPolEp,
+		remoteIp1: zombieSrcEp,
+	}, nil, nil, nil)
+
+	c.applyPacketInfo(ingressHit(tup, zombieProfileAllow)) // profile idx 0 -> conflict with EOT deny
+	ripenForReport(c.epStats[tup])
+	c.checkEpStats()
+	ageOut(t, c, tup)
+	assertDenyAggDrains(t, cap)
+}

--- a/felix/collector/stats.go
+++ b/felix/collector/stats.go
@@ -240,6 +240,16 @@ func (t *RuleTrace) addRuleID(rid *calc.RuleID, matchIdx, numPkts, numBytes int)
 		}
 	}
 
+	// A verdict hit at a different index than the recorded verdict means the rule trace has
+	// changed, even if the slot at matchIdx is empty (e.g. a policy update mid-flow shifts the
+	// verdict from an end-of-tier deny to a profile allow at a higher index). Silently moving the
+	// verdict would change the trace's action without expiring the previously reported flow,
+	// permanently leaking the flow's active reference in the flow log aggregator.
+	if !model.KindIsStaged(rid.Kind) && rid.Action != rules.RuleActionPass &&
+		t.verdictIdx >= 0 && t.verdictIdx != matchIdx {
+		return RuleMatchIsDifferent
+	}
+
 	if existingRuleID := t.path[matchIdx]; existingRuleID == nil {
 		// Position is empty, insert and be done. Reset the rules to report just incase we are adding a new staged
 		// policy hit.

--- a/felix/collector/stats_test.go
+++ b/felix/collector/stats_test.go
@@ -256,6 +256,20 @@ var _ = Describe("Rule Trace", func() {
 			})
 		})
 	})
+	Describe("Verdict moving to a different match index", func() {
+		BeforeEach(func() {
+			rm := data.AddRuleID(denyIngressRid0, 0, 0, 0)
+			Expect(rm).To(Equal(collector.RuleMatchSet))
+		})
+		It("should conflict when a verdict arrives at an empty higher index", func() {
+			Expect(data.AddRuleID(allowIngressRid1, 1, 0, 0)).To(Equal(collector.RuleMatchIsDifferent))
+		})
+		It("should leave the existing trace untouched on the conflict", func() {
+			Expect(data.AddRuleID(allowIngressRid1, 1, 0, 0)).To(Equal(collector.RuleMatchIsDifferent))
+			Expect(data.IngressRuleTrace.Path()).To(HaveLen(1))
+			Expect(data.IngressAction()).To(Equal(rules.RuleActionDeny))
+		})
+	})
 
 	// A staged policy never enforces anything, so it must never be recorded as the verdict, whether
 	// the hit arrives through AddRuleID or through ReplaceRuleID after a mid-flow rule change.

--- a/felix/dataplane/linux/bpf_ep_mgr.go
+++ b/felix/dataplane/linux/bpf_ep_mgr.go
@@ -1563,6 +1563,12 @@ func (m *bpfEndpointManager) onInterfaceUpdate(update *ifaceStateUpdate) {
 			iface.info.ifIndex = 0
 			iface.info.masterIfIndex = 0
 			iface.info.ifaceType = 0
+			// The interface is gone, so every scrap of state we derived from
+			// it is stale; drop it wholesale rather than field by field.
+			// withIface only forgets an interface once its bpfInterface is
+			// back to the zero value, so a field left set here would leak the
+			// entry for the lifetime of the process.
+			iface.dpState = zeroIface.dpState
 		}
 		// Capture the WEP binding + (possibly zero) ifIndex so we can
 		// refresh the connlimit pod info snapshot after the withIface
@@ -1623,7 +1629,11 @@ func (m *bpfEndpointManager) onWorkloadEndpointRemove(msg *proto.WorkloadEndpoin
 	}
 
 	m.withIface(oldWEP.Name, func(iface *bpfInterface) bool {
+		// Clear everything we learned from the endpoint, not just its ID:
+		// withIface only forgets an interface once its bpfInterface is back
+		// to the zero value.
 		iface.info.endpointID = nil
+		iface.info.hasIstioDSCP = false
 		return false
 	})
 	// Remove policy debug info if any

--- a/felix/dataplane/linux/bpf_ep_mgr_test.go
+++ b/felix/dataplane/linux/bpf_ep_mgr_test.go
@@ -1271,6 +1271,52 @@ var _ = Describe("BPF Endpoint Manager", func() {
 		})
 	})
 
+	// The manager only drops a nameToIface entry once every field of the
+	// bpfInterface has gone back to its zero value.  A field left set by a
+	// teardown leaks the entry for the lifetime of the process, so check the
+	// teardown of each kind of workload that sets an otherwise-sticky field.
+	//
+	// Both teardown orderings matter.  In practice the CNI deletes the veth
+	// before the datastore reports the endpoint gone, and that ordering is the
+	// weaker one: once the interface is down, applyPolicy short-circuits and
+	// stops refreshing the derived state.
+	describeTeardown := func(desc string, teardown func(name string)) {
+		DescribeTable("should not leak a nameToIface entry when the workload is torn down, "+desc,
+			func(ep *proto.WorkloadEndpoint) {
+				newBpfEpMgr(false)
+				ep.Name = "cali12345"
+				bpfEpMgr.OnUpdate(&proto.WorkloadEndpointUpdate{
+					Id: &proto.WorkloadEndpointID{
+						OrchestratorId: "k8s",
+						WorkloadId:     ep.Name,
+						EndpointId:     ep.Name,
+					},
+					Endpoint: ep,
+				})
+				genIfaceUpdate(ep.Name, ifacemonitor.StateUp, 15)()
+				Expect(bpfEpMgr.nameToIface).To(HaveKey(ep.Name))
+				// Pre-flight: the entry must actually be carrying the sticky
+				// state, otherwise the teardown check below is vacuous.
+				Expect(bpfEpMgr.nameToIface[ep.Name].info.hasIstioDSCP).
+					To(Equal(ep.IsIstioAmbient), "istio DSCP flag not recorded")
+
+				teardown(ep.Name)
+				Expect(bpfEpMgr.nameToIface).NotTo(HaveKey(ep.Name))
+			},
+			Entry("plain workload", &proto.WorkloadEndpoint{}),
+			Entry("istio ambient workload", &proto.WorkloadEndpoint{IsIstioAmbient: true}),
+		)
+	}
+
+	describeTeardown("interface first", func(name string) {
+		genIfaceUpdate(name, ifacemonitor.StateNotPresent, 15)()
+		genWLUpdateEpRemove(name)()
+	})
+	describeTeardown("endpoint first", func(name string) {
+		genWLUpdateEpRemove(name)()
+		genIfaceUpdate(name, ifacemonitor.StateNotPresent, 15)()
+	})
+
 	Context("with jit-harden", func() {
 		JustBeforeEach(func() {
 			dp.jitHarden = true

--- a/felix/dataplane/linux/int_dataplane.go
+++ b/felix/dataplane/linux/int_dataplane.go
@@ -314,6 +314,26 @@ type Config struct {
 	NewNftablesDataplane nftables.NewNftablesDataplaneFn
 }
 
+// ctlbExcludesUDP returns whether the connect-time load balancer leaves UDP to
+// the TC programs.
+func (config *Config) ctlbExcludesUDP() bool {
+	return config.BPFConnTimeLB == string(apiv3.BPFConnectTimeLBTCP) &&
+		config.BPFHostNetworkedNAT == string(apiv3.BPFHostNetworkedNATEnabled)
+}
+
+// ctlbUDPAffinityTimeout returns how long the connect-time load balancer holds a
+// backend affine to an unconnected UDP socket, or 0 if the CTLB does not handle
+// UDP on this node. The CTLB uses this so that consecutive datagrams from one
+// socket reach one backend; the BPF kube-proxy needs the same value so that its
+// affinity map cleanup leaves those entries alone until they really have expired.
+func (config *Config) ctlbUDPAffinityTimeout() time.Duration {
+	if config.BPFConnTimeLB == string(apiv3.BPFConnectTimeLBDisabled) || config.ctlbExcludesUDP() {
+		return 0
+	}
+	// The BPF programs are given the timeout in whole seconds.
+	return config.BPFConntrackTimeouts.UDPTimeout.Truncate(time.Second)
+}
+
 type UpdateBatchResolver interface {
 	// Opportunity for a manager component to resolve state that depends jointly on the updates
 	// that it has seen since the preceding CompleteDeferredWork call.  Processing here can
@@ -1167,10 +1187,7 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 		}
 
 		if config.BPFConnTimeLB != string(apiv3.BPFConnectTimeLBDisabled) {
-			excludeUDP := false
-			if config.BPFConnTimeLB == string(apiv3.BPFConnectTimeLBTCP) && config.BPFHostNetworkedNAT == string(apiv3.BPFHostNetworkedNATEnabled) {
-				excludeUDP = true
-			}
+			excludeUDP := config.ctlbExcludesUDP()
 			logLevel := strings.ToLower(config.BPFLogLevel)
 			if config.BPFLogFilters != nil {
 				if logLevel != "off" && config.BPFCTLBLogFilter != "all" {
@@ -3127,6 +3144,7 @@ func startBPFDataplaneComponents(
 	bpfproxyOpts := []bpfproxy.Option{
 		bpfproxy.WithMinSyncPeriod(config.KubeProxyMinSyncPeriod),
 		bpfproxy.WithMaglevLUTSize(config.BPFMaglevLUTSize),
+		bpfproxy.WithCTLBUDPAffinityTimeout(config.ctlbUDPAffinityTimeout()),
 	}
 
 	if config.bpfProxyHealthCheck != nil {

--- a/felix/design/bpf-services.md
+++ b/felix/design/bpf-services.md
@@ -424,6 +424,35 @@ per-packet forwarding does not revisit the affinity map. The affinity
 map's `last_used` is updated opportunistically on new-flow backend
 resolution; flow-lifetime fast-path packets are not affected.
 
+### Enforced affinity for unconnected UDP
+
+An *unconnected* UDP socket has no connect() for the CTLB to hook, so
+every `sendmsg` runs backend selection afresh. Without affinity,
+consecutive datagrams from one socket would land on different backends.
+The CTLB therefore enforces affinity for unconnected UDP on **every** UDP
+service, whether or not it asks for `sessionAffinity: ClientIP`
+(`connect.h`, passing `CTLB_UDP_NOT_SEEN_TIMEO` as
+`affinity_always_timeo` to `calico_nat_lookup`). The timeout is the
+`UDPTimeout` BPF conntrack timeout, and the entry's timestamp is
+refreshed on each use, so the affinity lasts as long as the socket keeps
+sending.
+
+These entries live in the same affinity map as the `sessionAffinity`
+ones. When both apply — a UDP service that also sets
+`sessionAffinity: ClientIP` — `calico_nat_lookup` uses whichever timeout
+is **longer**. Using the shorter one would break the promise the other
+made; in particular, honouring the CTLB's timeout over a service's
+3-hour `sessionAffinity` would re-pick a backend after a few idle
+seconds, which is not the stickiness the user asked for.
+
+A caveat on granularity: the CTLB looks the entry up with `client_ip` set
+to `VOID_IP`, because the source IP is not known at connect/sendmsg time.
+So there is one CTLB affinity entry per (service, port), shared by every
+workload on the node, rather than one per client IP. That is a known
+limitation (see the `XXX` comment in `connect.h`), independent of the
+timeout: within a burst of traffic the entry is refreshed on each use, so
+node-local clients coalesce onto one backend at any timeout value.
+
 ### Applicability
 
 - Works for both the TC path and the CTLB path: CTLB's connect-time
@@ -450,6 +479,19 @@ resolution; flow-lifetime fast-path packets are not affected.
 - An affinity entry that points at a backend that no longer exists
   must be treated as a miss, not as a drop. A change that tightens
   the "is backend still valid" check must preserve that.
+- The BPF programs never delete affinity entries; the syncer's
+  `cleanupSticky()` is the only reclaim path, and it runs on every
+  sync. Its notion of which frontends may hold entries, and for how
+  long, must therefore cover **every** writer — including the CTLB's
+  enforced UDP affinity, which has no `sessionAffinity` on the service
+  to key off. An entry the syncer does not recognise is deleted on the
+  next sync, which silently un-pins a live client. There are two
+  frontend writers — `writeSvc()` and, for a `LoadBalancer` or
+  `ExternalIP` frontend with `loadBalancerSourceRanges`,
+  `writeLBSrcRangeSvcNATKeys()` — and both must register the frontend
+  with `registerStickyFrontend()`. The BPF programs key affinity
+  entries on the destination alone, so all of a service's source-range
+  frontends share the affinity key of its zero-source-range frontend.
 
 
 

--- a/felix/fv/bpf_test.go
+++ b/felix/fv/bpf_test.go
@@ -3532,66 +3532,76 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 								"Service endpoints didn't get created? Is controller-manager happy?")
 						})
 
+						affKV := func() (nat.AffinityKeyInterface, nat.AffinityValueInterface) {
+							if testOpts.ipv6 {
+								aff := dumpAffMapV6(tc.Felixes[0])
+								ExpectWithOffset(1, aff).To(HaveLen(1), "expected exactly one affinity entry")
+
+								// get the only key
+								for k, v := range aff {
+									return k, v
+								}
+							} else {
+								aff := dumpAffMap(tc.Felixes[0])
+								ExpectWithOffset(1, aff).To(HaveLen(1), "expected exactly one affinity entry")
+
+								// get the only key
+								for k, v := range aff {
+									return k, v
+								}
+							}
+
+							Fail("no value in aff map")
+							return nil, nil
+						}
+
+						affLen := func() int {
+							if testOpts.ipv6 {
+								return len(dumpAffMapV6(tc.Felixes[0]))
+							}
+							return len(dumpAffMap(tc.Felixes[0]))
+						}
+
+						family := 4
+						natFEKey := func(ip string, port uint16) nat.FrontendKeyInterface {
+							return nat.NewNATKeyIntf(net.ParseIP(ip), port, numericProto)
+						}
+						if testOpts.ipv6 {
+							family = 6
+							natFEKey = func(ip string, port uint16) nat.FrontendKeyInterface {
+								return nat.NewNATKeyV6Intf(net.ParseIP(ip), port, numericProto)
+							}
+						}
+
+						// waitForSvcProgrammed waits until felix-0 has the service's NAT
+						// frontend and its first backend. Syncing with the NAT tables stops
+						// us creating an extra affinity entry when the CTLB misses but the
+						// regular DNAT hits, the connection fails, and then the CTLB
+						// succeeds.
+						waitForSvcProgrammed := func(ip string, port uint16) {
+							natFtKey := natFEKey(ip, port)
+							EventuallyWithOffset(1, func() bool {
+								m, be, _ := dumpNATMapsAny(family, tc.Felixes[0])
+
+								v, ok := m[natFtKey]
+								if !ok || v.Count() == 0 {
+									return false
+								}
+
+								_, ok = be[nat.NewNATBackendKey(v.ID(), 0)]
+								return ok
+							}, 10*time.Second).Should(BeTrue(), "service was not programmed")
+						}
+
 						// Since the affinity map is shared by cgroup programs on
 						// all nodes, we must be careful to use only client(s) on a
 						// single node for the experiments.
 						It("should have connectivity from a workload to a service with multiple backends", func() {
-							affKV := func() (nat.AffinityKeyInterface, nat.AffinityValueInterface) {
-								if testOpts.ipv6 {
-									aff := dumpAffMapV6(tc.Felixes[0])
-									ExpectWithOffset(1, aff).To(HaveLen(1))
-
-									// get the only key
-									for k, v := range aff {
-										return k, v
-									}
-								} else {
-									aff := dumpAffMap(tc.Felixes[0])
-									ExpectWithOffset(1, aff).To(HaveLen(1))
-
-									// get the only key
-									for k, v := range aff {
-										return k, v
-									}
-								}
-
-								Fail("no value in aff map")
-								return nil, nil
-							}
-
 							ip := testSvc.Spec.ClusterIP
 							port := uint16(testSvc.Spec.Ports[0].Port)
 
 							if setAffinity {
-								// Sync with NAT tables to prevent creating extra entry when
-								// CTLB misses but regular DNAT hits, but connection fails and
-								// then CTLB succeeds.
-								var (
-									family   int
-									natFtKey nat.FrontendKeyInterface
-								)
-
-								if testOpts.ipv6 {
-									natFtKey = nat.NewNATKeyV6Intf(net.ParseIP(ip), port, numericProto)
-									family = 6
-								} else {
-									natFtKey = nat.NewNATKeyIntf(net.ParseIP(ip), port, numericProto)
-									family = 4
-								}
-
-								Eventually(func() bool {
-									m, be, _ := dumpNATMapsAny(family, tc.Felixes[0])
-
-									v, ok := m[natFtKey]
-									if !ok || v.Count() == 0 {
-										return false
-									}
-
-									beKey := nat.NewNATBackendKey(v.ID(), 0)
-
-									_, ok = be[beKey]
-									return ok
-								}, 5*time.Second).Should(BeTrue())
+								waitForSvcProgrammed(ip, port)
 							}
 
 							cc.ExpectSome(w[0][1], TargetIP(ip), port)
@@ -3605,6 +3615,39 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 
 							// This should happen consistently, but that may take quite some time.
 							Expect(val1.Backend()).To(Equal(v2.Backend()))
+
+							// The affinity entry must survive a kube-proxy sync. The
+							// syncer cleans the affinity map on every sync, and it only
+							// knows to keep an entry for a service it expects to have
+							// affinity - which, for unconnected UDP, includes services
+							// without session affinity because the CTLB enforces
+							// affinity for them too.
+							//
+							// Creating an unrelated service forces a sync; once felix
+							// has programmed it, the cleanup has definitely run.
+							By("keeping the affinity across a kube-proxy sync", func() {
+								syncSvcIP := "10.101.0.13"
+								if testOpts.ipv6 {
+									syncSvcIP = "dead:beef::abcd:0:0:13"
+								}
+								syncSvc := k8sService("test-service-sync", syncSvcIP, w[0][0], 80, 8055, 0, testOpts.protocol)
+								_, err := k8sClient.CoreV1().Services(testSvcNamespace).
+									Create(context.Background(), syncSvc, metav1.CreateOptions{})
+								Expect(err).NotTo(HaveOccurred())
+
+								syncSvcKey := natFEKey(syncSvcIP, 80)
+								Eventually(func() bool {
+									m, _, _ := dumpNATMapsAny(family, tc.Felixes[0])
+									_, ok := m[syncSvcKey]
+									return ok
+								}, "10s", "300ms").Should(BeTrue(), "kube-proxy did not sync the extra service")
+
+								Expect(affLen()).To(Equal(1),
+									"the kube-proxy sync deleted the affinity entry")
+								_, v3 := affKV()
+								Expect(v3.Backend()).To(Equal(val1.Backend()),
+									"the kube-proxy sync changed the affinity backend")
+							})
 
 							cc.ResetExpectations()
 
@@ -3684,6 +3727,47 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 								Not(Equal(mVal.Backend())),
 							))
 						})
+
+						// The CTLB enforces its own, short, affinity for unconnected UDP on
+						// every UDP service. A service that asks for session affinity has a
+						// much longer timeout of its own, and that is the one the user asked
+						// for, so it must win.
+						if setAffinity && testOpts.protocol == "udp" && testOpts.udpUnConnected && testOpts.connTimeEnabled {
+							It("should keep the affinity for longer than the CTLB's UDP timeout", func() {
+								ip := testSvc.Spec.ClusterIP
+								port := uint16(testSvc.Spec.Ports[0].Port)
+
+								// Shrink the CTLB's timeout so that the test can idle past it in
+								// a few seconds. The service keeps Kubernetes' default session
+								// affinity timeout of 3 hours.
+								By("restarting felix-0 with a 3s UDP conntrack timeout", func() {
+									tc.Felixes[0].SetEnv(map[string]string{"FELIX_BPFCONNTRACKTIMEOUTS": "UDPTimeout=3s"})
+									tc.Felixes[0].Restart()
+									waitForSvcProgrammed(ip, port)
+								})
+
+								// N.B. Client must be on felix-0 to be subject to ctlb!
+								cc.ExpectSome(w[0][1], TargetIP(ip), port)
+								cc.CheckConnectivity()
+								_, first := affKV()
+
+								// Each round idles for longer than the CTLB's UDP timeout. If the
+								// CTLB applied that timeout it would treat the entry as expired
+								// and re-pick at random, so with three backends a run of rounds
+								// all picking the same backend by luck is vanishingly unlikely.
+								for round := range 8 {
+									time.Sleep(4 * time.Second)
+									cc.CheckConnectivity()
+
+									Expect(affLen()).To(Equal(1),
+										fmt.Sprintf("round %d: affinity entry disappeared", round))
+									_, v := affKV()
+									Expect(v.Backend()).To(Equal(first.Backend()),
+										fmt.Sprintf("round %d: affinity backend changed after idling "+
+											"past the CTLB's UDP timeout", round))
+								}
+							})
+						}
 					}
 
 					Context("with affinity", func() {


### PR DESCRIPTION
## Cherry-pick history

Backport of the four `cherry-pick-candidate` fixes that merged to master after
`release-v3.33` was cut at `2619d6a289` and have not been picked yet. All four
picks are clean, in master merge order:

| Original PR | Master commit | Pick |
|---|---|---|
| #13185 | `3628520d32` (squash) | `git cherry-pick -x` |
| #13398 | `e2b0e44a00` (merge) | `git cherry-pick -x -m 1` |
| #13409 | `4aa5cbe216` (squash) | `git cherry-pick -x` |
| #13399 | `fb6e0cec90` (merge) | `git cherry-pick -x -m 1` |

No conflicts. All 19 touched files are byte-identical to master
(`git diff upstream/master HEAD -- <files>` is empty).

### Description

- **#13185 — expire flows when the rule trace verdict changes match index.** A
  verdict rule hit landing in an empty match-index slot moved the trace's
  verdict without expiring the previously reported flow, so the aggregator held
  an active reference forever and re-exported a zero-stat deny every flush
  interval. Whisker/Goldmane showed a live deny long after the traffic stopped
  being denied.

- **#13398 — `nameToIface` leak on workload teardown in the BPF endpoint
  manager.** Per-interface state was retained for every workload torn down on
  the node, which is unbounded growth on a node churning Istio ambient
  workloads.

- **#13409 — BPF flow-log age-out floor was dead code.** The guard meant to say
  "never age an entry out in less than two conntrack scans" compared a monotime
  timestamp against a duration, so it was only ever true for ~25s after boot.
  With `ICMPTimeout` at 5s and the conntrack scanner reporting once per 10s
  `ScanPeriod`, a live ICMP flow was expired and re-created every cycle,
  re-crediting the conntrack counters as a fresh delta and emitting a spurious
  expire/start pair.

- **#13399 — CTLB service affinity.** Two bugs: Felix's affinity map cleanup
  deleted the connect-time load balancer's entries, so consecutive datagrams
  from an unconnected UDP socket could land on different backends; and a
  service's own `sessionAffinityConfig` timeout was ignored on the CTLB path,
  capped instead at the much shorter BPF UDP conntrack timeout. Also registers
  the LB source-range frontend for affinity cleanup.

Full rationale and cluster verification are in the original PRs.

### Testing

Tests came across with the picks — `felix/collector/rule_trace_change_test.go`,
`felix/bpf/proxy/ctlb_udp_affinity_test.go`, plus additions to
`collector_test.go`, `stats_test.go`, `bpf_ep_mgr_test.go`,
`lb_src_range_test.go`, `syncer_test.go` and the BPF FV `bpf_test.go`.

Since every file is byte-identical to master, the master CI runs for #13185,
#13398, #13409 and #13399 apply directly; this branch's own CI is the check that
they compose on `release-v3.33`.

### Related issues/PRs

Cherry-pick of #13185, #13398, #13409, #13399.

### Release Note

```release-note
Fix that Felix kept re-emitting stale deny flow logs with zero counters (shown in Whisker as a live deny) after a policy change allowed the traffic.
Fixed a leak in the eBPF endpoint manager that retained per-interface state for every Istio ambient workload torn down on a node.
Fixed premature age-out of flow log entries in the eBPF dataplane, which duplicated packet and byte counts and emitted spurious expire/start flow logs for long-lived ICMP flows.
Fixed two eBPF dataplane service affinity bugs: consecutive datagrams from an unconnected UDP socket could be sent to different backends because Felix's affinity map cleanup deleted the connect-time load balancer's affinity entries; and a UDP service using sessionAffinity had its affinity timeout capped at the much shorter BPF UDP conntrack timeout on the connect-time load balancer path.
```

### Reminder for the reviewer

- [x] Includes tests
- [x] Updates the design docs (`felix/design/bpf-services.md`, carried from #13399)
