### PR TITLE
kube-controllers: use k8s.io/kubectl library for flannel migration, drop bundled kubectl

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -110,46 +110,18 @@ require (
 	k8s.io/klog/v2 v2.130.1
 	k8s.io/kube-aggregator v0.35.8
 	k8s.io/kube-openapi v0.31.0
+	k8s.io/kubectl v0.35.8
 	k8s.io/kubernetes v1.35.8
+	k8s.io/pod-security-admission v0.35.8
 	k8s.io/utils v0.0.0-20251002143259-bc988d571ff4
+	kubevirt.io/api v1.8.0-alpha.0
+	kubevirt.io/client-go v1.8.0-alpha.0
 	modernc.org/memory v1.11.0
 	sigs.k8s.io/controller-runtime v0.23.3
 	sigs.k8s.io/kind v0.30.0
 	sigs.k8s.io/knftables v0.0.21
 	sigs.k8s.io/network-policy-api v0.2.0
 	sigs.k8s.io/yaml v1.6.0
-)
-
-require (
-	github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c // indirect
-	github.com/MakeNowJust/heredoc v1.0.0 // indirect
-	github.com/chai2010/gettext-go v1.0.2 // indirect
-	github.com/docker/distribution v2.8.3+incompatible // indirect
-	github.com/docker/docker v28.5.1+incompatible // indirect
-	github.com/exponent-io/jsonpath v0.0.0-20210407135951-1de76d718b3f // indirect
-	github.com/go-kit/log v0.2.1 // indirect
-	github.com/go-logfmt/logfmt v0.6.0 // indirect
-	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 // indirect
-	github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de // indirect
-	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
-	github.com/moby/term v0.5.2 // indirect
-	github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 // indirect
-	github.com/openshift/custom-resource-status v1.1.2 // indirect
-	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
-	github.com/robfig/cron/v3 v3.0.1 // indirect
-	github.com/tigera/api v0.0.0-20260310182635-546021df243c // indirect
-	github.com/xlab/treeprint v1.2.0 // indirect
-	k8s.io/cli-runtime v0.35.8 // indirect
-	kubevirt.io/containerized-data-importer-api v1.63.1 // indirect
-	kubevirt.io/controller-lifecycle-operator-sdk/api v0.0.0-20220329064328-f3cc58c6ed90 // indirect
-	sigs.k8s.io/kustomize/api v0.20.1 // indirect
-	sigs.k8s.io/kustomize/kyaml v0.20.1 // indirect
-)
-
-require (
-	golang.org/x/crypto v0.55.0 // indirect
-	kubevirt.io/api v1.8.0-alpha.0
-	kubevirt.io/client-go v1.8.0-alpha.0
 )
 
 require (
@@ -163,10 +135,12 @@ require (
 	cloud.google.com/go/monitoring v1.24.2 // indirect
 	cyphar.com/go-pathrs v0.2.1 // indirect
 	filippo.io/edwards25519 v1.1.0 // indirect
+	github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.32.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.53.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.53.0 // indirect
 	github.com/JeffAshton/win_pdh v0.0.0-20161109143554-76bb4ee9f0ab // indirect
+	github.com/MakeNowJust/heredoc v1.0.0 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/Microsoft/hnslib v0.1.2 // indirect
 	github.com/NYTimes/gziphandler v1.1.1 // indirect
@@ -210,6 +184,7 @@ require (
 	github.com/boombuler/barcode v1.0.1 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.2 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+	github.com/chai2010/gettext-go v1.0.2 // indirect
 	github.com/cloudflare/circl v1.6.1 // indirect
 	github.com/cncf/xds/go v0.0.0-20260202195803-dba9d589def2 // indirect
 	github.com/containerd/cgroups/v3 v3.0.3 // indirect
@@ -227,6 +202,8 @@ require (
 	github.com/cyphar/filepath-securejoin v0.6.1 // indirect
 	github.com/distribution/reference v0.6.0 // indirect
 	github.com/docker/cli v27.5.0+incompatible // indirect
+	github.com/docker/distribution v2.8.3+incompatible // indirect
+	github.com/docker/docker v28.5.1+incompatible // indirect
 	github.com/docker/docker-credential-helpers v0.8.2 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/ebitengine/purego v0.9.0 // indirect
@@ -234,11 +211,14 @@ require (
 	github.com/envoyproxy/protoc-gen-validate v1.3.3 // indirect
 	github.com/euank/go-kmsg-parser v2.0.0+incompatible // indirect
 	github.com/evanphx/json-patch/v5 v5.9.11 // indirect
+	github.com/exponent-io/jsonpath v0.0.0-20210407135951-1de76d718b3f // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.10 // indirect
 	github.com/go-errors/errors v1.4.2 // indirect
 	github.com/go-jose/go-jose/v4 v4.1.4 // indirect
+	github.com/go-kit/log v0.2.1 // indirect
+	github.com/go-logfmt/logfmt v0.6.0 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect
@@ -271,6 +251,7 @@ require (
 	github.com/googleapis/gax-go/v2 v2.15.0 // indirect
 	github.com/gorilla/mux v1.8.1 // indirect
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 // indirect
+	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 // indirect
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.2 // indirect
 	github.com/gruntwork-io/go-commons v0.8.0 // indirect
@@ -290,6 +271,7 @@ require (
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
 	github.com/libopenstorage/openstorage v1.0.0 // indirect
+	github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de // indirect
 	github.com/lithammer/dedent v1.1.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
@@ -304,13 +286,16 @@ require (
 	github.com/mistifyio/go-zfs v2.1.2-0.20190413222219-f784269be439+incompatible // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/go-ps v1.0.0 // indirect
+	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
 	github.com/mitchellh/hashstructure v1.1.0 // indirect
 	github.com/moby/spdystream v0.5.1 // indirect
 	github.com/moby/sys/mountinfo v0.7.2 // indirect
 	github.com/moby/sys/userns v0.1.0 // indirect
+	github.com/moby/term v0.5.2 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 // indirect
+	github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
 	github.com/opencontainers/cgroups v0.0.3 // indirect
@@ -318,15 +303,18 @@ require (
 	github.com/opencontainers/image-spec v1.1.1 // indirect
 	github.com/opencontainers/runtime-spec v1.2.1 // indirect
 	github.com/opencontainers/selinux v1.13.0 // indirect
+	github.com/openshift/custom-resource-status v1.1.2 // indirect
 	github.com/pborman/uuid v1.2.1 // indirect
 	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
+	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 // indirect
 	github.com/pquerna/otp v1.4.0 // indirect
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.80.1 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
+	github.com/robfig/cron/v3 v3.0.1 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/sagikazarmark/locafero v0.11.0 // indirect
 	github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 // indirect
@@ -336,6 +324,7 @@ require (
 	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
 	github.com/texttheater/golang-levenshtein v1.0.1 // indirect
+	github.com/tigera/api v0.0.0-20260310182635-546021df243c // indirect
 	github.com/tklauser/go-sysconf v0.3.16 // indirect
 	github.com/tklauser/numcpus v0.11.0 // indirect
 	github.com/urfave/cli v1.22.16 // indirect
@@ -343,6 +332,7 @@ require (
 	github.com/virtuald/go-ordered-json v0.0.0-20170621173500-b18e6e673d74 // indirect
 	github.com/vishvananda/netns v0.0.5 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
+	github.com/xlab/treeprint v1.2.0 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
@@ -361,6 +351,7 @@ require (
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
+	golang.org/x/crypto v0.55.0 // indirect
 	golang.org/x/exp v0.0.0-20251219203646-944ab1f22d93 // indirect
 	golang.org/x/term v0.45.0 // indirect
 	golang.org/x/tools v0.49.0 // indirect
@@ -372,6 +363,7 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
+	k8s.io/cli-runtime v0.35.8 // indirect
 	k8s.io/cloud-provider v0.35.8 // indirect
 	k8s.io/component-helpers v0.35.8 // indirect
 	k8s.io/controller-manager v0.35.8 // indirect
@@ -381,12 +373,14 @@ require (
 	k8s.io/dynamic-resource-allocation v0.35.8 // indirect
 	k8s.io/kms v0.35.8 // indirect
 	k8s.io/kube-scheduler v0.35.8 // indirect
-	k8s.io/kubectl v0.35.8
 	k8s.io/kubelet v0.35.8 // indirect
 	k8s.io/mount-utils v0.35.8 // indirect
-	k8s.io/pod-security-admission v0.35.8
+	kubevirt.io/containerized-data-importer-api v1.63.1 // indirect
+	kubevirt.io/controller-lifecycle-operator-sdk/api v0.0.0-20220329064328-f3cc58c6ed90 // indirect
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.34.0 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
+	sigs.k8s.io/kustomize/api v0.20.1 // indirect
+	sigs.k8s.io/kustomize/kyaml v0.20.1 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.2-0.20260122202528-d9cc6641c482 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -121,15 +121,29 @@ require (
 )
 
 require (
+	github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c // indirect
+	github.com/MakeNowJust/heredoc v1.0.0 // indirect
+	github.com/chai2010/gettext-go v1.0.2 // indirect
 	github.com/docker/distribution v2.8.3+incompatible // indirect
 	github.com/docker/docker v28.5.1+incompatible // indirect
+	github.com/exponent-io/jsonpath v0.0.0-20210407135951-1de76d718b3f // indirect
 	github.com/go-kit/log v0.2.1 // indirect
 	github.com/go-logfmt/logfmt v0.6.0 // indirect
+	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 // indirect
+	github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de // indirect
+	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
+	github.com/moby/term v0.5.2 // indirect
+	github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 // indirect
 	github.com/openshift/custom-resource-status v1.1.2 // indirect
+	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/robfig/cron/v3 v3.0.1 // indirect
 	github.com/tigera/api v0.0.0-20260310182635-546021df243c // indirect
+	github.com/xlab/treeprint v1.2.0 // indirect
+	k8s.io/cli-runtime v0.35.8 // indirect
 	kubevirt.io/containerized-data-importer-api v1.63.1 // indirect
 	kubevirt.io/controller-lifecycle-operator-sdk/api v0.0.0-20220329064328-f3cc58c6ed90 // indirect
+	sigs.k8s.io/kustomize/api v0.20.1 // indirect
+	sigs.k8s.io/kustomize/kyaml v0.20.1 // indirect
 )
 
 require (
@@ -367,7 +381,7 @@ require (
 	k8s.io/dynamic-resource-allocation v0.35.8 // indirect
 	k8s.io/kms v0.35.8 // indirect
 	k8s.io/kube-scheduler v0.35.8 // indirect
-	k8s.io/kubectl v0.35.8 // indirect
+	k8s.io/kubectl v0.35.8
 	k8s.io/kubelet v0.35.8 // indirect
 	k8s.io/mount-utils v0.35.8 // indirect
 	k8s.io/pod-security-admission v0.35.8

--- a/go.sum
+++ b/go.sum
@@ -229,6 +229,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.5/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46t
 github.com/cpuguy83/go-md2man/v2 v2.0.6 h1:XJtiaUW6dEEqVuZiMTn1ldk455QWwEIsMIJlo5vtkx0=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
+github.com/creack/pty v1.1.18 h1:n56/Zwd5o6whRC5PMGretI4IdRLlmBXYNjScPaBgsbY=
+github.com/creack/pty v1.1.18/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
 github.com/cyphar/filepath-securejoin v0.6.1 h1:5CeZ1jPXEiYt3+Z6zqprSAgSWiggmpVyciv8syjIpVE=
 github.com/cyphar/filepath-securejoin v0.6.1/go.mod h1:A8hd4EnAeyujCJRrICiOWqjS1AX0a9kM5XL+NwKoYSc=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -1159,6 +1161,7 @@ golang.org/x/sys v0.0.0-20210112080510-489259a85091/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210420072515-93ed5bcd2bfe/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211019181941-9d821ace8654/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220209214540-3681064d5158/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/kube-controllers/Makefile
+++ b/kube-controllers/Makefile
@@ -69,10 +69,6 @@ endif
 $(BINDIR)/check-status-linux-$(ARCH): $(SRC_FILES)
 	$(call build_binary, ./cmd/check-status, $@)
 
-$(BINDIR)/kubectl-$(ARCH):
-	curl -sSf -L --retry 5 -o $@ https://dl.k8s.io/release/$(K8S_VERSION)/bin/linux/$(ARCH)/kubectl
-	chmod +x $@
-
 ###############################################################################
 # Building the image
 ###############################################################################
@@ -87,14 +83,14 @@ image: $(KUBE_CONTROLLER_CONTAINER_MARKER)
 
 IMAGE_DEPS = Dockerfile docker-image/flannel-migration/Dockerfile
 # register is order-only (|) so binfmt setup doesn't trigger unnecessary rebuilds.
-$(KUBE_CONTROLLER_CONTAINER_CREATED): $(IMAGE_DEPS) $(BINDIR)/kube-controllers-linux-$(ARCH) $(BINDIR)/check-status-linux-$(ARCH) $(BINDIR)/wrapper-$(ARCH) $(BINDIR)/kubectl-$(ARCH) | register
+$(KUBE_CONTROLLER_CONTAINER_CREATED): $(IMAGE_DEPS) $(BINDIR)/kube-controllers-linux-$(ARCH) $(BINDIR)/check-status-linux-$(ARCH) $(BINDIR)/wrapper-$(ARCH) | register
 	cp ../LICENSE.md $(BINDIR)/LICENSE
 	$(DOCKER_BUILD) --build-arg BIN_DIR=$(BINDIR) -t $(KUBE_CONTROLLERS_IMAGE):latest-$(ARCH) -f Dockerfile .
 	$(DOCKER_BUILD) --build-arg BIN_DIR=$(BINDIR) -t $(FLANNEL_MIGRATION_IMAGE):latest-$(ARCH) -f docker-image/flannel-migration/Dockerfile .
 	$(MAKE) retag-build-images-with-registries VALIDARCHES=$(ARCH) IMAGETAG=latest
 	touch $@
 
-$(KUBE_CONTROLLER_CONTAINER_FIPS_CREATED): $(IMAGE_DEPS) $(BINDIR)/kube-controllers-linux-$(ARCH) $(BINDIR)/check-status-linux-$(ARCH) $(BINDIR)/wrapper-$(ARCH) $(BINDIR)/kubectl-$(ARCH) | register
+$(KUBE_CONTROLLER_CONTAINER_FIPS_CREATED): $(IMAGE_DEPS) $(BINDIR)/kube-controllers-linux-$(ARCH) $(BINDIR)/check-status-linux-$(ARCH) $(BINDIR)/wrapper-$(ARCH) | register
 	cp ../LICENSE.md $(BINDIR)/LICENSE
 	$(DOCKER_BUILD) --build-arg BIN_DIR=$(BINDIR) -t $(KUBE_CONTROLLERS_IMAGE):latest-fips-$(ARCH) -f Dockerfile .
 	$(DOCKER_BUILD) --build-arg BIN_DIR=$(BINDIR) -t $(FLANNEL_MIGRATION_IMAGE):latest-fips-$(ARCH) -f docker-image/flannel-migration/Dockerfile .

--- a/kube-controllers/cmd/kube-controllers/main.go
+++ b/kube-controllers/cmd/kube-controllers/main.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2025 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017-2026 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/kube-controllers/cmd/kube-controllers/main.go
+++ b/kube-controllers/cmd/kube-controllers/main.go
@@ -186,7 +186,7 @@ func main() {
 		}
 		log.WithField("flannelConfig", flannelConfig).Info("Loaded Flannel configuration from environment")
 
-		flannelMigrationController := flannelmigration.NewFlannelMigrationController(ctx, k8sClientset, libcalicoClient, flannelConfig)
+		flannelMigrationController := flannelmigration.NewFlannelMigrationController(ctx, k8sClientset, k8sconfig, libcalicoClient, flannelConfig)
 		controllerCtrl.controllers["FlannelMigration"] = flannelMigrationController
 
 		// Set some global defaults for flannelmigration

--- a/kube-controllers/deps.txt
+++ b/kube-controllers/deps.txt
@@ -3,12 +3,14 @@ Run 'make gen-deps-files' to regenerate.
 
 go 1.25.14
 cel.dev/expr v0.25.1
+github.com/MakeNowJust/heredoc v1.0.0
 github.com/Masterminds/semver/v3 v3.4.0
 github.com/antlr4-go/antlr/v4 v4.13.1
 github.com/beorn7/perks v1.0.1
 github.com/blang/semver/v4 v4.0.0
 github.com/cenkalti/backoff/v5 v5.0.2
 github.com/cespare/xxhash/v2 v2.3.0
+github.com/chai2010/gettext-go v1.0.2
 github.com/coreos/go-semver v0.3.1
 github.com/coreos/go-systemd/v22 v22.6.0
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
@@ -16,8 +18,10 @@ github.com/emicklei/go-restful v2.15.0+incompatible
 github.com/emicklei/go-restful/v3 v3.12.2
 github.com/evanphx/json-patch v5.9.11+incompatible
 github.com/evanphx/json-patch/v5 v5.9.11
+github.com/exponent-io/jsonpath v0.0.0-20210407135951-1de76d718b3f
 github.com/felixge/httpsnoop v1.0.4
 github.com/fxamacker/cbor/v2 v2.9.0
+github.com/go-errors/errors v1.4.2
 github.com/go-ini/ini v1.67.0
 github.com/go-kit/log v0.2.1
 github.com/go-logfmt/logfmt v0.6.0
@@ -37,6 +41,7 @@ github.com/google/gnostic-models v0.7.0
 github.com/google/go-cmp v0.7.0
 github.com/google/uuid v1.6.0
 github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674
+github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.2
 github.com/jinzhu/copier v0.4.0
 github.com/joho/godotenv v1.5.1
@@ -47,21 +52,28 @@ github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0
 github.com/kelseyhightower/envconfig v1.4.0
 github.com/kylelemons/godebug v1.1.0
 github.com/leodido/go-urn v1.4.0
+github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de
 github.com/mailru/easyjson v0.7.7
 github.com/mattn/go-runewidth v0.0.16
 github.com/mdlayher/genetlink v1.3.2
 github.com/mdlayher/netlink v1.7.2
 github.com/mdlayher/socket v0.5.1
 github.com/mipearson/rfw v0.0.0-20170619235010-6f0a6f3266ba
+github.com/mitchellh/go-wordwrap v1.0.1
+github.com/moby/spdystream v0.5.1
+github.com/moby/term v0.5.2
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee
+github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822
+github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f
 github.com/olekukonko/tablewriter v0.0.5
 github.com/onsi/ginkgo v1.16.5
 github.com/onsi/ginkgo/v2 v2.28.1
 github.com/onsi/gomega v1.39.1
 github.com/openshift/custom-resource-status v1.1.2
 github.com/patrickmn/go-cache v2.1.0+incompatible
+github.com/peterbourgon/diskv v2.0.1+incompatible
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2
 github.com/projectcalico/calico
 github.com/prometheus/client_golang v1.23.2
@@ -69,6 +81,8 @@ github.com/prometheus/client_model v0.6.2
 github.com/prometheus/common v0.67.2
 github.com/prometheus/procfs v0.19.2
 github.com/rivo/uniseg v0.4.7
+github.com/russross/blackfriday v1.6.0
+github.com/russross/blackfriday/v2 v2.1.0
 github.com/sirupsen/logrus v1.9.3
 github.com/spf13/cobra v1.10.2
 github.com/spf13/pflag v1.0.10
@@ -76,6 +90,7 @@ github.com/tchap/go-patricia/v2 v2.3.3
 github.com/vishvananda/netlink v1.3.1
 github.com/vishvananda/netns v0.0.5
 github.com/x448/float16 v0.8.4
+github.com/xlab/treeprint v1.2.0
 go.etcd.io/etcd/api/v3 v3.6.5
 go.etcd.io/etcd/client/pkg/v3 v3.6.5
 go.etcd.io/etcd/client/v3 v3.6.5
@@ -118,6 +133,7 @@ k8s.io/api v0.35.8
 k8s.io/apiextensions-apiserver v0.35.8
 k8s.io/apimachinery v0.35.8
 k8s.io/apiserver v0.35.8
+k8s.io/cli-runtime v0.35.8
 k8s.io/client-go v0.35.8
 k8s.io/component-base v0.35.8
 k8s.io/component-helpers v0.35.8
@@ -126,6 +142,7 @@ k8s.io/klog v0.2.0
 k8s.io/klog/v2 v2.130.1
 k8s.io/kube-aggregator v0.35.8
 k8s.io/kube-openapi v0.0.0-20250910181357-589584f1c912
+k8s.io/kubectl v0.35.8
 k8s.io/kubernetes v1.35.8
 k8s.io/utils v0.0.0-20251002143259-bc988d571ff4
 kubevirt.io/api v1.8.0-alpha.0
@@ -134,6 +151,8 @@ kubevirt.io/controller-lifecycle-operator-sdk/api v0.0.0-20220329064328-f3cc58c6
 sigs.k8s.io/controller-runtime v0.23.3
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730
 sigs.k8s.io/knftables v0.0.21
+sigs.k8s.io/kustomize/api v0.20.1
+sigs.k8s.io/kustomize/kyaml v0.20.1
 sigs.k8s.io/network-policy-api v0.2.0
 sigs.k8s.io/randfill v1.0.0
 sigs.k8s.io/structured-merge-diff/v6 v6.3.2-0.20260122202528-d9cc6641c482

--- a/kube-controllers/docker-image/flannel-migration/Dockerfile
+++ b/kube-controllers/docker-image/flannel-migration/Dockerfile
@@ -30,7 +30,6 @@ COPY --from=builder /status /status/
 
 COPY ${BIN_DIR}/LICENSE /licenses/LICENSE
 
-COPY ${BIN_DIR}/kubectl-${TARGETARCH} /usr/bin/kubectl
 COPY ${BIN_DIR}/kube-controllers-linux-${TARGETARCH} /usr/bin/kube-controllers
 COPY ${BIN_DIR}/check-status-linux-${TARGETARCH} /usr/bin/check-status
 

--- a/kube-controllers/pkg/controllers/flannelmigration/k8s_resources.go
+++ b/kube-controllers/pkg/controllers/flannelmigration/k8s_resources.go
@@ -15,9 +15,11 @@
 package flannelmigration
 
 import (
+	"bytes"
 	"context"
+	"errors"
 	"fmt"
-	"os/exec"
+	"strings"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -26,8 +28,13 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/remotecommand"
+	"k8s.io/kubectl/pkg/drain"
 )
 
 // daemonset holds a collection of helper functions for Kubernetes daemonset.
@@ -459,7 +466,7 @@ func (n k8snode) waitPodReadyForNode(k8sClientset *kubernetes.Clientset, namespa
 }
 
 // Execute command in a pod on a node. Get command output.
-func (n k8snode) execCommandInPod(k8sClientset *kubernetes.Clientset, namespace, containerName string, label map[string]string, args ...string) (string, error) {
+func (n k8snode) execCommandInPod(k8sClientset *kubernetes.Clientset, restConfig *rest.Config, namespace, containerName string, label map[string]string, args ...string) (string, error) {
 	nodeName := string(n)
 	var pod v1.Pod
 	found := false
@@ -492,51 +499,124 @@ func (n k8snode) execCommandInPod(k8sClientset *kubernetes.Clientset, namespace,
 		return "", fmt.Errorf("failed to execute command in pod. Pod %s is not ready", pod.Name)
 	}
 
-	cmdArgs := []string{"exec", pod.Name, fmt.Sprintf("--namespace=%s", namespace), fmt.Sprintf("-c=%s", containerName), "--"}
-	cmdArgs = append(cmdArgs, args...)
-	out, err := exec.Command("/usr/bin/kubectl", cmdArgs...).CombinedOutput()
+	req := k8sClientset.CoreV1().RESTClient().Post().
+		Resource("pods").
+		Name(pod.Name).
+		Namespace(namespace).
+		SubResource("exec").
+		VersionedParams(&v1.PodExecOptions{
+			Container: containerName,
+			Command:   args,
+			Stdout:    true,
+			Stderr:    true,
+		}, scheme.ParameterCodec)
+
+	executor, err := remotecommand.NewSPDYExecutor(restConfig, "POST", req.URL())
 	if err != nil {
-		log.Errorf("Kubectl exec %s(%s) error. \n ---%v--- \n%s\n ------", pod.Name, containerName, cmdArgs, string(out))
+		return "", fmt.Errorf("failed to build SPDY executor for %s/%s: %w", namespace, pod.Name, err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	if err := executor.StreamWithContext(context.Background(), remotecommand.StreamOptions{
+		Stdout: &stdout,
+		Stderr: &stderr,
+	}); err != nil {
+		log.WithError(err).Errorf("Exec %s(%s) error. \n ---%v--- \nstdout:\n%s\nstderr:\n%s\n ------", pod.Name, containerName, args, stdout.String(), stderr.String())
 		return "", err
 	}
 
-	log.Infof("Kubectl exec %s(%s) completed successfully. \n ---%v--- \n%s\n ------", pod.Name, containerName, cmdArgs, string(out))
-	return string(out), nil
+	log.Infof("Exec %s(%s) completed successfully. \n ---%v--- \n%s\n ------", pod.Name, containerName, args, stdout.String())
+	return stdout.String(), nil
 }
 
-func (n k8snode) Drain() error {
+func (n k8snode) Drain(k8sClientset *kubernetes.Clientset) error {
 	nodeName := string(n)
 	log.Infof("Start drain node %s", nodeName)
-	out, err := exec.Command("/usr/bin/kubectl", "drain",
-		"--ignore-daemonsets", "--delete-emptydir-data", "--force", nodeName).CombinedOutput()
-	if err != nil {
-		log.Errorf("Drain node %s. \n ---Drain Node--- \n%s\n ------", nodeName, string(out))
-		return err
+
+	helper := newDrainHelper(k8sClientset)
+	if err := cordonNode(k8sClientset, nodeName, true); err != nil {
+		return fmt.Errorf("failed to cordon node %s: %w", nodeName, err)
 	}
 
-	log.Infof("Drain node %s completed successfully. \n ---Drain Node Logs--- \n%s\n ------", nodeName, string(out))
+	list, errs := helper.GetPodsForDeletion(nodeName)
+	if len(errs) > 0 {
+		return fmt.Errorf("failed to list pods for drain on node %s: %w", nodeName, errors.Join(errs...))
+	}
+	if warnings := list.Warnings(); warnings != "" {
+		log.Warnf("Drain warnings for node %s: %s", nodeName, warnings)
+	}
+	if err := helper.DeleteOrEvictPods(list.Pods()); err != nil {
+		return fmt.Errorf("failed to drain node %s: %w", nodeName, err)
+	}
+
+	log.Infof("Drain node %s completed successfully.", nodeName)
 	return nil
 }
 
-func (n k8snode) Uncordon() error {
+func (n k8snode) Uncordon(k8sClientset *kubernetes.Clientset) error {
 	nodeName := string(n)
 	log.Infof("Start uncordon node %s", nodeName)
-	out, err := exec.Command("/usr/bin/kubectl", "uncordon", nodeName).CombinedOutput()
-	if err != nil {
-		log.Errorf("Uncordon node %s. \n ---Uncordon Node Logs--- \n%s\n ------", nodeName, string(out))
-		return err
+	if err := cordonNode(k8sClientset, nodeName, false); err != nil {
+		return fmt.Errorf("failed to uncordon node %s: %w", nodeName, err)
 	}
-
 	log.Infof("Uncordon node %s completed successfully.", nodeName)
 	return nil
 }
 
-func removeLabelForAllNodes(key string) error {
-	log.Infof("Start remove node label %s", key)
-	out, err := exec.Command("/usr/bin/kubectl", "label", "node", key+"-", "--all").CombinedOutput()
+// newDrainHelper returns a kubectl drain.Helper configured with the same
+// semantics as `kubectl drain --ignore-daemonsets --delete-emptydir-data --force`.
+func newDrainHelper(k8sClientset *kubernetes.Clientset) *drain.Helper {
+	return &drain.Helper{
+		Ctx:                 context.Background(),
+		Client:              k8sClientset,
+		Force:               true,
+		IgnoreAllDaemonSets: true,
+		DeleteEmptyDirData:  true,
+		GracePeriodSeconds:  -1,
+		Out:                 log.StandardLogger().WriterLevel(log.InfoLevel),
+		ErrOut:              log.StandardLogger().WriterLevel(log.WarnLevel),
+	}
+}
+
+// cordonNode sets the node's Unschedulable flag to the desired value using
+// kubectl's CordonHelper, which patches only when an update is required.
+func cordonNode(k8sClientset *kubernetes.Clientset, nodeName string, desired bool) error {
+	node, err := k8sClientset.CoreV1().Nodes().Get(context.Background(), nodeName, metav1.GetOptions{})
 	if err != nil {
-		log.Errorf("Remove label node %s. \n ---Remove Node Label Logs--- \n %s \n ------", key, string(out))
 		return err
+	}
+	cordonHelper := drain.NewCordonHelper(node)
+	if !cordonHelper.UpdateIfRequired(desired) {
+		return nil
+	}
+	if err, patchErr := cordonHelper.PatchOrReplaceWithContext(context.Background(), k8sClientset, false); err != nil || patchErr != nil {
+		if err != nil {
+			return err
+		}
+		return patchErr
+	}
+	return nil
+}
+
+func removeLabelForAllNodes(k8sClientset *kubernetes.Clientset, key string) error {
+	log.Infof("Start remove node label %s", key)
+
+	nodes, err := k8sClientset.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to list nodes: %w", err)
+	}
+
+	// Escape the label key per RFC 6901 so it can be used in a JSON Patch path.
+	escaped := strings.ReplaceAll(strings.ReplaceAll(key, "~", "~0"), "/", "~1")
+	patch := []byte(fmt.Sprintf(`[{"op":"remove","path":"/metadata/labels/%s"}]`, escaped))
+
+	for _, node := range nodes.Items {
+		if _, ok := node.Labels[key]; !ok {
+			continue
+		}
+		if _, err := k8sClientset.CoreV1().Nodes().Patch(context.Background(), node.Name, types.JSONPatchType, patch, metav1.PatchOptions{}); err != nil {
+			return fmt.Errorf("failed to remove label %s from node %s: %w", key, node.Name, err)
+		}
 	}
 
 	log.Infof("Remove node label %s completed successfully.", key)

--- a/kube-controllers/pkg/controllers/flannelmigration/k8s_resources.go
+++ b/kube-controllers/pkg/controllers/flannelmigration/k8s_resources.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Tigera, Inc. All rights reserved.
+// Copyright (c) 2019-2026 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/kube-controllers/pkg/controllers/flannelmigration/migration_controller.go
+++ b/kube-controllers/pkg/controllers/flannelmigration/migration_controller.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2019-2026 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/kube-controllers/pkg/controllers/flannelmigration/migration_controller.go
+++ b/kube-controllers/pkg/controllers/flannelmigration/migration_controller.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/fields"
 	uruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 
 	"github.com/projectcalico/calico/kube-controllers/pkg/controllers/controller"
@@ -77,6 +78,7 @@ type flannelMigrationController struct {
 	indexer      cache.Store
 	calicoClient client.Interface
 	k8sClientset *kubernetes.Clientset
+	k8sConfig    *rest.Config
 
 	// ipamMigrator runs ipam migration process.
 	ipamMigrator ipamMigrator
@@ -92,11 +94,12 @@ type flannelMigrationController struct {
 }
 
 // NewFlannelMigrationController Constructor for Flannel migration controller
-func NewFlannelMigrationController(ctx context.Context, k8sClientset *kubernetes.Clientset, calicoClient client.Interface, cfg *Config) controller.Controller {
+func NewFlannelMigrationController(ctx context.Context, k8sClientset *kubernetes.Clientset, k8sConfig *rest.Config, calicoClient client.Interface, cfg *Config) controller.Controller {
 	mc := &flannelMigrationController{
 		ctx:             ctx,
 		calicoClient:    calicoClient,
 		k8sClientset:    k8sClientset,
+		k8sConfig:       k8sConfig,
 		ipamMigrator:    NewIPAMMigrator(ctx, k8sClientset, calicoClient, cfg),
 		networkMigrator: NewNetworkMigrator(ctx, k8sClientset, calicoClient, cfg),
 		config:          cfg,
@@ -287,7 +290,7 @@ func (c *flannelMigrationController) readAndUpdateFlannelEnvConfig() error {
 	}
 
 	n := k8snode(c.config.PodNodeName)
-	data, err := n.execCommandInPod(c.k8sClientset, c.config.FlannelDaemonsetNamespace, flannelContainerName,
+	data, err := n.execCommandInPod(c.k8sClientset, c.k8sConfig, c.config.FlannelDaemonsetNamespace, flannelContainerName,
 		podLabel, "cat", flannelConfigFile)
 	if err != nil {
 		return err
@@ -540,7 +543,7 @@ func (c *flannelMigrationController) completeMigration() error {
 	}
 
 	// Remove node labels
-	err = removeLabelForAllNodes(migrationNodeSelectorKey)
+	err = removeLabelForAllNodes(c.k8sClientset, migrationNodeSelectorKey)
 	if err != nil {
 		log.WithError(err).Errorf("Failed to remove node label %s.", migrationNodeSelectorKey)
 		return err

--- a/kube-controllers/pkg/controllers/flannelmigration/network_migrator.go
+++ b/kube-controllers/pkg/controllers/flannelmigration/network_migrator.go
@@ -148,7 +148,7 @@ func (m *networkMigrator) setupCalicoNetworkForNode(node *v1.Node) error {
 	}
 
 	// Cordon and Drain node. Make sure no pod (except daemonset pod or pod with nodeName selector) can run on this node.
-	err = n.Drain()
+	err = n.Drain(m.k8sClientset)
 	if err != nil {
 		log.WithError(err).Errorf("failed to drain node %s", node.Name)
 		return err
@@ -209,7 +209,7 @@ func (m *networkMigrator) setupCalicoNetworkForNode(node *v1.Node) error {
 	}
 
 	// Uncordon node.
-	err = n.Uncordon()
+	err = n.Uncordon(m.k8sClientset)
 	if err != nil {
 		log.WithError(err).Errorf("failed to uncordon node %s", node.Name)
 		return err


### PR DESCRIPTION
## Description

The `flannel-migration-controller` image bundles a prebuilt `kubectl` downloaded from dl.k8s.io (at `K8S_VERSION`, currently v1.35.8). That upstream binary is compiled with **Go 1.26.5**, which carries Go standard-library CVEs, **1 critical (CVE-2026-39821, CVSS 10.0) + 5 high + 2 medium**. We build our own binaries (kube-controllers, check-status) with Go 1.25.14, which is clean, so the finding is entirely the downloaded kubectl. Since we don't compile kubectl, rebuilding our images doesn't clear it, and there's no in-line fix available (the latest v1.35 patch is still on the vulnerable Go; the first k8s release with a fixed-Go kubectl is v1.37.0, two minors ahead).

This removes the bundled kubectl entirely by porting the flannel migration controller's runtime `kubectl` shell-outs to the `k8s.io/kubectl/pkg/drain` library + client-go:
- `Drain` / `Uncordon` → `drain.Helper` and `drain.NewCordonHelper`
- node label removal → client-go List + JSON patch
- exec-in-pod → client-go SPDY `remotecommand`

and drops the kubectl download (Makefile) and the `COPY .../kubectl` (Dockerfile). The logic is now compiled into kube-controllers with our own clean toolchain.

This mirrors what master already ships in #12225 (the components-consolidation PR), scoped to just the flannel migration path.

## Notes / validation
- The service account already had the permissions these operations need (kubectl ran under it), so no RBAC change.
- Builds clean (`go build ./kube-controllers/...`). The newly-linked deps (`k8s.io/kubectl`, `k8s.io/cli-runtime`, `sigs.k8s.io/kustomize/*`, etc., all v0.35.8 / v0.20.1) are CVE-clean per osv and compiled with Go 1.25.14, so no CVEs are traded in.
- **Needs the flannel-migration FV to validate the library-based drain/cordon at runtime** (couldn't run it locally, no cluster); that runs in CI here. Master shipping the same code is additional confidence.

## Release Note

```release-note
Resolve Go standard-library CVEs in the flannel-migration-controller image by replacing the bundled kubectl binary with the k8s.io/kubectl library.
```
