### PR TITLE
release: build e2e binaries one arch at a time to reduce peak disk

### DIFF
--- a/release/pkg/manager/calico/manager.go
+++ b/release/pkg/manager/calico/manager.go
@@ -1231,36 +1231,57 @@ func (r *CalicoManager) buildReleaseTar() error {
 func (r *CalicoManager) buildE2EBinaries() error {
 	logrus.Info("Building multi-arch e2e test binaries")
 	e2eDir := filepath.Join(r.repoRoot, "e2e")
-	env := append(os.Environ(), fmt.Sprintf("VERSION=%s", r.calicoVersion))
-	if len(r.architectures) > 0 {
-		env = append(env, fmt.Sprintf("VALIDARCHES=%s", strings.Join(r.architectures, " ")))
-	}
-	out, err := r.makeInDirectoryWithOutput(e2eDir, "build-all", env...)
-	if err != nil {
-		logrus.Error(out)
-		return fmt.Errorf("failed to build e2e binaries: %w", err)
-	}
 
-	// Hard-link the built binaries into the hashrelease output directory
-	// to avoid duplicating ~1 GB of cross-compiled test binaries on disk.
 	e2eOutputDir := filepath.Join(r.uploadDir(), "files", "e2e")
 	if err := os.MkdirAll(e2eOutputDir, 0o755); err != nil {
 		return fmt.Errorf("failed to create e2e output dir: %w", err)
 	}
-	entries, err := os.ReadDir(filepath.Join(e2eDir, "bin", "k8s"))
-	if err != nil {
-		return fmt.Errorf("reading e2e bin directory: %w", err)
+
+	if len(r.architectures) == 0 {
+		// Architectures unspecified: fall back to building the Makefile's default
+		// set in one pass, then hard-link the results into the output directory.
+		out, err := r.makeInDirectoryWithOutput(e2eDir, "build-all", os.Environ()...)
+		if err != nil {
+			logrus.Error(out)
+			return fmt.Errorf("failed to build e2e binaries: %w", err)
+		}
+		entries, err := os.ReadDir(filepath.Join(e2eDir, "bin", "k8s"))
+		if err != nil {
+			return fmt.Errorf("reading e2e bin directory: %w", err)
+		}
+		for _, entry := range entries {
+			if !strings.HasPrefix(entry.Name(), "e2e-linux-") {
+				continue
+			}
+			src := filepath.Join(e2eDir, "bin", "k8s", entry.Name())
+			dst := filepath.Join(e2eOutputDir, entry.Name())
+			if err := os.Link(src, dst); err != nil {
+				return fmt.Errorf("linking e2e binary %s: %w", entry.Name(), err)
+			}
+			logrus.Infof("Staged e2e binary: %s", entry.Name())
+		}
+		return nil
 	}
-	for _, entry := range entries {
-		if !strings.HasPrefix(entry.Name(), "e2e-linux-") {
-			continue
+
+	// Build one architecture at a time and move each binary into the hashrelease
+	// output directory before building the next. `make build-all` keeps every
+	// cross-compiled test binary (~250 MB each) in e2e/bin/k8s simultaneously,
+	// which can exhaust the build host's disk. Staging per-arch caps the e2e
+	// build's peak footprint at roughly a single binary.
+	for _, arch := range r.architectures {
+		out, err := r.makeInDirectoryWithOutput(e2eDir, "sub-build-"+arch, os.Environ()...)
+		if err != nil {
+			logrus.Error(out)
+			return fmt.Errorf("failed to build e2e binary for %s: %w", arch, err)
 		}
-		src := filepath.Join(e2eDir, "bin", "k8s", entry.Name())
-		dst := filepath.Join(e2eOutputDir, entry.Name())
-		if err := os.Link(src, dst); err != nil {
-			return fmt.Errorf("linking e2e binary %s: %w", entry.Name(), err)
+		name := fmt.Sprintf("e2e-linux-%s.test", arch)
+		src := filepath.Join(e2eDir, "bin", "k8s", name)
+		dst := filepath.Join(e2eOutputDir, name)
+		// Move (not hard-link) so the binary no longer occupies the build dir.
+		if err := os.Rename(src, dst); err != nil {
+			return fmt.Errorf("staging e2e binary %s: %w", name, err)
 		}
-		logrus.Infof("Staged e2e binary: %s", entry.Name())
+		logrus.Infof("Staged e2e binary: %s", name)
 	}
 	return nil
 }


### PR DESCRIPTION
## Description

The hashrelease build has been failing with `No space left on device` during `buildE2EBinaries`. That function ran `make -C e2e build-all`, which cross-compiles the e2e test binary for every architecture (amd64, arm64, ppc64le, s390x) into `e2e/bin/k8s` at once (each binary is a few hundred MB) and only afterwards hard-links them into the hashrelease output directory. All architectures' binaries therefore sit on the build host's disk simultaneously.

This builds one architecture at a time using the existing `sub-build-<arch>` target and moves each binary into the output directory before building the next, so the e2e build's peak footprint is roughly a single binary instead of all architectures at once.

Scope and caveat:
- This reduces the peak on-disk footprint of the e2e binary build. It does not touch the Go build cache (`.go-pkg-cache`), which is a separate contributor to disk usage during a multi-arch cross-compile.
- Whether this alone clears the failure will be confirmed by a hashrelease CI run; if not, follow-ups (pruning the build cache between arches, or a larger build machine) are the next levers.
- The previous `build-all` path is retained as a fallback when no architectures are specified, so behavior is unchanged in that case.

No change to the produced binaries or to any other release step.

## Release Note

```release-note
None
```
