### PR TITLE
ci: reuse cached nftables RPMs in node publish, raise time limit

### DIFF
--- a/.semaphore/push-images/node.yml
+++ b/.semaphore/push-images/node.yml
@@ -5,7 +5,7 @@ agent:
     type: f1-standard-2
     os_image: ubuntu2204
 execution_time_limit:
-  minutes: 60
+  minutes: 90
 global_job_config:
   env_vars:
     - name: DEV_REGISTRIES
@@ -37,12 +37,16 @@ blocks:
         # ppc64le and s390x build under QEMU emulation, which is slow. Give each its
         # own job so they run concurrently rather than serially in a single job that
         # exceeds the pipeline time limit. They have no native runner, so they emulate
-        # on the default machine.
+        # on the default machine. Pull the nftables RPMs already built by the "Build:
+        # nftables RPMs" block so `make image` skips rebuilding them under emulation
+        # (make -C hack/rpms/nftables image no-ops when the image is present locally).
         - name: Linux ppc64le
           commands:
+            - docker pull "calico/nftables-rpms:$(make --no-print-directory -C hack/rpms/nftables print-tag)-ppc64le" || true
             - if [ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]; then make -C node image cd-common ARCH=ppc64le VALIDARCHES=ppc64le CONFIRM=true; fi
         - name: Linux s390x
           commands:
+            - docker pull "calico/nftables-rpms:$(make --no-print-directory -C hack/rpms/nftables print-tag)-s390x" || true
             - if [ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]; then make -C node image cd-common ARCH=s390x VALIDARCHES=s390x CONFIRM=true; fi
         - name: Windows
           commands:

--- a/.semaphore/push-images/node.yml
+++ b/.semaphore/push-images/node.yml
@@ -38,15 +38,24 @@ blocks:
         # own job so they run concurrently rather than serially in a single job that
         # exceeds the pipeline time limit. They have no native runner, so they emulate
         # on the default machine. Pull the nftables RPMs already built by the "Build:
-        # nftables RPMs" block so `make image` skips rebuilding them under emulation
-        # (make -C hack/rpms/nftables image no-ops when the image is present locally).
+        # nftables RPMs" block and tag them to the DEV_REGISTRIES-prefixed name the
+        # node build inspects, so `make image` skips rebuilding them under emulation
+        # (make -C hack/rpms/nftables image no-ops when that image is present locally).
+        # The RPMs are pushed to Docker Hub as calico/nftables-rpms, but node.yml sets
+        # DEV_REGISTRIES with quay.io/calico first, so the local tag must be retagged.
         - name: Linux ppc64le
           commands:
-            - docker pull "calico/nftables-rpms:$(make --no-print-directory -C hack/rpms/nftables print-tag)-ppc64le" || true
+            - |-
+              TAG=$(make --no-print-directory -C hack/rpms/nftables print-tag)
+              docker pull "calico/nftables-rpms:${TAG}-ppc64le" || true
+              docker tag "calico/nftables-rpms:${TAG}-ppc64le" "$(make --no-print-directory -C hack/rpms/nftables print-image ARCH=ppc64le)" || true
             - if [ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]; then make -C node image cd-common ARCH=ppc64le VALIDARCHES=ppc64le CONFIRM=true; fi
         - name: Linux s390x
           commands:
-            - docker pull "calico/nftables-rpms:$(make --no-print-directory -C hack/rpms/nftables print-tag)-s390x" || true
+            - |-
+              TAG=$(make --no-print-directory -C hack/rpms/nftables print-tag)
+              docker pull "calico/nftables-rpms:${TAG}-s390x" || true
+              docker tag "calico/nftables-rpms:${TAG}-s390x" "$(make --no-print-directory -C hack/rpms/nftables print-image ARCH=s390x)" || true
             - if [ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]; then make -C node image cd-common ARCH=s390x VALIDARCHES=s390x CONFIRM=true; fi
         - name: Windows
           commands:


### PR DESCRIPTION
## Description

The ppc64le and s390x node publish jobs were hitting the pipeline time limit. **This is a targeted timing improvement to get them under budget on release-v3.32, not a root-cause fix.**

Most of a ppc64le/s390x publish job's runtime is the **emulated calico-node binary compile** (BPF + Go/CGO under QEMU, ~30 min), because release-v3.32 compiles these arches under emulation rather than cross-compiling. That is the dominant cost and is not addressed here; removing it would require backporting the clang cross-compilation toolchain change that master/v3.33 have, which is out of scope for a release branch. On top of that, the publish job also rebuilds the patched nftables RPMs under emulation, and the time a job spends queued for a CI agent counts against the limit.

This PR reduces the overrun in two ways:

1. Raise `execution_time_limit` from 60 to 90 minutes, so the inherent emulated work plus agent-queue time fits under the limit. This is what actually gets the jobs under budget.
2. Reuse the already-built `calico/nftables-rpms` image (produced and cached by the `Build: nftables RPMs` block earlier in the same workflow) instead of rebuilding it under emulation, recovering roughly 15-20 minutes.

On the RPM reuse: the image is pushed to Docker Hub as `calico/nftables-rpms:<tag>-<arch>`, but `node.yml` sets `DEV_REGISTRIES` with `quay.io/calico` first, and the node build inspects `$(firstword $(DEV_REGISTRIES))/nftables-rpms:<tag>-<arch>`. So the pulled image is retagged to the name `make -C hack/rpms/nftables print-image` resolves to, which is what `hack/rpms/nftables image:` inspects for its cache hit. (Thanks to the review for catching that pulling alone left the inspected tag absent, without the retag the reuse was a no-op.)

Notes:
- Safe by construction: the tag is computed from the job's own checkout (`print-tag`/`print-image`), so it only ever references the image matching that content. On a cache miss the pull/tag are no-ops (`|| true`) and the build proceeds exactly as before.
- amd64 and arm64 build the RPMs natively (no emulation), so they are left unchanged.
- This makes the ppc64le/s390x publish jobs fit; it does not make them fast. Matching master's speed would need the clang cross-compile.

## Release Note

```release-note
None
```
