### PR TITLE
Scope flow dedup by node rather than by connection

### DIFF
--- a/goldmane/pkg/server/flow_collector_service.go
+++ b/goldmane/pkg/server/flow_collector_service.go
@@ -148,8 +148,9 @@ func (p *flowCollectorService) handleClient(srv proto.FlowCollector_ConnectServe
 		// the same flow twice.
 		if !p.deduplicator.Has(flow, scope) {
 
-			// The cache will automatically time out this flow in the background when it is no
-			// longer relevant.
+			// Add it to the deduplicator, scoped to the client's address (i.e., per-node).
+			// The cache will automatically time out this flow in the background when it is no longer
+			// relevant.
 			p.deduplicator.Add(flow, scope)
 
 			// Send the flow to the configured Sink.

--- a/goldmane/pkg/server/flow_collector_service.go
+++ b/goldmane/pkg/server/flow_collector_service.go
@@ -17,6 +17,7 @@ package server
 import (
 	"context"
 	"io"
+	"net"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
@@ -92,6 +93,15 @@ func (p *flowCollectorService) RegisterWith(srv *grpc.Server) {
 	logrus.Info("Registered FlowCollector Server")
 }
 
+// nodeScope returns a scope that survives a reconnect. The peer's ephemeral port changes
+// on every reconnect, so including it would give each connection its own scope.
+func nodeScope(addr net.Addr) string {
+	if tcp, ok := addr.(*net.TCPAddr); ok {
+		return tcp.IP.String()
+	}
+	return addr.String()
+}
+
 func (p *flowCollectorService) Connect(srv proto.FlowCollector_ConnectServer) error {
 	return p.handleClient(srv)
 }
@@ -101,12 +111,13 @@ func (p *flowCollectorService) handleClient(srv proto.FlowCollector_ConnectServe
 	numClients.Inc()
 	defer numClients.Dec()
 
+	who := "unknown"
 	scope := "unknown"
-	pr, ok := peer.FromContext(srv.Context())
-	if ok {
-		scope = pr.Addr.String()
+	if pr, ok := peer.FromContext(srv.Context()); ok {
+		who = pr.Addr.String()
+		scope = nodeScope(pr.Addr)
 	}
-	logCtx := logrus.WithField("who", scope)
+	logCtx := logrus.WithField("who", who)
 	logCtx.Info("Connection from client")
 
 	num := 0
@@ -137,9 +148,8 @@ func (p *flowCollectorService) handleClient(srv proto.FlowCollector_ConnectServe
 		// the same flow twice.
 		if !p.deduplicator.Has(flow, scope) {
 
-			// Add it to the deduplicator, scoped to the client's address (i.e., per-node).
-			// The cache will automatically time out this flow in the background when it is no longer
-			// relevant.
+			// The cache will automatically time out this flow in the background when it is no
+			// longer relevant.
 			p.deduplicator.Add(flow, scope)
 
 			// Send the flow to the configured Sink.

--- a/goldmane/pkg/server/flow_collector_service_test.go
+++ b/goldmane/pkg/server/flow_collector_service_test.go
@@ -1,0 +1,124 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"context"
+	"io"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/peer"
+
+	"github.com/projectcalico/calico/goldmane/pkg/testutils"
+	"github.com/projectcalico/calico/goldmane/pkg/types"
+	"github.com/projectcalico/calico/goldmane/proto"
+)
+
+// recordingSink keeps every flow it is handed, so a test can count duplicates rather
+// than just check for presence.
+type recordingSink struct {
+	flows []*types.Flow
+}
+
+func (s *recordingSink) Receive(f *types.Flow) {
+	s.flows = append(s.flows, f)
+}
+
+// clientStream replays a fixed set of updates as though they arrived over one connection
+// from the given address.
+type clientStream struct {
+	grpc.ServerStream
+
+	ctx     context.Context
+	updates []*proto.FlowUpdate
+	idx     int
+}
+
+func newClientStream(ip string, port int, flows []*proto.Flow) *clientStream {
+	updates := make([]*proto.FlowUpdate, 0, len(flows))
+	for _, f := range flows {
+		updates = append(updates, &proto.FlowUpdate{Flow: f})
+	}
+	addr := &net.TCPAddr{IP: net.ParseIP(ip), Port: port}
+	return &clientStream{
+		ctx:     peer.NewContext(context.Background(), &peer.Peer{Addr: addr}),
+		updates: updates,
+	}
+}
+
+func (s *clientStream) Context() context.Context {
+	return s.ctx
+}
+
+func (s *clientStream) Send(*proto.FlowReceipt) error {
+	return nil
+}
+
+func (s *clientStream) Recv() (*proto.FlowUpdate, error) {
+	if s.idx >= len(s.updates) {
+		return nil, io.EOF
+	}
+	upd := s.updates[s.idx]
+	s.idx++
+	return upd, nil
+}
+
+func testFlows(n int) []*proto.Flow {
+	flows := make([]*proto.Flow, 0, n)
+	for i := range n {
+		flows = append(flows, testutils.NewRandomFlow(int64(i*15)))
+	}
+	return flows
+}
+
+// TestDedupAcrossReconnect covers a Felix reconnect: the node keeps its IP but gets a new
+// ephemeral port, and replays the flows it already sent.
+func TestDedupAcrossReconnect(t *testing.T) {
+	sink := &recordingSink{}
+	collector := NewFlowCollector(sink)
+	flows := testFlows(10)
+
+	require.NoError(t, collector.Connect(newClientStream("192.168.1.5", 45026, flows)))
+	require.Len(t, sink.flows, 10, "first connection should deliver every flow")
+
+	require.NoError(t, collector.Connect(newClientStream("192.168.1.5", 54148, flows)))
+	require.Len(t, sink.flows, 10, "replay after reconnect should be deduplicated")
+}
+
+func TestDedupWithinConnection(t *testing.T) {
+	sink := &recordingSink{}
+	collector := NewFlowCollector(sink)
+	flows := testFlows(10)
+	doubled := append(append([]*proto.Flow{}, flows...), flows...)
+
+	require.NoError(t, collector.Connect(newClientStream("192.168.1.5", 45026, doubled)))
+	require.Len(t, sink.flows, 10, "duplicates on one connection should be deduplicated")
+}
+
+// TestDedupIsPerNode fails if the scope is dropped from the cache key altogether, which
+// would satisfy the two tests above while discarding one node's copy of a flow that two
+// nodes legitimately both report.
+func TestDedupIsPerNode(t *testing.T) {
+	sink := &recordingSink{}
+	collector := NewFlowCollector(sink)
+	flows := testFlows(10)
+
+	require.NoError(t, collector.Connect(newClientStream("192.168.1.5", 45026, flows)))
+	require.NoError(t, collector.Connect(newClientStream("192.168.1.6", 45026, flows)))
+	require.Len(t, sink.flows, 20, "flows from a second node should not be deduplicated")
+}


### PR DESCRIPTION
Goldmane's server-side flow deduplication is scoped by the gRPC peer address, which includes the ephemeral port. Every reconnect gets a new port, so a replayed flow never matches the cache and its stats are added a second time. The client caches every flow it sends for 5 minutes and replays the whole cache when it reconnects, so up to 5 minutes of a node's stats are counted twice each time. Scoping by the peer IP fixes it, and is what the code comment already claimed to do.

The same scope labels the `goldmane_collector_received_flows` counter, so every reconnect also started a new Prometheus series.

A Goldmane restart is not affected: the bucket ring dies along with the dedup cache, so the replay repopulates rather than duplicates.

Three tests in a package that had none. The reconnect case fails without this change; the two-node case fails if the scope is dropped from the cache key altogether, which would otherwise look like a valid fix.

Related: [CORE-13496](https://tigera.atlassian.net/browse/CORE-13496)

**Release note:**
```release-note
Fix Goldmane counting a node's flow statistics twice when Felix reconnects to it.
```

**AI assistance:** Claude Code


[CORE-13496]: https://tigera.atlassian.net/browse/CORE-13496?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ