### PR TITLE
[v3.32] argoci: set RUN_AS_ROOT so the e2e test container starts

### DIFF
--- a/.argoci/scripts/phases/run_tests.sh
+++ b/.argoci/scripts/phases/run_tests.sh
@@ -74,6 +74,18 @@ if [[ -n "${E2E_BINARY:-}" ]]; then
     fi
   fi
 
+  # The go-build entrypoint creates a "user" account with
+  # `useradd -u ${LOCAL_USER_ID}` and then re-execs the command through
+  # `su-exec user`. ArgoCI runners execute as root, so LOCAL_USER_ID=0 makes
+  # useradd fail ("UID 0 is not unique" -- root already owns it), su-exec cannot
+  # resolve the account, and the container exits before ginkgo starts. The image
+  # supports RUN_AS_ROOT to skip that path, so set it when we are already root.
+  # Non-root runners (Semaphore agents) keep the existing behaviour.
+  run_as_root_env=()
+  if [[ "$(id -u)" -eq 0 ]]; then
+    run_as_root_env=(-e RUN_AS_ROOT=true)
+  fi
+
   echo "[INFO] starting e2e tests (ginkgo, K8S_E2E_FLAGS=${K8S_E2E_FLAGS:-<none>})..."
   # --junit-report writes report/junit.xml for the epilogue to publish. (v3.32's
   # Semaphore relied on bz for JUnit; the local-binary path emits it directly.)
@@ -90,6 +102,7 @@ if [[ -n "${E2E_BINARY:-}" ]]; then
   # shellcheck disable=SC2086
   docker run --rm --init --net=host \
     -e LOCAL_USER_ID="$(id -u)" \
+    "${run_as_root_env[@]}" \
     -e GOCACHE=/go-cache \
     -e GOPATH=/go \
     -e KUBECONFIG=/kubeconfig \


### PR DESCRIPTION
### Problem

Scheduled e2e runs on `release-v3.32` upload testsuites with **zero tests**. Validation for v3.32.2 currently has no e2e signal at all: 73 testsuites uploaded across every suite and platform, not one test executed.

The `calico/go-build` container exits at its entrypoint before ginkgo starts. `k8s-e2e-tests.log` is 10 lines and ends with:

```
Starting with UID: 0
useradd: UID 0 is not unique
su-exec: getpwnam(user): Success
```

### Cause

The go-build entrypoint creates a `user` account with `useradd -u ${LOCAL_USER_ID}` and re-execs through `su-exec user`. `run_tests.sh` passes `LOCAL_USER_ID="$(id -u)"`, and **ArgoCI runners execute as root** — so `useradd -u 0` fails because root already owns UID 0, `su-exec` then cannot resolve the account, and the container exits before running anything.

The docker-run path itself predates #13517, but until then only the **windows** pipeline used it — every other scheduled e2e went through `bz tests`. #13517 routed `TEST_TYPE=k8s-e2e` onto the same path, so the latent bug now affects every scheduled e2e suite on this branch. The dates line up: #13517 merged 2026-08-13, which is when e2es stopped producing results.

This was masked for ~12 days by the unrelated hashrelease disk-exhaustion failures that started the same day — with no hashreleases to test against, nobody saw that the test runner was also broken.

### Fix

The image already supports `RUN_AS_ROOT` to skip the account-creation path entirely:

```bash
if [ "${RUN_AS_ROOT}" = "true" ]; then
  exec "$@"
fi
```

So set it when the runner is already root. Non-root runners (Semaphore agents, where `$(id -u)` is the `semaphore` user) keep the existing behaviour unchanged.

### Verification

Against `calico/go-build:1.25.14-llvm18.1.8-k8s1.35.8`:

| Invocation | Result |
|---|---|
| `-e LOCAL_USER_ID=0` | `useradd: UID 0 is not unique` → `su-exec: getpwnam(user)` — command never runs |
| `-e LOCAL_USER_ID=0 -e RUN_AS_ROOT=true` | command runs ✅ |

This reproduces the CI failure exactly and confirms the fix. `bash -n` passes on the modified script.

### Notes

- Not a product issue — Calico installs fine in these runs (`Successfully installed calico-v3.32 in cluster!`, all TigeraStatus objects available). This is purely the test harness.
- Separately observed and **not** addressed here: a minority of jobs fail earlier at `kubectl wait --timeout 30s tigerastatus/apiserver --for=condition=Available`, where `tigerastatus/apiserver` only ever carries a `Degraded` condition and never gains `Available`. Worth a look on its own.