### PR TITLE
[v3.32] fix(tigera-operator): sanitize chart version labels

### DIFF
--- a/charts/tigera-operator/templates/tigera-operator/00-uninstall.yaml
+++ b/charts/tigera-operator/templates/tigera-operator/00-uninstall.yaml
@@ -4,7 +4,7 @@ metadata:
   name: tigera-operator-uninstall
   namespace: {{.Release.Namespace}}
   labels:
-    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     {{- include "tigera-operator.labels" (dict "context" .) | nindent 4 }}
   annotations:
     # Mark this Job as a pre-deletion hook. This will only be executed as part
@@ -18,7 +18,7 @@ spec:
     metadata:
       name: "{{ .Release.Name }}"
       labels:
-        helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+        helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     spec:
       {{- with .Values.nodeSelector }}
       nodeSelector:


### PR DESCRIPTION
**Cherry-pick history**
- Pick onto **release-v3.32**: projectcalico/calico#13412

## Description

Sanitize `helm.sh/chart` labels on the Tigera Operator uninstall hook.

Helm chart versions may contain SemVer build metadata such as `3.32.1+77bd63307a97`. The `+` character is invalid in Kubernetes label values, which prevents the pre-delete Job from being created during `helm uninstall`.

## Changes

- Replace `+` with `_` in the Job's `helm.sh/chart` label.
- Apply the same normalization to the Pod template label.

Fixes #13373.

## Validation

Rendered the chart with version `3.32.1+77bd63307a97` using Helm v3.18.6 and verified both labels render as `3.32.1_77bd63307a97` with no `+` remaining.

Also ran `git diff --check`.

