### PR TITLE
lib/kind/localregistry: multi-arch indexes + detached pull-through context

### DIFF
--- a/lib/kind/go.mod
+++ b/lib/kind/go.mod
@@ -5,6 +5,7 @@ go 1.26.5
 require (
 	github.com/google/go-containerregistry v0.21.6
 	github.com/projectcalico/calico/lib/std v0.0.0-00010101000000-000000000000
+	golang.org/x/sync v0.22.0
 	k8s.io/client-go v0.37.0-beta.0
 	sigs.k8s.io/kind v0.31.0
 )
@@ -56,7 +57,6 @@ require (
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/net v0.58.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
-	golang.org/x/sync v0.22.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/term v0.45.0 // indirect
 	golang.org/x/text v0.41.0 // indirect

--- a/lib/kind/localregistry/registry.go
+++ b/lib/kind/localregistry/registry.go
@@ -58,6 +58,8 @@ import (
 	"github.com/google/go-containerregistry/pkg/name"
 	ggcrregistry "github.com/google/go-containerregistry/pkg/registry"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/google/go-containerregistry/pkg/v1/types"
+	"golang.org/x/sync/singleflight"
 
 	"github.com/projectcalico/calico/lib/std/log"
 )
@@ -116,7 +118,28 @@ type Registry struct {
 
 	mu     sync.Mutex
 	cached map[string]bool // key(ns, repo, ref) -> present in the internal store
+
+	// sf coalesces concurrent ensureManifest / ensureBlob calls for the
+	// same (ns, repo, ref) — containerd fires many parallel GETs across
+	// nodes and pods, and without dedup each one would spawn its own
+	// full pull-through.
+	sf singleflight.Group
 }
+
+// detachContext returns a background context that inherits parent's
+// deadline (via Value only, not Done) so an in-flight pull-through
+// survives the incoming request being canceled — containerd's client
+// timeout mustn't abort a pull the next attempt will need anyway.
+// The pull instead runs under its own bounded timeout.
+func detachContext(_ context.Context) context.Context {
+	ctx, cancel := context.WithTimeout(context.Background(), pullTimeout)
+	// The cancel is intentionally leaked to timeout; the pull is
+	// short-lived (bounded by pullTimeout) and Go GCs the timer.
+	_ = cancel
+	return ctx
+}
+
+const pullTimeout = 10 * time.Minute
 
 // Start brings up the facade: an internal store on loopback and the public
 // node-facing listener. The caller owns shutdown via Stop (typically
@@ -232,7 +255,7 @@ func (f *Registry) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	switch {
 	case kind == "manifests" && (r.Method == http.MethodGet || r.Method == http.MethodHead):
 		// Populate on HEAD too — the manifest is a few KB either way.
-		if err := f.ensureManifest(r.Context(), ns, repo, ref); err != nil {
+		if err := f.ensureManifest(detachContext(r.Context()), ns, repo, ref); err != nil {
 			f.log.Warn("manifest pull-through failed", "ns", ns, "repo", repo, "ref", ref, "error", err)
 			http.Error(w, err.Error(), http.StatusBadGateway)
 			return
@@ -240,7 +263,7 @@ func (f *Registry) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	case kind == "blobs" && r.Method == http.MethodGet:
 		// GET only — a HEAD on a missing blob stays cheap (404 from
 		// the internal store); the follow-up GET triggers the pull.
-		if err := f.ensureBlob(r.Context(), ns, repo, ref); err != nil {
+		if err := f.ensureBlob(detachContext(r.Context()), ns, repo, ref); err != nil {
 			f.log.Warn("blob pull-through failed", "ns", ns, "repo", repo, "digest", ref, "error", err)
 			http.Error(w, err.Error(), http.StatusBadGateway)
 			return
@@ -276,6 +299,23 @@ func (f *Registry) ensureManifest(ctx context.Context, ns, repo, ref string) err
 	if present {
 		return nil
 	}
+	// Coalesce concurrent callers on the same manifest — containerd fires
+	// parallel HEADs from every node and pod.
+	_, err, _ := f.sf.Do("m:"+k, func() (any, error) {
+		return nil, f.pullManifest(ctx, ns, repo, ref, k)
+	})
+	return err
+}
+
+func (f *Registry) pullManifest(ctx context.Context, ns, repo, ref, k string) error {
+	// Re-check under singleflight: the previous holder may have populated
+	// it while we waited.
+	f.mu.Lock()
+	if f.cached[k] {
+		f.mu.Unlock()
+		return nil
+	}
+	f.mu.Unlock()
 
 	// The in-memory map is only a fast path. The authoritative "do I already
 	// have this?" is the internal store itself — which also covers manifests
@@ -302,9 +342,19 @@ func (f *Registry) ensureManifest(ctx context.Context, ns, repo, ref string) err
 		return fmt.Errorf("fetch manifest %s: %w", upstream, err)
 	}
 
-	// PUT the manifest under the safeNS'd repo. The store accepts a
-	// manifest whose referenced blobs aren't there yet; per-blob GETs
-	// follow and land in ensureBlob.
+	// If this is a manifest list / OCI image index, recursively pull
+	// its child manifests BEFORE PUTing the index — ggcr's internal
+	// registry rejects an index whose referenced manifests aren't
+	// present with 404. Child blobs still pull lazily via ensureBlob
+	// on the containerd GETs that follow.
+	if isIndex(desc.MediaType) {
+		if err := f.ensureIndexChildren(ctx, ns, repo, desc.Manifest); err != nil {
+			return fmt.Errorf("populate index children for %s: %w", upstream, err)
+		}
+	}
+
+	// PUT the manifest under the safeNS'd repo. Referenced blobs come
+	// later on containerd's per-blob GETs, which ensureBlob handles.
 	putURL := fmt.Sprintf("%s/v2/%s/%s/manifests/%s", f.internalURL.String(), safeNS(ns), repo, ref)
 	req, err := http.NewRequestWithContext(ctx, http.MethodPut, putURL, bytes.NewReader(desc.Manifest))
 	if err != nil {
@@ -332,6 +382,18 @@ func (f *Registry) ensureManifest(ctx context.Context, ns, repo, ref string) err
 // ensureBlob) already put it there. Otherwise: one blob, one HTTP transfer —
 // containerd's per-request timeout never blocks on unrelated layers.
 func (f *Registry) ensureBlob(ctx context.Context, ns, repo, digest string) error {
+	if f.blobExistsInternal(ctx, ns, repo, digest) {
+		return nil
+	}
+	_, err, _ := f.sf.Do("b:"+ns+"|"+repo+"|"+digest, func() (any, error) {
+		return nil, f.pullBlob(ctx, ns, repo, digest)
+	})
+	return err
+}
+
+func (f *Registry) pullBlob(ctx context.Context, ns, repo, digest string) error {
+	// Re-check under singleflight in case the previous holder populated
+	// this blob while we waited.
 	if f.blobExistsInternal(ctx, ns, repo, digest) {
 		return nil
 	}
@@ -385,6 +447,40 @@ func (f *Registry) internalHEAD(ctx context.Context, url, accept string) bool {
 	}
 	_ = resp.Body.Close()
 	return resp.StatusCode == http.StatusOK
+}
+
+// isIndex reports whether mt names a manifest list / OCI image index —
+// the multi-arch "one manifest referencing per-arch manifests" case.
+func isIndex(mt types.MediaType) bool {
+	switch mt {
+	case types.OCIImageIndex, types.DockerManifestList:
+		return true
+	}
+	return false
+}
+
+// ensureIndexChildren parses raw index bytes and recursively populates
+// each referenced child manifest so the subsequent index PUT succeeds
+// against ggcr's registry (which rejects an index whose referenced
+// manifests aren't present with 404).
+func (f *Registry) ensureIndexChildren(ctx context.Context, ns, repo string, indexBytes []byte) error {
+	var idx struct {
+		Manifests []struct {
+			Digest string `json:"digest"`
+		} `json:"manifests"`
+	}
+	if err := json.Unmarshal(indexBytes, &idx); err != nil {
+		return fmt.Errorf("parse index: %w", err)
+	}
+	for _, m := range idx.Manifests {
+		if m.Digest == "" {
+			continue
+		}
+		if err := f.ensureManifest(ctx, ns, repo, m.Digest); err != nil {
+			return fmt.Errorf("child manifest %s: %w", m.Digest, err)
+		}
+	}
+	return nil
 }
 
 // Stop shuts the facade down. Idempotent.

--- a/lib/kind/localregistry/registry.go
+++ b/lib/kind/localregistry/registry.go
@@ -126,17 +126,14 @@ type Registry struct {
 	sf singleflight.Group
 }
 
-// detachContext returns a background context that inherits parent's
-// deadline (via Value only, not Done) so an in-flight pull-through
-// survives the incoming request being canceled — containerd's client
-// timeout mustn't abort a pull the next attempt will need anyway.
-// The pull instead runs under its own bounded timeout.
-func detachContext(_ context.Context) context.Context {
-	ctx, cancel := context.WithTimeout(context.Background(), pullTimeout)
-	// The cancel is intentionally leaked to timeout; the pull is
-	// short-lived (bounded by pullTimeout) and Go GCs the timer.
-	_ = cancel
-	return ctx
+// detachContext returns a context whose values are inherited from parent
+// but whose cancellation is not — so an in-flight pull-through survives
+// containerd's client timeout closing the incoming HTTP request. The
+// pull instead runs under its own pullTimeout, and the caller MUST
+// defer the returned cancel to release the timer as soon as the pull
+// completes (otherwise every request leaks a live timer for pullTimeout).
+func detachContext(parent context.Context) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.WithoutCancel(parent), pullTimeout)
 }
 
 const pullTimeout = 10 * time.Minute
@@ -255,7 +252,10 @@ func (f *Registry) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	switch {
 	case kind == "manifests" && (r.Method == http.MethodGet || r.Method == http.MethodHead):
 		// Populate on HEAD too — the manifest is a few KB either way.
-		if err := f.ensureManifest(detachContext(r.Context()), ns, repo, ref); err != nil {
+		pullCtx, cancel := detachContext(r.Context())
+		err := f.ensureManifest(pullCtx, ns, repo, ref)
+		cancel()
+		if err != nil {
 			f.log.Warn("manifest pull-through failed", "ns", ns, "repo", repo, "ref", ref, "error", err)
 			http.Error(w, err.Error(), http.StatusBadGateway)
 			return
@@ -263,7 +263,10 @@ func (f *Registry) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	case kind == "blobs" && r.Method == http.MethodGet:
 		// GET only — a HEAD on a missing blob stays cheap (404 from
 		// the internal store); the follow-up GET triggers the pull.
-		if err := f.ensureBlob(detachContext(r.Context()), ns, repo, ref); err != nil {
+		pullCtx, cancel := detachContext(r.Context())
+		err := f.ensureBlob(pullCtx, ns, repo, ref)
+		cancel()
+		if err != nil {
 			f.log.Warn("blob pull-through failed", "ns", ns, "repo", repo, "digest", ref, "error", err)
 			http.Error(w, err.Error(), http.StatusBadGateway)
 			return

--- a/lib/kind/localregistry/registry_test.go
+++ b/lib/kind/localregistry/registry_test.go
@@ -14,9 +14,13 @@ import (
 	"testing"
 
 	"github.com/google/go-containerregistry/pkg/crane"
+	"github.com/google/go-containerregistry/pkg/name"
 	ggcrregistry "github.com/google/go-containerregistry/pkg/registry"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/empty"
+	"github.com/google/go-containerregistry/pkg/v1/mutate"
 	"github.com/google/go-containerregistry/pkg/v1/random"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
 )
 
 // startUpstream stands up a throwaway OCI registry and returns its host
@@ -180,5 +184,45 @@ func TestOverrideRejectsDigest(t *testing.T) {
 		"quay.io/team/app@sha256:"+strings.Repeat("a", 64), img)
 	if err == nil {
 		t.Fatal("expected error overriding a digest ref, got nil")
+	}
+}
+
+// TestPullThroughMultiArchIndex proves ensureManifest handles a real
+// multi-arch image: pushing an OCI image index whose referenced child
+// manifests aren't yet in the internal store used to 404 the index PUT
+// (ggcr's registry rejects an index whose children are missing). The
+// facade must recursively populate each child before PUTing the index.
+func TestPullThroughMultiArchIndex(t *testing.T) {
+	host, _ := startUpstream(t)
+
+	// Build a two-arch OCI image index; push to the upstream.
+	imgA, err := random.Image(1024, 2)
+	if err != nil {
+		t.Fatalf("random.Image A: %v", err)
+	}
+	imgB, err := random.Image(1024, 2)
+	if err != nil {
+		t.Fatalf("random.Image B: %v", err)
+	}
+	idx := mutate.AppendManifests(empty.Index,
+		mutate.IndexAddendum{Add: imgA, Descriptor: v1.Descriptor{Platform: &v1.Platform{OS: "linux", Architecture: "amd64"}}},
+		mutate.IndexAddendum{Add: imgB, Descriptor: v1.Descriptor{Platform: &v1.Platform{OS: "linux", Architecture: "arm64"}}},
+	)
+	ref, err := name.ParseReference(host+"/team/multi:v1", name.Insecure)
+	if err != nil {
+		t.Fatalf("parse ref: %v", err)
+	}
+	if err := remote.WriteIndex(ref, idx); err != nil {
+		t.Fatalf("push index: %v", err)
+	}
+
+	f := startRegistry(t)
+	got := manifestDigestVia(t, f.Addr(), host, "team/multi", "v1")
+	want, err := idx.Digest()
+	if err != nil {
+		t.Fatalf("index digest: %v", err)
+	}
+	if got != want.String() {
+		t.Errorf("index served %s, want %s", got, want.String())
 	}
 }


### PR DESCRIPTION
## Problem

Two follow-ups to #13617's per-blob pull-through, both surfaced by running a real gcr.io multi-arch image (\`calico:master\`) through the facade.

### 1. Multi-arch manifest indexes couldn't PUT

An OCI image index or Docker manifest list references per-arch child manifests by digest. ggcr's in-memory registry rejects a PUT of an index whose referenced manifests aren't already present with 404 — so \`ensureManifest\`'s PUT of the index came back 404 and the facade returned 502 to containerd.

Reproducer against the running facade:

\`\`\`
$ curl -sv 'http://172.18.0.1:38845/v2/unique-caldron-775/cnx/tigera/calico/manifests/master?ns=gcr.io'
< HTTP/1.1 502 Bad Gateway
push manifest to internal: status 404
\`\`\`

### 2. Pulls were being aborted mid-copy when containerd hung up

\`ensureManifest\` / \`ensureBlob\` ran with \`r.Context()\` from the incoming HTTP request. containerd's client-side transport carries a \`response_header_timeout\` that fires on the first big blob; when it fires containerd closes the connection, \`net/http\` cancels \`r.Context()\`, and that cancellation propagates into \`remote.WriteLayer\` as:

\`\`\`
Patch \"http://127.0.0.1:.../blobs/uploads/...\": context canceled
\`\`\`

The blob upload aborts mid-PATCH, nothing lands in the internal store, and the next kubelet retry starts over. On a 100+ MB layer with a slow upstream, no single attempt might ever finish → indefinite \`ImagePullBackOff\`.

Bumping the \`hosts.toml\` \`response_header_timeout\` doesn't help — the key isn't respected per-host in containerd 2.x (verified against \`kindest/node v1.35.5\`'s containerd 2.3.1).

## Fix

- **Index children**: after \`remote.Get\`, if the descriptor's media type is \`types.OCIImageIndex\` or \`types.DockerManifestList\`, parse \`.manifests[]\` and recursively \`ensureManifest\` each child digest before PUTing the index. Child blobs still populate lazily via \`ensureBlob\`.
- **Detached context**: \`detachContext\` swaps in a bounded background context (10 min); the pull survives containerd disconnecting, so the next kubelet retry hits a populated store and returns in ms.
- **Singleflight**: containerd fires HEAD/GET storms for the same blob from every node and pod; without dedup each one spawned its own full pull-through. \`singleflight.Group\` coalesces them onto a single in-flight fetch.

## Test plan

- [x] \`go build ./lib/kind/...\` — clean.
- [x] Local dev cluster (calico-mcp-dev) reproducing the multi-arch \`gcr.io/unique-caldron-775/cnx/tigera/calico:master\` pull: previously stuck in \`ImagePullBackOff\`, now converges within 1–2 kubelet backoff cycles.
- [ ] Semaphore CI green.

**Release note:**
\`\`\`release-note
None
\`\`\`