### PR TITLE
Take the Lens Elasticsearch user name from the secret

### DIFF
--- a/.semaphore/semaphore-scheduled-builds.yml
+++ b/.semaphore/semaphore-scheduled-builds.yml
@@ -1961,9 +1961,12 @@ blocks:
             - ../.semaphore/run-and-monitor tox.log bash -c 'make tox-caracal && make tox-fv-caracal'
         - name: "OpenStack: Mainline ST (DevStack + Tempest) on Caracal"
           commands:
-            # Env vars needed for saving performance results.
+            # Env vars needed for saving performance results.  Take the user name
+            # from the secret alongside the token, rather than hardcoding it, so
+            # that rotating the Lens credential to a different account does not
+            # silently break publishing.
             - export ELASTICSEARCH_URL=https://banzai-lens-es.dev-tools.tigera.net:9200
-            - export ELASTICSEARCH_USER=elastic
+            - export ELASTICSEARCH_USER=${LENS_ELASTICSEARCH_USER}
             - export ELASTICSEARCH_TOKEN=${LENS_ELASTICSEARCH_TOKEN}
             # For some reason python3-wrapt is pre-installed on a Semaphore ubuntu2004 node, but with
             # a version (1.11.2) that is different from the version that OpenStack needs (1.13.3), and
@@ -2017,8 +2020,11 @@ blocks:
             # not a per-PR gate.
             - sudo env NFT_BENCH_PERF_ARTIFACTS_DIR="$(pwd)/artifacts/perf" felix/bin/nft.test -test.run='^$' -test.bench=. -test.benchmem -test.benchtime=6x
             # Publish to Lens. send-perf-results no-ops if the creds are unset.
+            # Take the user name from the secret alongside the token, rather than
+            # hardcoding it, so that rotating the Lens credential to a different
+            # account does not silently break publishing.
             - export ELASTICSEARCH_URL=https://banzai-lens-es.dev-tools.tigera.net:9200
-            - export ELASTICSEARCH_USER=elastic
+            - export ELASTICSEARCH_USER=${LENS_ELASTICSEARCH_USER}
             - export ELASTICSEARCH_TOKEN=${LENS_ELASTICSEARCH_TOKEN}
             - ./bin/send-perf-results --dir artifacts/perf
       epilogue:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -6418,9 +6418,12 @@ blocks:
             - ../.semaphore/run-and-monitor tox.log bash -c 'make tox-caracal && make tox-fv-caracal'
         - name: "OpenStack: Mainline ST (DevStack + Tempest) on Caracal"
           commands:
-            # Env vars needed for saving performance results.
+            # Env vars needed for saving performance results.  Take the user name
+            # from the secret alongside the token, rather than hardcoding it, so
+            # that rotating the Lens credential to a different account does not
+            # silently break publishing.
             - export ELASTICSEARCH_URL=https://banzai-lens-es.dev-tools.tigera.net:9200
-            - export ELASTICSEARCH_USER=elastic
+            - export ELASTICSEARCH_USER=${LENS_ELASTICSEARCH_USER}
             - export ELASTICSEARCH_TOKEN=${LENS_ELASTICSEARCH_TOKEN}
             # For some reason python3-wrapt is pre-installed on a Semaphore ubuntu2004 node, but with
             # a version (1.11.2) that is different from the version that OpenStack needs (1.13.3), and
@@ -6516,8 +6519,11 @@ blocks:
             # not a per-PR gate.
             - sudo env NFT_BENCH_PERF_ARTIFACTS_DIR="$(pwd)/artifacts/perf" felix/bin/nft.test -test.run='^$' -test.bench=. -test.benchmem -test.benchtime=6x
             # Publish to Lens. send-perf-results no-ops if the creds are unset.
+            # Take the user name from the secret alongside the token, rather than
+            # hardcoding it, so that rotating the Lens credential to a different
+            # account does not silently break publishing.
             - export ELASTICSEARCH_URL=https://banzai-lens-es.dev-tools.tigera.net:9200
-            - export ELASTICSEARCH_USER=elastic
+            - export ELASTICSEARCH_USER=${LENS_ELASTICSEARCH_USER}
             - export ELASTICSEARCH_TOKEN=${LENS_ELASTICSEARCH_TOKEN}
             - ./bin/send-perf-results --dir artifacts/perf
       epilogue:

--- a/.semaphore/semaphore.yml.d/blocks/40-openstack.yml
+++ b/.semaphore/semaphore.yml.d/blocks/40-openstack.yml
@@ -24,9 +24,12 @@
           - ../.semaphore/run-and-monitor tox.log bash -c 'make tox-caracal && make tox-fv-caracal'
       - name: "OpenStack: Mainline ST (DevStack + Tempest) on Caracal"
         commands:
-          # Env vars needed for saving performance results.
+          # Env vars needed for saving performance results.  Take the user name
+          # from the secret alongside the token, rather than hardcoding it, so
+          # that rotating the Lens credential to a different account does not
+          # silently break publishing.
           - export ELASTICSEARCH_URL=https://banzai-lens-es.dev-tools.tigera.net:9200
-          - export ELASTICSEARCH_USER=elastic
+          - export ELASTICSEARCH_USER=${LENS_ELASTICSEARCH_USER}
           - export ELASTICSEARCH_TOKEN=${LENS_ELASTICSEARCH_TOKEN}
           # For some reason python3-wrapt is pre-installed on a Semaphore ubuntu2004 node, but with
           # a version (1.11.2) that is different from the version that OpenStack needs (1.13.3), and

--- a/.semaphore/semaphore.yml.d/blocks/45-nft-bench.yml
+++ b/.semaphore/semaphore.yml.d/blocks/45-nft-bench.yml
@@ -28,8 +28,11 @@
           # not a per-PR gate.
           - sudo env NFT_BENCH_PERF_ARTIFACTS_DIR="$(pwd)/artifacts/perf" felix/bin/nft.test -test.run='^$' -test.bench=. -test.benchmem -test.benchtime=6x
           # Publish to Lens. send-perf-results no-ops if the creds are unset.
+          # Take the user name from the secret alongside the token, rather than
+          # hardcoding it, so that rotating the Lens credential to a different
+          # account does not silently break publishing.
           - export ELASTICSEARCH_URL=https://banzai-lens-es.dev-tools.tigera.net:9200
-          - export ELASTICSEARCH_USER=elastic
+          - export ELASTICSEARCH_USER=${LENS_ELASTICSEARCH_USER}
           - export ELASTICSEARCH_TOKEN=${LENS_ELASTICSEARCH_TOKEN}
           - ./bin/send-perf-results --dir artifacts/perf
     epilogue:


### PR DESCRIPTION
Fixes CORE-13473. **Confirmed working on both publishing paths** — see Result below.

### Problem

`send-perf-results` had been publishing nothing to Lens since 24 July. Elasticsearch rejected every request — index-template PUTs and all document POSTs — with `HTTP 401: unable to authenticate user [elastic]`. Example: [job c02155cc](https://tigera.semaphoreci.com/jobs/c02155cc-702c-46b8-abf7-79562c990b41).

It failed invisibly: the tool logs send failures as warnings and exits 0 by design ("Lens is observability, not a critical path"), and the pipeline wraps the call in `|| true`. So CI stayed green while a month of trend data went nowhere.

### Cause

`banzai-secrets` supplies **both** `LENS_ELASTICSEARCH_TOKEN` **and** `LENS_ELASTICSEARCH_USER`, but the pipeline used only the token and hardcoded `ELASTICSEARCH_USER=elastic`. `LENS_ELASTICSEARCH_USER` was referenced nowhere in the repo.

The Lens credential was rotated to the account `lens-argo-write-all` on 2026-07-24 17:18 UTC — exactly when `banzai-secrets` was last updated — and `LENS_ELASTICSEARCH_USER` was set accordingly. The pipeline carried on presenting the new token under the old user name, hence the 401s.

### The change

Use the user name the secret provides, in both blocks that publish to Lens (`40-openstack.yml`, `45-nft-bench.yml`), and regenerate `semaphore.yml` and `semaphore-scheduled-builds.yml`. The generated diff contains nothing but these lines and their comments.

### Result

Both publishing blocks run on this PR, since each block's `change_in` list includes its own template path — so both paths are verified here rather than one riding along untested. Both blocks passed, and both published cleanly:

| Job | Documents | `warning: POST` | HTTP 401 |
|---|---|---|---|
| [Felix: dataplane benchmark](https://tigera.semaphoreci.com/jobs/df72678f-1244-4508-b33b-1979705fed4a) | 9 | 0 | none |
| [OpenStack: Mainline ST (DevStack + Tempest)](https://tigera.semaphoreci.com/jobs/ae7d4dd8-e000-4b82-84f5-9413116b5d13) | 12 | 0 | none |

Documents confirmed visible in Lens, and they are the first pushed for these tests since 24 July.

### Known residual, tracked separately

Authentication is fixed; authorisation is only partly there. In both jobs the two index-template upserts fail with **403** rather than 401, because `lens-argo-write-all` lacks the `manage_index_templates` cluster privilege. No data is lost — a missing template just means new fields get default dynamic mappings — but template changes under `hack/perf/index-templates/` no longer propagate. Tracked as CORE-13474; out of scope here.

### Not doing yet

Leaving the silent-failure behaviour alone, per discussion on the ticket. Worth noting that `--require-creds` only checks that user and token are *non-empty*, so it cannot detect *rejected* credentials and gives false assurance — which is why this cost a month of data rather than one run. Worth revisiting as we come to rely on the trend data more, but not in this PR.

**Release note:**
```release-note
None
```
