### PR TITLE
Check out CNI_VERSION after cloning containernetworking-plugins

### DIFF
--- a/cni-plugin/Makefile
+++ b/cni-plugin/Makefile
@@ -149,10 +149,13 @@ CN_FILES := host-local portmap loopback tuning
 
 CONTAINERNETWORKING_PLUGINS_CLONED=.containernetworking-plugins-$(CNI_VERSION).cloned
 
+# CNI_VERSION may be a commit SHA, which --branch does not accept, so clone
+# then check it out.
 $(CONTAINERNETWORKING_PLUGINS_CLONED):
 	rm -rf containernetworking-plugins .containernetworking-plugins-*.cloned
 	@$(foreach file,$(CN_FILES),find bin -name $(file) -type f -delete;)
-	git clone --single-branch --branch $(CNI_VERSION) https://github.com/projectcalico/containernetworking-plugins.git
+	git clone https://github.com/projectcalico/containernetworking-plugins.git
+	git -C containernetworking-plugins checkout $(CNI_VERSION)
 	touch $@
 
 CN_FLAGS=-ldflags "-X github.com/containernetworking/plugins/pkg/utils/buildversion.BuildVersion=$(GIT_VERSION)"


### PR DESCRIPTION
The bundled CNI plugin build fails when `CNI_VERSION` is pinned to a commit SHA, because git only accepts a branch or tag name with `--branch`. This clones the fork first and then checks the pin out, which works for both a SHA and a branch name.

The upstream sync bot pins `CNI_VERSION` to the latest commit on the fork, and release-v3.31 is in its matrix, so this lands ahead of the first sync PR there. Same change as #13641 on release-v3.32.

```release-note
None
```
