### PR TITLE
[release-v3.32] Document the tigera-operator chart dnsPolicy value

### DIFF
--- a/charts/tigera-operator/values.yaml
+++ b/charts/tigera-operator/values.yaml
@@ -142,7 +142,12 @@ podAnnotations: {}
 # Custom labels for the tigera/operator pod.
 podLabels: {}
 
-# Custom DNS configuration for the tigera/operator pod.
+# DNS policy for the tigera/operator pod. Set "None" with a dnsConfig listing cluster and node
+# resolvers where cluster DNS is not reachable at install time, such as EKS with kube-proxy disabled.
+dnsPolicy: ""
+
+# Custom DNS configuration for the tigera/operator pod. calico-node inherits this and dnsPolicy
+# when set.
 dnsConfig: {}
 # Image and registry configuration for the tigera/operator pod.
 tigeraOperator:


### PR DESCRIPTION
Backport of https://github.com/projectcalico/calico/pull/13638.

The chart has taken a `dnsPolicy` value since https://github.com/projectcalico/calico/commit/d0ddf54ca, but it was never listed in `values.yaml`, so there is no signal in the repo that the knob exists. It matters on a cluster where the Kubernetes API server is reachable only by name and cluster DNS is not up yet, such as EKS with kube-proxy disabled.

**Release note:**
```release-note
None
```
