### PR TITLE
lib/kind: control-plane ExtraMounts hook

### DIFF
--- a/lib/kind/kind.go
+++ b/lib/kind/kind.go
@@ -73,6 +73,12 @@ type Config struct {
 	// KubeadmConfigPatches is forwarded to kind. Use this for kubeadm-level
 	// tweaks (e.g. extra apiServer certSANs).
 	KubeadmConfigPatches []string
+	// ControlPlaneExtraMounts is applied to the control-plane node. Each
+	// Mount is host→node; combined with an apiServer extraVolumes entry
+	// in KubeadmConfigPatches this lets a caller drop a file
+	// (AuthenticationConfiguration, audit policy, etc.) at a known path
+	// in the kube-apiserver container before boot.
+	ControlPlaneExtraMounts []v1alpha4.Mount
 }
 
 // Cluster is a brought-up kind cluster the test suite owns.
@@ -129,8 +135,12 @@ func Up(ctx context.Context, c Config) (*Cluster, error) {
 	prov := cluster.NewProvider(cluster.ProviderWithLogger(kindLoggerAdapter{logger: logger}))
 
 	kc := &v1alpha4.Cluster{
-		Networking:              networking,
-		Nodes:                   []v1alpha4.Node{{Role: v1alpha4.ControlPlaneRole, Image: nodeImage}},
+		Networking: networking,
+		Nodes: []v1alpha4.Node{{
+			Role:        v1alpha4.ControlPlaneRole,
+			Image:       nodeImage,
+			ExtraMounts: c.ControlPlaneExtraMounts,
+		}},
 		ContainerdConfigPatches: c.ContainerdConfigPatches,
 		KubeadmConfigPatches:    c.KubeadmConfigPatches,
 	}


### PR DESCRIPTION
## Problem

\`lib/kind.Config\` doesn't expose kind's \`v1alpha4.Node.ExtraMounts\`, so a
caller that needs a host-side file mounted into the control-plane node
(AuthenticationConfiguration, audit policy, extra CA bundle, …) has no
way to hand it to \`Up\` — they'd have to bring up a bare cluster and then
build the file out via \`docker cp\` after the fact, which is too late for
kubeadm's boot-time flags.

## Fix

Add \`Config.ControlPlaneExtraMounts []v1alpha4.Mount\`, plumbed straight
into the control-plane node's \`ExtraMounts\`. Paired with a
\`KubeadmConfigPatches\` entry naming an apiServer \`extraVolumes\` mount,
this lets a caller stage a file at a known path in the kube-apiserver
container before boot.

Worker nodes are left as-is — the callers we've hit so far only ever
need to hand a file to kube-apiserver, and adding a per-worker mounts
field can wait for a caller that needs it.

## Test plan

- [x] \`go build ./lib/kind/...\` — clean.
- [x] Downstream caller (enterprise \`calico-mcp\` OIDC issuer install)
  mounts a static JWKS / AuthenticationConfiguration file into the
  apiserver container this way; kube-apiserver picks up
  \`--authentication-config\` from the mounted path on boot.

**Release note:**
\`\`\`release-note
None
\`\`\`