### PR TITLE
fix(whisker): bump react-router-dom to 6.30.6 to resolve CVE-2026-53668

### DIFF
--- a/whisker/package.json
+++ b/whisker/package.json
@@ -49,7 +49,7 @@
         "react-dom": "^19.2.1",
         "react-hook-form": "^7.54.2",
         "react-json-view-lite": "2.5.0",
-        "react-router-dom": "6.30.4",
+        "react-router-dom": "6.30.6",
         "react-table": "^7.7.0",
         "react-window": "^1.8.6",
         "tailwind-merge": "^3.3.1",

--- a/whisker/yarn.lock
+++ b/whisker/yarn.lock
@@ -1805,10 +1805,10 @@
   resolved "https://registry.yarnpkg.com/@radix-ui/rect/-/rect-1.1.1.tgz#78244efe12930c56fd255d7923865857c41ac8cb"
   integrity sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==
 
-"@remix-run/router@1.23.3":
-  version "1.23.3"
-  resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.23.3.tgz#957c098d4393d301a8aa7dccf3ef28ea5430e36a"
-  integrity sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q==
+"@remix-run/router@1.23.4":
+  version "1.23.4"
+  resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.23.4.tgz#d2becd2afca4a40c30a659d913b9b0bcc28bced8"
+  integrity sha512-q7j5geK7xs3UJSdm9/iytUNclBnLmYx1EnSeCFXHPeutdqgIMeFeHtUZgS3EhlKxdBEAu8OwtJCwmLrEzpSs7Q==
 
 "@rsbuild/core@^1.1.10":
   version "1.1.10"
@@ -5075,20 +5075,20 @@ react-remove-scroll@^2.6.3:
     use-callback-ref "^1.3.3"
     use-sidecar "^1.1.3"
 
-react-router-dom@6.30.4:
-  version "6.30.4"
-  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.30.4.tgz#f7167bf3da6c7d9132130ea985dd06def25e84d5"
-  integrity sha512-q4HvNl+mmDdkS0g+MqiBZNteQJCuimWoOyHMy4T/RQLAn9Z29+E91QXRaxOujeMl2HTzRSS0KFPd7lxX3PjV0Q==
+react-router-dom@6.30.6:
+  version "6.30.6"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.30.6.tgz#acaf0db65efeddabd0840616243c97f578b3baf3"
+  integrity sha512-0RHKZz7wwffvkU+2MFVT2NnjK44ssLEV+m0CAJaS2Ksmorrwj7WxH00jO0SOCW26/tINUnJHToXblDs33I38YQ==
   dependencies:
-    "@remix-run/router" "1.23.3"
-    react-router "6.30.4"
+    "@remix-run/router" "1.23.4"
+    react-router "6.30.6"
 
-react-router@6.30.4:
-  version "6.30.4"
-  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.30.4.tgz#638f35176527bd243d96d81d35d33b757bad46c2"
-  integrity sha512-SVUsDe+DybHM/WmYKIVYhZh1o5Dcuf16yM6WjG02Q9XVFMZIJyHYhwrr6bFBXZkVP6z69kNkMyBCujt8FaFLJA==
+react-router@6.30.6:
+  version "6.30.6"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.30.6.tgz#a2ad70f3472de61c61e44182b3e5a25fd91f9f68"
+  integrity sha512-5HfK7k5im7LTOB0EqCQmfvy4C13G92Ssj1VTmouTK3AJvyjKTnFuCV0vcMAD/JS+JC4DvDIBRrlAeJIFjh5VWg==
   dependencies:
-    "@remix-run/router" "1.23.3"
+    "@remix-run/router" "1.23.4"
 
 react-select@5.10.x:
   version "5.10.2"


### PR DESCRIPTION
## Description

`react-router-dom` 6.30.2 through 6.30.4 is affected by **GHSA-jjmj-jmhj-qwj2 / CVE-2026-53668** (open redirect leading to XSS). The Whisker UI is pinned to 6.30.4.

The advisory's vulnerable range is `>= 6.30.2, <= 6.30.4`, and `6.30.6` is a same-major patch release outside that range, so this resolves the alert **without** moving to the react-router 7.x major.

Change is `whisker/package.json` (`6.30.4 -> 6.30.6`) plus the regenerated `whisker/yarn.lock` (react-router-dom, react-router, and the transitive `@remix-run/router` move to 6.30.6 / 1.23.4).

The two remaining react-router advisories, GHSA-337j-9hxr-rhxg and GHSA-wrjc-x8rr-h8h6, only have fixes in 7.18.0 (all of 6.x is in their vulnerable range), so they are not addressed here.

## Release Note

```release-note
Update the react-router-dom dependency in the Whisker UI to 6.30.6 to resolve CVE-2026-53668.
```
