### PR TITLE
e2e: regenerate the test sets for the QoS connection-limit spec

### DIFF
--- a/e2e/testsets/index.txt
+++ b/e2e/testsets/index.txt
@@ -2,83 +2,83 @@
 # ci file | lane | test set | specs
 .argoci/cron/e2e-benchmarking.yaml | benchmarks | (benchmark) | -
 .argoci/cron/e2e-benchmarking.yaml | tiger-bench | (tiger-bench) | -
-.argoci/cron/e2e-bpf.yaml | 9k-mtu-runs-aws-bpf-9k-mtu | bpf/bpf-extnode-aws | 219
-.argoci/cron/e2e-bpf.yaml | 9k-mtu-runs-aws-iptables-9k-mtu | bpf/xtables-extnode-aws | 223
-.argoci/cron/e2e-bpf.yaml | arm64-smoke-tests-aks-arm64 [stable-1-azure-] | bpf/aks-bpf-nobgp | 209
-.argoci/cron/e2e-bpf.yaml | arm64-smoke-tests-aks-arm64 [stable-1-none-] | bpf/aks-bpf | 212
-.argoci/cron/e2e-bpf.yaml | arm64-smoke-tests-kubeadm-arm64 | bpf/bpf | 216
+.argoci/cron/e2e-bpf.yaml | 9k-mtu-runs-aws-bpf-9k-mtu | bpf/bpf-extnode-aws | 220
+.argoci/cron/e2e-bpf.yaml | 9k-mtu-runs-aws-iptables-9k-mtu | bpf/xtables-extnode-aws | 224
+.argoci/cron/e2e-bpf.yaml | arm64-smoke-tests-aks-arm64 [stable-1-azure-] | bpf/aks-bpf-nobgp | 210
+.argoci/cron/e2e-bpf.yaml | arm64-smoke-tests-aks-arm64 [stable-1-none-] | bpf/aks-bpf | 213
+.argoci/cron/e2e-bpf.yaml | arm64-smoke-tests-kubeadm-arm64 | bpf/bpf | 217
 .argoci/cron/e2e-bpf.yaml | bpf-mini-scale-runs | (scale-test) | -
-.argoci/cron/e2e-bpf.yaml | bpf-run-matrix-aks-w-aks-cni | bpf/aks-bpf-nobgp | 209
-.argoci/cron/e2e-bpf.yaml | bpf-run-matrix-aks-w-calico-cni | bpf/aks-bpf | 212
-.argoci/cron/e2e-bpf.yaml | bpf-run-matrix-aws-encap [false] | bpf/bpf-v3crd-extnode-aws | 215
-.argoci/cron/e2e-bpf.yaml | bpf-run-matrix-aws-encap [true] | bpf/bpf-encap-v3crd-extnode-aws | 211
-.argoci/cron/e2e-bpf.yaml | bpf-run-matrix-aws-kops-rhel8-2 | bpf/kops-bpf-extnode-aws | 208
-.argoci/cron/e2e-bpf.yaml | bpf-run-matrix-aws-kubeadm-dual-stack [dual-calicobpf] | bpf/bpf-encap-extnode-aws | 215
-.argoci/cron/e2e-bpf.yaml | bpf-run-matrix-aws-kubeadm-dual-stack [dual-calicoiptables] | bpf/xtables-encap-extnode-aws | 219
-.argoci/cron/e2e-bpf.yaml | bpf-run-matrix-aws-lb-bpf | bpf/eks-bpf-encap-extnode-aws | 205
-.argoci/cron/e2e-bpf.yaml | bpf-run-matrix-aws-lb-iptables | bpf/eks-xtables-encap-extnode-aws | 209
-.argoci/cron/e2e-bpf.yaml | bpf-run-matrix-aws-single-subnet-dual-ip-family | bpf-aws-single-subnet | 554
-.argoci/cron/e2e-bpf.yaml | bpf-run-matrix-aws-talos-no-encap-dsr | bpf/bpf-aws | 215
-.argoci/cron/e2e-bpf.yaml | bpf-run-matrix-bpf-aks-w-aks-cni-overlay | bpf/aks-bpf-encap-nobgp | 207
-.argoci/cron/e2e-bpf.yaml | bpf-run-matrix-eks-w-aws-cni | bpf/bpf-nobgp-extnode-aws | 216
-.argoci/cron/e2e-bpf.yaml | bpf-run-matrix-eks-w-calico-cni | bpf/eks-bpf-encap-extnode-aws | 205
-.argoci/cron/e2e-bpf.yaml | bpf-run-matrix-gcp-bpf-dp-dsr | bpf/bpf-v3crd-extnode | 215
-.argoci/cron/e2e-bpf.yaml | bpf-run-matrix-gcp-bpf-dp-encap-w-nodelocal-dnscache [false-netkit] | bpf/bpf-extnode | 219
-.argoci/cron/e2e-bpf.yaml | bpf-run-matrix-gcp-bpf-dp-encap-w-nodelocal-dnscache [true] | bpf/bpf-encap-extnode | 215
-.argoci/cron/e2e-bpf.yaml | bpf-run-matrix-kops-w-calico-cni-ipv4 [calicobpf-ipv4] | bpf/kops-bpf-encap-nobgp-extnode-aws | 203
-.argoci/cron/e2e-bpf.yaml | bpf-run-matrix-kops-w-calico-cni-ipv4 [calicoiptables-ipv4] | bpf/kops-xtables-encap-nobgp-extnode-aws | 207
-.argoci/cron/e2e-bpf.yaml | bpf-run-matrix-kops-w-calico-cni-ipv6 [calicobpf-ipv6] | bpf/kops-bpf-encap-nobgp-extnode-aws | 203
-.argoci/cron/e2e-bpf.yaml | bpf-run-matrix-kops-w-calico-cni-ipv6 [calicoiptables-ipv6] | bpf/kops-xtables-encap-nobgp-extnode-aws | 207
+.argoci/cron/e2e-bpf.yaml | bpf-run-matrix-aks-w-aks-cni | bpf/aks-bpf-nobgp | 210
+.argoci/cron/e2e-bpf.yaml | bpf-run-matrix-aks-w-calico-cni | bpf/aks-bpf | 213
+.argoci/cron/e2e-bpf.yaml | bpf-run-matrix-aws-encap [false] | bpf/bpf-v3crd-extnode-aws | 216
+.argoci/cron/e2e-bpf.yaml | bpf-run-matrix-aws-encap [true] | bpf/bpf-encap-v3crd-extnode-aws | 212
+.argoci/cron/e2e-bpf.yaml | bpf-run-matrix-aws-kops-rhel8-2 | bpf/kops-bpf-extnode-aws | 209
+.argoci/cron/e2e-bpf.yaml | bpf-run-matrix-aws-kubeadm-dual-stack [dual-calicobpf] | bpf/bpf-encap-extnode-aws | 216
+.argoci/cron/e2e-bpf.yaml | bpf-run-matrix-aws-kubeadm-dual-stack [dual-calicoiptables] | bpf/xtables-encap-extnode-aws | 220
+.argoci/cron/e2e-bpf.yaml | bpf-run-matrix-aws-lb-bpf | bpf/eks-bpf-encap-extnode-aws | 206
+.argoci/cron/e2e-bpf.yaml | bpf-run-matrix-aws-lb-iptables | bpf/eks-xtables-encap-extnode-aws | 210
+.argoci/cron/e2e-bpf.yaml | bpf-run-matrix-aws-single-subnet-dual-ip-family | bpf-aws-single-subnet | 555
+.argoci/cron/e2e-bpf.yaml | bpf-run-matrix-aws-talos-no-encap-dsr | bpf/bpf-aws | 216
+.argoci/cron/e2e-bpf.yaml | bpf-run-matrix-bpf-aks-w-aks-cni-overlay | bpf/aks-bpf-encap-nobgp | 208
+.argoci/cron/e2e-bpf.yaml | bpf-run-matrix-eks-w-aws-cni | bpf/bpf-nobgp-extnode-aws | 217
+.argoci/cron/e2e-bpf.yaml | bpf-run-matrix-eks-w-calico-cni | bpf/eks-bpf-encap-extnode-aws | 206
+.argoci/cron/e2e-bpf.yaml | bpf-run-matrix-gcp-bpf-dp-dsr | bpf/bpf-v3crd-extnode | 216
+.argoci/cron/e2e-bpf.yaml | bpf-run-matrix-gcp-bpf-dp-encap-w-nodelocal-dnscache [false-netkit] | bpf/bpf-extnode | 220
+.argoci/cron/e2e-bpf.yaml | bpf-run-matrix-gcp-bpf-dp-encap-w-nodelocal-dnscache [true] | bpf/bpf-encap-extnode | 216
+.argoci/cron/e2e-bpf.yaml | bpf-run-matrix-kops-w-calico-cni-ipv4 [calicobpf-ipv4] | bpf/kops-bpf-encap-nobgp-extnode-aws | 204
+.argoci/cron/e2e-bpf.yaml | bpf-run-matrix-kops-w-calico-cni-ipv4 [calicoiptables-ipv4] | bpf/kops-xtables-encap-nobgp-extnode-aws | 208
+.argoci/cron/e2e-bpf.yaml | bpf-run-matrix-kops-w-calico-cni-ipv6 [calicobpf-ipv6] | bpf/kops-bpf-encap-nobgp-extnode-aws | 204
+.argoci/cron/e2e-bpf.yaml | bpf-run-matrix-kops-w-calico-cni-ipv6 [calicoiptables-ipv6] | bpf/kops-xtables-encap-nobgp-extnode-aws | 208
 .argoci/cron/e2e-bpf.yaml | kubevirt-e2e-tests | gcp/kubevirt | 8
 .argoci/cron/e2e-bpf.yaml | usage-reporting-with-bpf | (usage-reporting) | -
-.argoci/cron/e2e-bpf.yaml | wireguard | bpf/aks-bpf-encap-nobgp | 207
+.argoci/cron/e2e-bpf.yaml | wireguard | bpf/aks-bpf-encap-nobgp | 208
 .argoci/cron/e2e-certification.yaml | hcp-hosted-setup-and-tests | (ocp-cert) | -
 .argoci/cron/e2e-certification.yaml | hcp-setup-hosting | (ocp-cert) | -
 .argoci/cron/e2e-certification.yaml | standalone-cluster-tests | (ocp-cert) | -
-.argoci/cron/e2e-iptables.yaml | aks-aks-migrate-from-vendored-calico-cni-to-calico-cni | iptables/aks-xtables-encap | 212
-.argoci/cron/e2e-iptables.yaml | aks-aks-private-w-aks-cni-overlay | iptables/aks-xtables-nobgp | 196
-.argoci/cron/e2e-iptables.yaml | aks-aks-w-aks-cni | iptables/aks-xtables-nobgp | 196
-.argoci/cron/e2e-iptables.yaml | aks-aks-w-calico-cni | iptables/aks-xtables-encap | 212
-.argoci/cron/e2e-iptables.yaml | arm64-smoke-tests-aks-arm64 [stable-1-azure-] | iptables/aks-xtables-nobgp | 196
-.argoci/cron/e2e-iptables.yaml | arm64-smoke-tests-aks-arm64 [stable-1-none-] | iptables/aks-xtables-encap | 212
-.argoci/cron/e2e-iptables.yaml | arm64-smoke-tests-eks-arm64-calico-cni | iptables/eks-xtables-encap-aws | 205
-.argoci/cron/e2e-iptables.yaml | autohep-test | iptables/xtables-autohep | 222
-.argoci/cron/e2e-iptables.yaml | datastore-k8s-e2e-etcd | iptables/xtables-manifest-v3crd | 207
-.argoci/cron/e2e-iptables.yaml | datastore-k8s-e2e-kdd-new | iptables/xtables-manifest | 211
-.argoci/cron/e2e-iptables.yaml | datastore-k8s-e2e-kdd-old | iptables/xtables-manifest | 211
-.argoci/cron/e2e-iptables.yaml | distro-support | iptables/xtables-encap-nobgp | 214
-.argoci/cron/e2e-iptables.yaml | dual-stack-k8s-e2e-etcd | iptables/xtables-manifest-v3crd | 207
-.argoci/cron/e2e-iptables.yaml | dual-stack-k8s-e2e-kdd | iptables/xtables-manifest | 211
+.argoci/cron/e2e-iptables.yaml | aks-aks-migrate-from-vendored-calico-cni-to-calico-cni | iptables/aks-xtables-encap | 213
+.argoci/cron/e2e-iptables.yaml | aks-aks-private-w-aks-cni-overlay | iptables/aks-xtables-nobgp | 197
+.argoci/cron/e2e-iptables.yaml | aks-aks-w-aks-cni | iptables/aks-xtables-nobgp | 197
+.argoci/cron/e2e-iptables.yaml | aks-aks-w-calico-cni | iptables/aks-xtables-encap | 213
+.argoci/cron/e2e-iptables.yaml | arm64-smoke-tests-aks-arm64 [stable-1-azure-] | iptables/aks-xtables-nobgp | 197
+.argoci/cron/e2e-iptables.yaml | arm64-smoke-tests-aks-arm64 [stable-1-none-] | iptables/aks-xtables-encap | 213
+.argoci/cron/e2e-iptables.yaml | arm64-smoke-tests-eks-arm64-calico-cni | iptables/eks-xtables-encap-aws | 206
+.argoci/cron/e2e-iptables.yaml | autohep-test | iptables/xtables-autohep | 223
+.argoci/cron/e2e-iptables.yaml | datastore-k8s-e2e-etcd | iptables/xtables-manifest-v3crd | 208
+.argoci/cron/e2e-iptables.yaml | datastore-k8s-e2e-kdd-new | iptables/xtables-manifest | 212
+.argoci/cron/e2e-iptables.yaml | datastore-k8s-e2e-kdd-old | iptables/xtables-manifest | 212
+.argoci/cron/e2e-iptables.yaml | distro-support | iptables/xtables-encap-nobgp | 215
+.argoci/cron/e2e-iptables.yaml | dual-stack-k8s-e2e-etcd | iptables/xtables-manifest-v3crd | 208
+.argoci/cron/e2e-iptables.yaml | dual-stack-k8s-e2e-kdd | iptables/xtables-manifest | 212
 .argoci/cron/e2e-iptables.yaml | focused-wireguard-e2e-aks-w-azure-cni | wireguard | 1
 .argoci/cron/e2e-iptables.yaml | focused-wireguard-e2e-aks-with-calico-cni | wireguard | 1
 .argoci/cron/e2e-iptables.yaml | focused-wireguard-e2e-eks-kdd-aws-cni | wireguard | 1
 .argoci/cron/e2e-iptables.yaml | focused-wireguard-e2e-eks-kdd-calico-cni | wireguard | 1
-.argoci/cron/e2e-iptables.yaml | ipvs | iptables/xtables-v3crd | 215
-.argoci/cron/e2e-iptables.yaml | k8s-beta-runs | iptables/xtables-manifest | 211
-.argoci/cron/e2e-iptables.yaml | k8s-distros | iptables/xtables | 219
+.argoci/cron/e2e-iptables.yaml | ipvs | iptables/xtables-v3crd | 216
+.argoci/cron/e2e-iptables.yaml | k8s-beta-runs | iptables/xtables-manifest | 212
+.argoci/cron/e2e-iptables.yaml | k8s-distros | iptables/xtables | 220
 .argoci/cron/e2e-iptables.yaml | kubevirt-e2e-tests | gcp/kubevirt | 8
-.argoci/cron/e2e-iptables.yaml | migration | iptables/xtables-manifest | 211
+.argoci/cron/e2e-iptables.yaml | migration | iptables/xtables-manifest | 212
 .argoci/cron/e2e-iptables.yaml | migration [pre-migration] | legacy/iptables/migration-pre-migration | 1
-.argoci/cron/e2e-iptables.yaml | native-v3-crds-aks | iptables/aks-xtables-nobgp-v3crd | 192
-.argoci/cron/e2e-iptables.yaml | native-v3-crds-eks | iptables/eks-xtables-nobgp-v3crd | 185
-.argoci/cron/e2e-iptables.yaml | openshift-ocp | iptables/openshift-xtables-encap-aws | 215
-.argoci/cron/e2e-iptables.yaml | operator-migration-kind-dual-stack | iptables/xtables | 219
-.argoci/cron/e2e-iptables.yaml | operator-migration-kind-ipv6 | iptables/xtables | 219
+.argoci/cron/e2e-iptables.yaml | native-v3-crds-aks | iptables/aks-xtables-nobgp-v3crd | 193
+.argoci/cron/e2e-iptables.yaml | native-v3-crds-eks | iptables/eks-xtables-nobgp-v3crd | 186
+.argoci/cron/e2e-iptables.yaml | openshift-ocp | iptables/openshift-xtables-encap-aws | 216
+.argoci/cron/e2e-iptables.yaml | operator-migration-kind-dual-stack | iptables/xtables | 220
+.argoci/cron/e2e-iptables.yaml | operator-migration-kind-ipv6 | iptables/xtables | 220
 .argoci/cron/e2e-iptables.yaml | usage-reporting | (usage-reporting) | -
-.argoci/cron/e2e-iptables.yaml | wireguard-k8s-e2e | iptables/xtables-wireguard | 216
-.argoci/cron/e2e-iptables.yaml | wireguard-regression-k8s-e2e-aks-w-aks-cni-overlay | iptables/aks-xtables-nobgp-wireguard | 197
-.argoci/cron/e2e-iptables.yaml | wireguard-regression-k8s-e2e-kdd-new | iptables/xtables-aws | 220
-.argoci/cron/e2e-iptables.yaml | wireguard-regression-k8s-e2e-kdd-old | iptables/xtables-v3crd-aws | 216
-.argoci/cron/e2e-iptables.yaml | wireguard-vxlan-k8s-e2e | iptables/xtables-wireguard | 216
+.argoci/cron/e2e-iptables.yaml | wireguard-k8s-e2e | iptables/xtables-wireguard | 217
+.argoci/cron/e2e-iptables.yaml | wireguard-regression-k8s-e2e-aks-w-aks-cni-overlay | iptables/aks-xtables-nobgp-wireguard | 198
+.argoci/cron/e2e-iptables.yaml | wireguard-regression-k8s-e2e-kdd-new | iptables/xtables-aws | 221
+.argoci/cron/e2e-iptables.yaml | wireguard-regression-k8s-e2e-kdd-old | iptables/xtables-v3crd-aws | 217
+.argoci/cron/e2e-iptables.yaml | wireguard-vxlan-k8s-e2e | iptables/xtables-wireguard | 217
 .argoci/cron/e2e-nftables.yaml | kubevirt-e2e-tests | gcp/kubevirt | 8
-.argoci/cron/e2e-nftables.yaml | nftables-mode-arm64-wg | nftables/xtables-autohep | 222
-.argoci/cron/e2e-nftables.yaml | nftables-mode-eks-eks-w-aws-cni | nftables/eks-xtables-nobgp-aws-autohep | 209
-.argoci/cron/e2e-nftables.yaml | nftables-mode-eks-eks-w-calico-cni | nftables/eks-xtables-aws-autohep | 212
-.argoci/cron/e2e-nftables.yaml | nftables-mode-kind-nftables-mode-ipv6-only | nftables/xtables-autohep | 222
-.argoci/cron/e2e-nftables.yaml | nftables-mode-kind-nftables-mode-vxlan-dual-stack | nftables/xtables-encap-autohep | 218
-.argoci/cron/e2e-nftables.yaml | nftables-talos-native-v3-crds-aws | nftables/xtables-v3crd-aws-autohep | 218
-.argoci/cron/e2e-nftables.yaml | nftables-talos-native-v3-crds-gcp | nftables/xtables-encap-nobgp-v3crd-autohep | 213
-.argoci/cron/e2e-nftables.yaml | nftables-talos-nftables-talos | nftables/xtables-encap-aws-autohep | 218
+.argoci/cron/e2e-nftables.yaml | nftables-mode-arm64-wg | nftables/xtables-autohep | 223
+.argoci/cron/e2e-nftables.yaml | nftables-mode-eks-eks-w-aws-cni | nftables/eks-xtables-nobgp-aws-autohep | 210
+.argoci/cron/e2e-nftables.yaml | nftables-mode-eks-eks-w-calico-cni | nftables/eks-xtables-aws-autohep | 213
+.argoci/cron/e2e-nftables.yaml | nftables-mode-kind-nftables-mode-ipv6-only | nftables/xtables-autohep | 223
+.argoci/cron/e2e-nftables.yaml | nftables-mode-kind-nftables-mode-vxlan-dual-stack | nftables/xtables-encap-autohep | 219
+.argoci/cron/e2e-nftables.yaml | nftables-talos-native-v3-crds-aws | nftables/xtables-v3crd-aws-autohep | 219
+.argoci/cron/e2e-nftables.yaml | nftables-talos-native-v3-crds-gcp | nftables/xtables-encap-nobgp-v3crd-autohep | 214
+.argoci/cron/e2e-nftables.yaml | nftables-talos-nftables-talos | nftables/xtables-encap-aws-autohep | 219
 .argoci/cron/e2e-openstack.yaml | full-fv | (openstack-e2e) | -
 .argoci/cron/e2e-openstack.yaml | multi-region | (openstack-e2e) | -
 .argoci/cron/e2e-patch-verification.yaml | kind-tests | patch-verification/xtables | 83
@@ -104,98 +104,98 @@
 .argoci/cron/e2e-upgrade.yaml | calico-tests-kubeadm-iptables | upgrade/xtables-aws | 83
 .argoci/cron/e2e-upgrade.yaml | calico-tests-openshift | upgrade/xtables-aws | 83
 .argoci/cron/e2e-upgrade.yaml | calico-tests-rke2 | upgrade/xtables | 83
-.argoci/cron/e2e-vpp.yaml | iptables-openshift | vpp/xtables-encap-extnode-aws | 121
-.argoci/cron/e2e-vpp.yaml | k8s-e2e-st-v3-28-regression-test [gcp-kubeadm-calico-vpp-nohuge-yaml-v3-28-v3-28-0] | vpp/vpp-encap-extnode | 117
-.argoci/cron/e2e-vpp.yaml | k8s-e2e-st-vpp-eks | vpp/eks-vpp-encap-extnode-aws | 116
-.argoci/cron/e2e-vpp.yaml | k8s-e2e-st-vpp-eks-dpdk | vpp/eks-vpp-encap-extnode-aws | 116
-.argoci/cron/e2e-vpp.yaml | k8s-e2e-st-vpp-kadm [aws-kubeadm-calico-vpp-nohuge-yaml] | vpp/vpp-encap-extnode-aws | 117
-.argoci/cron/e2e-vpp.yaml | k8s-e2e-st-vpp-kadm [gcp-kubeadm-calico-vpp-nohuge-yaml] | vpp/vpp-encap-extnode | 117
-.argoci/cron/e2e-vpp.yaml | k8s-e2e-st-vpp-kadm-huge [aws-kubeadm-calico-vpp-dpdk-yaml] | vpp/vpp-encap-extnode-aws | 117
-.argoci/cron/e2e-vpp.yaml | k8s-e2e-st-vpp-kadm-huge [gcp-kubeadm-calico-vpp-dpdk-yaml] | vpp/vpp-encap-extnode | 117
-.argoci/cron/e2e-vpp.yaml | k8s-e2e-st-vpp-kadm-ipsec-huge [aws-kubeadm-calico-vpp-dpdk-yaml] | vpp/vpp-encap-extnode-aws | 117
-.argoci/cron/e2e-vpp.yaml | k8s-e2e-st-vpp-kadm-vx-huge [gcp-kubeadm-calico-vpp-dpdk-yaml] | vpp/vpp-encap-extnode | 117
-.argoci/cron/e2e-vpp.yaml | k8s-e2e-st-vpp-kadm-wg-huge [gcp-kubeadm-calico-vpp-dpdk-yaml] | vpp/vpp-encap-extnode | 117
-.argoci/cron/e2e-vpp.yaml | vpp-openshift | vpp/vpp-encap-extnode-aws | 117
+.argoci/cron/e2e-vpp.yaml | iptables-openshift | vpp/xtables-encap-extnode-aws | 122
+.argoci/cron/e2e-vpp.yaml | k8s-e2e-st-v3-28-regression-test [gcp-kubeadm-calico-vpp-nohuge-yaml-v3-28-v3-28-0] | vpp/vpp-encap-extnode | 118
+.argoci/cron/e2e-vpp.yaml | k8s-e2e-st-vpp-eks | vpp/eks-vpp-encap-extnode-aws | 117
+.argoci/cron/e2e-vpp.yaml | k8s-e2e-st-vpp-eks-dpdk | vpp/eks-vpp-encap-extnode-aws | 117
+.argoci/cron/e2e-vpp.yaml | k8s-e2e-st-vpp-kadm [aws-kubeadm-calico-vpp-nohuge-yaml] | vpp/vpp-encap-extnode-aws | 118
+.argoci/cron/e2e-vpp.yaml | k8s-e2e-st-vpp-kadm [gcp-kubeadm-calico-vpp-nohuge-yaml] | vpp/vpp-encap-extnode | 118
+.argoci/cron/e2e-vpp.yaml | k8s-e2e-st-vpp-kadm-huge [aws-kubeadm-calico-vpp-dpdk-yaml] | vpp/vpp-encap-extnode-aws | 118
+.argoci/cron/e2e-vpp.yaml | k8s-e2e-st-vpp-kadm-huge [gcp-kubeadm-calico-vpp-dpdk-yaml] | vpp/vpp-encap-extnode | 118
+.argoci/cron/e2e-vpp.yaml | k8s-e2e-st-vpp-kadm-ipsec-huge [aws-kubeadm-calico-vpp-dpdk-yaml] | vpp/vpp-encap-extnode-aws | 118
+.argoci/cron/e2e-vpp.yaml | k8s-e2e-st-vpp-kadm-vx-huge [gcp-kubeadm-calico-vpp-dpdk-yaml] | vpp/vpp-encap-extnode | 118
+.argoci/cron/e2e-vpp.yaml | k8s-e2e-st-vpp-kadm-wg-huge [gcp-kubeadm-calico-vpp-dpdk-yaml] | vpp/vpp-encap-extnode | 118
+.argoci/cron/e2e-vpp.yaml | vpp-openshift | vpp/vpp-encap-extnode-aws | 118
 .argoci/cron/e2e-windows.yaml | calico-windows-azr-aks-2022-stable-1-iptables-no-encap-azure-cni | windows/aks-xtables-nobgp | 8
 .argoci/cron/e2e-windows.yaml | calico-windows-azr-aso-2022-stable-nftables-vxlan | windows/xtables-encap | 8
 .semaphore/end-to-end/pipelines/benchmarking.yml | Benchmarks / Benchmark tests Calico | (benchmark) | -
 .semaphore/end-to-end/pipelines/benchmarking.yml | Tiger-bench / Tiger-bench tests Calico | (tiger-bench) | -
-.semaphore/end-to-end/pipelines/bpf.yml | 9K MTU runs / aws-bpf - 9k MTU | bpf/bpf-extnode-aws | 219
-.semaphore/end-to-end/pipelines/bpf.yml | 9K MTU runs / aws-iptables - 9k MTU | bpf/xtables-extnode-aws | 223
-.semaphore/end-to-end/pipelines/bpf.yml | ARM64 - smoke tests / AKS - ARM64 w/ AKS-CNI | bpf/aks-bpf-nobgp | 209
-.semaphore/end-to-end/pipelines/bpf.yml | ARM64 - smoke tests / AKS - ARM64 w/ Calico-CNI | bpf/aks-bpf | 212
-.semaphore/end-to-end/pipelines/bpf.yml | ARM64 - smoke tests / Kubeadm - ARM64 | bpf/bpf | 216
+.semaphore/end-to-end/pipelines/bpf.yml | 9K MTU runs / aws-bpf - 9k MTU | bpf/bpf-extnode-aws | 220
+.semaphore/end-to-end/pipelines/bpf.yml | 9K MTU runs / aws-iptables - 9k MTU | bpf/xtables-extnode-aws | 224
+.semaphore/end-to-end/pipelines/bpf.yml | ARM64 - smoke tests / AKS - ARM64 w/ AKS-CNI | bpf/aks-bpf-nobgp | 210
+.semaphore/end-to-end/pipelines/bpf.yml | ARM64 - smoke tests / AKS - ARM64 w/ Calico-CNI | bpf/aks-bpf | 213
+.semaphore/end-to-end/pipelines/bpf.yml | ARM64 - smoke tests / Kubeadm - ARM64 | bpf/bpf | 217
 .semaphore/end-to-end/pipelines/bpf.yml | BPF mini-scale runs / gcp-bpf - mini-scale | (scale-test) | -
-.semaphore/end-to-end/pipelines/bpf.yml | BPF run matrix / AKS w/ AKS-CNI | bpf/aks-bpf-nobgp | 209
-.semaphore/end-to-end/pipelines/bpf.yml | BPF run matrix / AKS w/ Calico-CNI | bpf/aks-bpf | 212
-.semaphore/end-to-end/pipelines/bpf.yml | BPF run matrix / AWS encap, VXLAN | bpf/bpf-encap-v3crd-extnode-aws | 211
-.semaphore/end-to-end/pipelines/bpf.yml | BPF run matrix / AWS encap, no VXLAN | bpf/bpf-v3crd-extnode-aws | 215
-.semaphore/end-to-end/pipelines/bpf.yml | BPF run matrix / AWS single subnet, dual IP-family | bpf-aws-single-subnet | 554
-.semaphore/end-to-end/pipelines/bpf.yml | BPF run matrix / AWS-Talos, no encap, DSR | bpf/bpf-aws | 215
-.semaphore/end-to-end/pipelines/bpf.yml | BPF run matrix / BPF + AKS w AKS CNI + Overlay | bpf/aks-bpf-encap-nobgp | 207
-.semaphore/end-to-end/pipelines/bpf.yml | BPF run matrix / EKS w/ aws CNI | bpf/bpf-nobgp-extnode-aws | 216
-.semaphore/end-to-end/pipelines/bpf.yml | BPF run matrix / EKS w/ calico CNI | bpf/eks-bpf-encap-extnode-aws | 205
-.semaphore/end-to-end/pipelines/bpf.yml | BPF run matrix / GCP BPF DP encap w/ NodeLocal DNSCache, VXLAN | bpf/bpf-encap-extnode | 215
-.semaphore/end-to-end/pipelines/bpf.yml | BPF run matrix / GCP BPF DP encap w/ NodeLocal DNSCache, no VXLAN | bpf/bpf-extnode | 219
-.semaphore/end-to-end/pipelines/bpf.yml | BPF run matrix / GCP BPF DP, DSR | bpf/bpf-v3crd-extnode | 215
-.semaphore/end-to-end/pipelines/bpf.yml | BPF run matrix / Kops w/ calico CNI IPv4, BPF | bpf/kops-bpf-encap-nobgp-extnode-aws | 203
-.semaphore/end-to-end/pipelines/bpf.yml | BPF run matrix / Kops w/ calico CNI IPv4, iptables | bpf/kops-xtables-encap-nobgp-extnode-aws | 207
-.semaphore/end-to-end/pipelines/bpf.yml | BPF run matrix / Kops w/ calico CNI IPv6, BPF | bpf/kops-bpf-encap-nobgp-extnode-aws | 203
-.semaphore/end-to-end/pipelines/bpf.yml | BPF run matrix / Kops w/ calico CNI IPv6, iptables | bpf/kops-xtables-encap-nobgp-extnode-aws | 207
-.semaphore/end-to-end/pipelines/bpf.yml | BPF run matrix / aws-kops RHEL8.2 | bpf/kops-bpf-extnode-aws | 208
-.semaphore/end-to-end/pipelines/bpf.yml | BPF run matrix / aws-kubeadm dual stack, BPF | bpf/bpf-encap-extnode-aws | 215
-.semaphore/end-to-end/pipelines/bpf.yml | BPF run matrix / aws-kubeadm dual stack, iptables | bpf/xtables-encap-extnode-aws | 219
-.semaphore/end-to-end/pipelines/bpf.yml | BPF run matrix / aws-lb-bpf | bpf/eks-bpf-encap-extnode-aws | 205
-.semaphore/end-to-end/pipelines/bpf.yml | BPF run matrix / aws-lb-iptables | bpf/eks-xtables-encap-extnode-aws | 209
+.semaphore/end-to-end/pipelines/bpf.yml | BPF run matrix / AKS w/ AKS-CNI | bpf/aks-bpf-nobgp | 210
+.semaphore/end-to-end/pipelines/bpf.yml | BPF run matrix / AKS w/ Calico-CNI | bpf/aks-bpf | 213
+.semaphore/end-to-end/pipelines/bpf.yml | BPF run matrix / AWS encap, VXLAN | bpf/bpf-encap-v3crd-extnode-aws | 212
+.semaphore/end-to-end/pipelines/bpf.yml | BPF run matrix / AWS encap, no VXLAN | bpf/bpf-v3crd-extnode-aws | 216
+.semaphore/end-to-end/pipelines/bpf.yml | BPF run matrix / AWS single subnet, dual IP-family | bpf-aws-single-subnet | 555
+.semaphore/end-to-end/pipelines/bpf.yml | BPF run matrix / AWS-Talos, no encap, DSR | bpf/bpf-aws | 216
+.semaphore/end-to-end/pipelines/bpf.yml | BPF run matrix / BPF + AKS w AKS CNI + Overlay | bpf/aks-bpf-encap-nobgp | 208
+.semaphore/end-to-end/pipelines/bpf.yml | BPF run matrix / EKS w/ aws CNI | bpf/bpf-nobgp-extnode-aws | 217
+.semaphore/end-to-end/pipelines/bpf.yml | BPF run matrix / EKS w/ calico CNI | bpf/eks-bpf-encap-extnode-aws | 206
+.semaphore/end-to-end/pipelines/bpf.yml | BPF run matrix / GCP BPF DP encap w/ NodeLocal DNSCache, VXLAN | bpf/bpf-encap-extnode | 216
+.semaphore/end-to-end/pipelines/bpf.yml | BPF run matrix / GCP BPF DP encap w/ NodeLocal DNSCache, no VXLAN | bpf/bpf-extnode | 220
+.semaphore/end-to-end/pipelines/bpf.yml | BPF run matrix / GCP BPF DP, DSR | bpf/bpf-v3crd-extnode | 216
+.semaphore/end-to-end/pipelines/bpf.yml | BPF run matrix / Kops w/ calico CNI IPv4, BPF | bpf/kops-bpf-encap-nobgp-extnode-aws | 204
+.semaphore/end-to-end/pipelines/bpf.yml | BPF run matrix / Kops w/ calico CNI IPv4, iptables | bpf/kops-xtables-encap-nobgp-extnode-aws | 208
+.semaphore/end-to-end/pipelines/bpf.yml | BPF run matrix / Kops w/ calico CNI IPv6, BPF | bpf/kops-bpf-encap-nobgp-extnode-aws | 204
+.semaphore/end-to-end/pipelines/bpf.yml | BPF run matrix / Kops w/ calico CNI IPv6, iptables | bpf/kops-xtables-encap-nobgp-extnode-aws | 208
+.semaphore/end-to-end/pipelines/bpf.yml | BPF run matrix / aws-kops RHEL8.2 | bpf/kops-bpf-extnode-aws | 209
+.semaphore/end-to-end/pipelines/bpf.yml | BPF run matrix / aws-kubeadm dual stack, BPF | bpf/bpf-encap-extnode-aws | 216
+.semaphore/end-to-end/pipelines/bpf.yml | BPF run matrix / aws-kubeadm dual stack, iptables | bpf/xtables-encap-extnode-aws | 220
+.semaphore/end-to-end/pipelines/bpf.yml | BPF run matrix / aws-lb-bpf | bpf/eks-bpf-encap-extnode-aws | 206
+.semaphore/end-to-end/pipelines/bpf.yml | BPF run matrix / aws-lb-iptables | bpf/eks-xtables-encap-extnode-aws | 210
 .semaphore/end-to-end/pipelines/bpf.yml | KubeVirt e2e tests / KubeVirt IP persistence and live migration | gcp/kubevirt | 8
-.semaphore/end-to-end/pipelines/bpf.yml | Wireguard / BPF + AKS w AKS CNI + Overlay | bpf/aks-bpf-encap-nobgp | 207
+.semaphore/end-to-end/pipelines/bpf.yml | Wireguard / BPF + AKS w AKS CNI + Overlay | bpf/aks-bpf-encap-nobgp | 208
 .semaphore/end-to-end/pipelines/bpf.yml | usage reporting with bpf / mainline | (usage-reporting) | -
 .semaphore/end-to-end/pipelines/certification.yml | HCP hosted setup and tests / HCP tests - hosted (cert) | (ocp-cert) | -
 .semaphore/end-to-end/pipelines/certification.yml | HCP setup hosting / HCP setup hosting | (ocp-cert) | -
 .semaphore/end-to-end/pipelines/certification.yml | Standalone cluster tests / Standalone cluster tests (cert) | (ocp-cert) | -
 .semaphore/end-to-end/pipelines/cleanup.yml | Cleanup jobs / cleanup job VMs | (no tests) | -
-.semaphore/end-to-end/pipelines/iptables.yml | AKS / AKS Private w AKS CNI + Overlay | iptables/aks-xtables-nobgp | 196
-.semaphore/end-to-end/pipelines/iptables.yml | AKS / AKS migrate from vendored Calico CNI to Calico CNI | iptables/aks-xtables-encap | 212
-.semaphore/end-to-end/pipelines/iptables.yml | AKS / AKS w AKS CNI | iptables/aks-xtables-nobgp | 196
-.semaphore/end-to-end/pipelines/iptables.yml | AKS / AKS w Calico CNI | iptables/aks-xtables-encap | 212
-.semaphore/end-to-end/pipelines/iptables.yml | ARM64 - smoke tests / AKS - ARM64 w/ AKS-CNI | iptables/aks-xtables-nobgp | 196
-.semaphore/end-to-end/pipelines/iptables.yml | ARM64 - smoke tests / AKS - ARM64 w/ Calico-CNI | iptables/aks-xtables-encap | 212
-.semaphore/end-to-end/pipelines/iptables.yml | ARM64 - smoke tests / EKS - ARM64 - Calico CNI | iptables/eks-xtables-encap-aws | 205
-.semaphore/end-to-end/pipelines/iptables.yml | AutoHEP test / Test with AutoHEP enabled | iptables/xtables-autohep | 222
-.semaphore/end-to-end/pipelines/iptables.yml | Distro support / kdd | iptables/xtables-encap-nobgp | 214
+.semaphore/end-to-end/pipelines/iptables.yml | AKS / AKS Private w AKS CNI + Overlay | iptables/aks-xtables-nobgp | 197
+.semaphore/end-to-end/pipelines/iptables.yml | AKS / AKS migrate from vendored Calico CNI to Calico CNI | iptables/aks-xtables-encap | 213
+.semaphore/end-to-end/pipelines/iptables.yml | AKS / AKS w AKS CNI | iptables/aks-xtables-nobgp | 197
+.semaphore/end-to-end/pipelines/iptables.yml | AKS / AKS w Calico CNI | iptables/aks-xtables-encap | 213
+.semaphore/end-to-end/pipelines/iptables.yml | ARM64 - smoke tests / AKS - ARM64 w/ AKS-CNI | iptables/aks-xtables-nobgp | 197
+.semaphore/end-to-end/pipelines/iptables.yml | ARM64 - smoke tests / AKS - ARM64 w/ Calico-CNI | iptables/aks-xtables-encap | 213
+.semaphore/end-to-end/pipelines/iptables.yml | ARM64 - smoke tests / EKS - ARM64 - Calico CNI | iptables/eks-xtables-encap-aws | 206
+.semaphore/end-to-end/pipelines/iptables.yml | AutoHEP test / Test with AutoHEP enabled | iptables/xtables-autohep | 223
+.semaphore/end-to-end/pipelines/iptables.yml | Distro support / kdd | iptables/xtables-encap-nobgp | 215
 .semaphore/end-to-end/pipelines/iptables.yml | Focused WireGuard E2E (AKS w/ Azure CNI) / kdd | wireguard | 1
 .semaphore/end-to-end/pipelines/iptables.yml | Focused WireGuard E2E (AKS with Calico CNI) / kdd | wireguard | 1
 .semaphore/end-to-end/pipelines/iptables.yml | Focused WireGuard E2E (EKS) / kdd (AWS CNI) | wireguard | 1
 .semaphore/end-to-end/pipelines/iptables.yml | Focused WireGuard E2E (EKS) / kdd (Calico CNI) | wireguard | 1
-.semaphore/end-to-end/pipelines/iptables.yml | IPVS / ipvs | iptables/xtables-v3crd | 215
+.semaphore/end-to-end/pipelines/iptables.yml | IPVS / ipvs | iptables/xtables-v3crd | 216
 .semaphore/end-to-end/pipelines/iptables.yml | KubeVirt e2e tests / KubeVirt IP persistence and live migration | gcp/kubevirt | 8
-.semaphore/end-to-end/pipelines/iptables.yml | Migration / Flannel migration | iptables/xtables-manifest | 211
+.semaphore/end-to-end/pipelines/iptables.yml | Migration / Flannel migration | iptables/xtables-manifest | 212
 .semaphore/end-to-end/pipelines/iptables.yml | Migration / Flannel migration [pre-migration] | legacy/iptables/migration-flannel-migration-pre-migration | 1
-.semaphore/end-to-end/pipelines/iptables.yml | Openshift OCP / hashrelease | iptables/openshift-xtables-encap-aws | 215
-.semaphore/end-to-end/pipelines/iptables.yml | Operator Migration / kind IPv6 | iptables/xtables | 219
-.semaphore/end-to-end/pipelines/iptables.yml | Operator Migration / kind dual-stack | iptables/xtables | 219
-.semaphore/end-to-end/pipelines/iptables.yml | WireGuard VXLAN k8s-e2e / wireguard-vxlan-aws-kubeadm | iptables/xtables-wireguard | 216
-.semaphore/end-to-end/pipelines/iptables.yml | WireGuard k8s-e2e / aws-kubeadm-calico-cni with/without IP-in-IP | iptables/xtables-wireguard | 216
-.semaphore/end-to-end/pipelines/iptables.yml | WireGuard regression k8s-e2e / AKS w AKS CNI + Overlay | iptables/aks-xtables-nobgp-wireguard | 197
-.semaphore/end-to-end/pipelines/iptables.yml | WireGuard regression k8s-e2e / kdd - new | iptables/xtables-aws | 220
-.semaphore/end-to-end/pipelines/iptables.yml | WireGuard regression k8s-e2e / kdd - old | iptables/xtables-v3crd-aws | 216
-.semaphore/end-to-end/pipelines/iptables.yml | datastore k8s-e2e / etcd | iptables/xtables-manifest-v3crd | 207
-.semaphore/end-to-end/pipelines/iptables.yml | datastore k8s-e2e / kdd - new | iptables/xtables-manifest | 211
-.semaphore/end-to-end/pipelines/iptables.yml | datastore k8s-e2e / kdd - old | iptables/xtables-manifest | 211
-.semaphore/end-to-end/pipelines/iptables.yml | dual-stack k8s-e2e / etcd | iptables/xtables-manifest-v3crd | 207
-.semaphore/end-to-end/pipelines/iptables.yml | dual-stack k8s-e2e / kdd | iptables/xtables-manifest | 211
-.semaphore/end-to-end/pipelines/iptables.yml | k8s beta runs / k8s beta | iptables/xtables-manifest | 211
-.semaphore/end-to-end/pipelines/iptables.yml | k8s distros / install required | iptables/xtables | 219
+.semaphore/end-to-end/pipelines/iptables.yml | Openshift OCP / hashrelease | iptables/openshift-xtables-encap-aws | 216
+.semaphore/end-to-end/pipelines/iptables.yml | Operator Migration / kind IPv6 | iptables/xtables | 220
+.semaphore/end-to-end/pipelines/iptables.yml | Operator Migration / kind dual-stack | iptables/xtables | 220
+.semaphore/end-to-end/pipelines/iptables.yml | WireGuard VXLAN k8s-e2e / wireguard-vxlan-aws-kubeadm | iptables/xtables-wireguard | 217
+.semaphore/end-to-end/pipelines/iptables.yml | WireGuard k8s-e2e / aws-kubeadm-calico-cni with/without IP-in-IP | iptables/xtables-wireguard | 217
+.semaphore/end-to-end/pipelines/iptables.yml | WireGuard regression k8s-e2e / AKS w AKS CNI + Overlay | iptables/aks-xtables-nobgp-wireguard | 198
+.semaphore/end-to-end/pipelines/iptables.yml | WireGuard regression k8s-e2e / kdd - new | iptables/xtables-aws | 221
+.semaphore/end-to-end/pipelines/iptables.yml | WireGuard regression k8s-e2e / kdd - old | iptables/xtables-v3crd-aws | 217
+.semaphore/end-to-end/pipelines/iptables.yml | datastore k8s-e2e / etcd | iptables/xtables-manifest-v3crd | 208
+.semaphore/end-to-end/pipelines/iptables.yml | datastore k8s-e2e / kdd - new | iptables/xtables-manifest | 212
+.semaphore/end-to-end/pipelines/iptables.yml | datastore k8s-e2e / kdd - old | iptables/xtables-manifest | 212
+.semaphore/end-to-end/pipelines/iptables.yml | dual-stack k8s-e2e / etcd | iptables/xtables-manifest-v3crd | 208
+.semaphore/end-to-end/pipelines/iptables.yml | dual-stack k8s-e2e / kdd | iptables/xtables-manifest | 212
+.semaphore/end-to-end/pipelines/iptables.yml | k8s beta runs / k8s beta | iptables/xtables-manifest | 212
+.semaphore/end-to-end/pipelines/iptables.yml | k8s distros / install required | iptables/xtables | 220
 .semaphore/end-to-end/pipelines/iptables.yml | usage reporting / mainline | (usage-reporting) | -
 .semaphore/end-to-end/pipelines/nftables.yml | KubeVirt e2e tests / KubeVirt IP persistence and live migration | gcp/kubevirt | 8
-.semaphore/end-to-end/pipelines/nftables.yml | Nftables mode, EKS / EKS w/ Calico CNI | nftables/eks-xtables-aws-autohep | 212
-.semaphore/end-to-end/pipelines/nftables.yml | Nftables mode, EKS / EKS w/ aws CNI | nftables/eks-xtables-nobgp-aws-autohep | 209
-.semaphore/end-to-end/pipelines/nftables.yml | Nftables mode, KinD / Nftables mode, ipv6-only | nftables/xtables-autohep | 222
-.semaphore/end-to-end/pipelines/nftables.yml | Nftables mode, KinD / Nftables mode, vxlan, dual-stack | nftables/xtables-encap-autohep | 218
-.semaphore/end-to-end/pipelines/nftables.yml | Nftables mode, arm64, WG / Nftables mode, arm64, WG | nftables/xtables-autohep | 222
-.semaphore/end-to-end/pipelines/nftables.yml | Nftables, Talos / Native v3 CRDs (AWS) | nftables/xtables-v3crd-aws-autohep | 218
-.semaphore/end-to-end/pipelines/nftables.yml | Nftables, Talos / Native v3 CRDs (GCP) | nftables/xtables-encap-nobgp-v3crd-autohep | 213
-.semaphore/end-to-end/pipelines/nftables.yml | Nftables, Talos / Nftables, Talos | nftables/xtables-encap-aws-autohep | 218
+.semaphore/end-to-end/pipelines/nftables.yml | Nftables mode, EKS / EKS w/ Calico CNI | nftables/eks-xtables-aws-autohep | 213
+.semaphore/end-to-end/pipelines/nftables.yml | Nftables mode, EKS / EKS w/ aws CNI | nftables/eks-xtables-nobgp-aws-autohep | 210
+.semaphore/end-to-end/pipelines/nftables.yml | Nftables mode, KinD / Nftables mode, ipv6-only | nftables/xtables-autohep | 223
+.semaphore/end-to-end/pipelines/nftables.yml | Nftables mode, KinD / Nftables mode, vxlan, dual-stack | nftables/xtables-encap-autohep | 219
+.semaphore/end-to-end/pipelines/nftables.yml | Nftables mode, arm64, WG / Nftables mode, arm64, WG | nftables/xtables-autohep | 223
+.semaphore/end-to-end/pipelines/nftables.yml | Nftables, Talos / Native v3 CRDs (AWS) | nftables/xtables-v3crd-aws-autohep | 219
+.semaphore/end-to-end/pipelines/nftables.yml | Nftables, Talos / Native v3 CRDs (GCP) | nftables/xtables-encap-nobgp-v3crd-autohep | 214
+.semaphore/end-to-end/pipelines/nftables.yml | Nftables, Talos / Nftables, Talos | nftables/xtables-encap-aws-autohep | 219
 .semaphore/end-to-end/pipelines/patch-verification.yml | KinD tests / IPv6 | patch-verification/xtables | 83
 .semaphore/end-to-end/pipelines/patch-verification.yml | KubeVirt e2e tests / KubeVirt IP persistence and live migration | gcp/kubevirt | 8
 .semaphore/end-to-end/pipelines/patch-verification.yml | Manifests / Calico etcd | patch-verification/xtables-encap-manifest | 80
@@ -219,17 +219,17 @@
 .semaphore/end-to-end/pipelines/upgrade.yml | calico tests / RKE2 | upgrade/xtables | 83
 .semaphore/end-to-end/pipelines/upgrade.yml | calico tests / kubeadm - bpf | upgrade/bpf | 83
 .semaphore/end-to-end/pipelines/upgrade.yml | calico tests / kubeadm - iptables | upgrade/xtables-aws | 83
-.semaphore/end-to-end/pipelines/vpp.yml | Iptables (Openshift) / Iptables (Openshift) | vpp/xtables-encap-extnode-aws | 121
-.semaphore/end-to-end/pipelines/vpp.yml | VPP-openshift / VPP-openshift | vpp/vpp-encap-extnode-aws | 117
-.semaphore/end-to-end/pipelines/vpp.yml | k8s-e2e ST / VPP-EKS | vpp/eks-vpp-encap-extnode-aws | 116
-.semaphore/end-to-end/pipelines/vpp.yml | k8s-e2e ST / VPP-EKS-dpdk | vpp/eks-vpp-encap-extnode-aws | 116
-.semaphore/end-to-end/pipelines/vpp.yml | k8s-e2e ST / VPP-kadm - aws | vpp/vpp-encap-extnode-aws | 117
-.semaphore/end-to-end/pipelines/vpp.yml | k8s-e2e ST / VPP-kadm - gcp | vpp/vpp-encap-extnode | 117
-.semaphore/end-to-end/pipelines/vpp.yml | k8s-e2e ST / VPP-kadm-Huge - aws | vpp/vpp-encap-extnode-aws | 117
-.semaphore/end-to-end/pipelines/vpp.yml | k8s-e2e ST / VPP-kadm-Huge - gcp | vpp/vpp-encap-extnode | 117
-.semaphore/end-to-end/pipelines/vpp.yml | k8s-e2e ST / VPP-kadm-IPSec-Huge | vpp/vpp-encap-extnode-aws | 117
-.semaphore/end-to-end/pipelines/vpp.yml | k8s-e2e ST / VPP-kadm-VX-Huge | vpp/vpp-encap-extnode | 117
-.semaphore/end-to-end/pipelines/vpp.yml | k8s-e2e ST / VPP-kadm-WG-Huge | vpp/vpp-encap-extnode | 117
-.semaphore/end-to-end/pipelines/vpp.yml | k8s-e2e ST / v3.28 regression test | vpp/vpp-encap-extnode | 117
+.semaphore/end-to-end/pipelines/vpp.yml | Iptables (Openshift) / Iptables (Openshift) | vpp/xtables-encap-extnode-aws | 122
+.semaphore/end-to-end/pipelines/vpp.yml | VPP-openshift / VPP-openshift | vpp/vpp-encap-extnode-aws | 118
+.semaphore/end-to-end/pipelines/vpp.yml | k8s-e2e ST / VPP-EKS | vpp/eks-vpp-encap-extnode-aws | 117
+.semaphore/end-to-end/pipelines/vpp.yml | k8s-e2e ST / VPP-EKS-dpdk | vpp/eks-vpp-encap-extnode-aws | 117
+.semaphore/end-to-end/pipelines/vpp.yml | k8s-e2e ST / VPP-kadm - aws | vpp/vpp-encap-extnode-aws | 118
+.semaphore/end-to-end/pipelines/vpp.yml | k8s-e2e ST / VPP-kadm - gcp | vpp/vpp-encap-extnode | 118
+.semaphore/end-to-end/pipelines/vpp.yml | k8s-e2e ST / VPP-kadm-Huge - aws | vpp/vpp-encap-extnode-aws | 118
+.semaphore/end-to-end/pipelines/vpp.yml | k8s-e2e ST / VPP-kadm-Huge - gcp | vpp/vpp-encap-extnode | 118
+.semaphore/end-to-end/pipelines/vpp.yml | k8s-e2e ST / VPP-kadm-IPSec-Huge | vpp/vpp-encap-extnode-aws | 118
+.semaphore/end-to-end/pipelines/vpp.yml | k8s-e2e ST / VPP-kadm-VX-Huge | vpp/vpp-encap-extnode | 118
+.semaphore/end-to-end/pipelines/vpp.yml | k8s-e2e ST / VPP-kadm-WG-Huge | vpp/vpp-encap-extnode | 118
+.semaphore/end-to-end/pipelines/vpp.yml | k8s-e2e ST / v3.28 regression test | vpp/vpp-encap-extnode | 118
 .semaphore/end-to-end/pipelines/windows.yml | Calico Windows / azr-aks, 2022, stable-1, iptables, no encap, azure CNI | windows/aks-xtables-nobgp | 8
 .semaphore/end-to-end/pipelines/windows.yml | Calico Windows / azr-aso, 2022, stable, nftables, vxlan | windows/xtables-encap | 8

--- a/e2e/testsets/sets/bpf-aws-single-subnet.txt
+++ b/e2e/testsets/sets/bpf-aws-single-subnet.txt
@@ -179,6 +179,7 @@
 [sig-calico] [Team:CORE] [Feature:NetworkPolicy] [Category:Policy] service network policy Calico service network policy test ServiceMatch policy client egress by service, server ingress by service [Conformance]
 [sig-calico] [Team:CORE] [Feature:OwnerReferences] [Category:Configuration] OwnerReference tests should delete a NetworkSet if its owner has been deleted
 [sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit bandwidth with QoS annotations
+[sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit concurrent connections with QoS annotations
 [sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit packet rate with QoS annotations
 [sig-network] API Server should have Endpoints and EndpointSlices pointing to API Server [Conformance]
 [sig-network] API Server should provide secure master service [Conformance]

--- a/e2e/testsets/sets/bpf/aks-bpf-encap-nobgp.txt
+++ b/e2e/testsets/sets/bpf/aks-bpf-encap-nobgp.txt
@@ -112,6 +112,7 @@
 [sig-calico] [Team:CORE] [Feature:NetworkPolicy] [Category:Policy] service network policy Calico service network policy test ServiceMatch policy client egress by service, server ingress by service [Conformance]
 [sig-calico] [Team:CORE] [Feature:OwnerReferences] [Category:Configuration] OwnerReference tests should delete a NetworkSet if its owner has been deleted
 [sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit bandwidth with QoS annotations
+[sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit concurrent connections with QoS annotations
 [sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit packet rate with QoS annotations
 [sig-network] API Server should have Endpoints and EndpointSlices pointing to API Server [Conformance]
 [sig-network] API Server should provide secure master service [Conformance]

--- a/e2e/testsets/sets/bpf/aks-bpf-nobgp.txt
+++ b/e2e/testsets/sets/bpf/aks-bpf-nobgp.txt
@@ -114,6 +114,7 @@
 [sig-calico] [Team:CORE] [Feature:NetworkPolicy] [Category:Policy] service network policy Calico service network policy test ServiceMatch policy client egress by service, server ingress by service [Conformance]
 [sig-calico] [Team:CORE] [Feature:OwnerReferences] [Category:Configuration] OwnerReference tests should delete a NetworkSet if its owner has been deleted
 [sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit bandwidth with QoS annotations
+[sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit concurrent connections with QoS annotations
 [sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit packet rate with QoS annotations
 [sig-network] API Server should have Endpoints and EndpointSlices pointing to API Server [Conformance]
 [sig-network] API Server should provide secure master service [Conformance]

--- a/e2e/testsets/sets/bpf/aks-bpf.txt
+++ b/e2e/testsets/sets/bpf/aks-bpf.txt
@@ -117,6 +117,7 @@
 [sig-calico] [Team:CORE] [Feature:NetworkPolicy] [Category:Policy] service network policy Calico service network policy test ServiceMatch policy client egress by service, server ingress by service [Conformance]
 [sig-calico] [Team:CORE] [Feature:OwnerReferences] [Category:Configuration] OwnerReference tests should delete a NetworkSet if its owner has been deleted
 [sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit bandwidth with QoS annotations
+[sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit concurrent connections with QoS annotations
 [sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit packet rate with QoS annotations
 [sig-network] API Server should have Endpoints and EndpointSlices pointing to API Server [Conformance]
 [sig-network] API Server should provide secure master service [Conformance]

--- a/e2e/testsets/sets/bpf/bpf-aws.txt
+++ b/e2e/testsets/sets/bpf/bpf-aws.txt
@@ -119,6 +119,7 @@
 [sig-calico] [Team:CORE] [Feature:NetworkPolicy] [Category:Policy] service network policy Calico service network policy test ServiceMatch policy client egress by service, server ingress by service [Conformance]
 [sig-calico] [Team:CORE] [Feature:OwnerReferences] [Category:Configuration] OwnerReference tests should delete a NetworkSet if its owner has been deleted
 [sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit bandwidth with QoS annotations
+[sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit concurrent connections with QoS annotations
 [sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit packet rate with QoS annotations
 [sig-network] API Server should have Endpoints and EndpointSlices pointing to API Server [Conformance]
 [sig-network] API Server should provide secure master service [Conformance]

--- a/e2e/testsets/sets/bpf/bpf-encap-extnode-aws.txt
+++ b/e2e/testsets/sets/bpf/bpf-encap-extnode-aws.txt
@@ -119,6 +119,7 @@
 [sig-calico] [Team:CORE] [Feature:NetworkPolicy] [Category:Policy] service network policy Calico service network policy test ServiceMatch policy client egress by service, server ingress by service [Conformance]
 [sig-calico] [Team:CORE] [Feature:OwnerReferences] [Category:Configuration] OwnerReference tests should delete a NetworkSet if its owner has been deleted
 [sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit bandwidth with QoS annotations
+[sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit concurrent connections with QoS annotations
 [sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit packet rate with QoS annotations
 [sig-network] API Server should have Endpoints and EndpointSlices pointing to API Server [Conformance]
 [sig-network] API Server should provide secure master service [Conformance]

--- a/e2e/testsets/sets/bpf/bpf-encap-extnode.txt
+++ b/e2e/testsets/sets/bpf/bpf-encap-extnode.txt
@@ -119,6 +119,7 @@
 [sig-calico] [Team:CORE] [Feature:NetworkPolicy] [Category:Policy] service network policy Calico service network policy test ServiceMatch policy client egress by service, server ingress by service [Conformance]
 [sig-calico] [Team:CORE] [Feature:OwnerReferences] [Category:Configuration] OwnerReference tests should delete a NetworkSet if its owner has been deleted
 [sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit bandwidth with QoS annotations
+[sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit concurrent connections with QoS annotations
 [sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit packet rate with QoS annotations
 [sig-network] API Server should have Endpoints and EndpointSlices pointing to API Server [Conformance]
 [sig-network] API Server should provide secure master service [Conformance]

--- a/e2e/testsets/sets/bpf/bpf-encap-v3crd-extnode-aws.txt
+++ b/e2e/testsets/sets/bpf/bpf-encap-v3crd-extnode-aws.txt
@@ -115,6 +115,7 @@
 [sig-calico] [Team:CORE] [Feature:NetworkPolicy] [Category:Policy] service network policy Calico service network policy test ServiceMatch policy client egress by service, server ingress by service [Conformance]
 [sig-calico] [Team:CORE] [Feature:OwnerReferences] [Category:Configuration] OwnerReference tests should delete a NetworkSet if its owner has been deleted
 [sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit bandwidth with QoS annotations
+[sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit concurrent connections with QoS annotations
 [sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit packet rate with QoS annotations
 [sig-network] API Server should have Endpoints and EndpointSlices pointing to API Server [Conformance]
 [sig-network] API Server should provide secure master service [Conformance]

--- a/e2e/testsets/sets/bpf/bpf-extnode-aws.txt
+++ b/e2e/testsets/sets/bpf/bpf-extnode-aws.txt
@@ -123,6 +123,7 @@
 [sig-calico] [Team:CORE] [Feature:NetworkPolicy] [Category:Policy] service network policy Calico service network policy test ServiceMatch policy client egress by service, server ingress by service [Conformance]
 [sig-calico] [Team:CORE] [Feature:OwnerReferences] [Category:Configuration] OwnerReference tests should delete a NetworkSet if its owner has been deleted
 [sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit bandwidth with QoS annotations
+[sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit concurrent connections with QoS annotations
 [sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit packet rate with QoS annotations
 [sig-network] API Server should have Endpoints and EndpointSlices pointing to API Server [Conformance]
 [sig-network] API Server should provide secure master service [Conformance]

--- a/e2e/testsets/sets/bpf/bpf-extnode.txt
+++ b/e2e/testsets/sets/bpf/bpf-extnode.txt
@@ -123,6 +123,7 @@
 [sig-calico] [Team:CORE] [Feature:NetworkPolicy] [Category:Policy] service network policy Calico service network policy test ServiceMatch policy client egress by service, server ingress by service [Conformance]
 [sig-calico] [Team:CORE] [Feature:OwnerReferences] [Category:Configuration] OwnerReference tests should delete a NetworkSet if its owner has been deleted
 [sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit bandwidth with QoS annotations
+[sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit concurrent connections with QoS annotations
 [sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit packet rate with QoS annotations
 [sig-network] API Server should have Endpoints and EndpointSlices pointing to API Server [Conformance]
 [sig-network] API Server should provide secure master service [Conformance]

--- a/e2e/testsets/sets/bpf/bpf-nobgp-extnode-aws.txt
+++ b/e2e/testsets/sets/bpf/bpf-nobgp-extnode-aws.txt
@@ -120,6 +120,7 @@
 [sig-calico] [Team:CORE] [Feature:NetworkPolicy] [Category:Policy] service network policy Calico service network policy test ServiceMatch policy client egress by service, server ingress by service [Conformance]
 [sig-calico] [Team:CORE] [Feature:OwnerReferences] [Category:Configuration] OwnerReference tests should delete a NetworkSet if its owner has been deleted
 [sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit bandwidth with QoS annotations
+[sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit concurrent connections with QoS annotations
 [sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit packet rate with QoS annotations
 [sig-network] API Server should have Endpoints and EndpointSlices pointing to API Server [Conformance]
 [sig-network] API Server should provide secure master service [Conformance]

--- a/e2e/testsets/sets/bpf/bpf-v3crd-extnode-aws.txt
+++ b/e2e/testsets/sets/bpf/bpf-v3crd-extnode-aws.txt
@@ -119,6 +119,7 @@
 [sig-calico] [Team:CORE] [Feature:NetworkPolicy] [Category:Policy] service network policy Calico service network policy test ServiceMatch policy client egress by service, server ingress by service [Conformance]
 [sig-calico] [Team:CORE] [Feature:OwnerReferences] [Category:Configuration] OwnerReference tests should delete a NetworkSet if its owner has been deleted
 [sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit bandwidth with QoS annotations
+[sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit concurrent connections with QoS annotations
 [sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit packet rate with QoS annotations
 [sig-network] API Server should have Endpoints and EndpointSlices pointing to API Server [Conformance]
 [sig-network] API Server should provide secure master service [Conformance]

--- a/e2e/testsets/sets/bpf/bpf-v3crd-extnode.txt
+++ b/e2e/testsets/sets/bpf/bpf-v3crd-extnode.txt
@@ -119,6 +119,7 @@
 [sig-calico] [Team:CORE] [Feature:NetworkPolicy] [Category:Policy] service network policy Calico service network policy test ServiceMatch policy client egress by service, server ingress by service [Conformance]
 [sig-calico] [Team:CORE] [Feature:OwnerReferences] [Category:Configuration] OwnerReference tests should delete a NetworkSet if its owner has been deleted
 [sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit bandwidth with QoS annotations
+[sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit concurrent connections with QoS annotations
 [sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit packet rate with QoS annotations
 [sig-network] API Server should have Endpoints and EndpointSlices pointing to API Server [Conformance]
 [sig-network] API Server should provide secure master service [Conformance]

--- a/e2e/testsets/sets/bpf/bpf.txt
+++ b/e2e/testsets/sets/bpf/bpf.txt
@@ -119,6 +119,7 @@
 [sig-calico] [Team:CORE] [Feature:NetworkPolicy] [Category:Policy] service network policy Calico service network policy test ServiceMatch policy client egress by service, server ingress by service [Conformance]
 [sig-calico] [Team:CORE] [Feature:OwnerReferences] [Category:Configuration] OwnerReference tests should delete a NetworkSet if its owner has been deleted
 [sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit bandwidth with QoS annotations
+[sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit concurrent connections with QoS annotations
 [sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit packet rate with QoS annotations
 [sig-calico] [Team:CORE] [Feature:Wireguard] [Category:Networking] WireGuard tests should carry pod traffic between nodes over the tunnel
 [sig-network] API Server should have Endpoints and EndpointSlices pointing to API Server [Conformance]

--- a/e2e/testsets/sets/bpf/eks-bpf-encap-extnode-aws.txt
+++ b/e2e/testsets/sets/bpf/eks-bpf-encap-extnode-aws.txt
@@ -118,6 +118,7 @@
 [sig-calico] [Team:CORE] [Feature:NetworkPolicy] [Category:Policy] service network policy Calico service network policy test ServiceMatch policy client egress by service, server ingress by service [Conformance]
 [sig-calico] [Team:CORE] [Feature:OwnerReferences] [Category:Configuration] OwnerReference tests should delete a NetworkSet if its owner has been deleted
 [sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit bandwidth with QoS annotations
+[sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit concurrent connections with QoS annotations
 [sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit packet rate with QoS annotations
 [sig-network] API Server should have Endpoints and EndpointSlices pointing to API Server [Conformance]
 [sig-network] API Server should provide secure master service [Conformance]

--- a/e2e/testsets/sets/bpf/eks-xtables-encap-extnode-aws.txt
+++ b/e2e/testsets/sets/bpf/eks-xtables-encap-extnode-aws.txt
@@ -122,6 +122,7 @@
 [sig-calico] [Team:CORE] [Feature:NetworkPolicy] [Category:Policy] service network policy Calico service network policy test ServiceMatch policy client egress by service, server ingress by service [Conformance]
 [sig-calico] [Team:CORE] [Feature:OwnerReferences] [Category:Configuration] OwnerReference tests should delete a NetworkSet if its owner has been deleted
 [sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit bandwidth with QoS annotations
+[sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit concurrent connections with QoS annotations
 [sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit packet rate with QoS annotations
 [sig-network] API Server should have Endpoints and EndpointSlices pointing to API Server [Conformance]
 [sig-network] API Server should provide secure master service [Conformance]

--- a/e2e/testsets/sets/bpf/kops-bpf-encap-nobgp-extnode-aws.txt
+++ b/e2e/testsets/sets/bpf/kops-bpf-encap-nobgp-extnode-aws.txt
@@ -116,6 +116,7 @@
 [sig-calico] [Team:CORE] [Feature:NetworkPolicy] [Category:Policy] service network policy Calico service network policy test ServiceMatch policy client egress by service, server ingress by service [Conformance]
 [sig-calico] [Team:CORE] [Feature:OwnerReferences] [Category:Configuration] OwnerReference tests should delete a NetworkSet if its owner has been deleted
 [sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit bandwidth with QoS annotations
+[sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit concurrent connections with QoS annotations
 [sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit packet rate with QoS annotations
 [sig-network] API Server should provide secure master service [Conformance]
 [sig-network] DNS should support configurable pod DNS nameservers [Conformance]

--- a/e2e/testsets/sets/bpf/kops-bpf-extnode-aws.txt
+++ b/e2e/testsets/sets/bpf/kops-bpf-extnode-aws.txt
@@ -121,6 +121,7 @@
 [sig-calico] [Team:CORE] [Feature:NetworkPolicy] [Category:Policy] service network policy Calico service network policy test ServiceMatch policy client egress by service, server ingress by service [Conformance]
 [sig-calico] [Team:CORE] [Feature:OwnerReferences] [Category:Configuration] OwnerReference tests should delete a NetworkSet if its owner has been deleted
 [sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit bandwidth with QoS annotations
+[sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit concurrent connections with QoS annotations
 [sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit packet rate with QoS annotations
 [sig-network] API Server should provide secure master service [Conformance]
 [sig-network] DNS should support configurable pod DNS nameservers [Conformance]

--- a/e2e/testsets/sets/bpf/kops-xtables-encap-nobgp-extnode-aws.txt
+++ b/e2e/testsets/sets/bpf/kops-xtables-encap-nobgp-extnode-aws.txt
@@ -120,6 +120,7 @@
 [sig-calico] [Team:CORE] [Feature:NetworkPolicy] [Category:Policy] service network policy Calico service network policy test ServiceMatch policy client egress by service, server ingress by service [Conformance]
 [sig-calico] [Team:CORE] [Feature:OwnerReferences] [Category:Configuration] OwnerReference tests should delete a NetworkSet if its owner has been deleted
 [sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit bandwidth with QoS annotations
+[sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit concurrent connections with QoS annotations
 [sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit packet rate with QoS annotations
 [sig-network] API Server should provide secure master service [Conformance]
 [sig-network] DNS should support configurable pod DNS nameservers [Conformance]

--- a/e2e/testsets/sets/bpf/xtables-encap-extnode-aws.txt
+++ b/e2e/testsets/sets/bpf/xtables-encap-extnode-aws.txt
@@ -123,6 +123,7 @@
 [sig-calico] [Team:CORE] [Feature:NetworkPolicy] [Category:Policy] service network policy Calico service network policy test ServiceMatch policy client egress by service, server ingress by service [Conformance]
 [sig-calico] [Team:CORE] [Feature:OwnerReferences] [Category:Configuration] OwnerReference tests should delete a NetworkSet if its owner has been deleted
 [sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit bandwidth with QoS annotations
+[sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit concurrent connections with QoS annotations
 [sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit packet rate with QoS annotations
 [sig-network] API Server should have Endpoints and EndpointSlices pointing to API Server [Conformance]
 [sig-network] API Server should provide secure master service [Conformance]

--- a/e2e/testsets/sets/bpf/xtables-extnode-aws.txt
+++ b/e2e/testsets/sets/bpf/xtables-extnode-aws.txt
@@ -127,6 +127,7 @@
 [sig-calico] [Team:CORE] [Feature:NetworkPolicy] [Category:Policy] service network policy Calico service network policy test ServiceMatch policy client egress by service, server ingress by service [Conformance]
 [sig-calico] [Team:CORE] [Feature:OwnerReferences] [Category:Configuration] OwnerReference tests should delete a NetworkSet if its owner has been deleted
 [sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit bandwidth with QoS annotations
+[sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit concurrent connections with QoS annotations
 [sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit packet rate with QoS annotations
 [sig-network] API Server should have Endpoints and EndpointSlices pointing to API Server [Conformance]
 [sig-network] API Server should provide secure master service [Conformance]

--- a/e2e/testsets/sets/iptables/aks-xtables-encap.txt
+++ b/e2e/testsets/sets/iptables/aks-xtables-encap.txt
@@ -117,6 +117,7 @@
 [sig-calico] [Team:CORE] [Feature:NetworkPolicy] [Category:Policy] service network policy Calico service network policy test ServiceMatch policy client egress by service, server ingress by service [Conformance]
 [sig-calico] [Team:CORE] [Feature:OwnerReferences] [Category:Configuration] OwnerReference tests should delete a NetworkSet if its owner has been deleted
 [sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit bandwidth with QoS annotations
+[sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit concurrent connections with QoS annotations
 [sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit packet rate with QoS annotations
 [sig-network] API Server should have Endpoints and EndpointSlices pointing to API Server [Conformance]
 [sig-network] API Server should provide secure master service [Conformance]

--- a/e2e/testsets/sets/iptables/aks-xtables-nobgp-v3crd.txt
+++ b/e2e/testsets/sets/iptables/aks-xtables-nobgp-v3crd.txt
@@ -97,6 +97,7 @@
 [sig-calico] [Team:CORE] [Feature:NetworkPolicy] [Category:Policy] service network policy Calico service network policy test ServiceMatch policy client egress by service, server ingress by service [Conformance]
 [sig-calico] [Team:CORE] [Feature:OwnerReferences] [Category:Configuration] OwnerReference tests should delete a NetworkSet if its owner has been deleted
 [sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit bandwidth with QoS annotations
+[sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit concurrent connections with QoS annotations
 [sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit packet rate with QoS annotations
 [sig-network] API Server should have Endpoints and EndpointSlices pointing to API Server [Conformance]
 [sig-network] API Server should provide secure master service [Conformance]

--- a/e2e/testsets/sets/iptables/aks-xtables-nobgp-wireguard.txt
+++ b/e2e/testsets/sets/iptables/aks-xtables-nobgp-wireguard.txt
@@ -101,6 +101,7 @@
 [sig-calico] [Team:CORE] [Feature:NetworkPolicy] [Category:Policy] service network policy Calico service network policy test ServiceMatch policy client egress by service, server ingress by service [Conformance]
 [sig-calico] [Team:CORE] [Feature:OwnerReferences] [Category:Configuration] OwnerReference tests should delete a NetworkSet if its owner has been deleted
 [sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit bandwidth with QoS annotations
+[sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit concurrent connections with QoS annotations
 [sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit packet rate with QoS annotations
 [sig-calico] [Team:CORE] [Feature:Wireguard] [Category:Networking] WireGuard tests should carry pod traffic between nodes over the tunnel
 [sig-network] API Server should have Endpoints and EndpointSlices pointing to API Server [Conformance]

--- a/e2e/testsets/sets/iptables/aks-xtables-nobgp.txt
+++ b/e2e/testsets/sets/iptables/aks-xtables-nobgp.txt
@@ -101,6 +101,7 @@
 [sig-calico] [Team:CORE] [Feature:NetworkPolicy] [Category:Policy] service network policy Calico service network policy test ServiceMatch policy client egress by service, server ingress by service [Conformance]
 [sig-calico] [Team:CORE] [Feature:OwnerReferences] [Category:Configuration] OwnerReference tests should delete a NetworkSet if its owner has been deleted
 [sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit bandwidth with QoS annotations
+[sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit concurrent connections with QoS annotations
 [sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit packet rate with QoS annotations
 [sig-network] API Server should have Endpoints and EndpointSlices pointing to API Server [Conformance]
 [sig-network] API Server should provide secure master service [Conformance]

--- a/e2e/testsets/sets/iptables/eks-xtables-encap-aws.txt
+++ b/e2e/testsets/sets/iptables/eks-xtables-encap-aws.txt
@@ -118,6 +118,7 @@
 [sig-calico] [Team:CORE] [Feature:NetworkPolicy] [Category:Policy] service network policy Calico service network policy test ServiceMatch policy client egress by service, server ingress by service [Conformance]
 [sig-calico] [Team:CORE] [Feature:OwnerReferences] [Category:Configuration] OwnerReference tests should delete a NetworkSet if its owner has been deleted
 [sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit bandwidth with QoS annotations
+[sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit concurrent connections with QoS annotations
 [sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit packet rate with QoS annotations
 [sig-network] API Server should have Endpoints and EndpointSlices pointing to API Server [Conformance]
 [sig-network] API Server should provide secure master service [Conformance]

--- a/e2e/testsets/sets/iptables/eks-xtables-nobgp-v3crd.txt
+++ b/e2e/testsets/sets/iptables/eks-xtables-nobgp-v3crd.txt
@@ -98,6 +98,7 @@
 [sig-calico] [Team:CORE] [Feature:NetworkPolicy] [Category:Policy] service network policy Calico service network policy test ServiceMatch policy client egress by service, server ingress by service [Conformance]
 [sig-calico] [Team:CORE] [Feature:OwnerReferences] [Category:Configuration] OwnerReference tests should delete a NetworkSet if its owner has been deleted
 [sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit bandwidth with QoS annotations
+[sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit concurrent connections with QoS annotations
 [sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit packet rate with QoS annotations
 [sig-network] API Server should have Endpoints and EndpointSlices pointing to API Server [Conformance]
 [sig-network] API Server should provide secure master service [Conformance]

--- a/e2e/testsets/sets/iptables/openshift-xtables-encap-aws.txt
+++ b/e2e/testsets/sets/iptables/openshift-xtables-encap-aws.txt
@@ -119,6 +119,7 @@
 [sig-calico] [Team:CORE] [Feature:NetworkPolicy] [Category:Policy] service network policy Calico service network policy test ServiceMatch policy client egress by service, server ingress by service [Conformance]
 [sig-calico] [Team:CORE] [Feature:OwnerReferences] [Category:Configuration] OwnerReference tests should delete a NetworkSet if its owner has been deleted
 [sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit bandwidth with QoS annotations
+[sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit concurrent connections with QoS annotations
 [sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit packet rate with QoS annotations
 [sig-network] API Server should have Endpoints and EndpointSlices pointing to API Server [Conformance]
 [sig-network] API Server should provide secure master service [Conformance]

--- a/e2e/testsets/sets/iptables/xtables-autohep.txt
+++ b/e2e/testsets/sets/iptables/xtables-autohep.txt
@@ -126,6 +126,7 @@
 [sig-calico] [Team:CORE] [Feature:NetworkPolicy] [Category:Policy] service network policy Calico service network policy test ServiceMatch policy client egress by service, server ingress by service [Conformance]
 [sig-calico] [Team:CORE] [Feature:OwnerReferences] [Category:Configuration] OwnerReference tests should delete a NetworkSet if its owner has been deleted
 [sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit bandwidth with QoS annotations
+[sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit concurrent connections with QoS annotations
 [sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit packet rate with QoS annotations
 [sig-network] API Server should have Endpoints and EndpointSlices pointing to API Server [Conformance]
 [sig-network] API Server should provide secure master service [Conformance]

--- a/e2e/testsets/sets/iptables/xtables-aws.txt
+++ b/e2e/testsets/sets/iptables/xtables-aws.txt
@@ -123,6 +123,7 @@
 [sig-calico] [Team:CORE] [Feature:NetworkPolicy] [Category:Policy] service network policy Calico service network policy test ServiceMatch policy client egress by service, server ingress by service [Conformance]
 [sig-calico] [Team:CORE] [Feature:OwnerReferences] [Category:Configuration] OwnerReference tests should delete a NetworkSet if its owner has been deleted
 [sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit bandwidth with QoS annotations
+[sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit concurrent connections with QoS annotations
 [sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit packet rate with QoS annotations
 [sig-calico] [Team:CORE] [Feature:Wireguard] [Category:Networking] WireGuard tests should carry pod traffic between nodes over the tunnel
 [sig-network] API Server should have Endpoints and EndpointSlices pointing to API Server [Conformance]

--- a/e2e/testsets/sets/iptables/xtables-encap-nobgp.txt
+++ b/e2e/testsets/sets/iptables/xtables-encap-nobgp.txt
@@ -118,6 +118,7 @@
 [sig-calico] [Team:CORE] [Feature:NetworkPolicy] [Category:Policy] service network policy Calico service network policy test ServiceMatch policy client egress by service, server ingress by service [Conformance]
 [sig-calico] [Team:CORE] [Feature:OwnerReferences] [Category:Configuration] OwnerReference tests should delete a NetworkSet if its owner has been deleted
 [sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit bandwidth with QoS annotations
+[sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit concurrent connections with QoS annotations
 [sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit packet rate with QoS annotations
 [sig-network] API Server should have Endpoints and EndpointSlices pointing to API Server [Conformance]
 [sig-network] API Server should provide secure master service [Conformance]

--- a/e2e/testsets/sets/iptables/xtables-manifest-v3crd.txt
+++ b/e2e/testsets/sets/iptables/xtables-manifest-v3crd.txt
@@ -111,6 +111,7 @@
 [sig-calico] [Team:CORE] [Feature:NetworkPolicy] [Category:Policy] service network policy Calico service network policy test ServiceMatch policy client egress by service, server ingress by service [Conformance]
 [sig-calico] [Team:CORE] [Feature:OwnerReferences] [Category:Configuration] OwnerReference tests should delete a NetworkSet if its owner has been deleted
 [sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit bandwidth with QoS annotations
+[sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit concurrent connections with QoS annotations
 [sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit packet rate with QoS annotations
 [sig-network] API Server should have Endpoints and EndpointSlices pointing to API Server [Conformance]
 [sig-network] API Server should provide secure master service [Conformance]

--- a/e2e/testsets/sets/iptables/xtables-manifest.txt
+++ b/e2e/testsets/sets/iptables/xtables-manifest.txt
@@ -115,6 +115,7 @@
 [sig-calico] [Team:CORE] [Feature:NetworkPolicy] [Category:Policy] service network policy Calico service network policy test ServiceMatch policy client egress by service, server ingress by service [Conformance]
 [sig-calico] [Team:CORE] [Feature:OwnerReferences] [Category:Configuration] OwnerReference tests should delete a NetworkSet if its owner has been deleted
 [sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit bandwidth with QoS annotations
+[sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit concurrent connections with QoS annotations
 [sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit packet rate with QoS annotations
 [sig-network] API Server should have Endpoints and EndpointSlices pointing to API Server [Conformance]
 [sig-network] API Server should provide secure master service [Conformance]

--- a/e2e/testsets/sets/iptables/xtables-v3crd-aws.txt
+++ b/e2e/testsets/sets/iptables/xtables-v3crd-aws.txt
@@ -119,6 +119,7 @@
 [sig-calico] [Team:CORE] [Feature:NetworkPolicy] [Category:Policy] service network policy Calico service network policy test ServiceMatch policy client egress by service, server ingress by service [Conformance]
 [sig-calico] [Team:CORE] [Feature:OwnerReferences] [Category:Configuration] OwnerReference tests should delete a NetworkSet if its owner has been deleted
 [sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit bandwidth with QoS annotations
+[sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit concurrent connections with QoS annotations
 [sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit packet rate with QoS annotations
 [sig-calico] [Team:CORE] [Feature:Wireguard] [Category:Networking] WireGuard tests should carry pod traffic between nodes over the tunnel
 [sig-network] API Server should have Endpoints and EndpointSlices pointing to API Server [Conformance]

--- a/e2e/testsets/sets/iptables/xtables-v3crd.txt
+++ b/e2e/testsets/sets/iptables/xtables-v3crd.txt
@@ -119,6 +119,7 @@
 [sig-calico] [Team:CORE] [Feature:NetworkPolicy] [Category:Policy] service network policy Calico service network policy test ServiceMatch policy client egress by service, server ingress by service [Conformance]
 [sig-calico] [Team:CORE] [Feature:OwnerReferences] [Category:Configuration] OwnerReference tests should delete a NetworkSet if its owner has been deleted
 [sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit bandwidth with QoS annotations
+[sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit concurrent connections with QoS annotations
 [sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit packet rate with QoS annotations
 [sig-network] API Server should have Endpoints and EndpointSlices pointing to API Server [Conformance]
 [sig-network] API Server should provide secure master service [Conformance]

--- a/e2e/testsets/sets/iptables/xtables-wireguard.txt
+++ b/e2e/testsets/sets/iptables/xtables-wireguard.txt
@@ -119,6 +119,7 @@
 [sig-calico] [Team:CORE] [Feature:NetworkPolicy] [Category:Policy] service network policy Calico service network policy test ServiceMatch policy client egress by service, server ingress by service [Conformance]
 [sig-calico] [Team:CORE] [Feature:OwnerReferences] [Category:Configuration] OwnerReference tests should delete a NetworkSet if its owner has been deleted
 [sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit bandwidth with QoS annotations
+[sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit concurrent connections with QoS annotations
 [sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit packet rate with QoS annotations
 [sig-calico] [Team:CORE] [Feature:Wireguard] [Category:Networking] WireGuard tests should carry pod traffic between nodes over the tunnel
 [sig-network] API Server should have Endpoints and EndpointSlices pointing to API Server [Conformance]

--- a/e2e/testsets/sets/iptables/xtables.txt
+++ b/e2e/testsets/sets/iptables/xtables.txt
@@ -123,6 +123,7 @@
 [sig-calico] [Team:CORE] [Feature:NetworkPolicy] [Category:Policy] service network policy Calico service network policy test ServiceMatch policy client egress by service, server ingress by service [Conformance]
 [sig-calico] [Team:CORE] [Feature:OwnerReferences] [Category:Configuration] OwnerReference tests should delete a NetworkSet if its owner has been deleted
 [sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit bandwidth with QoS annotations
+[sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit concurrent connections with QoS annotations
 [sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit packet rate with QoS annotations
 [sig-network] API Server should have Endpoints and EndpointSlices pointing to API Server [Conformance]
 [sig-network] API Server should provide secure master service [Conformance]

--- a/e2e/testsets/sets/nftables/eks-xtables-aws-autohep.txt
+++ b/e2e/testsets/sets/nftables/eks-xtables-aws-autohep.txt
@@ -125,6 +125,7 @@
 [sig-calico] [Team:CORE] [Feature:NetworkPolicy] [Category:Policy] service network policy Calico service network policy test ServiceMatch policy client egress by service, server ingress by service [Conformance]
 [sig-calico] [Team:CORE] [Feature:OwnerReferences] [Category:Configuration] OwnerReference tests should delete a NetworkSet if its owner has been deleted
 [sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit bandwidth with QoS annotations
+[sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit concurrent connections with QoS annotations
 [sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit packet rate with QoS annotations
 [sig-network] API Server should have Endpoints and EndpointSlices pointing to API Server [Conformance]
 [sig-network] API Server should provide secure master service [Conformance]

--- a/e2e/testsets/sets/nftables/eks-xtables-nobgp-aws-autohep.txt
+++ b/e2e/testsets/sets/nftables/eks-xtables-nobgp-aws-autohep.txt
@@ -122,6 +122,7 @@
 [sig-calico] [Team:CORE] [Feature:NetworkPolicy] [Category:Policy] service network policy Calico service network policy test ServiceMatch policy client egress by service, server ingress by service [Conformance]
 [sig-calico] [Team:CORE] [Feature:OwnerReferences] [Category:Configuration] OwnerReference tests should delete a NetworkSet if its owner has been deleted
 [sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit bandwidth with QoS annotations
+[sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit concurrent connections with QoS annotations
 [sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit packet rate with QoS annotations
 [sig-network] API Server should have Endpoints and EndpointSlices pointing to API Server [Conformance]
 [sig-network] API Server should provide secure master service [Conformance]

--- a/e2e/testsets/sets/nftables/xtables-autohep.txt
+++ b/e2e/testsets/sets/nftables/xtables-autohep.txt
@@ -126,6 +126,7 @@
 [sig-calico] [Team:CORE] [Feature:NetworkPolicy] [Category:Policy] service network policy Calico service network policy test ServiceMatch policy client egress by service, server ingress by service [Conformance]
 [sig-calico] [Team:CORE] [Feature:OwnerReferences] [Category:Configuration] OwnerReference tests should delete a NetworkSet if its owner has been deleted
 [sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit bandwidth with QoS annotations
+[sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit concurrent connections with QoS annotations
 [sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit packet rate with QoS annotations
 [sig-network] API Server should have Endpoints and EndpointSlices pointing to API Server [Conformance]
 [sig-network] API Server should provide secure master service [Conformance]

--- a/e2e/testsets/sets/nftables/xtables-encap-autohep.txt
+++ b/e2e/testsets/sets/nftables/xtables-encap-autohep.txt
@@ -122,6 +122,7 @@
 [sig-calico] [Team:CORE] [Feature:NetworkPolicy] [Category:Policy] service network policy Calico service network policy test ServiceMatch policy client egress by service, server ingress by service [Conformance]
 [sig-calico] [Team:CORE] [Feature:OwnerReferences] [Category:Configuration] OwnerReference tests should delete a NetworkSet if its owner has been deleted
 [sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit bandwidth with QoS annotations
+[sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit concurrent connections with QoS annotations
 [sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit packet rate with QoS annotations
 [sig-network] API Server should have Endpoints and EndpointSlices pointing to API Server [Conformance]
 [sig-network] API Server should provide secure master service [Conformance]

--- a/e2e/testsets/sets/nftables/xtables-encap-aws-autohep.txt
+++ b/e2e/testsets/sets/nftables/xtables-encap-aws-autohep.txt
@@ -122,6 +122,7 @@
 [sig-calico] [Team:CORE] [Feature:NetworkPolicy] [Category:Policy] service network policy Calico service network policy test ServiceMatch policy client egress by service, server ingress by service [Conformance]
 [sig-calico] [Team:CORE] [Feature:OwnerReferences] [Category:Configuration] OwnerReference tests should delete a NetworkSet if its owner has been deleted
 [sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit bandwidth with QoS annotations
+[sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit concurrent connections with QoS annotations
 [sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit packet rate with QoS annotations
 [sig-network] API Server should have Endpoints and EndpointSlices pointing to API Server [Conformance]
 [sig-network] API Server should provide secure master service [Conformance]

--- a/e2e/testsets/sets/nftables/xtables-encap-nobgp-v3crd-autohep.txt
+++ b/e2e/testsets/sets/nftables/xtables-encap-nobgp-v3crd-autohep.txt
@@ -117,6 +117,7 @@
 [sig-calico] [Team:CORE] [Feature:NetworkPolicy] [Category:Policy] service network policy Calico service network policy test ServiceMatch policy client egress by service, server ingress by service [Conformance]
 [sig-calico] [Team:CORE] [Feature:OwnerReferences] [Category:Configuration] OwnerReference tests should delete a NetworkSet if its owner has been deleted
 [sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit bandwidth with QoS annotations
+[sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit concurrent connections with QoS annotations
 [sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit packet rate with QoS annotations
 [sig-network] API Server should have Endpoints and EndpointSlices pointing to API Server [Conformance]
 [sig-network] API Server should provide secure master service [Conformance]

--- a/e2e/testsets/sets/nftables/xtables-v3crd-aws-autohep.txt
+++ b/e2e/testsets/sets/nftables/xtables-v3crd-aws-autohep.txt
@@ -122,6 +122,7 @@
 [sig-calico] [Team:CORE] [Feature:NetworkPolicy] [Category:Policy] service network policy Calico service network policy test ServiceMatch policy client egress by service, server ingress by service [Conformance]
 [sig-calico] [Team:CORE] [Feature:OwnerReferences] [Category:Configuration] OwnerReference tests should delete a NetworkSet if its owner has been deleted
 [sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit bandwidth with QoS annotations
+[sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit concurrent connections with QoS annotations
 [sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit packet rate with QoS annotations
 [sig-network] API Server should have Endpoints and EndpointSlices pointing to API Server [Conformance]
 [sig-network] API Server should provide secure master service [Conformance]

--- a/e2e/testsets/sets/vpp/eks-vpp-encap-extnode-aws.txt
+++ b/e2e/testsets/sets/vpp/eks-vpp-encap-extnode-aws.txt
@@ -113,4 +113,5 @@
 [sig-calico] [Team:CORE] [Feature:NetworkPolicy] [Category:Policy] service network policy Calico service network policy test ServiceMatch policy client egress by service, server ingress by service [Conformance]
 [sig-calico] [Team:CORE] [Feature:OwnerReferences] [Category:Configuration] OwnerReference tests should delete a NetworkSet if its owner has been deleted
 [sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit bandwidth with QoS annotations
+[sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit concurrent connections with QoS annotations
 [sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit packet rate with QoS annotations

--- a/e2e/testsets/sets/vpp/vpp-encap-extnode-aws.txt
+++ b/e2e/testsets/sets/vpp/vpp-encap-extnode-aws.txt
@@ -114,4 +114,5 @@
 [sig-calico] [Team:CORE] [Feature:NetworkPolicy] [Category:Policy] service network policy Calico service network policy test ServiceMatch policy client egress by service, server ingress by service [Conformance]
 [sig-calico] [Team:CORE] [Feature:OwnerReferences] [Category:Configuration] OwnerReference tests should delete a NetworkSet if its owner has been deleted
 [sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit bandwidth with QoS annotations
+[sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit concurrent connections with QoS annotations
 [sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit packet rate with QoS annotations

--- a/e2e/testsets/sets/vpp/vpp-encap-extnode.txt
+++ b/e2e/testsets/sets/vpp/vpp-encap-extnode.txt
@@ -114,4 +114,5 @@
 [sig-calico] [Team:CORE] [Feature:NetworkPolicy] [Category:Policy] service network policy Calico service network policy test ServiceMatch policy client egress by service, server ingress by service [Conformance]
 [sig-calico] [Team:CORE] [Feature:OwnerReferences] [Category:Configuration] OwnerReference tests should delete a NetworkSet if its owner has been deleted
 [sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit bandwidth with QoS annotations
+[sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit concurrent connections with QoS annotations
 [sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit packet rate with QoS annotations

--- a/e2e/testsets/sets/vpp/xtables-encap-extnode-aws.txt
+++ b/e2e/testsets/sets/vpp/xtables-encap-extnode-aws.txt
@@ -118,4 +118,5 @@
 [sig-calico] [Team:CORE] [Feature:NetworkPolicy] [Category:Policy] service network policy Calico service network policy test ServiceMatch policy client egress by service, server ingress by service [Conformance]
 [sig-calico] [Team:CORE] [Feature:OwnerReferences] [Category:Configuration] OwnerReference tests should delete a NetworkSet if its owner has been deleted
 [sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit bandwidth with QoS annotations
+[sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit concurrent connections with QoS annotations
 [sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit packet rate with QoS annotations


### PR DESCRIPTION
## Description

**Type:** generated-file fix. `make -C e2e gen-test-set` output only; no test selection has changed.

`make -C e2e check-test-set` currently fails on master. Every lane's spec count in
`e2e/testsets/index.txt` is one short, and the missing spec is the same one everywhere:

```
[sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit concurrent connections with QoS annotations
```

## How it got here

Two steps, neither of which conflicted with the other:

1. **#13237** (`e2e: add QoS connection-limit test`, 24 Aug) added the spec in
   `e2e/pkg/tests/networking/qos.go` but did not regenerate `e2e/testsets`, leaving them stale.
2. **#13601** (`Move the auto host endpoint exclusion into the base e2e config`, 25 Aug) *did*
   regenerate — but from a branch based before #13237, so its output was also missing the spec.
   Because #13237 had not touched these files, that regenerated output merged without conflict and
   the staleness survived.

So the drift is one spec, present in `e2e/pkg/tests/` since 24 Aug and absent from every generated
set.

## Note on the CI gate

The `E2E test set drift` block runs `check-test-set` gated on
`CHANGE_IN(e2e, non-go:/e2e/config/, non-go:/.argoci/cron/, non-go:/.semaphore/end-to-end/pipelines/)`,
so both PRs above should have run it, and #13237's run should have failed. Worth someone checking
whether that block ran and what it reported on #13237 — a gate that can be satisfied on the PR's own
tree while the merge result stays stale (as in step 2) is a second, separate weakness, since
`check-test-set` compares the generator's output against the branch rather than against the
post-merge tree.

I have not changed the gate here; this PR only brings the checked-in output back in line.

## Testing

`make -C e2e gen-test-set` on `origin/master`, then committed the result. The diff is 49 files,
+196/-148: one added spec line per selecting lane, plus the corresponding count changes in
`index.txt`.

**Release note:**
```release-note
None
```