### PR TITLE
Fix flake in Workload Ingress Datapath E2E

### DIFF
--- a/e2e/pkg/tests/networking/workload_ingress.go
+++ b/e2e/pkg/tests/networking/workload_ingress.go
@@ -16,8 +16,10 @@ package networking
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
+	"os/exec"
 	"time"
 
 	//nolint:staticcheck // Ignore ST1001: should not use dot imports
@@ -545,19 +547,63 @@ var _ = describe.CalicoDescribe(
 				framework.Failf("unsupported dest %q for external scenario", s.dest)
 			}
 
+			const (
+				probeTimeout    = 5 * time.Second
+				wgetMaxCode     = 8   // GNU wget only exits 0-8; anything above is not wget speaking.
+				sshKilledCode   = 124 // ExecTimeout's local `timeout` wrapper killed ssh.
+				cmdNotFoundCode = 127 // The remote shell could not find wget.
+			)
+
+			// probe makes exactly one connection attempt and reports wget's exit
+			// status. `-t 1` is essential: wget retries 20 times by default, which
+			// outlasts the ssh wrapper's own timeout, so a dropped-packet block and
+			// a stalled ssh would both surface as the wrapper killing the command.
+			// Omitting `-q` keeps wget's reason for failing in the log.
+			probe := func() (int, string) {
+				cmd := fmt.Sprintf("wget -O- -t 1 -T %d http://%s/clientip",
+					int(probeTimeout.Seconds()), targetAddr)
+				out, err := extNode.Exec("sh", "-c", cmd)
+				if err == nil {
+					return 0, out
+				}
+				var exitErr *exec.ExitError
+				if errors.As(err, &exitErr) {
+					return exitErr.ExitCode(), out
+				}
+				return -1, out
+			}
+
 			tryConnect := func() error {
-				cmd := fmt.Sprintf("wget -qO- -T 5 http://%s/clientip", targetAddr)
-				_, err := extNode.Exec("sh", "-c", cmd)
-				return err
+				code, out := probe()
+				if code != 0 {
+					return fmt.Errorf("expected connection to succeed, wget exited %d (output %q)", code, out)
+				}
+				return nil
 			}
 
 			tryConnectBlocked := func() error {
-				cmd := fmt.Sprintf("wget -qO- -T 5 http://%s/clientip", targetAddr)
-				_, err := extNode.Exec("sh", "-c", cmd)
-				if err != nil {
-					return nil // blocked as expected
+				code, out := probe()
+				switch {
+				case code == 0:
+					return fmt.Errorf("expected connection to be blocked but it succeeded (output %q)", out)
+				case code >= 1 && code <= wgetMaxCode:
+					// Only wget's own exit codes are evidence about policy: they mean
+					// wget ran to completion and the connection failed.
+					return nil
+				case code == sshKilledCode:
+					// The ssh wrapper killed the command, so this attempt carries no
+					// information about policy. Reporting it as a block would let an
+					// unenforced policy pass as enforced.
+					return fmt.Errorf("probe inconclusive: ssh was killed before wget returned, " +
+						"so a policy block cannot be distinguished from a stalled connection")
+				case code == cmdNotFoundCode:
+					return fmt.Errorf("probe inconclusive: wget is not installed on the external node")
+				default:
+					// ssh exits 255 on a transport failure; -1 means the command
+					// produced no exit status at all. Counting these as blocks would
+					// let an unreachable external node pass as an enforced policy.
+					return fmt.Errorf("probe inconclusive: probe transport failed (exit %d), not a wget result", code)
 				}
-				return fmt.Errorf("expected connection to be blocked but it succeeded")
 			}
 
 			By("Verifying baseline: external node can reach the server before any policy")

--- a/e2e/pkg/tests/networking/workload_ingress.go
+++ b/e2e/pkg/tests/networking/workload_ingress.go
@@ -564,66 +564,55 @@ var _ = describe.CalicoDescribe(
 			cmd := fmt.Sprintf("wget -O- -t 1 -T %d http://%s/clientip",
 				int(probeTimeout.Seconds()), targetAddr)
 
-			// probe makes exactly one connection attempt and reports wget's exit
-			// status. `-t 1` is essential: wget retries 20 times by default, which
-			// outlasts the ssh wrapper's own timeout, so a dropped-packet block and
-			// a stalled ssh would both surface as the wrapper killing the command.
-			// Omitting `-q` keeps wget's reason for failing in the log.
-			probe := func() (int, string) {
+			// probe makes exactly one connection attempt. It returns nil when the
+			// connection succeeded, an error wrapping errBlocked when wget ran to
+			// completion and the connection failed, and any other error when the
+			// attempt says nothing about policy. Only the first two are evidence:
+			// counting an inconclusive probe as a block would let an unenforced
+			// policy, or an unreachable external node, pass as enforced.
+			//
+			// `-t 1` is essential: wget retries 20 times by default, which outlasts
+			// the ssh wrapper's own timeout, so a dropped-packet block and a stalled
+			// ssh would both surface as the wrapper killing the command. Omitting
+			// `-q` keeps wget's reason for failing in the log.
+			errBlocked := errors.New("connection blocked")
+			probe := func() error {
 				out, err := extNode.Exec("sh", "-c", cmd)
 				if err == nil {
-					return 0, out
+					return nil
 				}
 				var exitErr *exec.ExitError
-				if errors.As(err, &exitErr) {
-					return exitErr.ExitCode(), out
+				if !errors.As(err, &exitErr) {
+					// The command never produced an exit status, e.g. the local
+					// `timeout` or ssh binary is missing.
+					return fmt.Errorf("probe inconclusive: %w (output %q)", err, out)
 				}
-				return -1, out
-			}
-
-			tryConnect := func() error {
-				code, out := probe()
-				if code != 0 {
-					return fmt.Errorf("expected connection to succeed, wget exited %d (output %q)", code, out)
-				}
-				return nil
-			}
-
-			tryConnectBlocked := func() error {
-				code, out := probe()
+				code := exitErr.ExitCode()
 				switch {
-				case code == 0:
-					return fmt.Errorf("expected connection to be blocked but it succeeded (output %q)", out)
 				case code >= 1 && code <= wgetMaxCode:
-					// Only wget's own exit codes are evidence about policy: they mean
-					// wget ran to completion and the connection failed.
-					return nil
+					return fmt.Errorf("%w: wget exited %d (output %q)", errBlocked, code, out)
 				case code == sshKilledCode:
-					// The ssh wrapper killed the command, so this attempt carries no
-					// information about policy. Reporting it as a block would let an
-					// unenforced policy pass as enforced.
-					return fmt.Errorf("probe inconclusive: ssh was killed before wget returned, " +
+					return errors.New("probe inconclusive: ssh was killed before wget returned, " +
 						"so a policy block cannot be distinguished from a stalled connection")
 				case code == cmdNotFoundCode:
-					return fmt.Errorf("probe inconclusive: wget is not installed on the external node")
+					return errors.New("probe inconclusive: wget is not installed on the external node")
 				default:
-					// ssh exits 255 on a transport failure; -1 means the command
-					// produced no exit status at all. Counting these as blocks would
-					// let an unreachable external node pass as an enforced policy.
+					// ssh exits 255 on a transport failure; -1 means the local wrapper
+					// was killed by a signal.
 					return fmt.Errorf("probe inconclusive: probe transport failed (exit %d), not a wget result", code)
 				}
 			}
 
 			By("Verifying baseline: external node can reach the server before any policy")
-			Eventually(tryConnect, probeSettle, probePoll).Should(Succeed())
+			Eventually(probe, probeSettle, probePoll).Should(Succeed())
 
 			By("Installing deny-all ingress policy")
 			denyAll := ingressCreateDenyAllPolicy(f)
 			DeferCleanup(ingressDeletePolicy, f, denyAll.Namespace, denyAll.Name)
 
 			By("Verifying external node is blocked after deny-all")
-			Eventually(tryConnectBlocked, probeSettle, probePoll).Should(Succeed())
-			Consistently(tryConnectBlocked, probeHold, probePoll).Should(Succeed())
+			Eventually(probe, probeSettle, probePoll).Should(MatchError(errBlocked))
+			Consistently(probe, probeHold, probePoll).Should(MatchError(errBlocked))
 
 			// Build /32 (IPv4) or /128 (IPv6) CIDRs for the external node's source IPs.
 			cidrs := make([]string, 0, len(extIPs))
@@ -641,12 +630,12 @@ var _ = describe.CalicoDescribe(
 			switch expect {
 			case noSNAT:
 				By("Verifying external node is allowed (CIDR policy, source IP preserved)")
-				Eventually(tryConnect, probeSettle, probePoll).Should(Succeed())
+				Eventually(probe, probeSettle, probePoll).Should(Succeed())
 
 			case snatNoWorkingPolicy:
 				// SNAT rewrites the source IP so the CIDR allow rule never matches.
 				By("Verifying external node is still blocked (SNAT breaks CIDR policy)")
-				Consistently(tryConnectBlocked, probeHold, probePoll).Should(Succeed())
+				Consistently(probe, probeHold, probePoll).Should(MatchError(errBlocked))
 			}
 		}
 

--- a/e2e/pkg/tests/networking/workload_ingress.go
+++ b/e2e/pkg/tests/networking/workload_ingress.go
@@ -552,24 +552,25 @@ var _ = describe.CalicoDescribe(
 			// window shorter than a single probe only ever runs one probe, which
 			// asserts nothing about whether a state persists.
 			const (
-				probeTimeout    = 5 * time.Second
-				probePoll       = 8 * time.Second
-				probeSettle     = 30 * time.Second
-				probeHold       = 25 * time.Second
-				wgetMaxCode     = 8   // GNU wget only exits 0-8; anything above is not wget speaking.
-				sshKilledCode   = 124 // ExecTimeout's local `timeout` wrapper killed ssh.
-				cmdNotFoundCode = 127 // The remote shell could not find wget.
+				probeTimeout           = 5 * time.Second
+				probePoll              = 8 * time.Second
+				probeSettle            = 30 * time.Second
+				probeHold              = 25 * time.Second
+				wgetNetworkFailureCode = 4   // GNU wget: refused, timed out, or unresolvable. The only status that shows a block.
+				wgetServerErrorCode    = 8   // GNU wget's highest status: the server answered with an HTTP error.
+				sshKilledCode          = 124 // ExecTimeout's local `timeout` wrapper killed ssh.
+				cmdNotFoundCode        = 127 // The remote shell could not find wget.
 			)
 
 			cmd := fmt.Sprintf("wget -O- -t 1 -T %d http://%s/clientip",
 				int(probeTimeout.Seconds()), targetAddr)
 
 			// probe makes exactly one connection attempt. It returns nil when the
-			// connection succeeded, an error wrapping errBlocked when wget ran to
-			// completion and the connection failed, and any other error when the
-			// attempt says nothing about policy. Only the first two are evidence:
-			// counting an inconclusive probe as a block would let an unenforced
-			// policy, or an unreachable external node, pass as enforced.
+			// connection succeeded, an error wrapping errBlocked when wget reported
+			// a network failure, and any other error when the attempt says nothing
+			// about policy. Only the first two are evidence: counting any other
+			// probe as a block would let an unenforced policy, or an unreachable
+			// external node, pass as enforced.
 			//
 			// `-t 1` is essential: wget retries 20 times by default, which outlasts
 			// the ssh wrapper's own timeout, so a dropped-packet block and a stalled
@@ -589,8 +590,16 @@ var _ = describe.CalicoDescribe(
 				}
 				code := exitErr.ExitCode()
 				switch {
-				case code >= 1 && code <= wgetMaxCode:
+				case code == wgetNetworkFailureCode:
 					return fmt.Errorf("%w: wget exited %d (output %q)", errBlocked, code, out)
+				case code == wgetServerErrorCode:
+					// The request reached the server and got an answer, so nothing
+					// blocked this connection.
+					return fmt.Errorf("server reached but it returned an HTTP error (wget exited %d, output %q)", code, out)
+				case code >= 1 && code < wgetServerErrorCode:
+					// wget's other statuses are local, TLS, or protocol problems that
+					// say nothing about whether the connection was blocked.
+					return fmt.Errorf("probe inconclusive: wget exited %d, which is not a network failure (output %q)", code, out)
 				case code == sshKilledCode:
 					return errors.New("probe inconclusive: ssh was killed before wget returned, " +
 						"so a policy block cannot be distinguished from a stalled connection")

--- a/e2e/pkg/tests/networking/workload_ingress.go
+++ b/e2e/pkg/tests/networking/workload_ingress.go
@@ -547,8 +547,15 @@ var _ = describe.CalicoDescribe(
 				framework.Failf("unsupported dest %q for external scenario", s.dest)
 			}
 
+			// One probe costs an ssh round trip plus at most probeTimeout for the
+			// request. Poll intervals and hold windows are sized against that: a
+			// window shorter than a single probe only ever runs one probe, which
+			// asserts nothing about whether a state persists.
 			const (
 				probeTimeout    = 5 * time.Second
+				probePoll       = 8 * time.Second
+				probeSettle     = 30 * time.Second
+				probeHold       = 25 * time.Second
 				wgetMaxCode     = 8   // GNU wget only exits 0-8; anything above is not wget speaking.
 				sshKilledCode   = 124 // ExecTimeout's local `timeout` wrapper killed ssh.
 				cmdNotFoundCode = 127 // The remote shell could not find wget.
@@ -607,15 +614,15 @@ var _ = describe.CalicoDescribe(
 			}
 
 			By("Verifying baseline: external node can reach the server before any policy")
-			Eventually(tryConnect, 30*time.Second, 2*time.Second).Should(Succeed())
+			Eventually(tryConnect, probeSettle, probePoll).Should(Succeed())
 
 			By("Installing deny-all ingress policy")
 			denyAll := ingressCreateDenyAllPolicy(f)
 			DeferCleanup(ingressDeletePolicy, f, denyAll.Namespace, denyAll.Name)
 
 			By("Verifying external node is blocked after deny-all")
-			Eventually(tryConnectBlocked, 30*time.Second, 2*time.Second).Should(Succeed())
-			Consistently(tryConnectBlocked, 5*time.Second, 1*time.Second).Should(Succeed())
+			Eventually(tryConnectBlocked, probeSettle, probePoll).Should(Succeed())
+			Consistently(tryConnectBlocked, probeHold, probePoll).Should(Succeed())
 
 			// Build /32 (IPv4) or /128 (IPv6) CIDRs for the external node's source IPs.
 			cidrs := make([]string, 0, len(extIPs))
@@ -633,12 +640,12 @@ var _ = describe.CalicoDescribe(
 			switch expect {
 			case noSNAT:
 				By("Verifying external node is allowed (CIDR policy, source IP preserved)")
-				Eventually(tryConnect, 30*time.Second, 2*time.Second).Should(Succeed())
+				Eventually(tryConnect, probeSettle, probePoll).Should(Succeed())
 
 			case snatNoWorkingPolicy:
 				// SNAT rewrites the source IP so the CIDR allow rule never matches.
 				By("Verifying external node is still blocked (SNAT breaks CIDR policy)")
-				Consistently(tryConnectBlocked, 10*time.Second, 2*time.Second).Should(Succeed())
+				Consistently(tryConnectBlocked, probeHold, probePoll).Should(Succeed())
 			}
 		}
 

--- a/e2e/pkg/tests/networking/workload_ingress.go
+++ b/e2e/pkg/tests/networking/workload_ingress.go
@@ -561,14 +561,15 @@ var _ = describe.CalicoDescribe(
 				cmdNotFoundCode = 127 // The remote shell could not find wget.
 			)
 
+			cmd := fmt.Sprintf("wget -O- -t 1 -T %d http://%s/clientip",
+				int(probeTimeout.Seconds()), targetAddr)
+
 			// probe makes exactly one connection attempt and reports wget's exit
 			// status. `-t 1` is essential: wget retries 20 times by default, which
 			// outlasts the ssh wrapper's own timeout, so a dropped-packet block and
 			// a stalled ssh would both surface as the wrapper killing the command.
 			// Omitting `-q` keeps wget's reason for failing in the log.
 			probe := func() (int, string) {
-				cmd := fmt.Sprintf("wget -O- -t 1 -T %d http://%s/clientip",
-					int(probeTimeout.Seconds()), targetAddr)
 				out, err := extNode.Exec("sh", "-c", cmd)
 				if err == nil {
 					return 0, out

--- a/e2e/pkg/utils/externalnode/client.go
+++ b/e2e/pkg/utils/externalnode/client.go
@@ -145,9 +145,9 @@ func (e *Client) ExecTimeout(timeoutSecs int, shell, opt, cmd string) (string, e
 	outstr := strings.TrimSpace(string(out))
 	logrus.Infof("Output: %q", outstr)
 	if err != nil {
-		// Not every failure is an ExitError — a missing ssh binary or a context
-		// cancellation is not — and asserting the type would panic the whole
-		// Ginkgo node rather than failing the caller's assertion.
+		// Not every failure is an ExitError — a missing `timeout` binary is not,
+		// nor is an I/O error reading the output — and asserting the type would
+		// panic the whole Ginkgo node rather than failing the caller's assertion.
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) {
 			logrus.WithError(err).Errorf("Stderr: %s", string(exitErr.Stderr))

--- a/e2e/pkg/utils/externalnode/client.go
+++ b/e2e/pkg/utils/externalnode/client.go
@@ -150,9 +150,9 @@ func (e *Client) ExecTimeout(timeoutSecs int, shell, opt, cmd string) (string, e
 		// Ginkgo node rather than failing the caller's assertion.
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) {
-			logrus.Infof("Stderr: %s", string(exitErr.Stderr))
+			logrus.WithError(err).Errorf("Stderr: %s", string(exitErr.Stderr))
 		} else {
-			logrus.Infof("Command failed without an exit status: %v", err)
+			logrus.WithError(err).Errorf("Command failed without an exit status")
 		}
 	}
 	return outstr, err

--- a/e2e/pkg/utils/externalnode/client.go
+++ b/e2e/pkg/utils/externalnode/client.go
@@ -4,6 +4,7 @@ package externalnode
 
 import (
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"os/exec"
 	"regexp"
@@ -144,8 +145,15 @@ func (e *Client) ExecTimeout(timeoutSecs int, shell, opt, cmd string) (string, e
 	outstr := strings.TrimSpace(string(out))
 	logrus.Infof("Output: %q", outstr)
 	if err != nil {
-		err := err.(*exec.ExitError)
-		logrus.Infof("Stderr: %s", string(err.Stderr))
+		// Not every failure is an ExitError — a missing ssh binary or a context
+		// cancellation is not — and asserting the type would panic the whole
+		// Ginkgo node rather than failing the caller's assertion.
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			logrus.Infof("Stderr: %s", string(exitErr.Stderr))
+		} else {
+			logrus.Infof("Command failed without an exit status: %v", err)
+		}
 	}
 	return outstr, err
 }

--- a/e2e/pkg/utils/externalnode/client_test.go
+++ b/e2e/pkg/utils/externalnode/client_test.go
@@ -15,8 +15,10 @@
 package externalnode
 
 import (
+	"errors"
 	"io/fs"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -110,4 +112,17 @@ func fileContains(t *testing.T, path, s string) bool {
 		t.Fatalf("reading %s: %v", path, err)
 	}
 	return strings.Contains(string(contents), s)
+}
+
+// ExecTimeout used to type-assert its error to *exec.ExitError. A failure that
+// produced no exit status — here, no `timeout` binary on PATH — panicked and
+// took the whole Ginkgo node down instead of failing the caller's assertion.
+func TestExecTimeoutReturnsFailureWithoutExitStatus(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+	c := &Client{extIP: "10.0.0.1", extKey: "/dev/null", extUser: "test"}
+
+	_, err := c.ExecTimeout(1, "sh", "-c", "true")
+	if !errors.Is(err, exec.ErrNotFound) {
+		t.Fatalf("ExecTimeout() error = %v, want exec.ErrNotFound", err)
+	}
 }


### PR DESCRIPTION
Fixes a few things in the Workload Ingress Datapath tests:

- handle other possible error cases instead of casting as an `exec.ExitError`
- handle a slow CI node running wget
- extend timeouts to 25s so the loop has time to run multiple times

**Release note:**
```release-note
TBD
```
