### PR TITLE
PMREQ-821: E2E tests for Whisker access via Calico Ingress Gateway

### DIFF
--- a/e2e/pkg/describe/describe.go
+++ b/e2e/pkg/describe/describe.go
@@ -74,6 +74,7 @@ var features = map[string]bool{
 	"Pods":            true,
 	"QoS":             true,
 	"Datapath":        true,
+	"Ingress-Gateway": true,
 	"Istio":           true,
 	"KubeVirt":        true,
 	"Wireguard":       true,

--- a/e2e/pkg/tests/operator/ingress_gateway_whisker.go
+++ b/e2e/pkg/tests/operator/ingress_gateway_whisker.go
@@ -1,0 +1,342 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package calico
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
+	operatorv1 "github.com/tigera/operator/api/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/kubernetes/test/e2e/framework"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/projectcalico/calico/e2e/pkg/describe"
+	"github.com/projectcalico/calico/e2e/pkg/utils"
+)
+
+const (
+	whiskerGatewayName     = "calico-whisker-gateway"
+	whiskerHTTPRouteName   = "calico-whisker-route"
+	whiskerGatewayTLSName  = "calico-whisker-gateway-tls"
+	whiskerBackendNS       = "calico-system"
+	whiskerGatewayHostname = "whisker.e2e-test.local"
+
+	// The Whisker UI's document title. Envoy's own error pages do not carry it,
+	// so it separates "reached Whisker" from "reached the proxy".
+	whiskerPageMarker = "<title>Calico Whisker"
+
+	// Bound every context so a hung API call fails the spec with a readable
+	// error instead of running into Ginkgo's global timeout.
+	whiskerSpecTimeout    = 10 * time.Minute
+	whiskerCleanupTimeout = 2 * time.Minute
+
+	// A delete poll runs on its own context, so it always gets the full window
+	// however much of the cleanup budget the steps before it used.
+	whiskerGoneTimeout = 2 * time.Minute
+)
+
+// This test validates Whisker access via Calico Ingress Gateway: the full
+// lifecycle wired end to end — Whisker CR patch, operator render, Envoy proxy
+// serving the Whisker UI, and teardown. That is the one thing that needs a real
+// cluster; everything else lives at a lower test level: rendered object shapes,
+// the degrade cases, and the per-namespace RBAC the GatewayAPI controller
+// provisions are all covered by operator unit and FV tests.
+//
+// Unlike the Manager gateway, Whisker's gateway defaults to the namespace its
+// backing Service already lives in, so this exercises the same-namespace render
+// including the proxy NetworkPolicy.
+var _ = describe.CalicoDescribe(
+	describe.WithTeam(describe.Core),
+	describe.WithFeature("Ingress-Gateway"),
+	describe.WithCategory(describe.Operator),
+	// Patches the cluster-singleton Whisker and GatewayAPI CRs, so it must not
+	// run alongside other specs.
+	describe.WithSerial(),
+	describe.RequiresGoldmane(),
+	"whisker access via calico ingress gateway",
+	func() {
+		f := utils.NewDefaultFramework("ingress-gateway-whisker")
+
+		var (
+			cli ctrlclient.Client
+			ctx context.Context
+		)
+
+		ginkgo.BeforeEach(func() {
+			ctx = context.Background()
+
+			scheme := runtime.NewScheme()
+			Expect(operatorv1.AddToScheme(scheme)).NotTo(HaveOccurred(), "registering operator.tigera.io/v1")
+			Expect(gatewayv1.Install(scheme)).NotTo(HaveOccurred(), "registering gateway.networking.k8s.io/v1")
+
+			var err error
+			cli, err = ctrlclient.NewWithWatch(f.ClientConfig(), ctrlclient.Options{Scheme: scheme})
+			Expect(err).NotTo(HaveOccurred(), "creating a controller-runtime client")
+
+			// Skip rather than fail on a cluster this feature cannot run on: it
+			// needs an operator-managed Calico install with Whisker present.
+			installation := &operatorv1.Installation{}
+			if err := cli.Get(ctx, types.NamespacedName{Name: "default"}, installation); apierrors.IsNotFound(err) {
+				ginkgo.Skip("No Installation; this cluster is not operator managed")
+			} else {
+				Expect(err).NotTo(HaveOccurred(), "reading the Installation")
+			}
+			if installation.Spec.Variant != operatorv1.Calico {
+				ginkgo.Skip("Whisker only runs on the Calico variant")
+			}
+			if err := cli.Get(ctx, types.NamespacedName{Name: "default"}, &operatorv1.Whisker{}); apierrors.IsNotFound(err) {
+				ginkgo.Skip("No Whisker CR on this cluster")
+			} else {
+				Expect(err).NotTo(HaveOccurred(), "reading the Whisker CR")
+			}
+		})
+
+		// expectGone polls until get returns NotFound. Any other error (or the
+		// object still existing) keeps the poll going and is reported on
+		// timeout instead of a bare "expected false to be true".
+		//
+		// The poll gets a fresh context rather than the caller's: a cleanup
+		// context part-spent on earlier steps would expire mid-poll, and every
+		// remaining attempt would then fail on the dead context instead of
+		// reporting what was still there.
+		expectGone := func(get func(context.Context) error, what string) {
+			pollCtx, cancel := context.WithTimeout(context.Background(), whiskerGoneTimeout+30*time.Second)
+			defer cancel()
+			Eventually(func() error {
+				err := get(pollCtx)
+				if err == nil {
+					return fmt.Errorf("%s still exists", what)
+				}
+				if apierrors.IsNotFound(err) {
+					return nil
+				}
+				return err
+			}, whiskerGoneTimeout, 5*time.Second).Should(Succeed(), "%s should be deleted", what)
+		}
+
+		ginkgo.Context("Whisker accessible through Gateway in the install namespace", ginkgo.Ordered, func() {
+			ginkgo.BeforeAll(func() {
+				ctx, cancel := context.WithTimeout(context.Background(), whiskerSpecTimeout)
+				ginkgo.DeferCleanup(cancel)
+
+				ginkgo.By("Enabling Gateway API support")
+				createWhiskerGatewayAPICR(ctx, cli)
+
+				ginkgo.By("Setting spec.ingressGateway on the Whisker CR")
+				whisker := &operatorv1.Whisker{}
+				Expect(cli.Get(ctx, types.NamespacedName{Name: "default"}, whisker)).NotTo(HaveOccurred(), "reading the Whisker CR")
+				patch := fmt.Sprintf(`{"spec":{"ingressGateway":{"hostname":%q}}}`, whiskerGatewayHostname)
+				Expect(cli.Patch(ctx, whisker, ctrlclient.RawPatch(types.MergePatchType, []byte(patch)))).NotTo(HaveOccurred(),
+					"setting spec.ingressGateway on the Whisker CR")
+
+				ginkgo.DeferCleanup(func() {
+					cleanupCtx, cancel := context.WithTimeout(context.Background(), whiskerCleanupTimeout)
+					defer cancel()
+
+					ginkgo.By("Removing spec.ingressGateway from the Whisker CR")
+					w := &operatorv1.Whisker{}
+					if err := cli.Get(cleanupCtx, types.NamespacedName{Name: "default"}, w); err != nil {
+						logrus.WithError(err).Warn("Failed to get Whisker CR for cleanup")
+						return
+					}
+					removePatch := []byte(`{"spec":{"ingressGateway":null}}`)
+					if err := cli.Patch(cleanupCtx, w, ctrlclient.RawPatch(types.MergePatchType, removePatch)); err != nil {
+						logrus.WithError(err).Warn("Failed to remove spec.ingressGateway from the Whisker CR")
+					}
+
+					// Wait the Gateway out before dropping the GatewayAPI CR.
+					// Envoy Gateway holds a finalizer on the GatewayClass while
+					// any Gateway still references it, so tearing the controller
+					// down first leaves nothing to clear it and the GatewayClass
+					// and its namespace hang in Terminating.
+					ginkgo.By("Waiting for gateway resources to be cleaned up")
+					expectGone(func(ctx context.Context) error {
+						return cli.Get(ctx, types.NamespacedName{Name: whiskerGatewayName, Namespace: whiskerBackendNS}, &gatewayv1.Gateway{})
+					}, "Gateway")
+
+					ginkgo.By("Deleting the GatewayAPI CR")
+					deleteWhiskerGatewayAPICR(cleanupCtx, cli)
+				})
+
+				ginkgo.By("Waiting for the Gateway to be accepted")
+				// Accepted is set by the Gateway API controller without needing
+				// a cloud LoadBalancer; Programmed never goes True without an
+				// assigned address, so it is deliberately not waited on here.
+				Eventually(func() error {
+					gw := &gatewayv1.Gateway{}
+					if err := cli.Get(ctx, types.NamespacedName{Name: whiskerGatewayName, Namespace: whiskerBackendNS}, gw); err != nil {
+						return err
+					}
+					for _, cond := range gw.Status.Conditions {
+						if cond.Type == string(gatewayv1.GatewayConditionAccepted) && cond.Status == metav1.ConditionTrue {
+							return nil
+						}
+					}
+					return fmt.Errorf("Gateway %s/%s not Accepted yet", whiskerBackendNS, whiskerGatewayName)
+				}, 3*time.Minute, 5*time.Second).Should(Succeed(), "Gateway should become Accepted")
+			})
+
+			ginkgo.It("should serve the Whisker UI through the Gateway", func() {
+				ctx, cancel := context.WithTimeout(context.Background(), whiskerSpecTimeout)
+				ginkgo.DeferCleanup(cancel)
+
+				ginkgo.By("Port-forwarding to the Gateway's Envoy proxy Service")
+				baseURL, stop := utils.GatewayProxyBaseURL(ctx, f.ClientSet, whiskerBackendNS, whiskerGatewayName, true)
+				ginkgo.DeferCleanup(stop)
+
+				ginkgo.By("Requesting the Whisker UI through the Gateway")
+				gwClient := &http.Client{
+					Transport: &http.Transport{
+						TLSClientConfig: &tls.Config{
+							RootCAs: whiskerCABundle(ctx, f),
+							// SNI must match the Gateway listener hostname or
+							// Envoy has no filter chain for the connection.
+							ServerName: whiskerGatewayHostname,
+						},
+					},
+					CheckRedirect: func(req *http.Request, via []*http.Request) error {
+						return http.ErrUseLastResponse
+					},
+					Timeout: 10 * time.Second,
+				}
+
+				// Envoy's default handler answers unrouted requests, so a
+				// response alone proves nothing: require the Whisker UI's own
+				// 200 with its document title.
+				Eventually(func() error {
+					req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+"/", nil)
+					if err != nil {
+						return err
+					}
+					req.Host = whiskerGatewayHostname
+
+					resp, err := gwClient.Do(req)
+					if err != nil {
+						return err
+					}
+					defer resp.Body.Close()
+
+					body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<16))
+					if err != nil {
+						return err
+					}
+					if resp.StatusCode != http.StatusOK {
+						return fmt.Errorf("got status %d, want 200", resp.StatusCode)
+					}
+					if !strings.Contains(string(body), whiskerPageMarker) {
+						return fmt.Errorf("response did not contain %q; reached the proxy but not Whisker", whiskerPageMarker)
+					}
+					return nil
+				}, 3*time.Minute, 5*time.Second).Should(Succeed(), "the Whisker UI should be served through the Gateway")
+			})
+
+			ginkgo.It("should clean up gateway resources when spec.ingressGateway is removed", func() {
+				ctx, cancel := context.WithTimeout(context.Background(), whiskerSpecTimeout)
+				ginkgo.DeferCleanup(cancel)
+
+				ginkgo.By("Removing spec.ingressGateway from the Whisker CR")
+				whisker := &operatorv1.Whisker{}
+				Expect(cli.Get(ctx, types.NamespacedName{Name: "default"}, whisker)).NotTo(HaveOccurred(), "reading the Whisker CR")
+				removePatch := []byte(`{"spec":{"ingressGateway":null}}`)
+				Expect(cli.Patch(ctx, whisker, ctrlclient.RawPatch(types.MergePatchType, removePatch))).NotTo(HaveOccurred(),
+					"removing spec.ingressGateway from the Whisker CR")
+
+				expectGone(func(ctx context.Context) error {
+					return cli.Get(ctx, types.NamespacedName{Name: whiskerGatewayName, Namespace: whiskerBackendNS}, &gatewayv1.Gateway{})
+				}, "Gateway")
+				expectGone(func(ctx context.Context) error {
+					return cli.Get(ctx, types.NamespacedName{Name: whiskerHTTPRouteName, Namespace: whiskerBackendNS}, &gatewayv1.HTTPRoute{})
+				}, "HTTPRoute")
+				expectGone(func(ctx context.Context) error {
+					_, err := f.ClientSet.CoreV1().Secrets(whiskerBackendNS).Get(ctx, whiskerGatewayTLSName, metav1.GetOptions{})
+					return err
+				}, "TLS Secret")
+			})
+		})
+	},
+)
+
+// createWhiskerGatewayAPICR enables Gateway API support, waiting out any
+// deletion still in progress from a previous run's cleanup. The CR is stamped
+// so cleanup can tell it apart from one the cluster already had.
+func createWhiskerGatewayAPICR(ctx context.Context, cli ctrlclient.Client) {
+	Eventually(func() error {
+		gatewayAPI := &operatorv1.GatewayAPI{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   "tigera-secure",
+				Labels: map[string]string{gatewayAPICreatedByLabel: gatewayAPICreatedByValue},
+			},
+		}
+		err := cli.Create(ctx, gatewayAPI)
+		if err == nil || apierrors.IsAlreadyExists(err) {
+			return nil
+		}
+		return err
+	}, 2*time.Minute, 5*time.Second).Should(Succeed(), "the GatewayAPI CR should be created")
+}
+
+// deleteWhiskerGatewayAPICR deletes the GatewayAPI CR, but only when this suite
+// created it: deleting one the cluster already had takes envoy-gateway down
+// with it and breaks every later suite.
+func deleteWhiskerGatewayAPICR(ctx context.Context, cli ctrlclient.Client) {
+	existing := &operatorv1.GatewayAPI{}
+	if err := cli.Get(ctx, types.NamespacedName{Name: "tigera-secure"}, existing); err != nil {
+		if !apierrors.IsNotFound(err) {
+			logrus.WithError(err).Warn("Failed to read GatewayAPI CR for cleanup")
+		}
+		return
+	}
+	if existing.Labels[gatewayAPICreatedByLabel] != gatewayAPICreatedByValue {
+		logrus.Info("Leaving pre-existing GatewayAPI CR in place")
+		return
+	}
+	if err := cli.Delete(ctx, existing); err != nil && !apierrors.IsNotFound(err) {
+		logrus.WithError(err).Warn("Failed to delete GatewayAPI CR")
+	}
+}
+
+// whiskerCABundle returns the cluster's CA bundle, which signs the Gateway
+// listener certificate the operator renders.
+func whiskerCABundle(ctx context.Context, f *framework.Framework) *x509.CertPool {
+	cm, err := f.ClientSet.CoreV1().ConfigMaps(whiskerBackendNS).Get(ctx, "tigera-ca-bundle", metav1.GetOptions{})
+	Expect(err).NotTo(HaveOccurred(), "reading the tigera-ca-bundle ConfigMap")
+
+	roots := x509.NewCertPool()
+	caCert, ok := cm.Data["tigera-ca-bundle.crt"]
+	Expect(ok).To(BeTrue(), "tigera-ca-bundle ConfigMap should hold tigera-ca-bundle.crt")
+	Expect(roots.AppendCertsFromPEM([]byte(caCert))).To(BeTrue(), "the CA bundle should parse")
+	return roots
+}
+
+const (
+	// gatewayAPICreatedByLabel marks a GatewayAPI CR this suite created, so
+	// cleanup only removes its own and never a CR the cluster came with.
+	gatewayAPICreatedByLabel = "e2e.tigera.io/created-by"
+	gatewayAPICreatedByValue = "ingress-gateway-whisker-e2e"
+)

--- a/e2e/pkg/tests/operator/ingress_gateway_whisker.go
+++ b/e2e/pkg/tests/operator/ingress_gateway_whisker.go
@@ -59,6 +59,11 @@ const (
 	// A delete poll runs on its own context, so it always gets the full window
 	// however much of the cleanup budget the steps before it used.
 	whiskerGoneTimeout = 2 * time.Minute
+
+	// gatewayAPICreatedByLabel marks a GatewayAPI CR this suite created, so
+	// cleanup only removes its own and never a CR the cluster came with.
+	gatewayAPICreatedByLabel = "e2e.tigera.io/created-by"
+	gatewayAPICreatedByValue = "ingress-gateway-whisker-e2e"
 )
 
 // This test validates Whisker access via Calico Ingress Gateway: the full
@@ -89,7 +94,9 @@ var _ = describe.CalicoDescribe(
 		)
 
 		ginkgo.BeforeEach(func() {
-			ctx = context.Background()
+			var cancel context.CancelFunc
+			ctx, cancel = context.WithTimeout(context.Background(), whiskerSpecTimeout)
+			ginkgo.DeferCleanup(cancel)
 
 			scheme := runtime.NewScheme()
 			Expect(operatorv1.AddToScheme(scheme)).NotTo(HaveOccurred(), "registering operator.tigera.io/v1")
@@ -333,10 +340,3 @@ func whiskerCABundle(ctx context.Context, f *framework.Framework) *x509.CertPool
 	Expect(roots.AppendCertsFromPEM([]byte(caCert))).To(BeTrue(), "the CA bundle should parse")
 	return roots
 }
-
-const (
-	// gatewayAPICreatedByLabel marks a GatewayAPI CR this suite created, so
-	// cleanup only removes its own and never a CR the cluster came with.
-	gatewayAPICreatedByLabel = "e2e.tigera.io/created-by"
-	gatewayAPICreatedByValue = "ingress-gateway-whisker-e2e"
-)

--- a/e2e/pkg/tests/operator/ingress_gateway_whisker.go
+++ b/e2e/pkg/tests/operator/ingress_gateway_whisker.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -261,6 +262,42 @@ var _ = describe.CalicoDescribe(
 					}
 					return nil
 				}, 3*time.Minute, 5*time.Second).Should(Succeed(), "the Whisker UI should be served through the Gateway")
+
+				// The UI shell above is served by nginx alone. A flow query
+				// crosses the one hop nothing else tests end to end: nginx
+				// proxying over TLS to whisker-backend inside the pod.
+				ginkgo.By("Querying flows through the Gateway")
+				Eventually(func() error {
+					req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+"/whisker-backend/flows", nil)
+					if err != nil {
+						return err
+					}
+					req.Host = whiskerGatewayHostname
+
+					resp, err := gwClient.Do(req)
+					if err != nil {
+						return err
+					}
+					defer resp.Body.Close()
+
+					body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+					if err != nil {
+						return err
+					}
+					if resp.StatusCode != http.StatusOK {
+						return fmt.Errorf("got status %d, want 200: %.200s", resp.StatusCode, body)
+					}
+					// nginx rewrites errors to HTML pages, so require the
+					// backend's JSON list shape, not just a 200.
+					var flows map[string]json.RawMessage
+					if err := json.Unmarshal(body, &flows); err != nil {
+						return fmt.Errorf("response is not JSON; reached nginx but not whisker-backend: %.200s", body)
+					}
+					if _, ok := flows["items"]; !ok {
+						return fmt.Errorf("JSON response has no items key; not a flows list: %.200s", body)
+					}
+					return nil
+				}, 3*time.Minute, 5*time.Second).Should(Succeed(), "flows should be served through the Gateway via nginx and whisker-backend")
 			})
 
 			ginkgo.It("should clean up gateway resources when spec.ingressGateway is removed", func() {

--- a/e2e/pkg/utils/gatewayproxy.go
+++ b/e2e/pkg/utils/gatewayproxy.go
@@ -30,7 +30,7 @@ const (
 	egOwningGatewayNameLabel      = "gateway.envoyproxy.io/owning-gateway-name"
 	egOwningGatewayNamespaceLabel = "gateway.envoyproxy.io/owning-gateway-namespace"
 
-	gatewayProxyReadyTimeout = 3 * time.Minute
+	gatewayProxyReadyTimeout = 5 * time.Minute
 	gatewayProxyPollInterval = 5 * time.Second
 )
 
@@ -94,10 +94,22 @@ func GatewayProxyBaseURL(ctx context.Context, clientset kubernetes.Interface, gw
 					chosen = p.Port
 				}
 			}
-			if chosen != 0 {
-				svcNS, svcName, remotePort = svc.Namespace, svc.Name, chosen
-				return nil
+			if chosen == 0 {
+				continue
 			}
+			// The Service exists as soon as the Gateway is accepted, but
+			// forwarding to it fails with a bare "connection refused" until a
+			// proxy Pod is actually serving, which on a cluster that is still
+			// installing Envoy Gateway can take minutes.
+			ready, err := proxyPodServing(listCtx, clientset, svc.Namespace, selector)
+			if err != nil {
+				return err
+			}
+			if !ready {
+				return fmt.Errorf("no serving Envoy Gateway proxy Pod for Gateway %s/%s yet", gwNamespace, gwName)
+			}
+			svcNS, svcName, remotePort = svc.Namespace, svc.Name, chosen
+			return nil
 		}
 		return fmt.Errorf("no Envoy Gateway proxy Service with a ClusterIP+TCP port for Gateway %s/%s yet", gwNamespace, gwName)
 	}).WithTimeout(gatewayProxyReadyTimeout).WithPolling(gatewayProxyPollInterval).Should(
@@ -110,4 +122,28 @@ func GatewayProxyBaseURL(ctx context.Context, clientset kubernetes.Interface, gw
 
 	stop := func() { close(stopCh) }
 	return fmt.Sprintf("%s://127.0.0.1:%d", scheme, localPort), stop
+}
+
+// proxyPodServing reports whether a proxy Pod behind the Gateway is ready to
+// take traffic. A Gateway reaching Accepted says nothing about its data plane:
+// the Gateway API controller sets that from configuration alone, so the Service
+// can exist well before any Pod backs it.
+func proxyPodServing(ctx context.Context, clientset kubernetes.Interface, namespace, selector string) (bool, error) {
+	pods, err := clientset.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{LabelSelector: selector})
+	if err != nil {
+		return false, fmt.Errorf("failed to list proxy Pods: %w", err)
+	}
+	for _, pod := range pods.Items {
+		if pod.Status.Phase != corev1.PodRunning || pod.DeletionTimestamp != nil {
+			continue
+		}
+		for _, cond := range pod.Status.Conditions {
+			// PodReady covers every container, so a proxy still starting one of
+			// them does not count as serving.
+			if cond.Type == corev1.PodReady && cond.Status == corev1.ConditionTrue {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
 }

--- a/e2e/pkg/utils/gatewayproxy.go
+++ b/e2e/pkg/utils/gatewayproxy.go
@@ -1,0 +1,113 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	egOwningGatewayNameLabel      = "gateway.envoyproxy.io/owning-gateway-name"
+	egOwningGatewayNamespaceLabel = "gateway.envoyproxy.io/owning-gateway-namespace"
+
+	gatewayProxyReadyTimeout = 3 * time.Minute
+	gatewayProxyPollInterval = 5 * time.Second
+)
+
+// GatewayProxyBaseURL port-forwards to the Envoy Gateway proxy Service that
+// fronts the given Gateway and returns a local base URL plus a stop function
+// the caller must invoke when done.
+//
+// The proxy Service is found by the Envoy Gateway owning-Gateway labels rather
+// than by a fixed namespace: the proxy runs in the Gateway's own namespace or
+// a dedicated one depending on the render, and the Service is named after the
+// Gateway. The Gateway's external address is never assigned on a cluster
+// without a cloud LoadBalancer, so this deliberately port-forwards to the
+// ClusterIP instead of waiting for Programmed=True.
+//
+// With https true the HTTPS port is preferred and the returned URL uses the
+// https scheme; otherwise the HTTP port. A port matches on Envoy Gateway's own
+// name for it, "<protocol>-<port>", or on the default port number. Either way
+// the first TCP port is the fallback.
+func GatewayProxyBaseURL(ctx context.Context, clientset kubernetes.Interface, gwNamespace, gwName string, https bool) (string, func()) {
+	selector := fmt.Sprintf("%s=%s,%s=%s",
+		egOwningGatewayNameLabel, gwName,
+		egOwningGatewayNamespaceLabel, gwNamespace)
+
+	preferredProto, preferredPort := "http", int32(80)
+	scheme := "http"
+	if https {
+		preferredProto, preferredPort = "https", 443
+		scheme = "https"
+	}
+
+	var svcNS, svcName string
+	var remotePort int32
+	gomega.Eventually(func() error {
+		listCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		defer cancel()
+
+		// Empty namespace lists across all namespaces; see above.
+		svcList, err := clientset.CoreV1().Services("").List(listCtx, metav1.ListOptions{LabelSelector: selector})
+		if err != nil {
+			return fmt.Errorf("failed to list proxy Services: %w", err)
+		}
+		for _, svc := range svcList.Items {
+			if svc.Spec.ClusterIP == "" || svc.Spec.ClusterIP == "None" {
+				continue
+			}
+			var chosen int32
+			for _, p := range svc.Spec.Ports {
+				if p.Protocol != "" && p.Protocol != corev1.ProtocolTCP {
+					continue
+				}
+				// Envoy Gateway names the port "<protocol>-<port>", so match
+				// the protocol prefix rather than the bare scheme, which never
+				// equals the name. Without this a TLS listener on a port other
+				// than 443 falls through to the fallback below and can hand
+				// back a plaintext port behind an https:// URL.
+				if strings.HasPrefix(p.Name, preferredProto+"-") || p.Port == preferredPort {
+					chosen = p.Port
+					break
+				}
+				if chosen == 0 {
+					chosen = p.Port
+				}
+			}
+			if chosen != 0 {
+				svcNS, svcName, remotePort = svc.Namespace, svc.Name, chosen
+				return nil
+			}
+		}
+		return fmt.Errorf("no Envoy Gateway proxy Service with a ClusterIP+TCP port for Gateway %s/%s yet", gwNamespace, gwName)
+	}).WithTimeout(gatewayProxyReadyTimeout).WithPolling(gatewayProxyPollInterval).Should(
+		gomega.Succeed(), "Envoy Gateway proxy Service for Gateway %s/%s should be provisioned", gwNamespace, gwName)
+
+	stopCh := make(chan time.Time)
+	kc := &Kubectl{}
+	localPort, err := kc.PortForward(svcNS, "svc/"+svcName, fmt.Sprintf("%d", remotePort), "", stopCh)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to port-forward to Gateway proxy Service %s/%s", svcNS, svcName)
+
+	stop := func() { close(stopCh) }
+	return fmt.Sprintf("%s://127.0.0.1:%d", scheme, localPort), stop
+}


### PR DESCRIPTION
Adds E2E coverage for exposing the Whisker UI through Calico Ingress Gateway (`spec.ingressGateway` on the Whisker CR), the OSS counterpart of the Manager gateway tests in the Enterprise repo.

The suite is deliberately minimal — the one thing that needs a real cluster: it enables Gateway API support, sets `spec.ingressGateway`, waits for the Gateway to be accepted, port-forwards to the Envoy proxy Service, and asserts the real Whisker backend responds over HTTPS; a second spec removes `spec.ingressGateway` and asserts the Gateway, HTTPRoute, and TLS secret are cleaned up. Rendered object shapes, degrade cases, and per-namespace RBAC are covered by operator unit tests.

Notes:
- Port-forwards to the proxy's ClusterIP instead of waiting for an external address, so the suite works on clusters without a cloud LoadBalancer.
- Waits for a serving proxy Pod before port-forwarding: a Gateway can be Accepted minutes before its data plane exists on a cluster still installing Envoy Gateway.
- Restores cluster state: `spec.ingressGateway` is removed and a GatewayAPI CR is deleted only if the suite created it.

Depends on the operator change (tigera/operator#5146); the specs skip cleanly where the CRD field is absent.

Tested against OpenShift 4.20 (EKS) and GKE: 2/2 specs pass.

**Release note:**
```release-note
None (test-only change)
```
