### PR TITLE
[v3.33] fix(manifests): version the calico image in static manifests

### DIFF
--- a/manifests/apiserver.yaml
+++ b/manifests/apiserver.yaml
@@ -76,7 +76,7 @@ spec:
           env:
             - name: DATASTORE_TYPE
               value: kubernetes
-          image: quay.io/calico/calico:master
+          image: quay.io/calico/calico:release-v3.33
           name: calico-apiserver
           readinessProbe:
             httpGet:

--- a/manifests/calicoctl-etcd.yaml
+++ b/manifests/calicoctl-etcd.yaml
@@ -1,7 +1,7 @@
 # Calico Version master
 # https://projectcalico.docs.tigera.io/releases#master
 # This manifest includes the following component versions:
-#   calico/ctl:master
+#   calico/calico:master
 
 apiVersion: v1
 kind: Pod
@@ -14,9 +14,9 @@ spec:
   hostNetwork: true
   containers:
     - name: calicoctl
-      image: quay.io/calico/ctl:master
+      image: quay.io/calico/calico:master
       command:
-        - calicoctl
+        - /usr/bin/calicoctl
       args:
         - version
         - --poll=1m

--- a/manifests/calicoctl-etcd.yaml
+++ b/manifests/calicoctl-etcd.yaml
@@ -1,7 +1,7 @@
-# Calico Version master
-# https://projectcalico.docs.tigera.io/releases#master
+# Calico Version release-v3.33
+# https://projectcalico.docs.tigera.io/releases#release-v3.33
 # This manifest includes the following component versions:
-#   calico/calico:master
+#   calico/calico:release-v3.33
 
 apiVersion: v1
 kind: Pod
@@ -14,7 +14,7 @@ spec:
   hostNetwork: true
   containers:
     - name: calicoctl
-      image: quay.io/calico/calico:master
+      image: quay.io/calico/calico:release-v3.33
       command:
         - /usr/bin/calicoctl
       args:

--- a/manifests/calicoctl.yaml
+++ b/manifests/calicoctl.yaml
@@ -1,7 +1,7 @@
-# Calico Version master
-# https://projectcalico.docs.tigera.io/releases#master
+# Calico Version release-v3.33
+# https://projectcalico.docs.tigera.io/releases#release-v3.33
 # This manifest includes the following component versions:
-#   calico/calico:master
+#   calico/calico:release-v3.33
 
 apiVersion: v1
 kind: ServiceAccount
@@ -22,7 +22,7 @@ spec:
   serviceAccountName: calicoctl
   containers:
     - name: calicoctl
-      image: quay.io/calico/calico:master
+      image: quay.io/calico/calico:release-v3.33
       command:
         - /usr/bin/calicoctl
       args:

--- a/manifests/csi-driver.yaml
+++ b/manifests/csi-driver.yaml
@@ -46,7 +46,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: calico-csi
-          image: quay.io/calico/calico:master
+          image: quay.io/calico/calico:release-v3.33
           imagePullPolicy: IfNotPresent
           command: ["/usr/bin/calico", "component", "csi"]
           args:
@@ -72,7 +72,7 @@ spec:
               mountPath: /var/lib/kubelet/
               mountPropagation: "Bidirectional"
         - name: csi-node-driver-registrar
-          image: quay.io/calico/calico:master
+          image: quay.io/calico/calico:release-v3.33
           imagePullPolicy: IfNotPresent
           command: ["/usr/bin/csi-node-driver-registrar"]
           args:

--- a/manifests/flannel-migration/migration-job.yaml
+++ b/manifests/flannel-migration/migration-job.yaml
@@ -159,7 +159,7 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: flannel-migration-controller
-          image: quay.io/calico/calico:master
+          image: quay.io/calico/calico:release-v3.33
           command:
             - /usr/bin/calico
             - component

--- a/manifests/generate.sh
+++ b/manifests/generate.sh
@@ -44,7 +44,7 @@ OPERATOR_REGISTRY=${OPERATOR_REGISTRY_OVERRIDE:-$defaultOperatorRegistry}
 defaultOperatorImage=$($YQ .tigeraOperator.image <../charts/tigera-operator/values.yaml)
 OPERATOR_IMAGE=${OPERATOR_IMAGE_OVERRIDE:-$defaultOperatorImage}
 
-NON_HELM_MANIFEST_IMAGES="node-windows"
+NON_HELM_MANIFEST_IMAGES="node-windows calico"
 
 echo "Generating manifests for Calico=$CALICO_VERSION and tigera-operator=$OPERATOR_VERSION"
 
@@ -190,5 +190,11 @@ echo "Replacing image versions for static manifests"
 for img in $NON_HELM_MANIFEST_IMAGES; do
   new_img=${REGISTRY}/${img}
   echo "Update $img image to $new_img:$CALICO_VERSION"
-  find . -type f -exec sed -i "s|image: [a-zA-Z0-9/._-]*/${img}:[A-Za-z0-9_.-]*|image: ${new_img}:$CALICO_VERSION|g" {} \;
+  find . -type f -exec sed -i "s|image: [a-zA-Z0-9/._:-]*/${img}:[A-Za-z0-9_.-]*|image: ${new_img}:$CALICO_VERSION|g" {} \;
 done
+
+# Version the manifest header comments, which carry no "image:" prefix.
+find . -type f -name "*.yaml" -exec sed -i -E \
+  -e "s|^(#[[:space:]]+)calico/calico:[A-Za-z0-9_.-]*|\1calico/calico:$CALICO_VERSION|g" \
+  -e "s|^(#[[:space:]]*Calico Version[[:space:]]+)[A-Za-z0-9_.-]*|\1$CALICO_VERSION|g" \
+  -e "s|^(#[[:space:]]*https://\S*/releases#)[A-Za-z0-9_.-]*|\1$CALICO_VERSION|g" {} \;


### PR DESCRIPTION
Cherry-pick of projectcalico/calico#13543 onto release-v3.33.

Static manifests that Helm doesn't render kept their image tag at `master` instead of the release version. Consolidating the components into one `calico` image left no image name for the version-substitution step to match, so `calicoctl.yaml`, `calicoctl-etcd.yaml`, `apiserver.yaml` and `csi-driver.yaml` stopped getting stamped. Add `calico` to the substitution list and version the header comments too. `calicoctl-etcd.yaml` also referenced `calico/ctl`, which is no longer built, so it now uses the `calico` image and the same `/usr/bin/calicoctl` command as `calicoctl.yaml`. The second commit is the regenerated manifests, which now stamp `release-v3.33`.

**Release note:**
```release-note
TBD
```


<details>
<summary><b>Cherry-Pick PR details</b></summary>

- **Original PR ID**: 13543
- **Original Commit SHA**: ada2861030
- **Source Repo**: `projectcalico/calico`
- **Target Repo**: `projectcalico/calico`
- **Target Branch**: `release-v3.33`
</details>
