### PR TITLE
[release-v3.33] fix(release): publish the branch tag from hashrelease

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ check-dockerfiles:
 	./hack/check-dockerfiles.sh
 
 check-images-availability: bin/crane bin/yq
-	cd ./hack && ./check-images-availability.sh
+	cd ./hack && RELEASE_BRANCH_PREFIX=$(RELEASE_BRANCH_PREFIX) ./check-images-availability.sh
 
 check-language:
 	./hack/check-language.sh

--- a/hack/check-images-availability.sh
+++ b/hack/check-images-availability.sh
@@ -42,6 +42,15 @@ CALICO_VERSION="${PRODUCT_VERSION:-$defaultCalicoVersion}"
 echo "Using REGISTRY: $REGISTRY"
 echo "Using CALICO_VERSION: $CALICO_VERSION"
 
+# A branch-prefixed version is a moving tag that only exists once a hashrelease
+# has published from that branch, so a miss is expected rather than a failure.
+RELEASE_BRANCH_PREFIX="${RELEASE_BRANCH_PREFIX:-release}"
+BRANCH_TAG=0
+if [[ "$CALICO_VERSION" == "${RELEASE_BRANCH_PREFIX}-"* ]]; then
+  BRANCH_TAG=1
+  echo "⚠️  $CALICO_VERSION is a branch tag; missing images tagged with it will warn, not fail."
+fi
+
 #########################################
 # Step 1: Extract from manifests
 #########################################
@@ -90,11 +99,13 @@ echo "Total unique images: ${count}"
 #########################################
 FAILED=0
 FAILED_IMAGES=()
+WARNED_IMAGES=()
 
 while IFS= read -r image; do
   success=0
+  last_err=""
   for attempt in 1 2 3; do
-    if "$CRANE" digest "$image" >/dev/null 2>&1; then
+    if last_err=$("$CRANE" digest "$image" 2>&1 >/dev/null); then
       echo "✅ Available: $image"
       success=1
       break
@@ -108,15 +119,32 @@ while IFS= read -r image; do
   done
 
   if [ "$success" -ne 1 ]; then
-    echo "❌ NOT FOUND after 3 attempts: $image"
-    FAILED=1
-    FAILED_IMAGES+=("$image")
+    # Only an authoritative "not found" is an unpublished branch tag. Auth
+    # failures and outages must stay fatal or an unreachable registry passes.
+    if [ "$BRANCH_TAG" -eq 1 ] && [[ "$image" == *":$CALICO_VERSION" ]] \
+      && [[ "$last_err" == *MANIFEST_UNKNOWN* || "$last_err" == *NAME_UNKNOWN* || "$last_err" == *"404 Not Found"* ]]; then
+      echo "⚠️  NOT FOUND after 3 attempts (branch tag, not fatal): $image"
+      WARNED_IMAGES+=("$image")
+    else
+      echo "❌ NOT FOUND after 3 attempts: $image"
+      [ -n "$last_err" ] && echo "   last error: $last_err"
+      FAILED=1
+      FAILED_IMAGES+=("$image")
+    fi
   fi
 done <<< "$manifest_images"
 
 #########################################
 # Step 3: Final result
 #########################################
+if [ "${#WARNED_IMAGES[@]}" -gt 0 ]; then
+  echo ""
+  echo "⚠️  Not yet published under the $CALICO_VERSION branch tag (a hashrelease from this branch publishes it):"
+  for img in "${WARNED_IMAGES[@]}"; do
+    echo "   ⚠️  $img"
+  done
+fi
+
 if [ "$FAILED" -eq 1 ]; then
   echo ""
   echo "❗ Some images are missing or invalid:"
@@ -124,6 +152,8 @@ if [ "$FAILED" -eq 1 ]; then
     echo "   ❌ $img"
   done
   exit 1
+elif [ "${#WARNED_IMAGES[@]}" -gt 0 ]; then
+  echo "✅ All images from manifests are available. The images listed above are tagged with the branch name, which a hashrelease publishes from this branch; they will be available after the next hashrelease."
 else
   echo "✅ All images from manifests are available!"
 fi

--- a/release/cmd/hashrelease.go
+++ b/release/cmd/hashrelease.go
@@ -272,6 +272,7 @@ func hashreleaseSubCommands(cfg *Config) []*cli.Command {
 					calico.WithPublishHashrelease(c.Bool(publishHashreleaseFlag.Name)),
 					calico.WithValidation(c.Bool(validationFlag.Name)),
 					calico.WithReleaseBranchValidation(c.Bool(branchCheckFlag.Name)),
+					calico.WithReleaseBranchPrefix(c.String(releaseBranchPrefixFlag.Name)),
 				}
 				if reg := c.StringSlice(registryFlag.Name); len(reg) > 0 {
 					opts = append(opts,

--- a/release/pkg/manager/calico/manager.go
+++ b/release/pkg/manager/calico/manager.go
@@ -1506,6 +1506,37 @@ func (r *CalicoManager) publishContainerImages() error {
 			return err
 		}
 	}
+
+	if r.isHashRelease {
+		return r.publishBranchTag()
+	}
+	return nil
+}
+
+// publishBranchTag moves the branch-named tag (e.g. release-v3.33) onto the
+// images just published, so the branch always has a pullable tag between
+// official releases.
+func (r *CalicoManager) publishBranchTag() error {
+	if r.releaseBranchPrefix == "" {
+		return fmt.Errorf("release branch prefix is not set, cannot derive the branch tag")
+	}
+	ver := version.Version(r.calicoVersion)
+	tag := fmt.Sprintf("%s-%s", r.releaseBranchPrefix, ver.Stream())
+
+	env := append(os.Environ(),
+		fmt.Sprintf("IMAGETAG=%s", tag),
+		"CONFIRM=true",
+		fmt.Sprintf("DEV_REGISTRIES=%s", strings.Join(r.imageRegistries, " ")),
+	)
+	// The arch images must carry the branch tag before the manifest can list
+	// them as its children.
+	for _, dir := range imageReleaseDirs {
+		fullDir := filepath.Join(r.repoRoot, dir)
+		target := "retag-build-images-with-registries push-images-to-registries push-manifests"
+		if _, err := r.makeInDirectoryToFile(fullDir, target, "publish-branch-tag", env...); err != nil {
+			return fmt.Errorf("failed to publish branch tag %s for %s: %w", tag, dir, err)
+		}
+	}
 	return nil
 }
 

--- a/release/pkg/manager/calico/manager_test.go
+++ b/release/pkg/manager/calico/manager_test.go
@@ -16,6 +16,7 @@ package calico
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 	"testing"
 )
@@ -37,6 +38,9 @@ type fakeRunner struct {
 
 	// calls records every command invoked, as "name arg1 arg2 ...".
 	calls []string
+
+	// envs records the env passed alongside each recorded call, by index.
+	envs [][]string
 }
 
 func newFakeRunner() *fakeRunner {
@@ -50,8 +54,13 @@ func (f *fakeRunner) on(key, stdout string, err error) *fakeRunner {
 }
 
 func (f *fakeRunner) record(name string, args []string) (string, error) {
+	return f.recordEnv(name, args, nil)
+}
+
+func (f *fakeRunner) recordEnv(name string, args, env []string) (string, error) {
 	cmd := strings.TrimSpace(name + " " + strings.Join(args, " "))
 	f.calls = append(f.calls, cmd)
+	f.envs = append(f.envs, env)
 	if res, ok := f.responses[cmd]; ok {
 		return res.stdout, res.err
 	}
@@ -69,7 +78,7 @@ func (f *fakeRunner) record(name string, args []string) (string, error) {
 }
 
 func (f *fakeRunner) Run(name string, args, env []string) (string, error) {
-	return f.record(name, args)
+	return f.recordEnv(name, args, env)
 }
 
 func (f *fakeRunner) RunNoCapture(name string, args, env []string) error {
@@ -78,7 +87,7 @@ func (f *fakeRunner) RunNoCapture(name string, args, env []string) error {
 }
 
 func (f *fakeRunner) RunInDir(dir, name string, args, env []string) (string, error) {
-	return f.record(name, args)
+	return f.recordEnv(name, args, env)
 }
 
 func (f *fakeRunner) RunInDirNoCapture(dir, name string, args, env []string) error {
@@ -87,7 +96,7 @@ func (f *fakeRunner) RunInDirNoCapture(dir, name string, args, env []string) err
 }
 
 func (f *fakeRunner) RunInDirToFile(dir, name string, args, env []string, logPath string) (string, error) {
-	return f.record(name, args)
+	return f.recordEnv(name, args, env)
 }
 
 // ran reports whether any recorded call starts with the given command prefix.
@@ -104,6 +113,16 @@ func (f *fakeRunner) count(prefix string) int {
 		}
 	}
 	return n
+}
+
+// envFor returns the env of the first recorded call matching the given prefix.
+func (f *fakeRunner) envFor(prefix string) []string {
+	for i, c := range f.calls {
+		if strings.HasPrefix(c, prefix) {
+			return f.envs[i]
+		}
+	}
+	return nil
 }
 
 func TestTagRelease(t *testing.T) {
@@ -458,6 +477,109 @@ func TestOwnerFromRemoteURL(t *testing.T) {
 			}
 			if got != tt.want {
 				t.Errorf("ownerFromRemoteURL(%q) = %q, want %q", tt.url, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPublishContainerImagesBranchTag(t *testing.T) {
+	tests := []struct {
+		name          string
+		version       string
+		images        bool
+		isHashRelease bool
+		wantPublish   bool
+		wantBranchTag bool
+		wantTag       string
+		prefix        string
+		wantErr       bool
+	}{
+		{
+			name:          "hashrelease also pushes the branch tag",
+			version:       "v3.33.0-0.dev-1-gabcdef123456",
+			images:        true,
+			isHashRelease: true,
+			wantPublish:   true,
+			wantBranchTag: true,
+			wantTag:       "release-v3.33",
+		},
+		{
+			name:          "early preview keeps its stream suffix",
+			version:       "v3.33.0-1.0-0.dev-1-gabcdef123456",
+			images:        true,
+			isHashRelease: true,
+			wantPublish:   true,
+			wantBranchTag: true,
+			wantTag:       "release-v3.33-1",
+		},
+		{
+			name:          "official release does not move the branch tag",
+			version:       "v3.33.0",
+			images:        true,
+			isHashRelease: false,
+			wantPublish:   true,
+			wantBranchTag: false,
+		},
+		{
+			// An unset prefix would silently tag images "-v3.33".
+			name:          "missing branch prefix is an error",
+			version:       "v3.33.0-0.dev-1-gabcdef123456",
+			images:        true,
+			isHashRelease: true,
+			prefix:        "",
+			wantPublish:   true,
+			wantErr:       true,
+		},
+		{
+			name:          "images disabled publishes nothing",
+			version:       "v3.33.0-0.dev-1-gabcdef123456",
+			images:        false,
+			isHashRelease: true,
+			wantPublish:   false,
+			wantBranchTag: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := newFakeRunner()
+
+			prefix := tt.prefix
+			if prefix == "" && !tt.wantErr {
+				prefix = "release"
+			}
+			r := &CalicoManager{
+				runner:              f,
+				images:              tt.images,
+				isHashRelease:       tt.isHashRelease,
+				calicoVersion:       tt.version,
+				releaseBranchPrefix: prefix,
+			}
+
+			err := r.publishContainerImages()
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("publishContainerImages() = nil, want error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("publishContainerImages() unexpected error: %v", err)
+			}
+
+			if got := f.ran("make -C cmd/calico release-publish"); got != tt.wantPublish {
+				t.Errorf("release-publish ran = %v, want %v (calls: %v)", got, tt.wantPublish, f.calls)
+			}
+			if got := f.ran("make -C cmd/calico retag-build-images-with-registries"); got != tt.wantBranchTag {
+				t.Errorf("branch tag publish ran = %v, want %v (calls: %v)", got, tt.wantBranchTag, f.calls)
+			}
+			if tt.wantBranchTag {
+				if got := f.envFor("make -C cmd/calico retag-build-images-with-registries"); !slices.Contains(got, "IMAGETAG="+tt.wantTag) {
+					t.Errorf("branch tag env = %v, want IMAGETAG=%s", got, tt.wantTag)
+				}
+				if got, want := f.count("make -C"), 2*len(imageReleaseDirs)+len(windowsReleaseDirs); got != want {
+					t.Errorf("make invocations = %d, want %d (calls: %v)", got, want, f.calls)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
Cherry-pick of #13626 onto `release-v3.33`, which fixes the failing "Check images availability" job on this branch.

**Release note:**
```release-note
TBD
```
