### PR TITLE
[release-v3.32] cherry-pick: Avoid masquerading tunnel traffic onto the VXLAN port

### DIFF
--- a/felix/fv/vxlan_test.go
+++ b/felix/fv/vxlan_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2025 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2026 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ package fv_test
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -1028,6 +1029,115 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ VXLAN topology before addin
 			})
 		})
 	}
+})
+
+// The masquerade that Felix applies to host traffic leaving the tunnel must not pick the VXLAN
+// port as its source port.  If it does, the reply arrives with the VXLAN port as its destination
+// and gets caught by the "drop VXLAN packets from non-allowed hosts" rule.
+// See https://github.com/projectcalico/calico/issues/12244.
+var _ = infrastructure.DatastoreDescribe("VXLAN topology with masqueraded host traffic", []apiconfig.DatastoreType{apiconfig.Kubernetes}, func(getInfra infrastructure.InfraFactory) {
+	// Sit the VXLAN port near the middle of the masquerade range.  Felix takes the wider side
+	// of the port, so the range it programs is 33001-65535, roughly half of the 1024-65535 that
+	// an unconstrained masquerade would use.  That gives the sampling below decent odds of
+	// spotting a masquerade with no range on it.
+	const (
+		vxlanPort     = 33000
+		masqPortRange = "33001-65535"
+		minMasqPort   = 33001
+		workloadPort  = "8055"
+	)
+
+	var (
+		infra infrastructure.DatastoreInfra
+		tc    infrastructure.TopologyContainers
+		w     *workload.Workload
+	)
+
+	BeforeEach(func() {
+		infra = getInfra()
+
+		if BPFMode() {
+			Skip("BPF mode doesn't use the masquerade rules under test.")
+		}
+
+		topologyOptions := createVXLANBaseTopologyOptions(api.VXLANModeAlways, false, "CalicoIPAM", false)
+		topologyOptions.ExtraEnvVars["FELIX_VXLANPort"] = fmt.Sprint(vxlanPort)
+
+		var cli client.Interface
+		tc, cli = infrastructure.StartNNodeTopology(2, topologyOptions, infra)
+		assignTunnelAddresses(infra, tc, cli)
+
+		infra.AddDefaultAllow()
+		waitForVXLANDevice(tc, false)
+
+		// The first node sends to this workload over the tunnel.
+		wIP := "10.65.1.2"
+		infrastructure.AssignIP("w1", wIP, tc.Felixes[1].Hostname, cli)
+		w = workload.Run(tc.Felixes[1], "w1", "default", wIP, workloadPort, "udp")
+		w.ConfigureInInfra(infra)
+
+		ensureRoutesProgrammed(tc.Felixes)
+	})
+
+	AfterEach(func() {
+		if CurrentSpecReport().Failed() {
+			for _, felix := range tc.Felixes {
+				if NFTMode() {
+					logNFTDiags(felix)
+				} else {
+					felix.Exec("iptables-save", "-c", "-t", "nat")
+				}
+				felix.Exec("ip", "r")
+				felix.Exec("ip", "a")
+			}
+		}
+	})
+
+	It("should masquerade to a source port that can't be the VXLAN port", func() {
+		expectedRule := "--to-ports " + masqPortRange
+		if NFTMode() {
+			expectedRule = "masquerade to :" + masqPortRange
+		}
+		for _, felix := range tc.Felixes {
+			Eventually(func() string {
+				if NFTMode() {
+					out, _ := felix.ExecOutput("nft", "list", "table", "calico")
+					return out
+				}
+				out, _ := felix.ExecOutput("iptables-save", "-t", "nat")
+				return out
+			}, "10s", "100ms").Should(ContainSubstring(expectedRule))
+		}
+
+		// The masquerade only kicks in for host traffic that isn't already sourced from the
+		// tunnel address, so send from the node's own address.  The workload reports the
+		// source it sees, which is the masqueraded one.
+		masqueradedPort := func() (int, error) {
+			res := tc.Felixes[0].CanConnectTo(w.IP, workloadPort, "udp", connectivity.WithSourceIP(tc.Felixes[0].IP))
+			if !res.HasConnectivity() {
+				return 0, fmt.Errorf("no connectivity from %s to %s", tc.Felixes[0].IP, w.IP)
+			}
+			addr := res.LastResponse.SourceAddr
+			i := strings.LastIndex(addr, ":")
+			if i < 0 {
+				return 0, fmt.Errorf("no port in source address %q", addr)
+			}
+			return strconv.Atoi(addr[i+1:])
+		}
+
+		Eventually(func() error {
+			_, err := masqueradedPort()
+			return err
+		}, "30s", "1s").ShouldNot(HaveOccurred())
+
+		// Port selection is fully random, so one sample proves little.  Twenty of them put the
+		// odds of an unconstrained masquerade staying inside the range at about one in a million.
+		for range 20 {
+			port, err := masqueradedPort()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(port).To(BeNumerically(">=", minMasqPort), "masqueraded source port should be within %s", masqPortRange)
+		}
+	})
 })
 
 func createVXLANBaseTopologyOptions(vxlanMode api.VXLANMode, enableIPv6 bool, routeSource string, brokenXSum bool) infrastructure.TopologyOptions {

--- a/felix/rules/static.go
+++ b/felix/rules/static.go
@@ -918,6 +918,16 @@ func (r *DefaultRuleRenderer) StaticNATPostroutingChains(ipVersion uint8) []*gen
 		}, rules...)
 	}
 
+	// If a masquerade below picks the VXLAN port as the source port, replies come back
+	// with that as their dest port and get caught by our "Drop VXLAN packets from
+	// non-allowed hosts" filter rule. When VXLAN is enabled, build a source port range
+	// that excludes the VXLAN port and apply it to the UDP masquerade below.
+	// See https://github.com/projectcalico/calico/issues/12244.
+	masqToPorts := ""
+	if (ipVersion == 4 && r.VXLANEnabled) || (ipVersion == 6 && r.VXLANEnabledV6) {
+		masqToPorts = masqPortRangeExcluding(r.VXLANPort)
+	}
+
 	var tunnelIfaces []string
 
 	if ipVersion == 4 && r.IPIPEnabled && len(r.IPIPTunnelAddress) > 0 {
@@ -956,19 +966,29 @@ func (r *DefaultRuleRenderer) StaticNATPostroutingChains(ipVersion uint8) []*gen
 		// Other remote sources will only reach the tunnel if they're being NATted
 		// already (for example, a Kubernetes "NodePort").  The kernel will then
 		// choose the correct source on its own.
+		//
+		// Both rules below share the same match: packets going out the tunnel
+		// (OutInterface) whose source is not the tunnel's own address (NotSrcAddrType,
+		// limited to the output interface) but is some local IP on the box (SrcAddrType).
+		// Matching on address type rather than the specific IP keeps the rule static.
+		if masqToPorts != "" {
+			// Only UDP can hit the drop rule, so only UDP needs its source port
+			// constrained; the rule below masquerades everything else normally. A
+			// separate rule is needed regardless, since --to-ports is only valid on a
+			// rule that also matches a protocol.
+			rules = append(rules, generictables.Rule{
+				Match: r.NewMatch().
+					ProtocolNum(ProtoUDP).
+					OutInterface(tunnel).
+					NotSrcAddrType(generictables.AddrTypeLocal, true).
+					SrcAddrType(generictables.AddrTypeLocal, false),
+				Action: r.Masq(masqToPorts),
+			})
+		}
 		rules = append(rules, generictables.Rule{
 			Match: r.NewMatch().
-				// Only match packets going out the tunnel.
 				OutInterface(tunnel).
-				// Match packets that don't have the correct source address.  This
-				// matches local addresses (i.e. ones assigned to this host)
-				// limiting the match to the output interface (which we matched
-				// above as the tunnel).  Avoiding embedding the IP address lets
-				// us use a static rule, which is easier to manage.
 				NotSrcAddrType(generictables.AddrTypeLocal, true).
-				// Only match if the IP is also some local IP on the box.  This
-				// prevents us from matching packets from workloads, which are
-				// remote as far as the routing table is concerned.
 				SrcAddrType(generictables.AddrTypeLocal, false),
 			Action: r.Masq(""),
 		})
@@ -977,6 +997,21 @@ func (r *DefaultRuleRenderer) StaticNATPostroutingChains(ipVersion uint8) []*gen
 		Name:  ChainNATPostrouting,
 		Rules: rules,
 	}}
+}
+
+// masqPortRangeExcluding returns a masquerade "--to-ports" range that excludes the given
+// port. iptables and nftables only accept a single contiguous range, so we can't punch a
+// hole in the middle; instead we take whichever side of the port is wider, with a floor of
+// 1024 to stay off privileged ports. Returns "" (no restriction) for an out-of-range port.
+func masqPortRangeExcluding(port int) string {
+	if port <= 0 || port > 65535 {
+		return ""
+	}
+	const lo, hi = 1024, 65535
+	if port-lo >= hi-port {
+		return fmt.Sprintf("%d-%d", lo, port-1)
+	}
+	return fmt.Sprintf("%d-%d", port+1, hi)
 }
 
 func (r *DefaultRuleRenderer) StaticNATOutputChains(ipVersion uint8) []*generictables.Chain {

--- a/felix/rules/static_test.go
+++ b/felix/rules/static_test.go
@@ -1064,6 +1064,7 @@ var _ = Describe("Static", func() {
 			Describe("with IPv4 VXLAN enabled", func() {
 				BeforeEach(func() {
 					conf.VXLANEnabled = true
+					conf.VXLANPort = 4789
 				})
 
 				checkManglePostrouting(4, kubeIPVSEnabled)
@@ -1075,6 +1076,14 @@ var _ = Describe("Static", func() {
 							Rules: []generictables.Rule{
 								{Action: iptables.JumpAction{Target: "cali-fip-snat"}},
 								{Action: iptables.JumpAction{Target: "cali-nat-outgoing"}},
+								{
+									Match: iptables.Match().
+										ProtocolNum(ProtoUDP).
+										OutInterface(dataplanedefs.IPIPIfaceName).
+										NotSrcAddrType(generictables.AddrTypeLocal, true).
+										SrcAddrType(generictables.AddrTypeLocal, false),
+									Action: iptables.MasqAction{ToPorts: "4790-65535"},
+								},
 								{
 									Match: iptables.Match().
 										OutInterface(dataplanedefs.IPIPIfaceName).
@@ -1166,10 +1175,26 @@ var _ = Describe("Static", func() {
 									{Action: iptables.JumpAction{Target: "cali-nat-outgoing"}},
 									{
 										Match: iptables.Match().
+											ProtocolNum(ProtoUDP).
+											OutInterface(dataplanedefs.IPIPIfaceName).
+											NotSrcAddrType(generictables.AddrTypeLocal, true).
+											SrcAddrType(generictables.AddrTypeLocal, false),
+										Action: iptables.MasqAction{ToPorts: "4790-65535"},
+									},
+									{
+										Match: iptables.Match().
 											OutInterface(dataplanedefs.IPIPIfaceName).
 											NotSrcAddrType(generictables.AddrTypeLocal, true).
 											SrcAddrType(generictables.AddrTypeLocal, false),
 										Action: iptables.MasqAction{},
+									},
+									{
+										Match: iptables.Match().
+											ProtocolNum(ProtoUDP).
+											OutInterface(dataplanedefs.VXLANIfaceNameV4).
+											NotSrcAddrType(generictables.AddrTypeLocal, true).
+											SrcAddrType(generictables.AddrTypeLocal, false),
+										Action: iptables.MasqAction{ToPorts: "4790-65535"},
 									},
 									{
 										Match: iptables.Match().
@@ -1182,12 +1207,27 @@ var _ = Describe("Static", func() {
 							},
 						}))
 					})
+
+					Describe("with a high custom VXLAN port", func() {
+						BeforeEach(func() {
+							conf.VXLANPort = 60000
+						})
+
+						It("IPv4: Should masquerade UDP to the wider range below the VXLAN port", func() {
+							chains := rr.StaticNATPostroutingChains(4)
+							// Rules[2] is the UDP masquerade with the port range excluding the
+							// custom VXLAN port; Rules[3] is the catch-all with no range.
+							Expect(chains[0].Rules[2].Action).To(Equal(iptables.MasqAction{ToPorts: "1024-59999"}))
+							Expect(chains[0].Rules[3].Action).To(Equal(iptables.MasqAction{}))
+						})
+					})
 				})
 			})
 
 			Describe("with IPv6 VXLAN enabled", func() {
 				BeforeEach(func() {
 					conf.VXLANEnabledV6 = true
+					conf.VXLANPort = 4789
 				})
 
 				checkManglePostrouting(6, kubeIPVSEnabled)
@@ -1258,6 +1298,14 @@ var _ = Describe("Static", func() {
 								Rules: []generictables.Rule{
 									{Action: iptables.JumpAction{Target: "cali-fip-snat"}},
 									{Action: iptables.JumpAction{Target: "cali-nat-outgoing"}},
+									{
+										Match: iptables.Match().
+											ProtocolNum(ProtoUDP).
+											OutInterface(dataplanedefs.VXLANIfaceNameV6).
+											NotSrcAddrType(generictables.AddrTypeLocal, true).
+											SrcAddrType(generictables.AddrTypeLocal, false),
+										Action: iptables.MasqAction{ToPorts: "4790-65535"},
+									},
 									{
 										Match: iptables.Match().
 											OutInterface(dataplanedefs.VXLANIfaceNameV6).


### PR DESCRIPTION
## Summary
Cherry-pick of https://github.com/projectcalico/calico/pull/13118 onto `release-v3.32` for **v3.32.2**.

Fixes https://github.com/projectcalico/calico/issues/12244.

@matthewdupre — a couple of notes for review:

- **Cherry-pick had no conflicts.** This is a straight `git cherry-pick -x cc381bfc27` of the squash-merge of #13118 onto current `release-v3.32`. Same 3 files, +203/−10. No manual resolution, no extra commits, no 3.32-specific edits.
- **Please switch the docs label.** Marvin tagged this `docs-pr-required`; the original #13118 is `docs-not-required` (no docs change). I do not have permission to change labels on this repo. Same for requesting reviewers — I cannot `gh pr edit --add-reviewer`.
- `release-note-required` is correct; release note is below (same as #13118).

Casey confirmed this is OK to backport to v3.32 / v3.31. There was no cherry-pick PR until now, so it is targeting v3.32.2.

## Test plan
- [ ] CI on this PR
- [ ] Confirm NAT postrouting UDP masquerade uses `--to-ports` excluding the VXLAN port (iptables and nftables)
- [ ] Original FV: host traffic leaving the tunnel is not masqueraded onto the VXLAN port

```release-note
Fix VXLAN traffic being dropped when the kernel masqueraded a tunnel flow's source port onto the VXLAN port (default 4789).
```