### PR TITLE
[v3.32] ci: backport disk-space cleanup to fix v3.32 hashrelease builds

### DIFF
--- a/.semaphore/release/hashrelease.yml
+++ b/.semaphore/release/hashrelease.yml
@@ -29,6 +29,7 @@ global_job_config:
 
   prologue:
     commands:
+      - sudo rm -rf ~/.phpbrew ~/.kerl ~/.sbt ~/.nvm ~/.npm ~/.kiex /usr/local/golang/ /usr/lib/jvm /opt/* /opt/az
       - chmod 0600 ~/.keys/*
       - ssh-add ~/.keys/*
       # Checkout the code and unshallow it.

--- a/.semaphore/release/hashrelease.yml
+++ b/.semaphore/release/hashrelease.yml
@@ -53,6 +53,8 @@ global_job_config:
       - gcloud config set project --quiet "${OIDC_GCP_PROJECT_NAME}"
       # Configure docker to use the gcloud credential helper
       - gcloud auth configure-docker --quiet
+      # We need to prune the pre-loaded images to ensure we have enough /var/lib/docker disk space.
+      - docker system prune -af
 
 blocks:
   - name: Publish hashrelease

--- a/.semaphore/release/release.yml
+++ b/.semaphore/release/release.yml
@@ -21,6 +21,7 @@ blocks:
         - name: openstack-signing-publishing
       prologue:
         commands:
+          - sudo rm -rf ~/.phpbrew ~/.kerl ~/.sbt ~/.nvm ~/.npm ~/.kiex /usr/local/golang/ /usr/lib/jvm /opt/* /opt/az
           # Load the github access secrets.  First fix the permissions.
           - chmod 0600 /home/semaphore/.keys/git_ssh_rsa
           - ssh-add /home/semaphore/.keys/git_ssh_rsa

--- a/.semaphore/semaphore-scheduled-builds.yml
+++ b/.semaphore/semaphore-scheduled-builds.yml
@@ -704,6 +704,10 @@ blocks:
         machine:
           type: f1-standard-4
           os_image: ubuntu2204
+      prologue:
+        commands:
+          # We need to prune the pre-loaded images to ensure we have enough /var/lib/docker disk space.
+          - docker system prune -af
       jobs:
         - name: "E2E tests: Conformance (cluster routing: BIRD)"
           commands:
@@ -730,6 +734,10 @@ blocks:
         machine:
           type: f1-standard-4
           os_image: ubuntu2204
+      prologue:
+        commands:
+          # We need to prune the pre-loaded images to ensure we have enough /var/lib/docker disk space.
+          - docker system prune -af
       jobs:
         - name: "E2E tests: Conformance (cluster routing: Felix)"
           commands:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -704,6 +704,10 @@ blocks:
         machine:
           type: f1-standard-4
           os_image: ubuntu2204
+      prologue:
+        commands:
+          # We need to prune the pre-loaded images to ensure we have enough /var/lib/docker disk space.
+          - docker system prune -af
       jobs:
         - name: "E2E tests: Conformance (cluster routing: BIRD)"
           commands:
@@ -730,6 +734,10 @@ blocks:
         machine:
           type: f1-standard-4
           os_image: ubuntu2204
+      prologue:
+        commands:
+          # We need to prune the pre-loaded images to ensure we have enough /var/lib/docker disk space.
+          - docker system prune -af
       jobs:
         - name: "E2E tests: Conformance (cluster routing: Felix)"
           commands:

--- a/.semaphore/semaphore.yml.d/blocks/20-e2e.yml
+++ b/.semaphore/semaphore.yml.d/blocks/20-e2e.yml
@@ -11,6 +11,10 @@
       machine:
         type: f1-standard-4
         os_image: ubuntu2204
+    prologue:
+      commands:
+        # We need to prune the pre-loaded images to ensure we have enough /var/lib/docker disk space.
+        - docker system prune -af
     jobs:
       - name: "E2E tests: Conformance (cluster routing: BIRD)"
         commands:
@@ -37,6 +41,10 @@
       machine:
         type: f1-standard-4
         os_image: ubuntu2204
+    prologue:
+      commands:
+        # We need to prune the pre-loaded images to ensure we have enough /var/lib/docker disk space.
+        - docker system prune -af
     jobs:
       - name: "E2E tests: Conformance (cluster routing: Felix)"
         commands:


### PR DESCRIPTION
**Cherry-pick history**
- Pick onto **release-v3.32**: projectcalico/calico#12375
- Pick onto **release-v3.32**: projectcalico/calico#12607

The nightly `Publish hashrelease` job on `release-v3.32` has failed **8 weeknights in a row** (Aug 14–25, 2026), every time by running out of disk. The last successful hashrelease was `2026-08-13-v3-32-filth`.

```
write .../e2e/bin/k8s/e2e-linux-ppc64le.test: no space left on device
make[2]: *** [Makefile:19: bin/k8s/e2e-linux-ppc64le.test] Error 1
make[1]: *** [Makefile:27: sub-build-ppc64le] Error 2
FATAL  error="failed to build e2e binaries: exit status 2..."
make: *** [Makefile:52: hashrelease-build] Error 1
```

The volume was full enough that other tools failed too — Semaphore could not write its own metrics, and git could not write an index lock:

```
system-metrics-collector: echo: write error: No space left on device
fatal: sha1 file '.git/index.lock' write error. Out of diskspace
```

**Cause.** #13517 (commit `5d6d198c14`, Aug 13) added `buildE2EBinaries()`, which cross-compiles an e2e test binary for each of the four target architectures. Measured from the published artifacts of the current `master` hashrelease, those four binaries total **≈800 MB** — 183 MiB (amd64), 188 MiB (arm64), 194 MiB (ppc64le), 199 MiB (s390x); the `release-v3.33` hashrelease from the same day totals the same to within 0.1%. The four cross-compiles also populate additional Go build-cache entries, which have not been measured. This branch has no step to free disk space before the build, so the disk fills and the job dies. `master` and `release-v3.33` run the same workload successfully because they already carry both picks below. `release-v3.31` also lacks them, but does not build e2e binaries, so it still fits.

Files touched:

- `.semaphore/release/hashrelease.yml` - free disk in the prologue, then prune pre-loaded images
- `.semaphore/release/release.yml` - free disk in the prologue
- `.semaphore/semaphore.yml.d/blocks/20-e2e.yml` - prune before the two E2E conformance blocks
- `.semaphore/semaphore.yml` - regenerated output of the above
- `.semaphore/semaphore-scheduled-builds.yml` - same prune for the scheduled E2E blocks

5 files, 28 insertions, 0 deletions. Purely additive — no existing line is edited, removed, reordered or reindented. Every addition is one of:

```yaml
- sudo rm -rf ~/.phpbrew ~/.kerl ~/.sbt ~/.nvm ~/.npm ~/.kiex /usr/local/golang/ /usr/lib/jvm /opt/* /opt/az
```
```yaml
# We need to prune the pre-loaded images to ensure we have enough /var/lib/docker disk space.
- docker system prune -af
```

```release-note
None
```

**Cherry-pick notes**

- Both picks applied cleanly to `release-v3.32` at `7ac74fe1e0` with **no conflicts**, so no hunks were dropped or adapted. This is a faithful copy of both upstream commits, including the parts outside the hashrelease pipeline.
- Scope note for reviewers: beyond the hashrelease pipeline, this adds `docker system prune -af` to the two E2E conformance blocks in PR-time CI and in scheduled builds, and one `rm -rf` line to `release.yml`. That is the full content of the upstream commits, kept intact rather than trimmed. The prune runs in the block prologue, before any job command, so it cannot delete an image a job has already staged. The trade-off is that a job which previously reused a Semaphore-preloaded image will now pull it.
- No Go code is touched. The e2e binary build runs only when `isHashRelease` is true (`release/pkg/manager/calico/manager.go`), so the real release path is unaffected.
- Verified on this branch: all five files parse as valid YAML, with no duplicate `prologue:` key in any block — the two E2E conformance blocks had no task-level prologue before this change. `.semaphore/semaphore.yml` and its source `.semaphore/semaphore.yml.d/blocks/20-e2e.yml` were checked to agree on both modified blocks, so the generated file stays in sync with its template; the `Prerequisites` block runs `make gen-semaphore-yaml && make check-dirty` here, which confirms that conclusively.
- Verifying the fix end to end requires a hashrelease run on this branch, which is the point of the change.
