### PR TITLE
[v3.33] OpenStack: emit deprecation warnings for options the operator still sets

### DIFF
--- a/networking-calico/networking_calico/common/config.py
+++ b/networking-calico/networking_calico/common/config.py
@@ -167,6 +167,64 @@ def register_options(conf, additional_options=None):
     conf.register_opts(options_to_register, "calico")
 
 
+def read_deprecated_options(conf, opts, group="calico"):
+    """Read the deprecated-for-removal options in OPTS, for the warning side effect.
+
+    oslo.config emits its "deprecated for removal" warning when such an
+    option's value is *read*, and only when the operator actually set that
+    option in a config file or on the command line.  Parsing alone emits
+    nothing, and an option that nobody has set stays silent however often it is
+    read.  Arranging that read, at start of day, for every option we have
+    marked ``deprecated_for_removal``, is what this function is for.
+
+    Options carrying only a ``deprecated_name`` or ``deprecated_group`` are
+    skipped.  Those have a deprecated *name*, rather than being deprecated
+    themselves; they are live options that the driver reads in the normal
+    course of its work, so oslo.config warns about the old name without our
+    help.
+
+    We mark an option deprecated for removal in two rather different
+    situations, and the read is worth doing in both:
+
+    - The option still works exactly as it always has, and we intend to remove
+      it in some future release.  The driver goes on reading it as part of its
+      normal work, so the warning does come out by itself -- but only when the
+      reading code path first runs, which may be a long way into the log, or
+      not at all if that path is conditional.  Reading here brings the warning
+      forward to a predictable place, and makes it unconditional.
+
+    - The option has already been made moot by a change elsewhere, and now
+      survives only so that an existing neutron.conf continues to parse.
+      Nothing reads it any more, so without this call there is no warning at
+      all, and an operator who still sets it gets no signal that it is being
+      ignored.  This is the case that prompted the function; ``[calico]
+      resync_interval_secs`` in mech_calico.py is a worked example.
+
+    Either way the operator wants to know, and what they are told is defined by
+    the option rather than by us: the warning quotes that option's
+    ``deprecated_reason``, so that is the place to explain what has changed and
+    what, if anything, to do instead.
+
+    The reads below look pointless, and are not: the value is discarded and the
+    read performed solely to provoke oslo.config into warning.  Please don't
+    tidy them away.
+
+    One consequence to be aware of: under [DEFAULT] fatal_deprecations = true,
+    oslo.log turns the warning into a DeprecatedConfig exception rather than a
+    log line, so a deployment that sets both that and one of these options will
+    now fail to start.  That is the semantics the operator asked for -- they
+    are indeed still configuring a deprecated option -- and fatal_deprecations
+    defaults to false.
+    """
+    for opt in opts:
+        if opt.deprecated_for_removal:
+            # dest, not name: the two differ for a dashed name or an explicit
+            # dest=, and looking an option up by name then raises
+            # NoSuchOptError -- which, from here, would stop neutron-server
+            # starting at all.
+            conf[group][opt.dest]
+
+
 _cached_region_string = None
 MAX_DNS_LABEL_LEN = 63
 MAX_REGION_LEN = MAX_DNS_LABEL_LEN - len(

--- a/networking-calico/networking_calico/plugins/ml2/drivers/calico/mech_calico.py
+++ b/networking-calico/networking_calico/plugins/ml2/drivers/calico/mech_calico.py
@@ -68,7 +68,7 @@ from networking_calico.common import intern_string
 from networking_calico.logutils import logging_exceptions
 from networking_calico.monotonic import monotonic_time
 from networking_calico.plugins.ml2.drivers.calico import qos_driver
-from networking_calico.plugins.ml2.drivers.calico.election import Elector
+from networking_calico.plugins.ml2.drivers.calico.election import Elector, elector_opt
 from networking_calico.plugins.ml2.drivers.calico.endpoints import (
     WorkloadEndpointSyncer,
     _port_is_endpoint_port,
@@ -454,10 +454,22 @@ class CalicoMechanismDriver(mech_agent.SimpleAgentMechanismDriverBase):
 
         Also validate the configured MySQL driver up front so a bad
         ``[database] connection`` fails the worker at startup rather than
-        on the first port operation.
+        on the first port operation, and surface any deprecated-for-removal
+        options that the operator still has set.
         """
         super(CalicoMechanismDriver, self).initialize()
         _check_mysql_driver()
+
+        # Pass every list that feeds the [calico] group, not just this
+        # module's: election.py registers SHARED_OPTS and elector_opt into the
+        # same group, and this module imports it, so all three are live in the
+        # neutron-server process.  Miss one and a deprecation there would go
+        # unreported.
+        calico_config.read_deprecated_options(
+            cfg.CONF,
+            calico_config.SHARED_OPTS + [elector_opt] + calico_opts,
+        )
+
         if cfg.CONF.calico.fairy_gc_diagnostics:
             # Install once in the parent process before workers are forked.
             # The listeners attach to the SQLAlchemy Pool class; each forked

--- a/networking-calico/networking_calico/tests/test_common.py
+++ b/networking-calico/networking_calico/tests/test_common.py
@@ -12,15 +12,31 @@
 #    under the License.
 
 import logging
+import os
+import shutil
+import tempfile
 import unittest
 from collections import namedtuple
 
 import mock
 
 from oslo_config import cfg
+from oslo_log import versionutils
 
 import networking_calico.common as common
 from networking_calico.common import config
+from networking_calico.plugins.ml2.drivers.calico.mech_calico import calico_opts
+
+
+class _WarningCollector(logging.Handler):
+    """Collects the messages that oslo.config logs at WARNING."""
+
+    def __init__(self):
+        super(_WarningCollector, self).__init__(level=logging.WARNING)
+        self.messages = []
+
+    def emit(self, record):
+        self.messages.append(record.getMessage())
 
 
 class TestConfig(unittest.TestCase):
@@ -29,6 +45,82 @@ class TestConfig(unittest.TestCase):
         add_opt = cfg.StrOpt("test_option", default="test")
         config.register_options(cfg.CONF, additional_options=[add_opt])
         self.assertEqual(cfg.CONF["calico"]["test_option"], "test")
+
+    def _deprecation_warnings(self, opts, conf_file_body):
+        """Read the deprecated options in OPTS; return the warnings logged.
+
+        OPTS are registered into a private ConfigOpts -- not the global
+        cfg.CONF -- which is then populated from a neutron.conf whose [calico]
+        section is CONF_FILE_BODY.
+
+        oslo suppresses a repeated deprecation report in two separate places,
+        and both outlive an individual test: oslo.log remembers the (message,
+        args) pairs it has already logged, for the lifetime of the process, and
+        each Opt latches its own ``_logged_deprecation``.  Because OPTS are the
+        driver's real Opt objects, shared by every test here, that latch is
+        still set from whichever test ran first -- which is enough to stop a
+        later test observing any warning at all, and made the negative test
+        below incapable of failing.  So reset both, and let each test start from
+        a clean slate.
+        """
+        versionutils._deprecated_messages_sent.clear()
+        for opt in opts:
+            opt._logged_deprecation = False
+
+        conf = cfg.ConfigOpts()
+        conf.register_opts(opts, "calico")
+
+        conf_dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, conf_dir)
+        conf_file = os.path.join(conf_dir, "neutron.conf")
+        with open(conf_file, "w") as f:
+            f.write("[calico]\n" + conf_file_body)
+        conf(["--config-file", conf_file], project="neutron")
+
+        collector = _WarningCollector()
+        logger = logging.getLogger("oslo_config.cfg")
+        old_level = logger.level
+        logger.setLevel(logging.WARNING)
+        logger.addHandler(collector)
+        self.addCleanup(logger.setLevel, old_level)
+        self.addCleanup(logger.removeHandler, collector)
+
+        config.read_deprecated_options(conf, opts)
+        return collector.messages
+
+    def test_deprecation_warning_for_each_option_the_operator_set(self):
+        # Both of the driver's deprecated options, one set to a non-default
+        # value and the other pinned to its own default.  oslo.config keys the
+        # warning off the option being present in the operator's config, not
+        # off its value differing from the default, so both must warn -- the
+        # 0 is still a setting the operator has to remove.
+        warnings = self._deprecation_warnings(
+            calico_opts,
+            "resync_interval_secs = 60\nresync_max_interval_secs = 0\n",
+        )
+
+        # One warning each, in particular the second not swallowed by the
+        # first: oslo.log de-duplicates deprecation reports on the message,
+        # which starts out identical for every option.
+        self.assertEqual(len(warnings), 2)
+        logged = "\n".join(warnings)
+        self.assertIn('"resync_interval_secs"', logged)
+        self.assertIn('"resync_max_interval_secs"', logged)
+        self.assertIn("deprecated for removal", logged)
+
+        # Each option's own deprecated_reason is what tells the operator what
+        # to do instead, so it needs to reach the log too.
+        self.assertIn("calico-resync CLI", logged)
+
+    def test_no_deprecation_warning_when_no_such_option_set(self):
+        # The operator has already cleaned up their config, or never had these
+        # options set in the first place; they must not be nagged.  The live
+        # options they do set are read without complaint.
+        warnings = self._deprecation_warnings(
+            calico_opts,
+            "startup_resync = never\nnum_port_status_threads = 8\n",
+        )
+        self.assertEqual(warnings, [])
 
 
 Config = namedtuple("Config", ["IFACE_PREFIX", "HOSTNAME"])


### PR DESCRIPTION
**Cherry-pick history**
- Pick onto **release-v3.33**: projectcalico/calico#13653

Bug fix for CORE-13286.

### Problem

oslo.config emits its "deprecated for removal" warning only when a deprecated option's value is actually *read*, and only when the operator set that option in a config file or on the command line. Parsing alone emits nothing.

`resync_interval_secs` and `resync_max_interval_secs` were deprecated when the periodic resync thread was replaced by the one-shot startup resync and the `calico-resync` CLI. Nothing reads them any more — that is the point of the deprecation — so their warnings could never be emitted, and an operator whose `neutron.conf` still sets them got no signal that the settings are now ignored.

### Fix

Read every deprecated option once, in `CalicoMechanismDriver.initialize()`. That runs in the parent process, after config parsing and before any forks, so each warning is logged exactly once, near the top of the neutron-server startup log:

```
WARNING oslo_config.cfg Deprecated: Option "resync_interval_secs" from group
"calico" is deprecated for removal (The driver no longer runs a periodic resync
thread. Resync is now driven once on startup and on demand via the calico-resync
CLI.  This option has no effect.).  Its value may be silently ignored in the future.
```

The new `read_deprecated_options()` helper loops on `deprecated_for_removal` rather than a hard-coded list of names, so options deprecated in future are covered without anyone having to remember this call site. The warning text quotes each option's own `deprecated_reason`, so that stays the place to explain what changed.

An operator who has already cleaned up their config sees nothing new: oslo.config keys the warning off the option being *present* in the config, not off its value differing from the default, so it stays silent for an option nobody has set. It does warn for an option pinned to its default value, which is what we want — that setting is still there to be removed.

### Behaviour change to note

Under `[DEFAULT] fatal_deprecations = true`, oslo.log raises `DeprecatedConfig` instead of logging, so a deployment setting both that and a deprecated option will now fail to start where it previously started fine. That is the semantics the operator asked for — they are indeed still configuring a deprecated option — and `fatal_deprecations` defaults to false.

### Testing

Two unit tests in `test_common.py`, exercising the driver's real `calico_opts` against real oslo.config. (They live here rather than in the ml2 test package because that package replaces `oslo_config` with a `MagicMock` in `sys.modules`, so a test there could only assert against a mock.)

- **Warnings for each option the operator set** — both deprecated options at once, one set to a non-default value and the other pinned to its own default, since oslo.config keys the warning off the option being *present* in the config rather than differing from the default. Also checks that each option's own `deprecated_reason` reaches the log, and that the second warning is not swallowed by the first: oslo de-duplicates deprecation reports on the message, which starts out identical for every option.
- **Silence when no such option is set** — the operator who has already cleaned up their config must not be nagged.

Both mutation-checked, so neither is decorative: stubbing out the read makes the first fail, and setting a deprecated option in the second's config makes *it* fail. Full suite green via `make -C networking-calico tox-caracal` (216 tests, 7 pre-existing skips), plus `fmtpy` and `flake8`.

