### PR TITLE
Hold the migration finalizer until v1 CRDs are deleted

### DIFF
--- a/kube-controllers/pkg/controllers/migration/cleanup_test.go
+++ b/kube-controllers/pkg/controllers/migration/cleanup_test.go
@@ -1,0 +1,83 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+package migration
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	rtclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	migrationv1 "github.com/projectcalico/calico/kube-controllers/pkg/apis/migration/v1"
+)
+
+// terminatingCRDObj returns a v1 CRD that the API server has accepted for deletion but
+// whose cleanup finalizer has not finished.
+func terminatingCRDObj(name string) *unstructured.Unstructured {
+	crd := crdObj(name, "crd.projectcalico.org")
+	now := metav1.Now()
+	crd.SetDeletionTimestamp(&now)
+	return crd
+}
+
+// finalizingMigration returns a Complete migration that is being deleted, so the
+// controller runs the completed-cleanup path.
+func finalizingMigration() *migrationv1.DatastoreMigration {
+	now := metav1.Now()
+	return &migrationv1.DatastoreMigration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              defaultMigrationName,
+			Finalizers:        []string{finalizerName},
+			DeletionTimestamp: &now,
+		},
+		Status: migrationv1.DatastoreMigrationStatus{Phase: migrationv1.DatastoreMigrationPhaseComplete},
+	}
+}
+
+// TestCompletedCleanup_KeepsFinalizerWhileCRDsTerminate checks that the migration CR is held
+// until the v1 CRDs are gone, not released while they are still terminating.
+func TestCompletedCleanup_KeepsFinalizerWhileCRDsTerminate(t *testing.T) {
+	dm := finalizingMigration()
+	m, rt := newFakeController(t, []rtclient.Object{dm}, []*unstructured.Unstructured{
+		terminatingCRDObj("felixconfigurations.crd.projectcalico.org"),
+	})
+
+	err := m.handleCompletedCleanup(logrus.NewEntry(logrus.StandardLogger()), dm)
+	if err == nil {
+		t.Fatal("expected an error so the item is requeued while the CRD is still terminating")
+	}
+
+	got := &migrationv1.DatastoreMigration{}
+	if err := rt.Get(m.ctx, rtclient.ObjectKeyFromObject(dm), got); err != nil {
+		t.Fatalf("getting migration: %v", err)
+	}
+	if !slices.Contains(got.Finalizers, finalizerName) {
+		t.Errorf("finalizer was removed while a v1 CRD was still terminating, finalizers=%v", got.Finalizers)
+	}
+}
+
+// TestCompletedCleanup_RemovesFinalizerWhenCRDsGone checks the finalizer is released once
+// no crd.projectcalico.org CRDs remain.
+func TestCompletedCleanup_RemovesFinalizerWhenCRDsGone(t *testing.T) {
+	dm := finalizingMigration()
+	m, rt := newFakeController(t, []rtclient.Object{dm}, []*unstructured.Unstructured{
+		crdObj("installations.operator.tigera.io", "operator.tigera.io"),
+	})
+
+	if err := m.handleCompletedCleanup(logrus.NewEntry(logrus.StandardLogger()), dm); err != nil {
+		t.Fatalf("handleCompletedCleanup: %v", err)
+	}
+
+	// Removing the last finalizer on an object that is being deleted completes the deletion.
+	got := &migrationv1.DatastoreMigration{}
+	err := rt.Get(m.ctx, rtclient.ObjectKeyFromObject(dm), got)
+	if err == nil {
+		t.Fatalf("migration still present with finalizers=%v, want it released", got.Finalizers)
+	}
+	if !kerrors.IsNotFound(err) {
+		t.Fatalf("getting migration: %v", err)
+	}
+}

--- a/kube-controllers/pkg/controllers/migration/controller.go
+++ b/kube-controllers/pkg/controllers/migration/controller.go
@@ -61,6 +61,10 @@ const (
 	//   - Otherwise: abort migration and restore the APIService.
 	finalizerName = "migration.projectcalico.org/v1-crd-cleanup"
 
+	// nudgeAnnotation is written to a CRD that is stuck terminating, to re-queue the
+	// apiextensions cleanup finalizer. Only its presence matters, not its value.
+	nudgeAnnotation = "migration.projectcalico.org/cleanup-nudge"
+
 	// savedAPIServiceAnnotation holds the serialized APIService object so it
 	// can be restored on abort.
 	savedAPIServiceAnnotation = "migration.projectcalico.org/saved-apiservice"
@@ -979,10 +983,23 @@ func (m *migrationController) handleCompletedCleanup(logCtx *logrus.Entry, dm *m
 		return fmt.Errorf("listing CRDs: %w", err)
 	}
 
-	deleted := 0
+	// A CRD delete only marks the object. The apiextensions cleanup finalizer then removes the
+	// custom resources, which can fail and retry for minutes, so hold our finalizer until the
+	// CRDs are gone.
+	remaining := 0
 	for _, crd := range crdList.Items {
 		group, _, _ := unstructured.NestedString(crd.Object, "spec", "group")
 		if group != "crd.projectcalico.org" {
+			continue
+		}
+		remaining++
+		if crd.GetDeletionTimestamp() != nil {
+			// Deleting many CRDs at once can make the apiextensions cleanup finalizer fail, and it
+			// then backs off for several minutes. Any write to the CRD re-queues it immediately.
+			logCtx.WithField("crd", crd.GetName()).Debug("Nudging a terminating v1 CRD")
+			if err := m.nudgeTerminatingCRD(crdClient, crd.GetName()); err != nil {
+				logCtx.WithField("crd", crd.GetName()).WithError(err).Debug("Could not nudge terminating CRD")
+			}
 			continue
 		}
 		logCtx.WithField("crd", crd.GetName()).Info("Deleting v1 CRD")
@@ -990,12 +1007,29 @@ func (m *migrationController) handleCompletedCleanup(logCtx *logrus.Entry, dm *m
 			if !kerrors.IsNotFound(err) {
 				return fmt.Errorf("deleting CRD %s: %w", crd.GetName(), err)
 			}
+			remaining--
 		}
-		deleted++
 	}
-	logCtx.WithField("deleted", deleted).Info("Finished deleting v1 CRDs")
 
+	if remaining > 0 {
+		logCtx.WithField("remaining", remaining).Info("Waiting for v1 CRDs to be deleted")
+		return fmt.Errorf("waiting for %d v1 CRDs to finish deleting", remaining)
+	}
+
+	logCtx.Info("Finished deleting v1 CRDs")
 	return m.removeFinalizer(dm)
+}
+
+// nudgeTerminatingCRD writes an annotation to a CRD that is stuck terminating. The write
+// generates a watch event that re-queues the apiextensions cleanup finalizer straight away,
+// instead of waiting out its exponential backoff.
+func (m *migrationController) nudgeTerminatingCRD(crdClient dynamic.ResourceInterface, name string) error {
+	patch := []byte(fmt.Sprintf(`{"metadata":{"annotations":{%q:%q}}}`, nudgeAnnotation, time.Now().UTC().Format(time.RFC3339Nano)))
+	_, err := crdClient.Patch(m.ctx, name, types.MergePatchType, patch, metav1.PatchOptions{})
+	if err != nil && !kerrors.IsNotFound(err) {
+		return err
+	}
+	return nil
 }
 
 // handleAbort restores the cluster to pre-migration state when the CR is deleted

--- a/kube-controllers/pkg/controllers/migration/controller_v1crd_fv_test.go
+++ b/kube-controllers/pkg/controllers/migration/controller_v1crd_fv_test.go
@@ -17,6 +17,7 @@ package migration
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"path/filepath"
 	"testing"
 	"time"
@@ -135,7 +136,7 @@ func TestLifecycle_RealV1CRDs(t *testing.T) {
 	g.Eventually(func(g Gomega) {
 		err := fvRTClient.Get(ctx, dmKey, &migrationv1.DatastoreMigration{})
 		g.Expect(kerrors.IsNotFound(err)).To(BeTrue(), "CR should be deleted after cleanup, got: %v", err)
-		g.Expect(countV1CRDs(ctx)).To(Equal(0), "v1 CRDs should have been deleted by the finalizer")
+		g.Expect(describeV1CRDs(ctx)).To(BeEmpty(), "v1 CRDs should have been deleted by the finalizer")
 	}, 60*time.Second, 250*time.Millisecond).Should(Succeed())
 }
 
@@ -343,19 +344,26 @@ func ensureV1CRDs(t *testing.T, g Gomega) {
 	}, 60*time.Second, time.Second).Should(Succeed())
 }
 
-// countV1CRDs returns the number of installed crd.projectcalico.org CRDs.
-func countV1CRDs(ctx context.Context) (int, error) {
+// describeV1CRDs returns one line per remaining crd.projectcalico.org CRD, naming its
+// deletion timestamp, finalizers and conditions so a failure says why the CRD is still there.
+func describeV1CRDs(ctx context.Context) ([]string, error) {
 	crds, err := fvCRDClient.ApiextensionsV1().CustomResourceDefinitions().List(ctx, metav1.ListOptions{})
 	if err != nil {
-		return 0, err
+		return nil, err
 	}
-	count := 0
+	var out []string
 	for _, crd := range crds.Items {
-		if crd.Spec.Group == "crd.projectcalico.org" {
-			count++
+		if crd.Spec.Group != "crd.projectcalico.org" {
+			continue
 		}
+		var conditions []string
+		for _, c := range crd.Status.Conditions {
+			conditions = append(conditions, fmt.Sprintf("%s=%s(%s)", c.Type, c.Status, c.Reason))
+		}
+		out = append(out, fmt.Sprintf("%s deletionTimestamp=%v finalizers=%v conditions=%v",
+			crd.Name, crd.DeletionTimestamp, crd.Finalizers, conditions))
 	}
-	return count, nil
+	return out, nil
 }
 
 // createNamespace creates a namespace for the namespaced seed resources.


### PR DESCRIPTION
Deleting the migration CR reported cleanup as finished while v1 CRDs were still being deleted. A CRD delete only marks the object, and the apiextensions cleanup finalizer that removes the custom resources can fail and then back off for around five minutes, so the migration CR disappeared while some crd.projectcalico.org CRDs were still terminating. The finalizer is now held until those CRDs are actually gone, and a CRD stuck terminating gets an annotation write to re-queue the cleanup rather than waiting out the backoff.

That also fixes a flake in the v1 CRD lifecycle test, which asserts the CRDs are gone once the CR is: locally it failed 2 of 8 runs before this change and 0 of 24 after, worst case dropping from 4m45s to 2.1s.

**Release note:**
```release-note
Fixes the datastore migration reporting cleanup as complete while v1 CRDs were still being deleted.
```

**AI assistance:** Claude Code helped investigate the failure and draft the fix and tests.
