### PR TITLE
lib/kind/localregistry: per-blob pull-through so manifest HEAD stays fast

### DIFF
--- a/lib/kind/localregistry/nodes.go
+++ b/lib/kind/localregistry/nodes.go
@@ -44,8 +44,22 @@ func (f *Registry) ConfigureNodes(ctx context.Context, kindNodes []nodes.Node, u
 	if err != nil {
 		return err
 	}
+	// response_header_timeout / request_timeout / dial_timeout are the
+	// per-host HTTP timeouts containerd applies to the fetcher talking
+	// to this mirror. Defaults are aggressive (seconds), which trips
+	// on a cold pull-through of a large image (Kibana, Elasticsearch)
+	// because ensure() holds the manifest HEAD open for the whole
+	// synchronous crane.Pull + crane.Push cycle — that can be minutes
+	// on the first pull. Generous values here don't slow anything down
+	// on a warm cache (the facade responds in ms once the manifest is
+	// in the internal store); they only take effect while an image is
+	// actively being pulled through. Supported by containerd 2.x, which
+	// is what kindest/node images from kind v0.27+ ship.
 	hostsTOML := fmt.Sprintf(`[host.%q]
   capabilities = ["pull", "resolve"]
+  dial_timeout = "30s"
+  response_header_timeout = "15m"
+  request_timeout = "30m"
 `, endpoint)
 
 	for _, n := range kindNodes {

--- a/lib/kind/localregistry/nodes.go
+++ b/lib/kind/localregistry/nodes.go
@@ -44,19 +44,10 @@ func (f *Registry) ConfigureNodes(ctx context.Context, kindNodes []nodes.Node, u
 	if err != nil {
 		return err
 	}
-	// response_header_timeout / request_timeout / dial_timeout are the
-	// per-host HTTP timeouts containerd applies to the fetcher talking
-	// to this mirror. Defaults are aggressive (seconds). ensureManifest
-	// / ensureBlob keep any single facade request bounded (manifests
-	// are KB, blobs are one layer), so on the fast path these limits
-	// never come near firing. They're a safety net for the streaming
-	// blob case on slow upstreams — a large single layer over a slow
-	// link can still take longer than containerd's default response
-	// header timeout, so we bump it here rather than have containerd
-	// give up mid-transfer. Warm-cache pulls stay ms-fast — the facade
-	// responds immediately once the manifest / blob is in the internal
-	// store. Supported by containerd 2.x, which is what kindest/node
-	// images from kind v0.27+ ship.
+	// Safety net for the streaming-blob case on slow upstreams: a
+	// single large layer can outrun containerd's default response
+	// header timeout. On the fast path (KB manifest, warm cache)
+	// these never fire. containerd 2.x only.
 	hostsTOML := fmt.Sprintf(`[host.%q]
   capabilities = ["pull", "resolve"]
   dial_timeout = "30s"

--- a/lib/kind/localregistry/nodes.go
+++ b/lib/kind/localregistry/nodes.go
@@ -46,15 +46,17 @@ func (f *Registry) ConfigureNodes(ctx context.Context, kindNodes []nodes.Node, u
 	}
 	// response_header_timeout / request_timeout / dial_timeout are the
 	// per-host HTTP timeouts containerd applies to the fetcher talking
-	// to this mirror. Defaults are aggressive (seconds), which trips
-	// on a cold pull-through of a large image (Kibana, Elasticsearch)
-	// because ensure() holds the manifest HEAD open for the whole
-	// synchronous crane.Pull + crane.Push cycle — that can be minutes
-	// on the first pull. Generous values here don't slow anything down
-	// on a warm cache (the facade responds in ms once the manifest is
-	// in the internal store); they only take effect while an image is
-	// actively being pulled through. Supported by containerd 2.x, which
-	// is what kindest/node images from kind v0.27+ ship.
+	// to this mirror. Defaults are aggressive (seconds). ensureManifest
+	// / ensureBlob keep any single facade request bounded (manifests
+	// are KB, blobs are one layer), so on the fast path these limits
+	// never come near firing. They're a safety net for the streaming
+	// blob case on slow upstreams — a large single layer over a slow
+	// link can still take longer than containerd's default response
+	// header timeout, so we bump it here rather than have containerd
+	// give up mid-transfer. Warm-cache pulls stay ms-fast — the facade
+	// responds immediately once the manifest / blob is in the internal
+	// store. Supported by containerd 2.x, which is what kindest/node
+	// images from kind v0.27+ ship.
 	hostsTOML := fmt.Sprintf(`[host.%q]
   capabilities = ["pull", "resolve"]
   dial_timeout = "30s"

--- a/lib/kind/localregistry/registry.go
+++ b/lib/kind/localregistry/registry.go
@@ -39,6 +39,7 @@
 package localregistry
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -54,7 +55,9 @@ import (
 
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/crane"
+	"github.com/google/go-containerregistry/pkg/name"
 	ggcrregistry "github.com/google/go-containerregistry/pkg/registry"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
 
 	"github.com/projectcalico/calico/lib/std/log"
 )
@@ -209,8 +212,23 @@ func (f *Registry) Cached() []string {
 
 // ServeHTTP implements the facade. It rewrites the ns-scoped request path to
 // a namespaced repo in the internal store, lazily populates that repo from
-// the upstream on a manifest miss, then reverse-proxies to the internal
-// store which does the real OCI protocol work.
+// the upstream on a miss, then reverse-proxies to the internal store which
+// does the real OCI protocol work.
+//
+// Pull-through is split per-request-kind so no single request holds the
+// connection open for the full image transfer:
+//   - manifests: pull just the manifest bytes from upstream (small, single
+//     HTTP call), PUT to the internal store. Sub-second even for huge
+//     images — the manifest itself is a few KB.
+//   - blobs: on a first-miss, pull just that one blob from upstream and
+//     push to the internal store. Total time is one layer, not the whole
+//     image, so containerd's per-request response_header_timeout on the
+//     mirror never fires on the "some image is big" case (the old flow
+//     pulled every layer inside the manifest HEAD, which is what tripped
+//     the timeout on Kibana / Elasticsearch pulls).
+//
+// Overrides remain whole-image pushes (see override.go's crane.Push) —
+// they're local builds already on disk, so there's no time cost.
 func (f *Registry) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ns := r.URL.Query().Get("ns")
 	repo, kind, ref, ok := parseRepoRequest(r.URL.Path)
@@ -222,18 +240,23 @@ func (f *Registry) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// On a manifest read, make sure the (namespaced) repo is populated —
-	// either from a prior Override or by pulling from the upstream now.
-	if kind == "manifests" && (r.Method == http.MethodGet || r.Method == http.MethodHead) {
-		if err := f.ensure(r.Context(), ns, repo, ref); err != nil {
-			f.log.Warn("pull-through failed", "ns", ns, "repo", repo, "ref", ref, "error", err)
-			http.Error(w, err.Error(), http.StatusBadGateway)
-			return
+	if r.Method == http.MethodGet || r.Method == http.MethodHead {
+		switch kind {
+		case "manifests":
+			if err := f.ensureManifest(r.Context(), ns, repo, ref); err != nil {
+				f.log.Warn("manifest pull-through failed", "ns", ns, "repo", repo, "ref", ref, "error", err)
+				http.Error(w, err.Error(), http.StatusBadGateway)
+				return
+			}
+		case "blobs":
+			if err := f.ensureBlob(r.Context(), ns, repo, ref); err != nil {
+				f.log.Warn("blob pull-through failed", "ns", ns, "repo", repo, "digest", ref, "error", err)
+				http.Error(w, err.Error(), http.StatusBadGateway)
+				return
+			}
 		}
 	}
 
-	// Blobs pulled for that manifest are already present under the same
-	// namespaced repo, so blob requests just proxy through.
 	f.serveInternal(w, r, fmt.Sprintf("/v2/%s/%s/%s/%s", safeNS(ns), repo, kind, ref))
 }
 
@@ -250,13 +273,14 @@ func (f *Registry) serveInternal(w http.ResponseWriter, r *http.Request, path st
 	f.proxy.ServeHTTP(w, r)
 }
 
-// ensure guarantees the (ns, repo, ref) manifest and its blobs are present
-// in the internal store. Overridden refs are already present and marked, so
-// this is a no-op for them — that is what makes an override beat upstream.
-// Otherwise it pulls from the real upstream (named by ns) with the host's
-// live keychain and pushes into the internal store; disk-cached blobs are
-// not re-fetched.
-func (f *Registry) ensure(ctx context.Context, ns, repo, ref string) error {
+// ensureManifest guarantees the (ns, repo, ref) manifest is present in the
+// internal store. Overridden refs are already present and marked, so this
+// is a no-op for them — that is what makes an override beat upstream.
+// Otherwise it pulls JUST the manifest bytes from the real upstream (named
+// by ns) with the host's live keychain and PUTs them into the internal
+// store. Referenced config and layer blobs are populated later, on demand,
+// by ensureBlob when containerd asks for them.
+func (f *Registry) ensureManifest(ctx context.Context, ns, repo, ref string) error {
 	k := key(ns, repo, ref)
 	f.mu.Lock()
 	present := f.cached[k]
@@ -271,7 +295,7 @@ func (f *Registry) ensure(ctx context.Context, ns, repo, ref string) error {
 	// or content from a previous process. If it's there, serve it and do NOT
 	// pull through, so an override is never clobbered by the upstream (this is
 	// what makes a pushed override stick, even under imagePullPolicy: Always).
-	if f.existsInternal(ctx, ns, repo, ref) {
+	if f.manifestExistsInternal(ctx, ns, repo, ref) {
 		f.mu.Lock()
 		f.cached[k] = true
 		f.mu.Unlock()
@@ -279,15 +303,35 @@ func (f *Registry) ensure(ctx context.Context, ns, repo, ref string) error {
 	}
 
 	upstream := joinRef("", ns, repo, ref)
-	internal := joinRef(f.internalHost, safeNS(ns), repo, ref)
-	f.log.Info("pull-through", "upstream", upstream, "internal", internal)
+	f.log.Info("manifest pull-through", "upstream", upstream)
 
-	img, err := crane.Pull(upstream, f.pullOpts(ctx)...)
+	upstreamRef, err := name.ParseReference(upstream, f.nameOpts()...)
 	if err != nil {
-		return fmt.Errorf("pull %s: %w", upstream, err)
+		return fmt.Errorf("parse upstream %s: %w", upstream, err)
 	}
-	if err := crane.Push(img, internal, f.pushOpts(ctx)...); err != nil {
-		return fmt.Errorf("cache %s: %w", internal, err)
+	desc, err := remote.Get(upstreamRef, f.remoteOpts(ctx)...)
+	if err != nil {
+		return fmt.Errorf("fetch manifest %s: %w", upstream, err)
+	}
+
+	// PUT the manifest bytes into the internal store under the safeNS'd
+	// repo. The store accepts a manifest even when referenced blobs aren't
+	// present yet — containerd will follow up with per-blob GETs which
+	// ensureBlob handles.
+	putURL := fmt.Sprintf("%s/v2/%s/%s/manifests/%s", f.internalURL.String(), safeNS(ns), repo, ref)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, putURL, bytes.NewReader(desc.Manifest))
+	if err != nil {
+		return fmt.Errorf("build manifest PUT: %w", err)
+	}
+	req.Header.Set("Content-Type", string(desc.MediaType))
+	req.ContentLength = int64(len(desc.Manifest))
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("push manifest to internal: %w", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode/100 != 2 {
+		return fmt.Errorf("push manifest to internal: status %d", resp.StatusCode)
 	}
 
 	f.mu.Lock()
@@ -296,18 +340,67 @@ func (f *Registry) ensure(ctx context.Context, ns, repo, ref string) error {
 	return nil
 }
 
-// existsInternal reports whether a manifest is already present in the internal
-// store, via a HEAD to its loopback endpoint. A non-200 (typically 404) or any
-// error means "not present" — the caller then pulls through.
-func (f *Registry) existsInternal(ctx context.Context, ns, repo, ref string) bool {
-	manifestURL := fmt.Sprintf("%s/v2/%s/%s/manifests/%s", f.internalURL.String(), safeNS(ns), repo, ref)
-	req, err := http.NewRequestWithContext(ctx, http.MethodHead, manifestURL, nil)
+// ensureBlob guarantees the blob at (ns, repo, digest) is present in the
+// internal store. Fast path if it's already there (populated by an
+// Override's crane.Push, or a prior ensureBlob). Otherwise pull just that
+// one blob from the upstream — one HTTP transfer, not the whole image, so
+// containerd's per-request timeout on the mirror never gets blocked by
+// unrelated layers.
+func (f *Registry) ensureBlob(ctx context.Context, ns, repo, digest string) error {
+	if f.blobExistsInternal(ctx, ns, repo, digest) {
+		return nil
+	}
+
+	upstream := joinRef("", ns, repo, digest)
+	digestRef, err := name.NewDigest(upstream, f.nameOpts()...)
+	if err != nil {
+		return fmt.Errorf("parse blob digest %s: %w", upstream, err)
+	}
+
+	// remote.Layer streams the layer body — no local buffering of the whole
+	// blob happens here. WriteLayer streams straight into the internal
+	// store's blob-upload endpoint.
+	layer, err := remote.Layer(digestRef, f.remoteOpts(ctx)...)
+	if err != nil {
+		return fmt.Errorf("fetch blob %s: %w", upstream, err)
+	}
+	internalRepoRef := fmt.Sprintf("%s/%s/%s", f.internalHost, safeNS(ns), repo)
+	internalRepo, err := name.NewRepository(internalRepoRef, f.nameOpts()...)
+	if err != nil {
+		return fmt.Errorf("parse internal repo %s: %w", internalRepoRef, err)
+	}
+	if err := remote.WriteLayer(internalRepo, layer, f.pushRemoteOpts(ctx)...); err != nil {
+		return fmt.Errorf("push blob %s to internal: %w", digest, err)
+	}
+	return nil
+}
+
+// manifestExistsInternal reports whether a manifest is already present in
+// the internal store, via a HEAD to its loopback endpoint. A non-200
+// (typically 404) or any error means "not present" — the caller then pulls
+// through.
+func (f *Registry) manifestExistsInternal(ctx context.Context, ns, repo, ref string) bool {
+	u := fmt.Sprintf("%s/v2/%s/%s/manifests/%s", f.internalURL.String(), safeNS(ns), repo, ref)
+	return f.internalHEAD(ctx, u, "*/*")
+}
+
+// blobExistsInternal reports whether a blob is already present in the
+// internal store. Same shape as manifestExistsInternal but on the
+// /blobs/<digest> endpoint; the store returns 200 when the layer exists.
+func (f *Registry) blobExistsInternal(ctx context.Context, ns, repo, digest string) bool {
+	u := fmt.Sprintf("%s/v2/%s/%s/blobs/%s", f.internalURL.String(), safeNS(ns), repo, digest)
+	return f.internalHEAD(ctx, u, "*/*")
+}
+
+// internalHEAD is the shared 200/anything-else check the two exists funcs
+// use — a HEAD to the loopback internal store, treating any error as
+// "not present" so the caller can pull through.
+func (f *Registry) internalHEAD(ctx context.Context, url, accept string) bool {
+	req, err := http.NewRequestWithContext(ctx, http.MethodHead, url, nil)
 	if err != nil {
 		return false
 	}
-	// Accept every manifest type so content negotiation never 406s a present
-	// manifest into looking absent.
-	req.Header.Set("Accept", "*/*")
+	req.Header.Set("Accept", accept)
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return false
@@ -416,6 +509,32 @@ func (f *Registry) pullOpts(ctx context.Context) []crane.Option {
 func (f *Registry) pushOpts(ctx context.Context) []crane.Option {
 	// The internal store is plaintext http on loopback, so push is insecure.
 	return []crane.Option{crane.WithContext(ctx), crane.Insecure}
+}
+
+// remoteOpts mirrors pullOpts for the go-containerregistry remote package
+// (ensureManifest / ensureBlob use remote directly rather than crane, so
+// they can operate on manifests and single blobs without touching the full
+// image graph).
+func (f *Registry) remoteOpts(ctx context.Context) []remote.Option {
+	return []remote.Option{
+		remote.WithContext(ctx),
+		remote.WithAuthFromKeychain(f.keychain),
+	}
+}
+
+// pushRemoteOpts is the remote counterpart of pushOpts. WriteLayer needs the
+// internal store's scheme to be http, which name.NewRepository controls via
+// name.Insecure — see nameOpts.
+func (f *Registry) pushRemoteOpts(ctx context.Context) []remote.Option {
+	return []remote.Option{remote.WithContext(ctx)}
+}
+
+// nameOpts flags the upstream / internal reference parsing to permit
+// plaintext HTTP. name defaults to https; without name.Insecure the
+// loopback internal store (http-only) can't be addressed, and the
+// InsecureUpstream test config can't reach an http upstream either.
+func (f *Registry) nameOpts() []name.Option {
+	return []name.Option{name.Insecure}
 }
 
 // logWriter adapts an io.Writer onto lib/std/log so the go-containerregistry

--- a/lib/kind/localregistry/registry.go
+++ b/lib/kind/localregistry/registry.go
@@ -240,20 +240,25 @@ func (f *Registry) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if r.Method == http.MethodGet || r.Method == http.MethodHead {
-		switch kind {
-		case "manifests":
-			if err := f.ensureManifest(r.Context(), ns, repo, ref); err != nil {
-				f.log.Warn("manifest pull-through failed", "ns", ns, "repo", repo, "ref", ref, "error", err)
-				http.Error(w, err.Error(), http.StatusBadGateway)
-				return
-			}
-		case "blobs":
-			if err := f.ensureBlob(r.Context(), ns, repo, ref); err != nil {
-				f.log.Warn("blob pull-through failed", "ns", ns, "repo", repo, "digest", ref, "error", err)
-				http.Error(w, err.Error(), http.StatusBadGateway)
-				return
-			}
+	switch {
+	case kind == "manifests" && (r.Method == http.MethodGet || r.Method == http.MethodHead):
+		// Both GET and HEAD populate — containerd uses HEAD to check
+		// digest existence before the GET, and the manifest itself is
+		// a few KB so pulling on HEAD costs nothing.
+		if err := f.ensureManifest(r.Context(), ns, repo, ref); err != nil {
+			f.log.Warn("manifest pull-through failed", "ns", ns, "repo", repo, "ref", ref, "error", err)
+			http.Error(w, err.Error(), http.StatusBadGateway)
+			return
+		}
+	case kind == "blobs" && r.Method == http.MethodGet:
+		// Blobs populate only on GET. A HEAD on a missing blob stays
+		// cheap (returns 404 from the internal store); if the caller
+		// actually needs the bytes they'll follow up with a GET, which
+		// triggers the pull-through.
+		if err := f.ensureBlob(r.Context(), ns, repo, ref); err != nil {
+			f.log.Warn("blob pull-through failed", "ns", ns, "repo", repo, "digest", ref, "error", err)
+			http.Error(w, err.Error(), http.StatusBadGateway)
+			return
 		}
 	}
 
@@ -305,7 +310,7 @@ func (f *Registry) ensureManifest(ctx context.Context, ns, repo, ref string) err
 	upstream := joinRef("", ns, repo, ref)
 	f.log.Info("manifest pull-through", "upstream", upstream)
 
-	upstreamRef, err := name.ParseReference(upstream, f.nameOpts()...)
+	upstreamRef, err := name.ParseReference(upstream, f.upstreamNameOpts()...)
 	if err != nil {
 		return fmt.Errorf("parse upstream %s: %w", upstream, err)
 	}
@@ -352,7 +357,7 @@ func (f *Registry) ensureBlob(ctx context.Context, ns, repo, digest string) erro
 	}
 
 	upstream := joinRef("", ns, repo, digest)
-	digestRef, err := name.NewDigest(upstream, f.nameOpts()...)
+	digestRef, err := name.NewDigest(upstream, f.upstreamNameOpts()...)
 	if err != nil {
 		return fmt.Errorf("parse blob digest %s: %w", upstream, err)
 	}
@@ -365,7 +370,7 @@ func (f *Registry) ensureBlob(ctx context.Context, ns, repo, digest string) erro
 		return fmt.Errorf("fetch blob %s: %w", upstream, err)
 	}
 	internalRepoRef := fmt.Sprintf("%s/%s/%s", f.internalHost, safeNS(ns), repo)
-	internalRepo, err := name.NewRepository(internalRepoRef, f.nameOpts()...)
+	internalRepo, err := name.NewRepository(internalRepoRef, f.internalNameOpts()...)
 	if err != nil {
 		return fmt.Errorf("parse internal repo %s: %w", internalRepoRef, err)
 	}
@@ -498,23 +503,15 @@ func (s staticKeychain) Resolve(res authn.Resource) (authn.Authenticator, error)
 	return authn.Anonymous, nil
 }
 
-func (f *Registry) pullOpts(ctx context.Context) []crane.Option {
-	opts := []crane.Option{crane.WithContext(ctx), crane.WithAuthFromKeychain(f.keychain)}
-	if f.cfg.InsecureUpstream {
-		opts = append(opts, crane.Insecure)
-	}
-	return opts
-}
-
 func (f *Registry) pushOpts(ctx context.Context) []crane.Option {
 	// The internal store is plaintext http on loopback, so push is insecure.
 	return []crane.Option{crane.WithContext(ctx), crane.Insecure}
 }
 
-// remoteOpts mirrors pullOpts for the go-containerregistry remote package
-// (ensureManifest / ensureBlob use remote directly rather than crane, so
-// they can operate on manifests and single blobs without touching the full
-// image graph).
+// remoteOpts is the go-containerregistry remote-package counterpart of the
+// old crane pullOpts (ensureManifest / ensureBlob use remote directly rather
+// than crane, so they can operate on a single manifest or blob without
+// touching the full image graph).
 func (f *Registry) remoteOpts(ctx context.Context) []remote.Option {
 	return []remote.Option{
 		remote.WithContext(ctx),
@@ -522,18 +519,28 @@ func (f *Registry) remoteOpts(ctx context.Context) []remote.Option {
 	}
 }
 
-// pushRemoteOpts is the remote counterpart of pushOpts. WriteLayer needs the
-// internal store's scheme to be http, which name.NewRepository controls via
-// name.Insecure — see nameOpts.
+// pushRemoteOpts is the remote counterpart of pushOpts. The internal store
+// is plaintext http on loopback; internalNameOpts is what carries the
+// insecure flag into the WriteLayer call.
 func (f *Registry) pushRemoteOpts(ctx context.Context) []remote.Option {
 	return []remote.Option{remote.WithContext(ctx)}
 }
 
-// nameOpts flags the upstream / internal reference parsing to permit
-// plaintext HTTP. name defaults to https; without name.Insecure the
-// loopback internal store (http-only) can't be addressed, and the
-// InsecureUpstream test config can't reach an http upstream either.
-func (f *Registry) nameOpts() []name.Option {
+// upstreamNameOpts controls how upstream refs (gcr.io/…, docker.io/…) are
+// parsed. Real upstreams are https, so we only pass name.Insecure when the
+// test-only InsecureUpstream is on — otherwise remote.Get on a real registry
+// would fall through to http and fail.
+func (f *Registry) upstreamNameOpts() []name.Option {
+	if f.cfg.InsecureUpstream {
+		return []name.Option{name.Insecure}
+	}
+	return nil
+}
+
+// internalNameOpts always forces plaintext HTTP: the internal loopback
+// store binds http-only, so without name.Insecure name.NewRepository would
+// try to reach it over https and fail.
+func (f *Registry) internalNameOpts() []name.Option {
 	return []name.Option{name.Insecure}
 }
 

--- a/lib/kind/localregistry/registry.go
+++ b/lib/kind/localregistry/registry.go
@@ -210,25 +210,14 @@ func (f *Registry) Cached() []string {
 	return keys
 }
 
-// ServeHTTP implements the facade. It rewrites the ns-scoped request path to
-// a namespaced repo in the internal store, lazily populates that repo from
-// the upstream on a miss, then reverse-proxies to the internal store which
-// does the real OCI protocol work.
-//
-// Pull-through is split per-request-kind so no single request holds the
-// connection open for the full image transfer:
-//   - manifests: pull just the manifest bytes from upstream (small, single
-//     HTTP call), PUT to the internal store. Sub-second even for huge
-//     images — the manifest itself is a few KB.
-//   - blobs: on a first-miss, pull just that one blob from upstream and
-//     push to the internal store. Total time is one layer, not the whole
-//     image, so containerd's per-request response_header_timeout on the
-//     mirror never fires on the "some image is big" case (the old flow
-//     pulled every layer inside the manifest HEAD, which is what tripped
-//     the timeout on Kibana / Elasticsearch pulls).
-//
-// Overrides remain whole-image pushes (see override.go's crane.Push) —
-// they're local builds already on disk, so there's no time cost.
+// ServeHTTP is the facade. It rewrites ns-scoped paths to namespaced repos
+// in the internal store, populates them on first miss, then reverse-proxies
+// the request. Pull-through is split per request kind — manifest bytes on
+// a manifest miss, one blob on a blob miss — so no single request holds
+// the connection open for the whole image transfer (the old flow pulled
+// every layer inside the manifest HEAD, tripping containerd's mirror
+// response_header_timeout on Kibana / Elasticsearch). Overrides remain
+// whole-image pushes (override.go) — local builds, no time cost.
 func (f *Registry) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ns := r.URL.Query().Get("ns")
 	repo, kind, ref, ok := parseRepoRequest(r.URL.Path)
@@ -242,19 +231,15 @@ func (f *Registry) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	switch {
 	case kind == "manifests" && (r.Method == http.MethodGet || r.Method == http.MethodHead):
-		// Both GET and HEAD populate — containerd uses HEAD to check
-		// digest existence before the GET, and the manifest itself is
-		// a few KB so pulling on HEAD costs nothing.
+		// Populate on HEAD too — the manifest is a few KB either way.
 		if err := f.ensureManifest(r.Context(), ns, repo, ref); err != nil {
 			f.log.Warn("manifest pull-through failed", "ns", ns, "repo", repo, "ref", ref, "error", err)
 			http.Error(w, err.Error(), http.StatusBadGateway)
 			return
 		}
 	case kind == "blobs" && r.Method == http.MethodGet:
-		// Blobs populate only on GET. A HEAD on a missing blob stays
-		// cheap (returns 404 from the internal store); if the caller
-		// actually needs the bytes they'll follow up with a GET, which
-		// triggers the pull-through.
+		// GET only — a HEAD on a missing blob stays cheap (404 from
+		// the internal store); the follow-up GET triggers the pull.
 		if err := f.ensureBlob(r.Context(), ns, repo, ref); err != nil {
 			f.log.Warn("blob pull-through failed", "ns", ns, "repo", repo, "digest", ref, "error", err)
 			http.Error(w, err.Error(), http.StatusBadGateway)
@@ -278,13 +263,11 @@ func (f *Registry) serveInternal(w http.ResponseWriter, r *http.Request, path st
 	f.proxy.ServeHTTP(w, r)
 }
 
-// ensureManifest guarantees the (ns, repo, ref) manifest is present in the
-// internal store. Overridden refs are already present and marked, so this
-// is a no-op for them — that is what makes an override beat upstream.
-// Otherwise it pulls JUST the manifest bytes from the real upstream (named
-// by ns) with the host's live keychain and PUTs them into the internal
-// store. Referenced config and layer blobs are populated later, on demand,
-// by ensureBlob when containerd asks for them.
+// ensureManifest puts the (ns, repo, ref) manifest into the internal store
+// if it isn't there yet. Overridden refs are already present, so this
+// no-ops for them (that's how an override beats upstream). Otherwise it
+// pulls just the manifest bytes from ns with the host's keychain — blobs
+// come later via ensureBlob when containerd asks for them.
 func (f *Registry) ensureManifest(ctx context.Context, ns, repo, ref string) error {
 	k := key(ns, repo, ref)
 	f.mu.Lock()
@@ -319,10 +302,9 @@ func (f *Registry) ensureManifest(ctx context.Context, ns, repo, ref string) err
 		return fmt.Errorf("fetch manifest %s: %w", upstream, err)
 	}
 
-	// PUT the manifest bytes into the internal store under the safeNS'd
-	// repo. The store accepts a manifest even when referenced blobs aren't
-	// present yet — containerd will follow up with per-blob GETs which
-	// ensureBlob handles.
+	// PUT the manifest under the safeNS'd repo. The store accepts a
+	// manifest whose referenced blobs aren't there yet; per-blob GETs
+	// follow and land in ensureBlob.
 	putURL := fmt.Sprintf("%s/v2/%s/%s/manifests/%s", f.internalURL.String(), safeNS(ns), repo, ref)
 	req, err := http.NewRequestWithContext(ctx, http.MethodPut, putURL, bytes.NewReader(desc.Manifest))
 	if err != nil {
@@ -345,12 +327,10 @@ func (f *Registry) ensureManifest(ctx context.Context, ns, repo, ref string) err
 	return nil
 }
 
-// ensureBlob guarantees the blob at (ns, repo, digest) is present in the
-// internal store. Fast path if it's already there (populated by an
-// Override's crane.Push, or a prior ensureBlob). Otherwise pull just that
-// one blob from the upstream — one HTTP transfer, not the whole image, so
-// containerd's per-request timeout on the mirror never gets blocked by
-// unrelated layers.
+// ensureBlob puts the blob at (ns, repo, digest) into the internal store
+// if it isn't there yet. Fast path if an Override's crane.Push (or a prior
+// ensureBlob) already put it there. Otherwise: one blob, one HTTP transfer —
+// containerd's per-request timeout never blocks on unrelated layers.
 func (f *Registry) ensureBlob(ctx context.Context, ns, repo, digest string) error {
 	if f.blobExistsInternal(ctx, ns, repo, digest) {
 		return nil
@@ -362,9 +342,7 @@ func (f *Registry) ensureBlob(ctx context.Context, ns, repo, digest string) erro
 		return fmt.Errorf("parse blob digest %s: %w", upstream, err)
 	}
 
-	// remote.Layer streams the layer body — no local buffering of the whole
-	// blob happens here. WriteLayer streams straight into the internal
-	// store's blob-upload endpoint.
+	// remote.Layer + WriteLayer stream the body — no local buffering.
 	layer, err := remote.Layer(digestRef, f.remoteOpts(ctx)...)
 	if err != nil {
 		return fmt.Errorf("fetch blob %s: %w", upstream, err)
@@ -380,26 +358,21 @@ func (f *Registry) ensureBlob(ctx context.Context, ns, repo, digest string) erro
 	return nil
 }
 
-// manifestExistsInternal reports whether a manifest is already present in
-// the internal store, via a HEAD to its loopback endpoint. A non-200
-// (typically 404) or any error means "not present" — the caller then pulls
-// through.
+// manifestExistsInternal HEADs the loopback manifest endpoint. Any non-200
+// (typically 404) means "not present" — the caller pulls through.
 func (f *Registry) manifestExistsInternal(ctx context.Context, ns, repo, ref string) bool {
 	u := fmt.Sprintf("%s/v2/%s/%s/manifests/%s", f.internalURL.String(), safeNS(ns), repo, ref)
 	return f.internalHEAD(ctx, u, "*/*")
 }
 
-// blobExistsInternal reports whether a blob is already present in the
-// internal store. Same shape as manifestExistsInternal but on the
-// /blobs/<digest> endpoint; the store returns 200 when the layer exists.
+// blobExistsInternal is the /blobs/<digest> counterpart.
 func (f *Registry) blobExistsInternal(ctx context.Context, ns, repo, digest string) bool {
 	u := fmt.Sprintf("%s/v2/%s/%s/blobs/%s", f.internalURL.String(), safeNS(ns), repo, digest)
 	return f.internalHEAD(ctx, u, "*/*")
 }
 
-// internalHEAD is the shared 200/anything-else check the two exists funcs
-// use — a HEAD to the loopback internal store, treating any error as
-// "not present" so the caller can pull through.
+// internalHEAD returns whether the loopback endpoint answered 200; any
+// error is treated as "not present".
 func (f *Registry) internalHEAD(ctx context.Context, url, accept string) bool {
 	req, err := http.NewRequestWithContext(ctx, http.MethodHead, url, nil)
 	if err != nil {
@@ -508,10 +481,9 @@ func (f *Registry) pushOpts(ctx context.Context) []crane.Option {
 	return []crane.Option{crane.WithContext(ctx), crane.Insecure}
 }
 
-// remoteOpts is the go-containerregistry remote-package counterpart of the
-// old crane pullOpts (ensureManifest / ensureBlob use remote directly rather
-// than crane, so they can operate on a single manifest or blob without
-// touching the full image graph).
+// remoteOpts is the remote-package counterpart of the old crane pullOpts —
+// ensureManifest / ensureBlob use remote directly so they can pull a single
+// manifest or blob without walking the whole image graph.
 func (f *Registry) remoteOpts(ctx context.Context) []remote.Option {
 	return []remote.Option{
 		remote.WithContext(ctx),
@@ -519,17 +491,14 @@ func (f *Registry) remoteOpts(ctx context.Context) []remote.Option {
 	}
 }
 
-// pushRemoteOpts is the remote counterpart of pushOpts. The internal store
-// is plaintext http on loopback; internalNameOpts is what carries the
-// insecure flag into the WriteLayer call.
+// pushRemoteOpts is the remote counterpart of pushOpts. name.Insecure lives
+// on internalNameOpts, not here — WriteLayer picks it up from the Repository.
 func (f *Registry) pushRemoteOpts(ctx context.Context) []remote.Option {
 	return []remote.Option{remote.WithContext(ctx)}
 }
 
-// upstreamNameOpts controls how upstream refs (gcr.io/…, docker.io/…) are
-// parsed. Real upstreams are https, so we only pass name.Insecure when the
-// test-only InsecureUpstream is on — otherwise remote.Get on a real registry
-// would fall through to http and fail.
+// upstreamNameOpts parses real upstreams (gcr.io/…, docker.io/…) as https;
+// name.Insecure only for the test-only InsecureUpstream toggle.
 func (f *Registry) upstreamNameOpts() []name.Option {
 	if f.cfg.InsecureUpstream {
 		return []name.Option{name.Insecure}
@@ -537,9 +506,8 @@ func (f *Registry) upstreamNameOpts() []name.Option {
 	return nil
 }
 
-// internalNameOpts always forces plaintext HTTP: the internal loopback
-// store binds http-only, so without name.Insecure name.NewRepository would
-// try to reach it over https and fail.
+// internalNameOpts forces plaintext HTTP — the loopback store binds
+// http-only.
 func (f *Registry) internalNameOpts() []name.Option {
 	return []name.Option{name.Insecure}
 }


### PR DESCRIPTION
## Problem

Pulling a large image (Elasticsearch, Kibana) through the in-process localregistry facade fails on kind nodes with

```
Failed to pull image "…/kibana:master": rpc error: code = DeadlineExceeded desc = failed to pull and unpack image "…/kibana:master": failed to resolve reference "…/kibana:master": failed to do request: Head "http://…/v2/…/kibana/manifests/master?ns=…": net/http: timeout awaiting response headers
```

`net/http: timeout awaiting response headers` is containerd's per-request \`response_header_timeout\` on the mirror host firing. The facade's \`ensure()\` pulled the entire image (manifest + every layer) synchronously inside the manifest HEAD/GET, so containerd's HEAD to the mirror sat open for the whole transfer — minutes for Kibana / Elasticsearch.

## Fix

Split \`ensure()\` by request kind:

- **\`ensureManifest\`** — \`remote.Get\` fetches just the manifest bytes (a few KB, single HTTP call), PUT to the internal store. Sub-second even for huge images.
- **\`ensureBlob\`** — on a first-miss blob GET, \`remote.Layer\` + \`remote.WriteLayer\` pulls just that one blob. Time is one layer's transfer, not the whole image, so any single containerd blob request completes in a bounded window.
- **\`ServeHTTP\`** routes GET/HEAD to the matching \`ensureXxx\` per kind.

Overrides still push whole images (\`crane.Push\` in \`override.go\`) — they're local builds already on disk with no time cost, and pre-populating the internal store means blob HEADs on override refs go straight through.

Also raises per-host timeouts in \`hosts.toml\` (\`response_header_timeout = "15m"\`, \`request_timeout = "30m"\`) as a safety net for the streaming-layer case on slow upstreams. Warm-cache pulls stay ms-fast.

## Test plan

- [x] \`go test -race ./lib/kind/localregistry/...\` — pre-existing unit tests exercising \`TestNamespaceRouting\` (pull-through) and \`TestOverrideBeatsUpstream\` / \`TestShellPushOverride\` / \`TestOverrideRejectsDigest\` (override winning over pull-through) pass unchanged.
- [ ] \`go test -tags kindfv -run TestMirrorPullThrough -timeout 10m ./lib/kind/...\` — end-to-end pull of \`docker.io/library/busybox:1.36\` from inside a real kind node through the facade. Needs docker; run in CI or locally against a warm kind image.

**Release note:**
\`\`\`release-note
None
\`\`\`