### PR TITLE
e2e: treat an unrecognised programClusterRoutes value as Felix owning IPIP

### DIFF
--- a/e2e/pkg/tests/bgp/utils.go
+++ b/e2e/pkg/tests/bgp/utils.go
@@ -48,7 +48,9 @@ func requireBGPIsSoleRoutingMechanism(cli ctrlclient.Client) {
 	var felixOwnsIPIP, felixOwnsNoEncap bool
 	switch programClusterRoutes {
 	case v3.Disabled:
-		// BIRD owns both classes.
+		// Felix programs neither class.  Whether BIRD picks them up is BGPConfiguration's
+		// business, and it is expressible for neither component to; this check only needs
+		// Felix to be keeping out of the way.
 	case v3.EnabledIPIPOnly:
 		felixOwnsIPIP = true
 	case v3.EnabledNoEncapOnly:

--- a/e2e/pkg/tests/bgp/utils.go
+++ b/e2e/pkg/tests/bgp/utils.go
@@ -44,8 +44,25 @@ func requireBGPIsSoleRoutingMechanism(cli ctrlclient.Client) {
 	if fc.Spec.ProgramClusterRoutes != nil {
 		programClusterRoutes = *fc.Spec.ProgramClusterRoutes
 	}
-	felixOwnsIPIP := programClusterRoutes == v3.Enabled || programClusterRoutes == v3.EnabledIPIPOnly
-	felixOwnsNoEncap := programClusterRoutes == v3.Enabled || programClusterRoutes == v3.EnabledNoEncapOnly
+
+	var felixOwnsIPIP, felixOwnsNoEncap bool
+	switch programClusterRoutes {
+	case v3.Disabled:
+		// BIRD owns both classes.
+	case v3.EnabledIPIPOnly:
+		felixOwnsIPIP = true
+	case v3.EnabledNoEncapOnly:
+		felixOwnsNoEncap = true
+	case v3.Enabled:
+		felixOwnsIPIP, felixOwnsNoEncap = true, true
+	default:
+		// A value this binary does not recognise, from a cluster whose CRD is newer than the
+		// test.  Felix replaces an unparseable value with the parameter's default, which is
+		// EnabledIPIPOnly, so conclude that rather than "Felix owns neither" -- the latter would
+		// let these tests run against a cluster where Felix is in fact programming the IPIP
+		// cluster routes, and they would fail on connectivity rather than skipping here.
+		felixOwnsIPIP = true
+	}
 
 	fail := func(pool v3.IPPool, why string) {
 		framework.Failf(


### PR DESCRIPTION
## Description

**Type:** bug fix, tests only. Follow-up to #13470, from a Copilot review comment on its
calico-private pick (tigera/calico-private#13431).

`requireBGPIsSoleRoutingMechanism` guards the `bgp` e2e specs that disable the node-to-node mesh
and expect connectivity to break — which only holds if BIRD owns every cross-node route. It worked
out ownership by naming the values that hand each class of route to Felix:

```go
felixOwnsIPIP := programClusterRoutes == v3.Enabled || programClusterRoutes == v3.EnabledIPIPOnly
```

so a value it did not recognise matched neither arm and it concluded Felix owned nothing. Felix does
not behave that way: it replaces an unparseable value with the parameter's default, which since
v3.33 is `EnabledIPIPOnly`. On a cluster whose CRD is newer than the test binary, the guard would
therefore let these specs proceed while Felix was in fact programming the IPIP cluster routes, and
they would fail later on a connectivity assertion rather than failing here with a clear reason.

This names the values that leave each class *with BIRD* instead, so anything unrecognised lands on
the default.

Note that only the IPIP conclusion changes. The default leaves unencapsulated pools with BIRD, so
"unrecognised means Felix does not own the no-encap routes" was already correct — the review comment
suggested both booleans needed it, but the second was already right.

The same fix was made in `expectedIPIPClusterRouteProto` in
`node/tests/k8st/tests/cluster_routes_test.go` and `e2e/pkg/tests/networking/routes.go` during
review of #13470; this third helper was missed. It is now written as a switch, matching those two,
with the reasoning in the `default:` arm where a reader will look for it.

## Testing

No behaviour change for any recognised value, so the existing `bgp` suite covers it; `go vet` clean.
The changed path needs a cluster carrying a `programClusterRoutes` value this binary does not know,
which cannot be constructed from within the test — hence no new test.

**Release note:**
```release-note
None
```