### PR TITLE
Document the tigera-operator chart dnsPolicy value

### DIFF
--- a/charts/tigera-operator/values.yaml
+++ b/charts/tigera-operator/values.yaml
@@ -154,7 +154,12 @@ podAnnotations: {}
 # Custom labels for the tigera/operator pod.
 podLabels: {}
 
-# Custom DNS configuration for the tigera/operator pod.
+# DNS policy for the tigera/operator pod. Set "None" with a dnsConfig listing cluster and node
+# resolvers where cluster DNS is not reachable at install time, such as EKS with kube-proxy disabled.
+dnsPolicy: ""
+
+# Custom DNS configuration for the tigera/operator pod. calico-node inherits this and dnsPolicy
+# when set.
 dnsConfig: {}
 
 # Image and registry configuration for the tigera/operator pod.


### PR DESCRIPTION
The chart has taken a `dnsPolicy` value since https://github.com/projectcalico/calico/commit/d0ddf54ca, but it was never listed in `values.yaml` and the inline hint pointing EKS users at it is gone, so there is no signal in the repo that the knob exists. This adds it, along with when to reach for it.

It matters on a cluster where the Kubernetes API server is reachable only by name and cluster DNS is not up yet, such as EKS with kube-proxy disabled. The operator defaults to `ClusterFirstWithHostNet`, which leaves the CoreDNS ClusterIP as its only resolver, and the install deadlocks.

**Release note:**
```release-note
None
```
