### PR TITLE
Add status subresources to IPPool, Tier, and CalicoNodeStatus v1 CRDs

### DIFF
--- a/api/config/crd/projectcalico.org_caliconodestatuses.yaml
+++ b/api/config/crd/projectcalico.org_caliconodestatuses.yaml
@@ -224,4 +224,5 @@ spec:
           type: object
       served: true
       storage: true
-      subresources: {}
+      subresources:
+        status: {}

--- a/api/pkg/apis/projectcalico/v3/nodestatus.go
+++ b/api/pkg/apis/projectcalico/v3/nodestatus.go
@@ -39,6 +39,7 @@ type CalicoNodeStatusList struct {
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:scope=Cluster
+// +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Node",type=string,JSONPath=".spec.node",description="The name of the node"
 // +kubebuilder:printcolumn:name="Classes",type=string,JSONPath=".spec.classes",description="The types of information to monitor for this calico/node"
 

--- a/apiserver/pkg/registry/projectcalico/caliconodestatus/storage.go
+++ b/apiserver/pkg/registry/projectcalico/caliconodestatus/storage.go
@@ -1,13 +1,17 @@
-// Copyright (c) 2021 Tigera, Inc. All rights reserved.
+// Copyright (c) 2021-2026 Tigera, Inc. All rights reserved.
 
 package caliconodestatus
 
 import (
+	"context"
+
 	calico "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
 	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/registry/generic/registry"
+	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/kubernetes/pkg/printers"
 	printerstorage "k8s.io/kubernetes/pkg/printers/storage"
 
@@ -38,11 +42,38 @@ func NewList() runtime.Object {
 	return &calico.CalicoNodeStatusList{}
 }
 
+// StatusREST implements the REST endpoint for changing the status of a CalicoNodeStatus.
+type StatusREST struct {
+	store      *registry.Store
+	shortNames []string
+}
+
+func (r *StatusREST) New() runtime.Object {
+	return &calico.CalicoNodeStatus{}
+}
+
+func (r *StatusREST) Destroy() {
+	r.store.Destroy()
+}
+
+// Get retrieves the object from the storage. It is required to support Patch.
+func (r *StatusREST) Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
+	return r.store.Get(ctx, name, options)
+}
+
+// Update alters the status subset of an object.
+func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, createValidation rest.ValidateObjectFunc,
+	updateValidation rest.ValidateObjectUpdateFunc, forceAllowCreate bool, options *metav1.UpdateOptions) (runtime.Object, bool, error) {
+	return r.store.Update(ctx, name, objInfo, createValidation, updateValidation, forceAllowCreate, options)
+}
+
 // NewREST returns a RESTStorage object that will work against API services.
-func NewREST(scheme *runtime.Scheme, opts server.Options) (*REST, error) {
+func NewREST(scheme *runtime.Scheme, opts server.Options, statusOpts server.Options) (*REST, *StatusREST, error) {
 	strategy := NewStrategy(scheme)
 
 	prefix := "/" + opts.ResourcePrefix()
+	statusPrefix := "/" + statusOpts.ResourcePrefix()
+
 	// We adapt the store's keyFunc so that we can use it with the StorageDecorator
 	// without making any assumptions about where objects are stored in etcd
 	keyFunc := func(obj runtime.Object) (string, error) {
@@ -53,6 +84,17 @@ func NewREST(scheme *runtime.Scheme, opts server.Options) (*REST, error) {
 		return registry.NoNamespaceKeyFunc(
 			genericapirequest.NewContext(),
 			prefix,
+			accessor.GetName(),
+		)
+	}
+	statusKeyFunc := func(obj runtime.Object) (string, error) {
+		accessor, err := meta.Accessor(obj)
+		if err != nil {
+			return "", err
+		}
+		return registry.NoNamespaceKeyFunc(
+			genericapirequest.NewContext(),
+			statusPrefix,
 			accessor.GetName(),
 		)
 	}
@@ -67,7 +109,7 @@ func NewREST(scheme *runtime.Scheme, opts server.Options) (*REST, error) {
 		nil,
 	)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	store := &registry.Store{
 		NewFunc:     func() runtime.Object { return &calico.CalicoNodeStatus{} },
@@ -91,5 +133,24 @@ func NewREST(scheme *runtime.Scheme, opts server.Options) (*REST, error) {
 		TableConvertor: printerstorage.TableConvertor{TableGenerator: printers.NewTableGenerator().With(calicoprinter.CalicoNodeStatusAddHandlers)},
 	}
 
-	return &REST{store, opts.ShortNames}, nil
+	statusStorageInterface, statusDFunc, err := statusOpts.GetStorage(
+		prefix,
+		statusKeyFunc,
+		strategy,
+		func() runtime.Object { return &calico.CalicoNodeStatus{} },
+		func() runtime.Object { return &calico.CalicoNodeStatusList{} },
+		GetAttrs,
+		nil,
+		nil,
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	statusStore := *store
+	statusStore.UpdateStrategy = NewStatusStrategy(strategy)
+	statusStore.Storage = statusStorageInterface
+	statusStore.DestroyFunc = statusDFunc
+
+	return &REST{store, opts.ShortNames}, &StatusREST{&statusStore, opts.ShortNames}, nil
 }

--- a/apiserver/pkg/registry/projectcalico/caliconodestatus/strategy.go
+++ b/apiserver/pkg/registry/projectcalico/caliconodestatus/strategy.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Tigera, Inc. All rights reserved.
+// Copyright (c) 2021-2026 Tigera, Inc. All rights reserved.
 
 package caliconodestatus
 
@@ -32,9 +32,14 @@ func (apiServerStrategy) NamespaceScoped() bool {
 }
 
 func (apiServerStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
+	cns := obj.(*calico.CalicoNodeStatus)
+	cns.Status = calico.CalicoNodeStatusStatus{}
 }
 
 func (apiServerStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Object) {
+	newCNS := obj.(*calico.CalicoNodeStatus)
+	oldCNS := old.(*calico.CalicoNodeStatus)
+	newCNS.Status = oldCNS.Status
 }
 
 func (apiServerStrategy) Validate(ctx context.Context, obj runtime.Object) field.ErrorList {
@@ -61,6 +66,25 @@ func (apiServerStrategy) Canonicalize(obj runtime.Object) {
 }
 
 func (apiServerStrategy) ValidateUpdate(ctx context.Context, obj, old runtime.Object) field.ErrorList {
+	return field.ErrorList{}
+}
+
+type apiServerStatusStrategy struct {
+	apiServerStrategy
+}
+
+func NewStatusStrategy(strategy apiServerStrategy) apiServerStatusStrategy {
+	return apiServerStatusStrategy{strategy}
+}
+
+func (apiServerStatusStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Object) {
+	newStatus := obj.(*calico.CalicoNodeStatus)
+	oldStatus := old.(*calico.CalicoNodeStatus)
+	newStatus.Spec = oldStatus.Spec
+	newStatus.Labels = oldStatus.Labels
+}
+
+func (apiServerStatusStrategy) ValidateUpdate(ctx context.Context, obj, old runtime.Object) field.ErrorList {
 	return field.ErrorList{}
 }
 

--- a/apiserver/pkg/registry/projectcalico/ippool/storage.go
+++ b/apiserver/pkg/registry/projectcalico/ippool/storage.go
@@ -1,13 +1,17 @@
-// Copyright (c) 2019 Tigera, Inc. All rights reserved.
+// Copyright (c) 2019-2026 Tigera, Inc. All rights reserved.
 
 package ippool
 
 import (
+	"context"
+
 	calico "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
 	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/registry/generic/registry"
+	"k8s.io/apiserver/pkg/registry/rest"
 
 	"github.com/projectcalico/calico/apiserver/pkg/registry/projectcalico/server"
 )
@@ -36,11 +40,38 @@ func NewList() runtime.Object {
 	return &calico.IPPoolList{}
 }
 
+// StatusREST implements the REST endpoint for changing the status of an IPPool.
+type StatusREST struct {
+	store      *registry.Store
+	shortNames []string
+}
+
+func (r *StatusREST) New() runtime.Object {
+	return &calico.IPPool{}
+}
+
+func (r *StatusREST) Destroy() {
+	r.store.Destroy()
+}
+
+// Get retrieves the object from the storage. It is required to support Patch.
+func (r *StatusREST) Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
+	return r.store.Get(ctx, name, options)
+}
+
+// Update alters the status subset of an object.
+func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, createValidation rest.ValidateObjectFunc,
+	updateValidation rest.ValidateObjectUpdateFunc, forceAllowCreate bool, options *metav1.UpdateOptions) (runtime.Object, bool, error) {
+	return r.store.Update(ctx, name, objInfo, createValidation, updateValidation, forceAllowCreate, options)
+}
+
 // NewREST returns a RESTStorage object that will work against API services.
-func NewREST(scheme *runtime.Scheme, opts server.Options) (*REST, error) {
+func NewREST(scheme *runtime.Scheme, opts server.Options, statusOpts server.Options) (*REST, *StatusREST, error) {
 	strategy := NewStrategy(scheme)
 
 	prefix := "/" + opts.ResourcePrefix()
+	statusPrefix := "/" + statusOpts.ResourcePrefix()
+
 	// We adapt the store's keyFunc so that we can use it with the StorageDecorator
 	// without making any assumptions about where objects are stored in etcd
 	keyFunc := func(obj runtime.Object) (string, error) {
@@ -51,6 +82,17 @@ func NewREST(scheme *runtime.Scheme, opts server.Options) (*REST, error) {
 		return registry.NoNamespaceKeyFunc(
 			genericapirequest.NewContext(),
 			prefix,
+			accessor.GetName(),
+		)
+	}
+	statusKeyFunc := func(obj runtime.Object) (string, error) {
+		accessor, err := meta.Accessor(obj)
+		if err != nil {
+			return "", err
+		}
+		return registry.NoNamespaceKeyFunc(
+			genericapirequest.NewContext(),
+			statusPrefix,
 			accessor.GetName(),
 		)
 	}
@@ -65,7 +107,7 @@ func NewREST(scheme *runtime.Scheme, opts server.Options) (*REST, error) {
 		nil,
 	)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	store := &registry.Store{
 		NewFunc:     func() runtime.Object { return &calico.IPPool{} },
@@ -87,5 +129,24 @@ func NewREST(scheme *runtime.Scheme, opts server.Options) (*REST, error) {
 		DestroyFunc: dFunc,
 	}
 
-	return &REST{store, opts.ShortNames}, nil
+	statusStorageInterface, statusDFunc, err := statusOpts.GetStorage(
+		prefix,
+		statusKeyFunc,
+		strategy,
+		func() runtime.Object { return &calico.IPPool{} },
+		func() runtime.Object { return &calico.IPPoolList{} },
+		GetAttrs,
+		nil,
+		nil,
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	statusStore := *store
+	statusStore.UpdateStrategy = NewStatusStrategy(strategy)
+	statusStore.Storage = statusStorageInterface
+	statusStore.DestroyFunc = statusDFunc
+
+	return &REST{store, opts.ShortNames}, &StatusREST{&statusStore, opts.ShortNames}, nil
 }

--- a/apiserver/pkg/registry/projectcalico/ippool/strategy.go
+++ b/apiserver/pkg/registry/projectcalico/ippool/strategy.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Tigera, Inc. All rights reserved.
+// Copyright (c) 2019-2026 Tigera, Inc. All rights reserved.
 
 package ippool
 
@@ -31,9 +31,14 @@ func (apiServerStrategy) NamespaceScoped() bool {
 }
 
 func (apiServerStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
+	pool := obj.(*calico.IPPool)
+	pool.Status = nil
 }
 
 func (apiServerStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Object) {
+	newPool := obj.(*calico.IPPool)
+	oldPool := old.(*calico.IPPool)
+	newPool.Status = oldPool.Status
 }
 
 func (apiServerStrategy) Validate(ctx context.Context, obj runtime.Object) field.ErrorList {
@@ -60,6 +65,25 @@ func (apiServerStrategy) Canonicalize(obj runtime.Object) {
 }
 
 func (apiServerStrategy) ValidateUpdate(ctx context.Context, obj, old runtime.Object) field.ErrorList {
+	return field.ErrorList{}
+}
+
+type apiServerStatusStrategy struct {
+	apiServerStrategy
+}
+
+func NewStatusStrategy(strategy apiServerStrategy) apiServerStatusStrategy {
+	return apiServerStatusStrategy{strategy}
+}
+
+func (apiServerStatusStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Object) {
+	newPool := obj.(*calico.IPPool)
+	oldPool := old.(*calico.IPPool)
+	newPool.Spec = oldPool.Spec
+	newPool.Labels = oldPool.Labels
+}
+
+func (apiServerStatusStrategy) ValidateUpdate(ctx context.Context, obj, old runtime.Object) field.ErrorList {
 	return field.ErrorList{}
 }
 

--- a/apiserver/pkg/registry/projectcalico/rest/storage_calico.go
+++ b/apiserver/pkg/registry/projectcalico/rest/storage_calico.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2025 Tigera, Inc. All rights reserved.
+// Copyright (c) 2021-2026 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -175,6 +175,28 @@ func (p RESTStorageProvider) NewV3Storage(
 		[]string{},
 	)
 
+	tierStatusRESTOptions, err := restOptionsGetter.GetRESTOptions(calico.Resource("tiers/status"), nil)
+	if err != nil {
+		return nil, err
+	}
+	tierStatusOpts := server.NewOptions(
+		etcd.Options{
+			RESTOptions:   tierStatusRESTOptions,
+			Capacity:      1000,
+			ObjectType:    calicotier.EmptyObject(),
+			ScopeStrategy: calicotier.NewStrategy(scheme),
+			NewListFunc:   calicotier.NewList,
+			GetAttrsFunc:  calicotier.GetAttrs,
+			Trigger:       nil,
+		},
+		calicostorage.Options{
+			RESTOptions: tierStatusRESTOptions,
+		},
+		p.StorageType,
+		authorizer,
+		[]string{},
+	)
+
 	gpolicyRESTOptions, err := restOptionsGetter.GetRESTOptions(calico.Resource("globalnetworkpolicies"), nil)
 	if err != nil {
 		return nil, err
@@ -279,6 +301,28 @@ func (p RESTStorageProvider) NewV3Storage(
 		},
 		calicostorage.Options{
 			RESTOptions: ipPoolRESTOptions,
+		},
+		p.StorageType,
+		authorizer,
+		[]string{},
+	)
+
+	ipPoolStatusRESTOptions, err := restOptionsGetter.GetRESTOptions(calico.Resource("ippools/status"), nil)
+	if err != nil {
+		return nil, err
+	}
+	ipPoolStatusOpts := server.NewOptions(
+		etcd.Options{
+			RESTOptions:   ipPoolStatusRESTOptions,
+			Capacity:      10,
+			ObjectType:    calicoippool.EmptyObject(),
+			ScopeStrategy: calicoippool.NewStrategy(scheme),
+			NewListFunc:   calicoippool.NewList,
+			GetAttrsFunc:  calicoippool.GetAttrs,
+			Trigger:       nil,
+		},
+		calicostorage.Options{
+			RESTOptions: ipPoolStatusRESTOptions,
 		},
 		p.StorageType,
 		authorizer,
@@ -505,6 +549,28 @@ func (p RESTStorageProvider) NewV3Storage(
 		[]string{"caliconodestatus"},
 	)
 
+	caliconodestatusStatusRESTOptions, err := restOptionsGetter.GetRESTOptions(calico.Resource("caliconodestatuses/status"), nil)
+	if err != nil {
+		return nil, err
+	}
+	caliconodestatusStatusOpts := server.NewOptions(
+		etcd.Options{
+			RESTOptions:   caliconodestatusStatusRESTOptions,
+			Capacity:      1000,
+			ObjectType:    caliconodestatus.EmptyObject(),
+			ScopeStrategy: caliconodestatus.NewStrategy(scheme),
+			NewListFunc:   caliconodestatus.NewList,
+			GetAttrsFunc:  caliconodestatus.GetAttrs,
+			Trigger:       nil,
+		},
+		calicostorage.Options{
+			RESTOptions: caliconodestatusStatusRESTOptions,
+		},
+		p.StorageType,
+		authorizer,
+		[]string{"caliconodestatus"},
+	)
+
 	ipamconfigRESTOptions, err := restOptionsGetter.GetRESTOptions(calico.Resource("ipamconfigurations"), nil)
 	if err != nil {
 		return nil, err
@@ -550,7 +616,13 @@ func (p RESTStorageProvider) NewV3Storage(
 	)
 
 	storage := map[string]rest.Storage{}
-	storage["tiers"] = rESTInPeace(calicotier.NewREST(scheme, *tierOpts))
+	tierStorage, tierStatusStorage, err := calicotier.NewREST(scheme, *tierOpts, *tierStatusOpts)
+	if err != nil {
+		err = fmt.Errorf("unable to create REST storage for a resource due to %v, will die", err)
+		panic(err)
+	}
+	storage["tiers"] = tierStorage
+	storage["tiers/status"] = tierStatusStorage
 	storage["networkpolicies"] = rESTInPeace(calicopolicy.NewREST(scheme, *policyOpts, calicoLister, watchManager))
 	storage["stagednetworkpolicies"] = rESTInPeace(calicostagedpolicy.NewREST(scheme, *stagedpolicyOpts, calicoLister, watchManager))
 	storage["stagedkubernetesnetworkpolicies"] = rESTInPeace(calicostagedk8spolicy.NewREST(scheme, *stagedk8spolicyOpts))
@@ -559,7 +631,13 @@ func (p RESTStorageProvider) NewV3Storage(
 	storage["globalnetworksets"] = rESTInPeace(calicognetworkset.NewREST(scheme, *gNetworkSetOpts))
 	storage["networksets"] = rESTInPeace(caliconetworkset.NewREST(scheme, *networksetOpts))
 	storage["hostendpoints"] = rESTInPeace(calicohostendpoint.NewREST(scheme, *hostEndpointOpts))
-	storage["ippools"] = rESTInPeace(calicoippool.NewREST(scheme, *ipPoolSetOpts))
+	ipPoolStorage, ipPoolStatusStorage, err := calicoippool.NewREST(scheme, *ipPoolSetOpts, *ipPoolStatusOpts)
+	if err != nil {
+		err = fmt.Errorf("unable to create REST storage for a resource due to %v, will die", err)
+		panic(err)
+	}
+	storage["ippools"] = ipPoolStorage
+	storage["ippools/status"] = ipPoolStatusStorage
 	storage["ipreservations"] = rESTInPeace(calicoipreservation.NewREST(scheme, *ipReservationSetOpts))
 	storage["bgpconfigurations"] = rESTInPeace(calicobgpconfiguration.NewREST(scheme, *bgpConfigurationOpts))
 	storage["bgppeers"] = rESTInPeace(calicobgppeer.NewREST(scheme, *bgpPeerOpts))
@@ -567,7 +645,13 @@ func (p RESTStorageProvider) NewV3Storage(
 	storage["profiles"] = rESTInPeace(calicoprofile.NewREST(scheme, *profileOpts))
 	storage["felixconfigurations"] = rESTInPeace(calicofelixconfig.NewREST(scheme, *felixConfigOpts))
 	storage["clusterinformations"] = rESTInPeace(calicoclusterinformation.NewREST(scheme, *clusterInformationOpts))
-	storage["caliconodestatuses"] = rESTInPeace(caliconodestatus.NewREST(scheme, *caliconodestatusOpts))
+	caliconodestatusStorage, caliconodestatusStatusStorage, err := caliconodestatus.NewREST(scheme, *caliconodestatusOpts, *caliconodestatusStatusOpts)
+	if err != nil {
+		err = fmt.Errorf("unable to create REST storage for a resource due to %v, will die", err)
+		panic(err)
+	}
+	storage["caliconodestatuses"] = caliconodestatusStorage
+	storage["caliconodestatuses/status"] = caliconodestatusStatusStorage
 	storage["ipamconfigurations"] = rESTInPeace(calicoipamconfig.NewREST(scheme, *ipamconfigOpts))
 	storage["blockaffinities"] = rESTInPeace(calicoblockaffinity.NewREST(scheme, *blockAffinityOpts))
 

--- a/apiserver/pkg/registry/projectcalico/tier/storage.go
+++ b/apiserver/pkg/registry/projectcalico/tier/storage.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Tigera, Inc. All rights reserved.
+// Copyright (c) 2024-2026 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,11 +15,15 @@
 package tier
 
 import (
+	"context"
+
 	calico "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
 	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/registry/generic/registry"
+	"k8s.io/apiserver/pkg/registry/rest"
 
 	"github.com/projectcalico/calico/apiserver/pkg/registry/projectcalico/server"
 )
@@ -39,11 +43,37 @@ func NewList() runtime.Object {
 	return &calico.TierList{}
 }
 
+// StatusREST implements the REST endpoint for changing the status of a Tier.
+type StatusREST struct {
+	store *registry.Store
+}
+
+func (r *StatusREST) New() runtime.Object {
+	return &calico.Tier{}
+}
+
+func (r *StatusREST) Destroy() {
+	r.store.Destroy()
+}
+
+// Get retrieves the object from the storage. It is required to support Patch.
+func (r *StatusREST) Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
+	return r.store.Get(ctx, name, options)
+}
+
+// Update alters the status subset of an object.
+func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, createValidation rest.ValidateObjectFunc,
+	updateValidation rest.ValidateObjectUpdateFunc, forceAllowCreate bool, options *metav1.UpdateOptions) (runtime.Object, bool, error) {
+	return r.store.Update(ctx, name, objInfo, createValidation, updateValidation, forceAllowCreate, options)
+}
+
 // NewREST returns a RESTStorage object that will work against API services.
-func NewREST(scheme *runtime.Scheme, opts server.Options) (*REST, error) {
+func NewREST(scheme *runtime.Scheme, opts server.Options, statusOpts server.Options) (*REST, *StatusREST, error) {
 	strategy := NewStrategy(scheme)
 
 	prefix := "/" + opts.ResourcePrefix()
+	statusPrefix := "/" + statusOpts.ResourcePrefix()
+
 	// We adapt the store's keyFunc so that we can use it with the StorageDecorator
 	// without making any assumptions about where objects are stored in etcd
 	keyFunc := func(obj runtime.Object) (string, error) {
@@ -54,6 +84,17 @@ func NewREST(scheme *runtime.Scheme, opts server.Options) (*REST, error) {
 		return registry.NoNamespaceKeyFunc(
 			genericapirequest.NewContext(),
 			prefix,
+			accessor.GetName(),
+		)
+	}
+	statusKeyFunc := func(obj runtime.Object) (string, error) {
+		accessor, err := meta.Accessor(obj)
+		if err != nil {
+			return "", err
+		}
+		return registry.NoNamespaceKeyFunc(
+			genericapirequest.NewContext(),
+			statusPrefix,
 			accessor.GetName(),
 		)
 	}
@@ -68,7 +109,7 @@ func NewREST(scheme *runtime.Scheme, opts server.Options) (*REST, error) {
 		nil,
 	)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	store := &registry.Store{
 		NewFunc:     func() runtime.Object { return &calico.Tier{} },
@@ -90,5 +131,24 @@ func NewREST(scheme *runtime.Scheme, opts server.Options) (*REST, error) {
 		DestroyFunc: dFunc,
 	}
 
-	return &REST{store}, nil
+	statusStorageInterface, statusDFunc, err := statusOpts.GetStorage(
+		prefix,
+		statusKeyFunc,
+		strategy,
+		func() runtime.Object { return &calico.Tier{} },
+		func() runtime.Object { return &calico.TierList{} },
+		GetAttrs,
+		nil,
+		nil,
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	statusStore := *store
+	statusStore.UpdateStrategy = NewStatusStrategy(strategy)
+	statusStore.Storage = statusStorageInterface
+	statusStore.DestroyFunc = statusDFunc
+
+	return &REST{store}, &StatusREST{&statusStore}, nil
 }

--- a/apiserver/pkg/registry/projectcalico/tier/strategy.go
+++ b/apiserver/pkg/registry/projectcalico/tier/strategy.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Tigera, Inc. All rights reserved.
+// Copyright (c) 2024-2026 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -43,9 +43,14 @@ func (apiServerStrategy) NamespaceScoped() bool {
 }
 
 func (apiServerStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
+	tier := obj.(*calico.Tier)
+	tier.Status = calico.TierStatus{}
 }
 
 func (apiServerStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Object) {
+	newTier := obj.(*calico.Tier)
+	oldTier := old.(*calico.Tier)
+	newTier.Status = oldTier.Status
 }
 
 func (apiServerStrategy) Validate(ctx context.Context, obj runtime.Object) field.ErrorList {
@@ -75,6 +80,25 @@ func (apiServerStrategy) Canonicalize(obj runtime.Object) {
 func (apiServerStrategy) ValidateUpdate(ctx context.Context, obj, old runtime.Object) field.ErrorList {
 	return field.ErrorList{}
 	// return validation.ValidateTierUpdate(obj.(*calico.Tier), old.(*calico.Tier))
+}
+
+type apiServerStatusStrategy struct {
+	apiServerStrategy
+}
+
+func NewStatusStrategy(strategy apiServerStrategy) apiServerStatusStrategy {
+	return apiServerStatusStrategy{strategy}
+}
+
+func (apiServerStatusStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Object) {
+	newTier := obj.(*calico.Tier)
+	oldTier := old.(*calico.Tier)
+	newTier.Spec = oldTier.Spec
+	newTier.Labels = oldTier.Labels
+}
+
+func (apiServerStatusStrategy) ValidateUpdate(ctx context.Context, obj, old runtime.Object) field.ErrorList {
+	return field.ErrorList{}
 }
 
 func GetAttrs(obj runtime.Object) (labels.Set, fields.Set, error) {

--- a/apiserver/pkg/storage/calico/caliconodestatus_storage.go
+++ b/apiserver/pkg/storage/calico/caliconodestatus_storage.go
@@ -20,6 +20,17 @@ import (
 // NewCalicoNodeStatusStorage creates a new libcalico-based storage.Interface implementation for CalicoNodeStatus
 func NewCalicoNodeStatusStorage(opts Options) (registry.DryRunnableStorage, factory.DestroyFunc) {
 	c := CreateClientFromConfig()
+	return newCalicoNodeStatusStorage(opts, c, false)
+}
+
+// NewCalicoNodeStatusStatusStorage creates a storage that uses the UpdateStatus
+// method for writes, ensuring the status subresource is used when persisting changes.
+func NewCalicoNodeStatusStatusStorage(opts Options) (registry.DryRunnableStorage, factory.DestroyFunc) {
+	c := CreateClientFromConfig()
+	return newCalicoNodeStatusStorage(opts, c, true)
+}
+
+func newCalicoNodeStatusStorage(opts Options, c clientv3.Interface, forStatus bool) (registry.DryRunnableStorage, factory.DestroyFunc) {
 	createFn := func(ctx context.Context, c clientv3.Interface, obj resourceObject, opts clientOpts) (resourceObject, error) {
 		oso := opts.(options.SetOptions)
 		res := obj.(*api.CalicoNodeStatus)
@@ -28,6 +39,9 @@ func NewCalicoNodeStatusStorage(opts Options) (registry.DryRunnableStorage, fact
 	updateFn := func(ctx context.Context, c clientv3.Interface, obj resourceObject, opts clientOpts) (resourceObject, error) {
 		oso := opts.(options.SetOptions)
 		res := obj.(*api.CalicoNodeStatus)
+		if forStatus {
+			return c.CalicoNodeStatus().UpdateStatus(ctx, res, oso)
+		}
 		return c.CalicoNodeStatus().Update(ctx, res, oso)
 	}
 	getFn := func(ctx context.Context, c clientv3.Interface, ns string, name string, opts clientOpts) (resourceObject, error) {
@@ -78,6 +92,7 @@ func (gc CalicoNodeStatusConverter) convertToLibcalico(aapiObj runtime.Object) r
 	lcgCalicoNodeStatus.Kind = api.KindCalicoNodeStatus
 	lcgCalicoNodeStatus.APIVersion = api.GroupVersionCurrent
 	lcgCalicoNodeStatus.Spec = aapiCalicoNodeStatus.Spec
+	lcgCalicoNodeStatus.Status = aapiCalicoNodeStatus.Status
 	return lcgCalicoNodeStatus
 }
 

--- a/apiserver/pkg/storage/calico/ippool_storage.go
+++ b/apiserver/pkg/storage/calico/ippool_storage.go
@@ -20,6 +20,17 @@ import (
 // NewIPPoolStorage creates a new libcalico-based storage.Interface implementation for IPPools
 func NewIPPoolStorage(opts Options) (registry.DryRunnableStorage, factory.DestroyFunc) {
 	c := CreateClientFromConfig()
+	return newIPPoolStorage(opts, c, false)
+}
+
+// NewIPPoolStatusStorage creates a storage that uses the UpdateStatus method for
+// writes, ensuring the status subresource is used when persisting changes.
+func NewIPPoolStatusStorage(opts Options) (registry.DryRunnableStorage, factory.DestroyFunc) {
+	c := CreateClientFromConfig()
+	return newIPPoolStorage(opts, c, true)
+}
+
+func newIPPoolStorage(opts Options, c clientv3.Interface, forStatus bool) (registry.DryRunnableStorage, factory.DestroyFunc) {
 	createFn := func(ctx context.Context, c clientv3.Interface, obj resourceObject, opts clientOpts) (resourceObject, error) {
 		oso := opts.(options.SetOptions)
 		res := obj.(*api.IPPool)
@@ -28,6 +39,9 @@ func NewIPPoolStorage(opts Options) (registry.DryRunnableStorage, factory.Destro
 	updateFn := func(ctx context.Context, c clientv3.Interface, obj resourceObject, opts clientOpts) (resourceObject, error) {
 		oso := opts.(options.SetOptions)
 		res := obj.(*api.IPPool)
+		if forStatus {
+			return c.IPPools().UpdateStatus(ctx, res, oso)
+		}
 		return c.IPPools().Update(ctx, res, oso)
 	}
 	getFn := func(ctx context.Context, c clientv3.Interface, ns string, name string, opts clientOpts) (resourceObject, error) {
@@ -78,6 +92,7 @@ func (gc IPPoolConverter) convertToLibcalico(aapiObj runtime.Object) resourceObj
 	lcgIPPool.Kind = api.KindIPPool
 	lcgIPPool.APIVersion = api.GroupVersionCurrent
 	lcgIPPool.Spec = aapiIPPool.Spec
+	lcgIPPool.Status = aapiIPPool.Status
 	return lcgIPPool
 }
 
@@ -85,6 +100,7 @@ func (gc IPPoolConverter) convertToAAPI(libcalicoObject resourceObject, aapiObj 
 	lcgIPPool := libcalicoObject.(*api.IPPool)
 	aapiIPPool := aapiObj.(*api.IPPool)
 	aapiIPPool.Spec = lcgIPPool.Spec
+	aapiIPPool.Status = lcgIPPool.Status
 	aapiIPPool.TypeMeta = lcgIPPool.TypeMeta
 	aapiIPPool.ObjectMeta = lcgIPPool.ObjectMeta
 }

--- a/apiserver/pkg/storage/calico/storage_interface.go
+++ b/apiserver/pkg/storage/calico/storage_interface.go
@@ -37,6 +37,8 @@ func NewStorage(opts Options) (registry.DryRunnableStorage, factory.DestroyFunc)
 		return NewStagedGlobalNetworkPolicyStorage(opts)
 	case "projectcalico.org/tiers":
 		return NewTierStorage(opts)
+	case "projectcalico.org/tiers/status":
+		return NewTierStatusStorage(opts)
 	case "projectcalico.org/globalnetworksets":
 		return NewGlobalNetworkSetStorage(opts)
 	case "projectcalico.org/networksets":
@@ -45,6 +47,8 @@ func NewStorage(opts Options) (registry.DryRunnableStorage, factory.DestroyFunc)
 		return NewHostEndpointStorage(opts)
 	case "projectcalico.org/ippools":
 		return NewIPPoolStorage(opts)
+	case "projectcalico.org/ippools/status":
+		return NewIPPoolStatusStorage(opts)
 	case "projectcalico.org/ipreservations":
 		return NewIPReservationStorage(opts)
 	case "projectcalico.org/bgpconfigurations":
@@ -65,6 +69,8 @@ func NewStorage(opts Options) (registry.DryRunnableStorage, factory.DestroyFunc)
 		return NewClusterInformationStorage(opts)
 	case "projectcalico.org/caliconodestatuses":
 		return NewCalicoNodeStatusStorage(opts)
+	case "projectcalico.org/caliconodestatuses/status":
+		return NewCalicoNodeStatusStatusStorage(opts)
 	case "projectcalico.org/ipamconfigurations":
 		return NewIPAMConfigurationStorage(opts)
 	case "projectcalico.org/blockaffinities":

--- a/apiserver/pkg/storage/calico/tier_storage.go
+++ b/apiserver/pkg/storage/calico/tier_storage.go
@@ -20,6 +20,17 @@ import (
 // NewTierStorage creates a new libcalico-based storage.Interface implementation for Tiers
 func NewTierStorage(opts Options) (registry.DryRunnableStorage, factory.DestroyFunc) {
 	c := CreateClientFromConfig()
+	return newTierStorage(opts, c, false)
+}
+
+// NewTierStatusStorage creates a storage that uses the UpdateStatus method for
+// writes, ensuring the status subresource is used when persisting changes.
+func NewTierStatusStorage(opts Options) (registry.DryRunnableStorage, factory.DestroyFunc) {
+	c := CreateClientFromConfig()
+	return newTierStorage(opts, c, true)
+}
+
+func newTierStorage(opts Options, c clientv3.Interface, forStatus bool) (registry.DryRunnableStorage, factory.DestroyFunc) {
 	createFn := func(ctx context.Context, c clientv3.Interface, obj resourceObject, opts clientOpts) (resourceObject, error) {
 		oso := opts.(options.SetOptions)
 		res := obj.(*v3.Tier)
@@ -28,6 +39,9 @@ func NewTierStorage(opts Options) (registry.DryRunnableStorage, factory.DestroyF
 	updateFn := func(ctx context.Context, c clientv3.Interface, obj resourceObject, opts clientOpts) (resourceObject, error) {
 		oso := opts.(options.SetOptions)
 		res := obj.(*v3.Tier)
+		if forStatus {
+			return c.Tiers().UpdateStatus(ctx, res, oso)
+		}
 		return c.Tiers().Update(ctx, res, oso)
 	}
 	getFn := func(ctx context.Context, c clientv3.Interface, ns string, name string, opts clientOpts) (resourceObject, error) {
@@ -80,6 +94,7 @@ func (tc TierConverter) convertToLibcalico(aapiObj runtime.Object) resourceObjec
 	lcgTier.Kind = v3.KindTier
 	lcgTier.APIVersion = v3.GroupVersionCurrent
 	lcgTier.Spec = aapiTier.Spec
+	lcgTier.Status = aapiTier.Status
 	return lcgTier
 }
 
@@ -87,6 +102,7 @@ func (tc TierConverter) convertToAAPI(libcalicoObject resourceObject, aapiObj ru
 	lcgTier := libcalicoObject.(*v3.Tier)
 	aapiTier := aapiObj.(*v3.Tier)
 	aapiTier.Spec = lcgTier.Spec
+	aapiTier.Status = lcgTier.Status
 	aapiTier.TypeMeta = lcgTier.TypeMeta
 	aapiTier.ObjectMeta = lcgTier.ObjectMeta
 }

--- a/apiserver/test/integration/clientset_test.go
+++ b/apiserver/test/integration/clientset_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2025 Tigera, Inc. All rights reserved.
+// Copyright (c) 2021-2026 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -1849,6 +1849,9 @@ func TestCalicoNodeStatusClient(t *testing.T) {
 			if err := testCalicoNodeStatusClient(client, name); err != nil {
 				t.Fatal(err)
 			}
+			if err := testCalicoNodeStatusUpdateStatus(client); err != nil {
+				t.Fatal(err)
+			}
 		}
 	}
 
@@ -1900,6 +1903,97 @@ func testCalicoNodeStatusClient(client calicoclient.Interface, name string) erro
 	err = caliconodestatusClient.Delete(ctx, name, metav1.DeleteOptions{})
 	if err != nil {
 		return fmt.Errorf("object should be deleted (%s)", err)
+	}
+
+	return nil
+}
+
+func testCalicoNodeStatusUpdateStatus(client calicoclient.Interface) error {
+	seconds := uint32(10)
+	caliconodestatusClient := client.ProjectcalicoV3().CalicoNodeStatuses()
+	caliconodestatus := &v3.CalicoNodeStatus{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-caliconodestatus-updatestatus"},
+		Spec: v3.CalicoNodeStatusSpec{
+			Node: "node1",
+			Classes: []v3.NodeStatusClassType{
+				v3.NodeStatusClassTypeAgent,
+			},
+			UpdatePeriodSeconds: &seconds,
+		},
+		Status: v3.CalicoNodeStatusStatus{
+			LastUpdated: metav1.Now(),
+		},
+	}
+	ctx := context.Background()
+
+	// Create with status populated. The status subresource should strip
+	// the status on create.
+	created, err := caliconodestatusClient.Create(ctx, caliconodestatus, metav1.CreateOptions{})
+	if err != nil {
+		return fmt.Errorf("error creating caliconodestatus (%s)", err)
+	}
+	if !created.Status.LastUpdated.IsZero() {
+		return fmt.Errorf("status was set on create: %v", created.Status)
+	}
+
+	// Use UpdateStatus to set the status.
+	toUpdate := created.DeepCopy()
+	toUpdate.Status.LastUpdated = metav1.Now()
+	toUpdate.Status.Agent = v3.CalicoNodeAgentStatus{
+		BIRDV4: v3.BGPDaemonStatus{State: v3.BGPDaemonStateReady},
+	}
+	updated, err := caliconodestatusClient.UpdateStatus(ctx, toUpdate, metav1.UpdateOptions{})
+	if err != nil {
+		return fmt.Errorf("error calling UpdateStatus (%s)", err)
+	}
+	if updated.Status.LastUpdated.IsZero() {
+		return fmt.Errorf("UpdateStatus did not persist status")
+	}
+	if updated.Status.Agent.BIRDV4.State != v3.BGPDaemonStateReady {
+		return fmt.Errorf("UpdateStatus did not persist agent status")
+	}
+
+	// Use Update to modify spec, verify status is not wiped.
+	specUpdate := updated.DeepCopy()
+	newSeconds := uint32(20)
+	specUpdate.Spec.UpdatePeriodSeconds = &newSeconds
+	specUpdate.Status = v3.CalicoNodeStatusStatus{}
+	afterSpecUpdate, err := caliconodestatusClient.Update(ctx, specUpdate, metav1.UpdateOptions{})
+	if err != nil {
+		return fmt.Errorf("error calling Update (%s)", err)
+	}
+	if *afterSpecUpdate.Spec.UpdatePeriodSeconds != 20 {
+		return fmt.Errorf("Update did not persist spec change")
+	}
+	if afterSpecUpdate.Status.LastUpdated.IsZero() {
+		return fmt.Errorf("Update wiped status")
+	}
+	if afterSpecUpdate.Status.Agent.BIRDV4.State != v3.BGPDaemonStateReady {
+		return fmt.Errorf("Update wiped agent status")
+	}
+
+	// Verify UpdateStatus does not modify spec or labels.
+	statusUpdate := afterSpecUpdate.DeepCopy()
+	statusUpdate.Labels = map[string]string{"should": "not-persist"}
+	statusUpdate.Spec.UpdatePeriodSeconds = &seconds
+	statusUpdate.Status.Agent.BIRDV4.State = v3.BGPDaemonStateNotReady
+	afterStatusUpdate, err := caliconodestatusClient.UpdateStatus(ctx, statusUpdate, metav1.UpdateOptions{})
+	if err != nil {
+		return fmt.Errorf("error calling UpdateStatus for isolation check (%s)", err)
+	}
+	if afterStatusUpdate.Status.Agent.BIRDV4.State != v3.BGPDaemonStateNotReady {
+		return fmt.Errorf("UpdateStatus did not persist new status")
+	}
+	if _, ok := afterStatusUpdate.Labels["should"]; ok {
+		return fmt.Errorf("UpdateStatus persisted labels")
+	}
+	if *afterStatusUpdate.Spec.UpdatePeriodSeconds != 20 {
+		return fmt.Errorf("UpdateStatus modified spec")
+	}
+
+	err = caliconodestatusClient.Delete(ctx, "test-caliconodestatus-updatestatus", metav1.DeleteOptions{})
+	if err != nil {
+		return fmt.Errorf("error deleting caliconodestatus (%s)", err)
 	}
 
 	return nil

--- a/libcalico-go/config/crd/crd.projectcalico.org_caliconodestatuses.yaml
+++ b/libcalico-go/config/crd/crd.projectcalico.org_caliconodestatuses.yaml
@@ -212,3 +212,5 @@ spec:
           type: object
       served: true
       storage: true
+      subresources:
+        status: {}

--- a/libcalico-go/config/crd/crd.projectcalico.org_ippools.yaml
+++ b/libcalico-go/config/crd/crd.projectcalico.org_ippools.yaml
@@ -113,6 +113,47 @@ spec:
                   rule:
                     "!self.cidr.contains(':') || !has(self.ipipMode) || self.ipipMode
                     == 'Never' || size(self.ipipMode) == 0"
+            status:
+              properties:
+                conditions:
+                  items:
+                    properties:
+                      lastTransitionTime:
+                        format: date-time
+                        type: string
+                      message:
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+              type: object
           type: object
       served: true
       storage: true
+      subresources:
+        status: {}

--- a/libcalico-go/config/crd/crd.projectcalico.org_tiers.yaml
+++ b/libcalico-go/config/crd/crd.projectcalico.org_tiers.yaml
@@ -41,6 +41,45 @@ spec:
                 order:
                   type: number
               type: object
+            status:
+              properties:
+                conditions:
+                  items:
+                    properties:
+                      lastTransitionTime:
+                        format: date-time
+                        type: string
+                      message:
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+              type: object
           required:
             - metadata
             - spec
@@ -60,3 +99,5 @@ spec:
                 : true"
       served: true
       storage: true
+      subresources:
+        status: {}

--- a/libcalico-go/lib/apis/crd.projectcalico.org/v1/caliconodestatus_types.go
+++ b/libcalico-go/lib/apis/crd.projectcalico.org/v1/caliconodestatus_types.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Tigera, Inc. All rights reserved.
+// Copyright (c) 2021-2026 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import (
 
 // +k8s:openapi-gen=true
 // +kubebuilder:resource:scope=Cluster
+// +kubebuilder:subresource:status
 type CalicoNodeStatus struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/libcalico-go/lib/apis/crd.projectcalico.org/v1/ippool_types.go
+++ b/libcalico-go/lib/apis/crd.projectcalico.org/v1/ippool_types.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017-2026 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -24,8 +24,12 @@ import (
 
 // +k8s:openapi-gen=true
 // +kubebuilder:resource:scope=Cluster
+// +kubebuilder:subresource:status
 type IPPool struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 	Spec              v3.IPPoolSpec `json:"spec,omitempty"`
+
+	// +optional
+	Status *v3.IPPoolStatus `json:"status,omitempty"`
 }

--- a/libcalico-go/lib/apis/crd.projectcalico.org/v1/tier_types.go
+++ b/libcalico-go/lib/apis/crd.projectcalico.org/v1/tier_types.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Tigera, Inc. All rights reserved.
+// Copyright (c) 2024-2026 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -27,8 +27,10 @@ import (
 // +kubebuilder:validation:XValidation:rule="self.metadata.name == 'kube-admin' ? self.spec.defaultAction == 'Pass' : true", message="The 'kube-admin' tier must have default action 'Pass'"
 // +kubebuilder:validation:XValidation:rule="self.metadata.name == 'kube-baseline' ? self.spec.defaultAction == 'Pass' : true", message="The 'kube-baseline' tier must have default action 'Pass'"
 // +kubebuilder:validation:XValidation:rule="self.metadata.name == 'default' ? self.spec.defaultAction == 'Deny' : true", message="The 'default' tier must have default action 'Deny'"
+// +kubebuilder:subresource:status
 type Tier struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata"`
-	Spec              v3.TierSpec `json:"spec"`
+	Spec              v3.TierSpec   `json:"spec"`
+	Status            v3.TierStatus `json:"status,omitempty"`
 }

--- a/libcalico-go/lib/clientv3/caliconodestatus.go
+++ b/libcalico-go/lib/clientv3/caliconodestatus.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Tigera, Inc. All rights reserved.
+// Copyright (c) 2021-2026 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ import (
 type CalicoNodeStatusInterface interface {
 	Create(ctx context.Context, res *apiv3.CalicoNodeStatus, opts options.SetOptions) (*apiv3.CalicoNodeStatus, error)
 	Update(ctx context.Context, res *apiv3.CalicoNodeStatus, opts options.SetOptions) (*apiv3.CalicoNodeStatus, error)
+	UpdateStatus(ctx context.Context, res *apiv3.CalicoNodeStatus, opts options.SetOptions) (*apiv3.CalicoNodeStatus, error)
 	Delete(ctx context.Context, name string, opts options.DeleteOptions) (*apiv3.CalicoNodeStatus, error)
 	Get(ctx context.Context, name string, opts options.GetOptions) (*apiv3.CalicoNodeStatus, error)
 	List(ctx context.Context, opts options.ListOptions) (*apiv3.CalicoNodeStatusList, error)
@@ -61,6 +62,16 @@ func (r calicoNodeStatus) Update(ctx context.Context, res *apiv3.CalicoNodeStatu
 	}
 
 	out, err := r.client.resources.Update(ctx, opts, apiv3.KindCalicoNodeStatus, res)
+	if out != nil {
+		return out.(*apiv3.CalicoNodeStatus), err
+	}
+	return nil, err
+}
+
+// UpdateStatus takes the representation of a CalicoNodeStatus and updates its status.
+// Returns the stored representation of the CalicoNodeStatus, and an error, if there is any.
+func (r calicoNodeStatus) UpdateStatus(ctx context.Context, res *apiv3.CalicoNodeStatus, opts options.SetOptions) (*apiv3.CalicoNodeStatus, error) {
+	out, err := r.client.resources.UpdateStatus(ctx, opts, apiv3.KindCalicoNodeStatus, res)
 	if out != nil {
 		return out.(*apiv3.CalicoNodeStatus), err
 	}

--- a/libcalico-go/lib/clientv3/caliconodestatus_e2e_test.go
+++ b/libcalico-go/lib/clientv3/caliconodestatus_e2e_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Tigera, Inc. All rights reserved.
+// Copyright (c) 2021-2026 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -213,27 +213,37 @@ var _ = testutils.E2eDatastoreDescribe("CalicoNodeStatus tests", testutils.Datas
 			Expect(outError).To(HaveOccurred())
 			Expect(outError.Error()).To(Equal("error with field Metadata.ResourceVersion = '12345' (field must not be set for a Create request)"))
 
-			By("Creating a new CalicoNodeStatus with name1/spec1/status1")
+			By("Creating a new CalicoNodeStatus with name1/spec1 and status1 included")
 			res1, outError := c.CalicoNodeStatus().Create(ctx, &apiv3.CalicoNodeStatus{
 				ObjectMeta: metav1.ObjectMeta{Name: name1},
 				Spec:       spec1,
 				Status:     status1,
 			}, options.SetOptions{})
 			Expect(outError).NotTo(HaveOccurred())
+			Expect(res1).To(MatchResource(apiv3.KindCalicoNodeStatus, testutils.ExpectNoNamespace, name1, spec1))
 
-			// The location field of LastUpdated (loc:(*time.Location)(0x2d1e7e0)}) will be populated
-			// by datastore on write. Hence we need to copy over it to original status before comparing against it.
+			if config.Spec.DatastoreType == apiconfig.Kubernetes {
+				By("Verifying that Create did not persist the status (status subresource isolation)")
+				Expect(res1.Status).To(Equal(apiv3.CalicoNodeStatusStatus{}))
+			}
+
+			By("Setting status1 on CalicoNodeStatus name1 via UpdateStatus")
+			res1.Status = status1
+			res1, outError = c.CalicoNodeStatus().UpdateStatus(ctx, res1, options.SetOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+
+			// The location field of LastUpdated will be populated by datastore on write.
+			// Copy it over to original status before comparing.
 			status1.LastUpdated = res1.Status.LastUpdated
 			Expect(res1).To(MatchResourceWithStatus(apiv3.KindCalicoNodeStatus, testutils.ExpectNoNamespace, name1, spec1, status1))
 
 			// Track the version of the original data for name1.
 			rv1_1 := res1.ResourceVersion
 
-			By("Attempting to create the same CalicoNodeStatus with name1 but with spec2/status2")
+			By("Attempting to create the same CalicoNodeStatus with name1 but with spec2")
 			_, outError = c.CalicoNodeStatus().Create(ctx, &apiv3.CalicoNodeStatus{
 				ObjectMeta: metav1.ObjectMeta{Name: name1},
 				Spec:       spec2,
-				Status:     status2,
 			}, options.SetOptions{})
 			Expect(outError).To(HaveOccurred())
 			Expect(outError.Error()).To(ContainSubstring("resource already exists: CalicoNodeStatus(" + name1 + ") with error:"))
@@ -256,12 +266,23 @@ var _ = testutils.E2eDatastoreDescribe("CalicoNodeStatus tests", testutils.Datas
 				testutils.ResourceWithStatus(apiv3.KindCalicoNodeStatus, testutils.ExpectNoNamespace, name1, spec1, status1),
 			))
 
-			By("Creating a new CalicoNodeStatus with name2/status2")
+			By("Creating a new CalicoNodeStatus with name2/spec2 and status2 included")
 			res2, outError := c.CalicoNodeStatus().Create(ctx, &apiv3.CalicoNodeStatus{
 				ObjectMeta: metav1.ObjectMeta{Name: name2},
 				Spec:       spec2,
 				Status:     status2,
 			}, options.SetOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			Expect(res2).To(MatchResource(apiv3.KindCalicoNodeStatus, testutils.ExpectNoNamespace, name2, spec2))
+
+			if config.Spec.DatastoreType == apiconfig.Kubernetes {
+				By("Verifying that Create did not persist the status for name2")
+				Expect(res2.Status).To(Equal(apiv3.CalicoNodeStatusStatus{}))
+			}
+
+			By("Setting status2 on CalicoNodeStatus name2 via UpdateStatus")
+			res2.Status = status2
+			res2, outError = c.CalicoNodeStatus().UpdateStatus(ctx, res2, options.SetOptions{})
 			Expect(outError).NotTo(HaveOccurred())
 			status2.LastUpdated = res2.Status.LastUpdated
 			Expect(res2).To(MatchResourceWithStatus(apiv3.KindCalicoNodeStatus, testutils.ExpectNoNamespace, name2, spec2, status2))
@@ -280,11 +301,37 @@ var _ = testutils.E2eDatastoreDescribe("CalicoNodeStatus tests", testutils.Datas
 				testutils.ResourceWithStatus(apiv3.KindCalicoNodeStatus, testutils.ExpectNoNamespace, name2, spec2, status2),
 			))
 
-			By("Updating CalicoNodeStatus name1 with status2")
+			By("Updating CalicoNodeStatus name1 status to status2 via UpdateStatus")
 			res1.Status = status2
-			res1, outError = c.CalicoNodeStatus().Update(ctx, res1, options.SetOptions{})
+			res1, outError = c.CalicoNodeStatus().UpdateStatus(ctx, res1, options.SetOptions{})
 			Expect(outError).NotTo(HaveOccurred())
 			Expect(res1).To(MatchResourceWithStatus(apiv3.KindCalicoNodeStatus, testutils.ExpectNoNamespace, name1, spec1, status2))
+
+			if config.Spec.DatastoreType == apiconfig.Kubernetes {
+				By("Verifying that Update (spec only) does not modify the status")
+				res1.Spec = spec2
+				res1, outError = c.CalicoNodeStatus().Update(ctx, res1, options.SetOptions{})
+				Expect(outError).NotTo(HaveOccurred())
+				Expect(res1).To(MatchResourceWithStatus(apiv3.KindCalicoNodeStatus, testutils.ExpectNoNamespace, name1, spec2, status2))
+
+				By("Verifying that UpdateStatus does not modify the spec")
+				res1.Spec = spec1
+				res1.Status = status1
+				res1, outError = c.CalicoNodeStatus().UpdateStatus(ctx, res1, options.SetOptions{})
+				Expect(outError).NotTo(HaveOccurred())
+				status1.LastUpdated = res1.Status.LastUpdated
+				Expect(res1).To(MatchResourceWithStatus(apiv3.KindCalicoNodeStatus, testutils.ExpectNoNamespace, name1, spec2, status1))
+
+				// Restore spec back to spec1 for the remaining tests.
+				res1.Spec = spec1
+				res1, outError = c.CalicoNodeStatus().Update(ctx, res1, options.SetOptions{})
+				Expect(outError).NotTo(HaveOccurred())
+
+				// Restore status back to status2 for the remaining tests.
+				res1.Status = status2
+				res1, outError = c.CalicoNodeStatus().UpdateStatus(ctx, res1, options.SetOptions{})
+				Expect(outError).NotTo(HaveOccurred())
+			}
 
 			By("Attempting to update the CalicoNodeStatus without a Creation Timestamp")
 			res, outError = c.CalicoNodeStatus().Update(ctx, &apiv3.CalicoNodeStatus{
@@ -437,28 +484,28 @@ var _ = testutils.E2eDatastoreDescribe("CalicoNodeStatus tests", testutils.Datas
 			Expect(outList.Items).To(HaveLen(0))
 			rev0 := outList.ResourceVersion
 
-			By("Configuring a CalicoNodeStatus name1/status1 and storing the response")
+			By("Configuring a CalicoNodeStatus name1/spec1 and storing the response")
 			outRes1, err := c.CalicoNodeStatus().Create(
 				ctx,
 				&apiv3.CalicoNodeStatus{
 					ObjectMeta: metav1.ObjectMeta{Name: name1},
 					Spec:       spec1,
-					Status:     status1,
 				},
 				options.SetOptions{},
 			)
+			Expect(err).NotTo(HaveOccurred())
 			rev1 := outRes1.ResourceVersion
 
-			By("Configuring a CalicoNodeStatus name2/spec2/status2 and storing the response")
+			By("Configuring a CalicoNodeStatus name2/spec2 and storing the response")
 			outRes2, err := c.CalicoNodeStatus().Create(
 				ctx,
 				&apiv3.CalicoNodeStatus{
 					ObjectMeta: metav1.ObjectMeta{Name: name2},
 					Spec:       spec2,
-					Status:     status2,
 				},
 				options.SetOptions{},
 			)
+			Expect(err).NotTo(HaveOccurred())
 
 			By("Starting a watcher from revision rev1 - this should skip the first creation")
 			w, err := c.CalicoNodeStatus().Watch(ctx, options.ListOptions{ResourceVersion: rev1})
@@ -470,7 +517,7 @@ var _ = testutils.E2eDatastoreDescribe("CalicoNodeStatus tests", testutils.Datas
 			_, err = c.CalicoNodeStatus().Delete(ctx, name1, options.DeleteOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
-			By("Checking for two events, create res2 and delete re1")
+			By("Checking for two events, create res2 and delete res1")
 			testWatcher1.ExpectEvents(apiv3.KindCalicoNodeStatus, []watch.Event{
 				{
 					Type:   watch.Added,
@@ -489,13 +536,12 @@ var _ = testutils.E2eDatastoreDescribe("CalicoNodeStatus tests", testutils.Datas
 			testWatcher2 := testutils.NewTestResourceWatch(config.Spec.DatastoreType, w)
 			defer testWatcher2.Stop()
 
-			By("Modifying res2")
+			By("Modifying res2 spec")
 			outRes3, err := c.CalicoNodeStatus().Update(
 				ctx,
 				&apiv3.CalicoNodeStatus{
 					ObjectMeta: outRes2.ObjectMeta,
-					Spec:       spec2,
-					Status:     status1,
+					Spec:       spec1,
 				},
 				options.SetOptions{},
 			)
@@ -554,16 +600,16 @@ var _ = testutils.E2eDatastoreDescribe("CalicoNodeStatus tests", testutils.Datas
 			})
 			testWatcher3.Stop()
 
-			By("Configuring CalicoNodeStatus name1/spec1/status1 again and storing the response")
+			By("Configuring CalicoNodeStatus name1/spec1 again and storing the response")
 			outRes1, err = c.CalicoNodeStatus().Create(
 				ctx,
 				&apiv3.CalicoNodeStatus{
 					ObjectMeta: metav1.ObjectMeta{Name: name1},
 					Spec:       spec1,
-					Status:     status1,
 				},
 				options.SetOptions{},
 			)
+			Expect(err).NotTo(HaveOccurred())
 
 			By("Starting a watcher not specifying a rev - expect the current snapshot")
 			w, err = c.CalicoNodeStatus().Watch(ctx, options.ListOptions{})

--- a/libcalico-go/lib/clientv3/ippool.go
+++ b/libcalico-go/lib/clientv3/ippool.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017-2026 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -36,6 +36,7 @@ import (
 type IPPoolInterface interface {
 	Create(ctx context.Context, res *apiv3.IPPool, opts options.SetOptions) (*apiv3.IPPool, error)
 	Update(ctx context.Context, res *apiv3.IPPool, opts options.SetOptions) (*apiv3.IPPool, error)
+	UpdateStatus(ctx context.Context, res *apiv3.IPPool, opts options.SetOptions) (*apiv3.IPPool, error)
 	Delete(ctx context.Context, name string, opts options.DeleteOptions) (*apiv3.IPPool, error)
 	Get(ctx context.Context, name string, opts options.GetOptions) (*apiv3.IPPool, error)
 	List(ctx context.Context, opts options.ListOptions) (*apiv3.IPPoolList, error)
@@ -140,6 +141,16 @@ func (r ipPools) Update(ctx context.Context, res *apiv3.IPPool, opts options.Set
 	}
 
 	out, err := r.client.resources.Update(ctx, opts, apiv3.KindIPPool, res)
+	if out != nil {
+		return out.(*apiv3.IPPool), err
+	}
+	return nil, err
+}
+
+// UpdateStatus takes the representation of an IPPool and updates its status.
+// Returns the stored representation of the IPPool, and an error, if there is any.
+func (r ipPools) UpdateStatus(ctx context.Context, res *apiv3.IPPool, opts options.SetOptions) (*apiv3.IPPool, error) {
+	out, err := r.client.resources.UpdateStatus(ctx, opts, apiv3.KindIPPool, res)
 	if out != nil {
 		return out.(*apiv3.IPPool), err
 	}

--- a/libcalico-go/lib/clientv3/ippool_e2e_test.go
+++ b/libcalico-go/lib/clientv3/ippool_e2e_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2025 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017-2026 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -1175,6 +1175,68 @@ var _ = testutils.E2eDatastoreDescribe("IPPool tests (etcd only)", testutils.Dat
 			_, err = c.IPPools().Delete(ctx, "ippool1", options.DeleteOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			_, err = c.IPPools().Delete(ctx, "ippool2", options.DeleteOptions{})
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Describe("IPPool UpdateStatus functionality", func() {
+		It("should set and preserve status across spec updates", func() {
+			c, err := clientv3.New(config)
+			Expect(err).NotTo(HaveOccurred())
+
+			be, err := backend.NewClient(config)
+			Expect(err).NotTo(HaveOccurred())
+			be.Clean()
+
+			By("Creating an IPPool")
+			pool, err := c.IPPools().Create(ctx, &apiv3.IPPool{
+				ObjectMeta: metav1.ObjectMeta{Name: "ippool-status-test"},
+				Spec: apiv3.IPPoolSpec{
+					CIDR: "10.0.0.0/24",
+				},
+			}, options.SetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Setting status via UpdateStatus")
+			pool.Status = &apiv3.IPPoolStatus{
+				Conditions: []metav1.Condition{
+					{
+						Type:               "Ready",
+						Status:             metav1.ConditionTrue,
+						Reason:             "PoolReady",
+						Message:            "Pool is ready",
+						LastTransitionTime: metav1.Now(),
+					},
+				},
+			}
+			pool, err = c.IPPools().UpdateStatus(ctx, pool, options.SetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(pool.Status).NotTo(BeNil())
+			Expect(pool.Status.Conditions).To(HaveLen(1))
+			Expect(pool.Status.Conditions[0].Type).To(Equal("Ready"))
+
+			By("Getting the pool and verifying status is present")
+			pool, err = c.IPPools().Get(ctx, "ippool-status-test", options.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(pool.Status).NotTo(BeNil())
+			Expect(pool.Status.Conditions).To(HaveLen(1))
+			Expect(pool.Status.Conditions[0].Type).To(Equal("Ready"))
+
+			By("Updating the pool spec and verifying status is preserved")
+			pool.Spec.NATOutgoing = true
+			pool, err = c.IPPools().Update(ctx, pool, options.SetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Getting the pool and verifying status is still present after spec update")
+			pool, err = c.IPPools().Get(ctx, "ippool-status-test", options.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(pool.Spec.NATOutgoing).To(BeTrue())
+			Expect(pool.Status).NotTo(BeNil())
+			Expect(pool.Status.Conditions).To(HaveLen(1))
+			Expect(pool.Status.Conditions[0].Type).To(Equal("Ready"))
+
+			By("Cleaning up")
+			_, err = c.IPPools().Delete(ctx, "ippool-status-test", options.DeleteOptions{})
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})

--- a/libcalico-go/lib/clientv3/tier.go
+++ b/libcalico-go/lib/clientv3/tier.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2025 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017-2026 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -33,6 +33,7 @@ import (
 type TierInterface interface {
 	Create(ctx context.Context, res *apiv3.Tier, opts options.SetOptions) (*apiv3.Tier, error)
 	Update(ctx context.Context, res *apiv3.Tier, opts options.SetOptions) (*apiv3.Tier, error)
+	UpdateStatus(ctx context.Context, res *apiv3.Tier, opts options.SetOptions) (*apiv3.Tier, error)
 	Delete(ctx context.Context, name string, opts options.DeleteOptions) (*apiv3.Tier, error)
 	Get(ctx context.Context, name string, opts options.GetOptions) (*apiv3.Tier, error)
 	List(ctx context.Context, opts options.ListOptions) (*apiv3.TierList, error)
@@ -78,6 +79,16 @@ func (r tiers) Update(ctx context.Context, res *apiv3.Tier, opts options.SetOpti
 		return nil, err
 	}
 	out, err := r.client.resources.Update(ctx, opts, apiv3.KindTier, res)
+	if out != nil {
+		return out.(*apiv3.Tier), err
+	}
+	return nil, err
+}
+
+// UpdateStatus takes the representation of a Tier and updates its status.
+// Returns the stored representation of the Tier, and an error, if there is any.
+func (r tiers) UpdateStatus(ctx context.Context, res *apiv3.Tier, opts options.SetOptions) (*apiv3.Tier, error) {
+	out, err := r.client.resources.UpdateStatus(ctx, opts, apiv3.KindTier, res)
 	if out != nil {
 		return out.(*apiv3.Tier), err
 	}

--- a/libcalico-go/lib/clientv3/tier_e2e_test.go
+++ b/libcalico-go/lib/clientv3/tier_e2e_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 Tigera, Inc. All rights reserved.
+// Copyright (c) 2024-2026 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -892,6 +892,69 @@ var _ = testutils.E2eDatastoreDescribe("Tier tests", testutils.DatastoreAll, fun
 			By("Attempting to delete tier-1 (expecting success)")
 			_, err = c.Tiers().Delete(ctx, "knp", options.DeleteOptions{ResourceVersion: tier.ResourceVersion})
 			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
+	Describe("Tier UpdateStatus functionality", func() {
+		It("should set and preserve status across spec updates", func() {
+			c, err := clientv3.New(config)
+			Expect(err).NotTo(HaveOccurred())
+
+			be, err := backend.NewClient(config)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(be.Clean()).NotTo(HaveOccurred())
+
+			By("Creating a tier")
+			order := 100.0
+			tier, err := c.Tiers().Create(ctx, &apiv3.Tier{
+				ObjectMeta: metav1.ObjectMeta{Name: "status-test"},
+				Spec: apiv3.TierSpec{
+					Order:         &order,
+					DefaultAction: &actionPass,
+				},
+			}, options.SetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(tier.Status.Conditions).To(BeEmpty())
+
+			By("Setting status via UpdateStatus")
+			tier.Status = apiv3.TierStatus{
+				Conditions: []metav1.Condition{
+					{
+						Type:               "Ready",
+						Status:             metav1.ConditionTrue,
+						Reason:             "TierReady",
+						Message:            "Tier is ready",
+						LastTransitionTime: metav1.Now(),
+					},
+				},
+			}
+			tier, err = c.Tiers().UpdateStatus(ctx, tier, options.SetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(tier.Status.Conditions).To(HaveLen(1))
+			Expect(tier.Status.Conditions[0].Type).To(Equal("Ready"))
+
+			By("Getting the tier and verifying status is present")
+			tier, err = c.Tiers().Get(ctx, "status-test", options.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(tier.Status.Conditions).To(HaveLen(1))
+			Expect(tier.Status.Conditions[0].Type).To(Equal("Ready"))
+
+			By("Updating the tier spec and verifying status is preserved")
+			newOrder := 200.0
+			tier.Spec.Order = &newOrder
+			tier, err = c.Tiers().Update(ctx, tier, options.SetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Getting the tier and verifying status is still present after spec update")
+			tier, err = c.Tiers().Get(ctx, "status-test", options.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(*tier.Spec.Order).To(Equal(newOrder))
+			Expect(tier.Status.Conditions).To(HaveLen(1))
+			Expect(tier.Status.Conditions[0].Type).To(Equal("Ready"))
+
+			By("Cleaning up")
+			_, err = c.Tiers().Delete(ctx, "status-test", options.DeleteOptions{})
+			Expect(err).NotTo(HaveOccurred())
 		})
 	})
 })

--- a/manifests/calico-bpf.yaml
+++ b/manifests/calico-bpf.yaml
@@ -1217,6 +1217,8 @@ spec:
           type: object
       served: true
       storage: true
+      subresources:
+        status: {}
 ---
 # Source: calico/templates/kdd-crds.yaml
 apiVersion: apiextensions.k8s.io/v1
@@ -3600,9 +3602,50 @@ spec:
                   rule:
                     "!self.cidr.contains(':') || !has(self.ipipMode) || self.ipipMode
                     == 'Never' || size(self.ipipMode) == 0"
+            status:
+              properties:
+                conditions:
+                  items:
+                    properties:
+                      lastTransitionTime:
+                        format: date-time
+                        type: string
+                      message:
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+              type: object
           type: object
       served: true
       storage: true
+      subresources:
+        status: {}
 ---
 # Source: calico/templates/kdd-crds.yaml
 apiVersion: apiextensions.k8s.io/v1
@@ -5716,6 +5759,45 @@ spec:
                 order:
                   type: number
               type: object
+            status:
+              properties:
+                conditions:
+                  items:
+                    properties:
+                      lastTransitionTime:
+                        format: date-time
+                        type: string
+                      message:
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+              type: object
           required:
             - metadata
             - spec
@@ -5735,6 +5817,8 @@ spec:
                 : true"
       served: true
       storage: true
+      subresources:
+        status: {}
 ---
 # Source: calico/templates/kdd-crds.yaml
 apiVersion: apiextensions.k8s.io/v1

--- a/manifests/calico-policy-only.yaml
+++ b/manifests/calico-policy-only.yaml
@@ -1227,6 +1227,8 @@ spec:
           type: object
       served: true
       storage: true
+      subresources:
+        status: {}
 ---
 # Source: calico/templates/kdd-crds.yaml
 apiVersion: apiextensions.k8s.io/v1
@@ -3610,9 +3612,50 @@ spec:
                   rule:
                     "!self.cidr.contains(':') || !has(self.ipipMode) || self.ipipMode
                     == 'Never' || size(self.ipipMode) == 0"
+            status:
+              properties:
+                conditions:
+                  items:
+                    properties:
+                      lastTransitionTime:
+                        format: date-time
+                        type: string
+                      message:
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+              type: object
           type: object
       served: true
       storage: true
+      subresources:
+        status: {}
 ---
 # Source: calico/templates/kdd-crds.yaml
 apiVersion: apiextensions.k8s.io/v1
@@ -5726,6 +5769,45 @@ spec:
                 order:
                   type: number
               type: object
+            status:
+              properties:
+                conditions:
+                  items:
+                    properties:
+                      lastTransitionTime:
+                        format: date-time
+                        type: string
+                      message:
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+              type: object
           required:
             - metadata
             - spec
@@ -5745,6 +5827,8 @@ spec:
                 : true"
       served: true
       storage: true
+      subresources:
+        status: {}
 ---
 # Source: calico/templates/kdd-crds.yaml
 apiVersion: apiextensions.k8s.io/v1

--- a/manifests/calico-typha.yaml
+++ b/manifests/calico-typha.yaml
@@ -1228,6 +1228,8 @@ spec:
           type: object
       served: true
       storage: true
+      subresources:
+        status: {}
 ---
 # Source: calico/templates/kdd-crds.yaml
 apiVersion: apiextensions.k8s.io/v1
@@ -3611,9 +3613,50 @@ spec:
                   rule:
                     "!self.cidr.contains(':') || !has(self.ipipMode) || self.ipipMode
                     == 'Never' || size(self.ipipMode) == 0"
+            status:
+              properties:
+                conditions:
+                  items:
+                    properties:
+                      lastTransitionTime:
+                        format: date-time
+                        type: string
+                      message:
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+              type: object
           type: object
       served: true
       storage: true
+      subresources:
+        status: {}
 ---
 # Source: calico/templates/kdd-crds.yaml
 apiVersion: apiextensions.k8s.io/v1
@@ -5727,6 +5770,45 @@ spec:
                 order:
                   type: number
               type: object
+            status:
+              properties:
+                conditions:
+                  items:
+                    properties:
+                      lastTransitionTime:
+                        format: date-time
+                        type: string
+                      message:
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+              type: object
           required:
             - metadata
             - spec
@@ -5746,6 +5828,8 @@ spec:
                 : true"
       served: true
       storage: true
+      subresources:
+        status: {}
 ---
 # Source: calico/templates/kdd-crds.yaml
 apiVersion: apiextensions.k8s.io/v1

--- a/manifests/calico-v3-crds.yaml
+++ b/manifests/calico-v3-crds.yaml
@@ -1302,7 +1302,8 @@ spec:
           type: object
       served: true
       storage: true
-      subresources: {}
+      subresources:
+        status: {}
 ---
 # Source: calico/templates/kdd-crds.yaml
 apiVersion: apiextensions.k8s.io/v1

--- a/manifests/calico-vxlan.yaml
+++ b/manifests/calico-vxlan.yaml
@@ -1212,6 +1212,8 @@ spec:
           type: object
       served: true
       storage: true
+      subresources:
+        status: {}
 ---
 # Source: calico/templates/kdd-crds.yaml
 apiVersion: apiextensions.k8s.io/v1
@@ -3595,9 +3597,50 @@ spec:
                   rule:
                     "!self.cidr.contains(':') || !has(self.ipipMode) || self.ipipMode
                     == 'Never' || size(self.ipipMode) == 0"
+            status:
+              properties:
+                conditions:
+                  items:
+                    properties:
+                      lastTransitionTime:
+                        format: date-time
+                        type: string
+                      message:
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+              type: object
           type: object
       served: true
       storage: true
+      subresources:
+        status: {}
 ---
 # Source: calico/templates/kdd-crds.yaml
 apiVersion: apiextensions.k8s.io/v1
@@ -5711,6 +5754,45 @@ spec:
                 order:
                   type: number
               type: object
+            status:
+              properties:
+                conditions:
+                  items:
+                    properties:
+                      lastTransitionTime:
+                        format: date-time
+                        type: string
+                      message:
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+              type: object
           required:
             - metadata
             - spec
@@ -5730,6 +5812,8 @@ spec:
                 : true"
       served: true
       storage: true
+      subresources:
+        status: {}
 ---
 # Source: calico/templates/kdd-crds.yaml
 apiVersion: apiextensions.k8s.io/v1

--- a/manifests/calico.yaml
+++ b/manifests/calico.yaml
@@ -1212,6 +1212,8 @@ spec:
           type: object
       served: true
       storage: true
+      subresources:
+        status: {}
 ---
 # Source: calico/templates/kdd-crds.yaml
 apiVersion: apiextensions.k8s.io/v1
@@ -3595,9 +3597,50 @@ spec:
                   rule:
                     "!self.cidr.contains(':') || !has(self.ipipMode) || self.ipipMode
                     == 'Never' || size(self.ipipMode) == 0"
+            status:
+              properties:
+                conditions:
+                  items:
+                    properties:
+                      lastTransitionTime:
+                        format: date-time
+                        type: string
+                      message:
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+              type: object
           type: object
       served: true
       storage: true
+      subresources:
+        status: {}
 ---
 # Source: calico/templates/kdd-crds.yaml
 apiVersion: apiextensions.k8s.io/v1
@@ -5711,6 +5754,45 @@ spec:
                 order:
                   type: number
               type: object
+            status:
+              properties:
+                conditions:
+                  items:
+                    properties:
+                      lastTransitionTime:
+                        format: date-time
+                        type: string
+                      message:
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+              type: object
           required:
             - metadata
             - spec
@@ -5730,6 +5812,8 @@ spec:
                 : true"
       served: true
       storage: true
+      subresources:
+        status: {}
 ---
 # Source: calico/templates/kdd-crds.yaml
 apiVersion: apiextensions.k8s.io/v1

--- a/manifests/canal.yaml
+++ b/manifests/canal.yaml
@@ -1229,6 +1229,8 @@ spec:
           type: object
       served: true
       storage: true
+      subresources:
+        status: {}
 ---
 # Source: calico/templates/kdd-crds.yaml
 apiVersion: apiextensions.k8s.io/v1
@@ -3612,9 +3614,50 @@ spec:
                   rule:
                     "!self.cidr.contains(':') || !has(self.ipipMode) || self.ipipMode
                     == 'Never' || size(self.ipipMode) == 0"
+            status:
+              properties:
+                conditions:
+                  items:
+                    properties:
+                      lastTransitionTime:
+                        format: date-time
+                        type: string
+                      message:
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+              type: object
           type: object
       served: true
       storage: true
+      subresources:
+        status: {}
 ---
 # Source: calico/templates/kdd-crds.yaml
 apiVersion: apiextensions.k8s.io/v1
@@ -5728,6 +5771,45 @@ spec:
                 order:
                   type: number
               type: object
+            status:
+              properties:
+                conditions:
+                  items:
+                    properties:
+                      lastTransitionTime:
+                        format: date-time
+                        type: string
+                      message:
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+              type: object
           required:
             - metadata
             - spec
@@ -5747,6 +5829,8 @@ spec:
                 : true"
       served: true
       storage: true
+      subresources:
+        status: {}
 ---
 # Source: calico/templates/kdd-crds.yaml
 apiVersion: apiextensions.k8s.io/v1

--- a/manifests/crds.yaml
+++ b/manifests/crds.yaml
@@ -1126,6 +1126,8 @@ spec:
           type: object
       served: true
       storage: true
+      subresources:
+        status: {}
 ---
 # Source: crds/crd.projectcalico.org_clusterinformations.yaml
 apiVersion: apiextensions.k8s.io/v1
@@ -3509,9 +3511,50 @@ spec:
                   rule:
                     "!self.cidr.contains(':') || !has(self.ipipMode) || self.ipipMode
                     == 'Never' || size(self.ipipMode) == 0"
+            status:
+              properties:
+                conditions:
+                  items:
+                    properties:
+                      lastTransitionTime:
+                        format: date-time
+                        type: string
+                      message:
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+              type: object
           type: object
       served: true
       storage: true
+      subresources:
+        status: {}
 ---
 # Source: crds/crd.projectcalico.org_ipreservations.yaml
 apiVersion: apiextensions.k8s.io/v1
@@ -5625,6 +5668,45 @@ spec:
                 order:
                   type: number
               type: object
+            status:
+              properties:
+                conditions:
+                  items:
+                    properties:
+                      lastTransitionTime:
+                        format: date-time
+                        type: string
+                      message:
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+              type: object
           required:
             - metadata
             - spec
@@ -5644,6 +5726,8 @@ spec:
                 : true"
       served: true
       storage: true
+      subresources:
+        status: {}
 ---
 # Source: crds/policy.networking.k8s.io_clusternetworkpolicies.yaml
 apiVersion: apiextensions.k8s.io/v1

--- a/manifests/flannel-migration/calico.yaml
+++ b/manifests/flannel-migration/calico.yaml
@@ -1212,6 +1212,8 @@ spec:
           type: object
       served: true
       storage: true
+      subresources:
+        status: {}
 ---
 # Source: calico/templates/kdd-crds.yaml
 apiVersion: apiextensions.k8s.io/v1
@@ -3595,9 +3597,50 @@ spec:
                   rule:
                     "!self.cidr.contains(':') || !has(self.ipipMode) || self.ipipMode
                     == 'Never' || size(self.ipipMode) == 0"
+            status:
+              properties:
+                conditions:
+                  items:
+                    properties:
+                      lastTransitionTime:
+                        format: date-time
+                        type: string
+                      message:
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+              type: object
           type: object
       served: true
       storage: true
+      subresources:
+        status: {}
 ---
 # Source: calico/templates/kdd-crds.yaml
 apiVersion: apiextensions.k8s.io/v1
@@ -5711,6 +5754,45 @@ spec:
                 order:
                   type: number
               type: object
+            status:
+              properties:
+                conditions:
+                  items:
+                    properties:
+                      lastTransitionTime:
+                        format: date-time
+                        type: string
+                      message:
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+              type: object
           required:
             - metadata
             - spec
@@ -5730,6 +5812,8 @@ spec:
                 : true"
       served: true
       storage: true
+      subresources:
+        status: {}
 ---
 # Source: calico/templates/kdd-crds.yaml
 apiVersion: apiextensions.k8s.io/v1

--- a/manifests/operator-crds.yaml
+++ b/manifests/operator-crds.yaml
@@ -34450,6 +34450,8 @@ spec:
           type: object
       served: true
       storage: true
+      subresources:
+        status: {}
 ---
 # Source: crd.projectcalico.org.v1/templates/calico/crd.projectcalico.org_clusterinformations.yaml
 apiVersion: apiextensions.k8s.io/v1
@@ -36833,9 +36835,50 @@ spec:
                   rule:
                     "!self.cidr.contains(':') || !has(self.ipipMode) || self.ipipMode
                     == 'Never' || size(self.ipipMode) == 0"
+            status:
+              properties:
+                conditions:
+                  items:
+                    properties:
+                      lastTransitionTime:
+                        format: date-time
+                        type: string
+                      message:
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+              type: object
           type: object
       served: true
       storage: true
+      subresources:
+        status: {}
 ---
 # Source: crd.projectcalico.org.v1/templates/calico/crd.projectcalico.org_ipreservations.yaml
 apiVersion: apiextensions.k8s.io/v1
@@ -38949,6 +38992,45 @@ spec:
                 order:
                   type: number
               type: object
+            status:
+              properties:
+                conditions:
+                  items:
+                    properties:
+                      lastTransitionTime:
+                        format: date-time
+                        type: string
+                      message:
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+              type: object
           required:
             - metadata
             - spec
@@ -38968,6 +39050,8 @@ spec:
                 : true"
       served: true
       storage: true
+      subresources:
+        status: {}
 ---
 # Source: crd.projectcalico.org.v1/templates/calico/policy.networking.k8s.io_clusternetworkpolicies.yaml
 apiVersion: apiextensions.k8s.io/v1

--- a/manifests/v1_crd_projectcalico_org.yaml
+++ b/manifests/v1_crd_projectcalico_org.yaml
@@ -34450,6 +34450,8 @@ spec:
           type: object
       served: true
       storage: true
+      subresources:
+        status: {}
 ---
 # Source: crd.projectcalico.org.v1/templates/calico/crd.projectcalico.org_clusterinformations.yaml
 apiVersion: apiextensions.k8s.io/v1
@@ -36833,9 +36835,50 @@ spec:
                   rule:
                     "!self.cidr.contains(':') || !has(self.ipipMode) || self.ipipMode
                     == 'Never' || size(self.ipipMode) == 0"
+            status:
+              properties:
+                conditions:
+                  items:
+                    properties:
+                      lastTransitionTime:
+                        format: date-time
+                        type: string
+                      message:
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+              type: object
           type: object
       served: true
       storage: true
+      subresources:
+        status: {}
 ---
 # Source: crd.projectcalico.org.v1/templates/calico/crd.projectcalico.org_ipreservations.yaml
 apiVersion: apiextensions.k8s.io/v1
@@ -38949,6 +38992,45 @@ spec:
                 order:
                   type: number
               type: object
+            status:
+              properties:
+                conditions:
+                  items:
+                    properties:
+                      lastTransitionTime:
+                        format: date-time
+                        type: string
+                      message:
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+              type: object
           required:
             - metadata
             - spec
@@ -38968,6 +39050,8 @@ spec:
                 : true"
       served: true
       storage: true
+      subresources:
+        status: {}
 ---
 # Source: crd.projectcalico.org.v1/templates/calico/policy.networking.k8s.io_clusternetworkpolicies.yaml
 apiVersion: apiextensions.k8s.io/v1

--- a/manifests/v3_projectcalico_org.yaml
+++ b/manifests/v3_projectcalico_org.yaml
@@ -34707,7 +34707,8 @@ spec:
           type: object
       served: true
       storage: true
-      subresources: {}
+      subresources:
+        status: {}
 ---
 # Source: projectcalico.org.v3/templates/calico/projectcalico.org_clusterinformations.yaml
 apiVersion: apiextensions.k8s.io/v1

--- a/node/pkg/status/nodestatus_test.go
+++ b/node/pkg/status/nodestatus_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Tigera, Inc. All rights reserved.
+// Copyright (c) 2021-2026 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/node/pkg/status/reporter.go
+++ b/node/pkg/status/reporter.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Tigera, Inc. All rights reserved.
+// Copyright (c) 2021-2026 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -223,7 +223,7 @@ func (r *reporter) reportStatus() error {
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
 		status.Status.LastUpdated = metav1.Time{Time: time.Now()}
-		updatedResource, err = r.client.CalicoNodeStatus().Update(ctx, &status, options.SetOptions{})
+		updatedResource, err = r.client.CalicoNodeStatus().UpdateStatus(ctx, &status, options.SetOptions{})
 		if err != nil {
 			if _, ok := err.(cerrors.ErrorResourceUpdateConflict); ok {
 				r.logCtx.Warn("Node status resource update conflict, trying to catch-up with current resource")

--- a/node/tests/k8st/tests/test_node_status.py
+++ b/node/tests/k8st/tests/test_node_status.py
@@ -41,7 +41,10 @@ EOF
 def read_status(name):
     status_json = kubectl("get caliconodestatus %s -o json" % name)
     status_dict = json.loads(status_json)
-    return status_dict['status']
+    status = status_dict.get('status')
+    if not status:
+        raise Exception("status not yet populated for %s" % name)
+    return status
 
 def delete_status(name):
     kubectl("delete caliconodestatus %s" % name)


### PR DESCRIPTION
Cherry-pick of #12352 to release-v3.32, with the CRDs and manifests regenerated on this branch since validation rules have diverged from master.

This PR fixes repeated "unknown field status" warnings logged by kube-controllers every 10 seconds. The tier, IP pool and node status custom resource definitions have no status subresource on this branch, so the API server prunes the status field on every write and warns.

Fixes #13682

```release-note
Fixes repeated "unknown field \"status\"" warnings logged by kube-controllers.
```
