### PR TITLE
[v3.31] Handle DeletedFinalStateUnknown across kube-controllers and confd delete handlers

### DIFF
--- a/confd/pkg/backends/calico/routes.go
+++ b/confd/pkg/backends/calico/routes.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2024 Tigera, Inc. All rights reserved.
+// Copyright (c) 2018-2026 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -578,10 +578,12 @@ func (rg *routeGenerator) advertiseThisService(svc *v1.Service, eps []*discovery
 }
 
 // unsetRouteForSvc removes the route from the svcClusterRouteMap
-// but checks to see if it wasn't already deleted by its sibling resource
+// but checks to see if it wasn't already deleted by its sibling resource.
+// Only called from delete handlers, so it must use the deletion-handling
+// key func to unwrap any cache.DeletedFinalStateUnknown tombstone.
 func (rg *routeGenerator) unsetRouteForSvc(obj interface{}) {
 	// generate key
-	key, err := cache.MetaNamespaceKeyFunc(obj)
+	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
 	if err != nil {
 		log.WithError(err).Warn("unsetRouteForSvc: error on retrieving key for object, passing")
 		return

--- a/kube-controllers/pkg/controllers/loadbalancer/loadbalancer_controller.go
+++ b/kube-controllers/pkg/controllers/loadbalancer/loadbalancer_controller.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2025 Tigera, Inc. All rights reserved.
+// Copyright (c) 2019-2026 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -213,14 +213,25 @@ func (c *loadBalancerController) onServiceUpdate(objNew interface{}, objOld inte
 	}
 }
 
-func (c *loadBalancerController) onServiceDelete(objNew interface{}) {
-	if svc, ok := objNew.(*v1.Service); ok {
-		svcKey, err := serviceKeyFromService(svc)
-		if err != nil {
+func (c *loadBalancerController) onServiceDelete(obj interface{}) {
+	svc, ok := obj.(*v1.Service)
+	if !ok {
+		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			log.WithField("type", fmt.Sprintf("%T", obj)).Warn("Unexpected object type in Service delete event")
 			return
 		}
-		c.serviceUpdates <- *svcKey
+		svc, ok = tombstone.Obj.(*v1.Service)
+		if !ok {
+			log.WithField("type", fmt.Sprintf("%T", tombstone.Obj)).Warn("Tombstone contained non-Service object")
+			return
+		}
 	}
+	svcKey, err := serviceKeyFromService(svc)
+	if err != nil {
+		return
+	}
+	c.serviceUpdates <- *svcKey
 }
 
 func (c *loadBalancerController) RegisterWith(f *utils.DataFeed) {

--- a/kube-controllers/pkg/controllers/node/controller.go
+++ b/kube-controllers/pkg/controllers/node/controller.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2025 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017-2026 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@ package node
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -103,17 +104,25 @@ func NewNodeController(ctx context.Context,
 	// respective informers.
 	nodeHandlers := cache.ResourceEventHandlerFuncs{
 		DeleteFunc: func(obj interface{}) {
+			node, ok := nodeFromDeleteObj(obj)
+			if !ok {
+				return
+			}
 			// Call all of the registered node deletion funcs.
 			for _, f := range nodeDeletionFuncs {
-				f(obj.(*v1.Node))
+				f(node)
 			}
 		},
 	}
 	podHandlers := cache.ResourceEventHandlerFuncs{
 		DeleteFunc: func(obj interface{}) {
+			pod, ok := podFromDeleteObj(obj)
+			if !ok {
+				return
+			}
 			// Call all of the registered pod deletion funcs.
 			for _, f := range podDeletionFuncs {
-				f(obj.(*v1.Pod))
+				f(pod)
 			}
 		},
 	}
@@ -144,6 +153,45 @@ func NewNodeController(ctx context.Context,
 	}
 
 	return nc
+}
+
+// nodeFromDeleteObj extracts a *v1.Node from an informer delete event object,
+// unwrapping the cache.DeletedFinalStateUnknown tombstone the informer may
+// deliver when its watch state is lost. Returns ok=false (and logs) if the
+// object is not a Node, so callers can skip the delete instead of panicking.
+func nodeFromDeleteObj(obj interface{}) (*v1.Node, bool) {
+	if node, ok := obj.(*v1.Node); ok {
+		return node, true
+	}
+	tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+	if !ok {
+		log.WithField("type", fmt.Sprintf("%T", obj)).Warn("Unexpected object type in node delete event")
+		return nil, false
+	}
+	node, ok := tombstone.Obj.(*v1.Node)
+	if !ok {
+		log.WithField("type", fmt.Sprintf("%T", tombstone.Obj)).Warn("Tombstone contained non-Node object")
+		return nil, false
+	}
+	return node, true
+}
+
+// podFromDeleteObj is the pod counterpart to nodeFromDeleteObj.
+func podFromDeleteObj(obj interface{}) (*v1.Pod, bool) {
+	if pod, ok := obj.(*v1.Pod); ok {
+		return pod, true
+	}
+	tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+	if !ok {
+		log.WithField("type", fmt.Sprintf("%T", obj)).Warn("Unexpected object type in pod delete event")
+		return nil, false
+	}
+	pod, ok := tombstone.Obj.(*v1.Pod)
+	if !ok {
+		log.WithField("type", fmt.Sprintf("%T", tombstone.Obj)).Warn("Tombstone contained non-Pod object")
+		return nil, false
+	}
+	return pod, true
 }
 
 // getK8sNodeName is a helper method that searches a calicoNode for its kubernetes nodeRef.

--- a/kube-controllers/pkg/controllers/node/controller_test.go
+++ b/kube-controllers/pkg/controllers/node/controller_test.go
@@ -1,0 +1,73 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package node
+
+import (
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
+)
+
+func TestNodeFromDeleteObj(t *testing.T) {
+	node := &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "n1"}}
+
+	tests := []struct {
+		name   string
+		obj    any
+		want   *v1.Node
+		wantOk bool
+	}{
+		{"direct node", node, node, true},
+		{"tombstone with node", cache.DeletedFinalStateUnknown{Key: "n1", Obj: node}, node, true},
+		{"tombstone with pod", cache.DeletedFinalStateUnknown{Key: "n1", Obj: &v1.Pod{}}, nil, false},
+		{"unrelated type", &v1.Pod{}, nil, false},
+		{"nil", nil, nil, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := nodeFromDeleteObj(tc.obj)
+			if ok != tc.wantOk || got != tc.want {
+				t.Fatalf("got (%v, %v), want (%v, %v)", got, ok, tc.want, tc.wantOk)
+			}
+		})
+	}
+}
+
+func TestPodFromDeleteObj(t *testing.T) {
+	pod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "p1"}}
+
+	tests := []struct {
+		name   string
+		obj    any
+		want   *v1.Pod
+		wantOk bool
+	}{
+		{"direct pod", pod, pod, true},
+		{"tombstone with pod", cache.DeletedFinalStateUnknown{Key: "p1", Obj: pod}, pod, true},
+		{"tombstone with node", cache.DeletedFinalStateUnknown{Key: "p1", Obj: &v1.Node{}}, nil, false},
+		{"unrelated type", &v1.Node{}, nil, false},
+		{"nil", nil, nil, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := podFromDeleteObj(tc.obj)
+			if ok != tc.wantOk || got != tc.want {
+				t.Fatalf("got (%v, %v), want (%v, %v)", got, ok, tc.want, tc.wantOk)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**Cherry-pick history**
- Pick onto **release-v3.31**: projectcalico/calico#12793

The informer can deliver a `cache.DeletedFinalStateUnknown` tombstone to `DeleteFunc` when its watch state is lost. Several delete paths in kube-controllers and confd cast the object directly or used `cache.MetaNamespaceKeyFunc`, which either panic (crash-looping the pod) or silently drop the cleanup on the tombstone case.

Fixes #12741

Files touched:

- `kube-controllers/.../node/controller.go` - node and pod delete handlers (the original report)
- `kube-controllers/.../ippool/pool_controller.go` - IPPool and IPAMBlock delete handlers
- `kube-controllers/.../loadbalancer/loadbalancer_controller.go` - Service delete handler
- `kube-controllers/.../migration/controller.go` - swap to `DeletionHandlingMetaNamespaceKeyFunc`
- `confd/.../routes.go` - `unsetRouteForSvc` is called from delete handlers, same swap

```release-note
Fixes a panic in kube-controllers when the informer delivers a tombstone object to a delete handler.
```

**Cherry-pick notes**

- `kube-controllers/pkg/controllers/migration/controller.go` and `kube-controllers/pkg/controllers/ippool/pool_controller.go` do not exist on this branch, so those hunks are dropped. The remaining three files carry the fix.
- The only conflicts were `interface{}` vs `any`: this branch predates the repo-wide `any` migration, so the signatures keep `interface{}`.
- Verified on this branch: `go build ./kube-controllers/... ./confd/...` passes, and `TestNodeFromDeleteObj` / `TestPodFromDeleteObj` pass.

