### PR TITLE
Reformat two test files with the Go 1.27 gofmt

### DIFF
--- a/libcalico-go/lib/backend/watchersyncer/watchersyncer_test.go
+++ b/libcalico-go/lib/backend/watchersyncer/watchersyncer_test.go
@@ -1207,16 +1207,16 @@ func (fc *fakeConverter) Process(kvp *model.KVPair) ([]*model.KVPair, error) {
 	if kvp.Value == nil {
 		// This is a delete.
 		return []*model.KVPair{
-				{
-					Key: l1Key1,
-				},
-				{
-					Key: l1Key2,
-				},
-			}, cerrors.ErrorParsingDatastoreEntry{
-				RawKey:   "zzzzz",
-				RawValue: "xxxxx",
-			}
+			{
+				Key: l1Key1,
+			},
+			{
+				Key: l1Key2,
+			},
+		}, cerrors.ErrorParsingDatastoreEntry{
+			RawKey:   "zzzzz",
+			RawValue: "xxxxx",
+		}
 	}
 
 	// This is an add.
@@ -1235,11 +1235,11 @@ func (fc *fakeConverter) Process(kvp *model.KVPair) ([]*model.KVPair, error) {
 		return nil, errors.New("Fake error that we should handle gracefully")
 	case 4: // Fourth contains event and error, event will be sent and parse error will be stored.
 		return []*model.KVPair{
-				fakeConverterKVP4,
-			}, cerrors.ErrorParsingDatastoreEntry{
-				RawKey:   "abcdef",
-				RawValue: "aabbccdd",
-			}
+			fakeConverterKVP4,
+		}, cerrors.ErrorParsingDatastoreEntry{
+			RawKey:   "abcdef",
+			RawValue: "aabbccdd",
+		}
 	case 5: // Fifth contains an update.
 		return []*model.KVPair{
 			fakeConverterKVP5,

--- a/release/internal/branch/refs_test.go
+++ b/release/internal/branch/refs_test.go
@@ -141,8 +141,8 @@ func TestCheckBranchCurrent(t *testing.T) {
 	// equalTips scripts local and remote tips for the explicit-remote path.
 	equalTips := func(local, remote string) map[string]string {
 		return map[string]string{
-			"rev-parse " + src:                 local,
-			"rev-parse --verify --quiet " + up: remote,
+			"rev-parse " + src:                                              local,
+			"rev-parse --verify --quiet " + up:                              remote,
 			"rev-parse --abbrev-ref --symbolic-full-name master@{upstream}": "upstream/master",
 		}
 	}


### PR DESCRIPTION
Master's `Check Go files` job has been red since #13613 merged: `make check-dirty` reports two files that Go 1.27's gofmt formats differently.

## Why the formatting changed

#13613 moved the toolchain to Go 1.27, and 1.27's gofmt changed two alignment rules. Neither file was edited — gofmt simply wants them laid out differently now.

**1. `watchersyncer_test.go` — indentation of a multi-value `return`.** When the first value is a multi-line composite literal, 1.26 indented the literal's body an extra level; 1.27 uses a single level.

```go
// go1.26                              // go1.27
return []*model.KVPair{                return []*model.KVPair{
		{                                      {
			Key: l1Key1,                           Key: l1Key1,
		},                                     },
	}, cerrors.ErrorParsingDatastoreEntry{ }, cerrors.ErrorParsingDatastoreEntry{
		RawKey: "zzzzz",                       RawKey: "zzzzz",
	}                                      }
```

**2. `refs_test.go` — value alignment in a map literal.** One key is far longer than the others. 1.26 excluded it from the alignment run and aligned only the two short keys among themselves; 1.27 aligns every value to the longest key's column.

```go
// go1.26
"rev-parse " + src:                 local,
"rev-parse --verify --quiet " + up: remote,
"rev-parse --abbrev-ref --symbolic-full-name master@{upstream}": "upstream/master",

// go1.27
"rev-parse " + src:                                              local,
"rev-parse --verify --quiet " + up:                              remote,
"rev-parse --abbrev-ref --symbolic-full-name master@{upstream}": "upstream/master",
```

I checked this empirically rather than inferring it: `gofmt -l` on the pre-fix files reports nothing under go1.26.5 and lists both under go1.27.0. So this is the toolchain change, not two files that were simply never swept.

## Why it broke master and not the PR

The `Check Go files` job formats different scopes depending on where it runs:

```yaml
if [ -n "$SEMAPHORE_GIT_PR_NUMBER" ]; then
  make fix-changed      # only the files the PR touched
else
  make fix-all          # the whole repo
fi
```

Neither file was touched by #13613, so `fix-changed` never looked at them and the PR went green. Master runs `fix-all`, which did look, and `check-dirty` failed on the result.

## Why this fix is safe

It is whitespace only — `git diff -w` is empty — and the content is exactly what `gofmt` produces, not a hand-tidy: I formatted the pristine files in the go1.27 build container and the output is byte-identical to what is committed here.

## Verification

- `make fix-all` (what master CI runs; it walks the whole repo bar `vendor/` and `third_party/`, including the nested `api/`, `lib/std/` and `lib/httpmachinery` modules) reports exactly these two files and no others, so there are no remaining stragglers.
- Re-running `make fix-all` on the result changes nothing, so `check-dirty` passes.
- `go test` passes for both packages.
- The failing master pipeline had exactly one real failure, `Check Go files`; the other 46 red blocks were `canceled / fast_failing`. This unblocks all of them.

## Follow-up worth considering

This class of breakage will land on master every time the Go pin moves, because a toolchain bump changes formatting repo-wide and `fix-changed` cannot see that by construction. Gating a repo-wide `fix-all` + `check-dirty` on `change_in(['/metadata.mk'])` would catch it on the PR instead. Left out here to keep this fix minimal.

**AI assistance:** This PR was written in part with the assistance of generative AI.

**Release note:**
```release-note
None
```
