### PR TITLE
lib/kind: add a tag-agnostic repo-level override to the registry facade

### DIFF
--- a/lib/kind/localregistry/override.go
+++ b/lib/kind/localregistry/override.go
@@ -47,10 +47,13 @@ func (f *Registry) Override(ctx context.Context, upstreamRef string, img v1.Imag
 //
 //	mir.OverrideFromDaemon(ctx, "quay.io/calico/node:v3.30.1", "calico/node:latest-amd64")
 func (f *Registry) OverrideFromDaemon(ctx context.Context, upstreamRef, localDockerRef string) error {
-	img, err := loadDaemonImage(ctx, localDockerRef)
+	img, tarPath, err := loadDaemonImage(ctx, localDockerRef)
 	if err != nil {
 		return err
 	}
+	// Override fully consumes img (crane.Push reads every layer) before it
+	// returns, so the lazy tarball is safe to remove right after.
+	defer func() { _ = os.Remove(tarPath) }()
 	return f.Override(ctx, upstreamRef, img)
 }
 
@@ -63,12 +66,16 @@ func (f *Registry) OverrideFromDaemon(ctx context.Context, upstreamRef, localDoc
 // image is materialized into the internal store lazily, under whatever ref the
 // node actually requests (see ensure), so it can be registered before any pull.
 func (f *Registry) OverrideRepoFromDaemon(ctx context.Context, leaf, localDockerRef string) error {
-	img, err := loadDaemonImage(ctx, localDockerRef)
+	img, tarPath, err := loadDaemonImage(ctx, localDockerRef)
 	if err != nil {
 		return err
 	}
+	// The image is served lazily on later pulls (materialized in ensure/pullManifest),
+	// so its tarball must live for the registry's lifetime -- keep it, and Stop
+	// removes it. Removing it here would break the serve with "no such file".
 	f.mu.Lock()
 	f.repoOverrides[leaf] = img
+	f.repoOverrideTars = append(f.repoOverrideTars, tarPath)
 	f.mu.Unlock()
 	f.log.Info("repo override registered", "repoLeaf", leaf, "local", localDockerRef)
 	return nil
@@ -76,25 +83,29 @@ func (f *Registry) OverrideRepoFromDaemon(ctx context.Context, leaf, localDocker
 
 // loadDaemonImage snapshots a local docker image (localDockerRef, a tag as
 // `docker images` shows it) to an OCI tarball via `docker save` and loads it as
-// a v1.Image. Reuses the docker CLI (already a hard dependency of kind).
-func loadDaemonImage(ctx context.Context, localDockerRef string) (v1.Image, error) {
+// a v1.Image. Reuses the docker CLI (already a hard dependency of kind). The
+// returned image is LAZY -- it reads tarPath on demand (when crane.Push consumes
+// it) -- so the caller MUST keep tarPath alive until the image is fully consumed,
+// then remove it. Returns tarPath so the caller controls that lifetime.
+func loadDaemonImage(ctx context.Context, localDockerRef string) (v1.Image, string, error) {
 	tar, err := os.CreateTemp("", "kind-mirror-*.tar")
 	if err != nil {
-		return nil, fmt.Errorf("temp file: %w", err)
+		return nil, "", fmt.Errorf("temp file: %w", err)
 	}
 	// Only the name is wanted; crane.Load reopens it.
 	_ = tar.Close()
-	defer func() { _ = os.Remove(tar.Name()) }()
 
 	out, err := exec.CommandContext(ctx, "docker", "save", "-o", tar.Name(), localDockerRef).CombinedOutput()
 	if err != nil {
-		return nil, fmt.Errorf("docker save %s: %s: %w", localDockerRef, strings.TrimSpace(string(out)), err)
+		_ = os.Remove(tar.Name())
+		return nil, "", fmt.Errorf("docker save %s: %s: %w", localDockerRef, strings.TrimSpace(string(out)), err)
 	}
 	img, err := crane.Load(tar.Name())
 	if err != nil {
-		return nil, fmt.Errorf("load tarball %s: %w", tar.Name(), err)
+		_ = os.Remove(tar.Name())
+		return nil, "", fmt.Errorf("load tarball %s: %w", tar.Name(), err)
 	}
-	return img, nil
+	return img, tar.Name(), nil
 }
 
 // OverrideFromTarball pins an image from a `docker save` / OCI tarball as the

--- a/lib/kind/localregistry/override.go
+++ b/lib/kind/localregistry/override.go
@@ -47,21 +47,54 @@ func (f *Registry) Override(ctx context.Context, upstreamRef string, img v1.Imag
 //
 //	mir.OverrideFromDaemon(ctx, "quay.io/calico/node:v3.30.1", "calico/node:latest-amd64")
 func (f *Registry) OverrideFromDaemon(ctx context.Context, upstreamRef, localDockerRef string) error {
+	img, err := loadDaemonImage(ctx, localDockerRef)
+	if err != nil {
+		return err
+	}
+	return f.Override(ctx, upstreamRef, img)
+}
+
+// OverrideRepoFromDaemon pins a locally-built docker image as the answer for
+// EVERY pull whose repository leaf (the last path segment, e.g. "calico" in
+// "gcr.io/tigera/calico") equals leaf — regardless of registry host or tag.
+// Where Override/OverrideFromDaemon pin one exact ref, this is tag-agnostic:
+// use it when your build should stand in for an image whose exact tag isn't
+// known ahead of time (e.g. an operator picks the version at deploy time). The
+// image is materialized into the internal store lazily, under whatever ref the
+// node actually requests (see ensure), so it can be registered before any pull.
+func (f *Registry) OverrideRepoFromDaemon(ctx context.Context, leaf, localDockerRef string) error {
+	img, err := loadDaemonImage(ctx, localDockerRef)
+	if err != nil {
+		return err
+	}
+	f.mu.Lock()
+	f.repoOverrides[leaf] = img
+	f.mu.Unlock()
+	f.log.Info("repo override registered", "repoLeaf", leaf, "local", localDockerRef)
+	return nil
+}
+
+// loadDaemonImage snapshots a local docker image (localDockerRef, a tag as
+// `docker images` shows it) to an OCI tarball via `docker save` and loads it as
+// a v1.Image. Reuses the docker CLI (already a hard dependency of kind).
+func loadDaemonImage(ctx context.Context, localDockerRef string) (v1.Image, error) {
 	tar, err := os.CreateTemp("", "kind-mirror-*.tar")
 	if err != nil {
-		return fmt.Errorf("temp file: %w", err)
+		return nil, fmt.Errorf("temp file: %w", err)
 	}
-	// Only the name is wanted; the writer below reopens it.
+	// Only the name is wanted; crane.Load reopens it.
 	_ = tar.Close()
 	defer func() { _ = os.Remove(tar.Name()) }()
 
-	// Reuse the docker CLI (already a hard dependency of kind) to snapshot
-	// the daemon image to a tarball crane can read.
 	out, err := exec.CommandContext(ctx, "docker", "save", "-o", tar.Name(), localDockerRef).CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("docker save %s: %s: %w", localDockerRef, strings.TrimSpace(string(out)), err)
+		return nil, fmt.Errorf("docker save %s: %s: %w", localDockerRef, strings.TrimSpace(string(out)), err)
 	}
-	return f.OverrideFromTarball(ctx, upstreamRef, tar.Name())
+	img, err := crane.Load(tar.Name())
+	if err != nil {
+		return nil, fmt.Errorf("load tarball %s: %w", tar.Name(), err)
+	}
+	return img, nil
 }
 
 // OverrideFromTarball pins an image from a `docker save` / OCI tarball as the
@@ -82,6 +115,15 @@ func (f *Registry) OverrideFromTarball(ctx context.Context, upstreamRef, tarPath
 // containerd actually requests.
 func key(registry, repo, ref string) string {
 	return registry + "|" + repo + "|" + ref
+}
+
+// repoLeaf returns the last path segment of an image repository (e.g.
+// "tigera/calico" -> "calico"), the identity a repo-level override matches on.
+func repoLeaf(repo string) string {
+	if i := strings.LastIndex(repo, "/"); i >= 0 {
+		return repo[i+1:]
+	}
+	return repo
 }
 
 // safeNS turns a registry host (the ns value, e.g. "gcr.io" or, in tests,

--- a/lib/kind/localregistry/override.go
+++ b/lib/kind/localregistry/override.go
@@ -64,13 +64,19 @@ func (f *Registry) OverrideFromDaemon(ctx context.Context, upstreamRef, localDoc
 // use it when your build should stand in for an image whose exact tag isn't
 // known ahead of time (e.g. an operator picks the version at deploy time). The
 // image is materialized into the internal store lazily, under whatever ref the
-// node actually requests (see ensure), so it can be registered before any pull.
+// node actually requests (see pullManifest), so it can be registered before any
+// pull. leaf must be a single, non-empty path segment (it's matched against a
+// repository's last segment); a multi-segment value like "tigera/calico" would
+// silently never match, so it's rejected.
 func (f *Registry) OverrideRepoFromDaemon(ctx context.Context, leaf, localDockerRef string) error {
+	if leaf == "" || strings.Contains(leaf, "/") {
+		return fmt.Errorf("repo override leaf %q must be a single non-empty path segment (e.g. \"calico\", not \"tigera/calico\")", leaf)
+	}
 	img, tarPath, err := loadDaemonImage(ctx, localDockerRef)
 	if err != nil {
 		return err
 	}
-	// The image is served lazily on later pulls (materialized in ensure/pullManifest),
+	// The image is served lazily on later pulls (materialized in pullManifest),
 	// so its tarball must live for the registry's lifetime -- keep it, and Stop
 	// removes it. Removing it here would break the serve with "no such file".
 	f.mu.Lock()

--- a/lib/kind/localregistry/registry.go
+++ b/lib/kind/localregistry/registry.go
@@ -130,6 +130,10 @@ type Registry struct {
 	// to a local image served for EVERY ns/tag of that repo — a tag-agnostic
 	// override (see OverrideRepoFromDaemon), applied lazily in pullManifest.
 	repoOverrides map[string]v1.Image
+	// repoOverrideTars are the `docker save` tarballs backing the lazy images in
+	// repoOverrides; they must outlive registration (the images read them on each
+	// serve) and are removed on Stop.
+	repoOverrideTars []string
 }
 
 // detachContext returns a context whose values are inherited from parent
@@ -528,6 +532,14 @@ func (f *Registry) Stop() error {
 			firstErr = err
 		}
 	}
+	// Remove the docker-save tarballs backing any repo overrides (kept alive for
+	// the registry's lifetime so lazy serves could read them).
+	f.mu.Lock()
+	for _, p := range f.repoOverrideTars {
+		_ = os.Remove(p)
+	}
+	f.repoOverrideTars = nil
+	f.mu.Unlock()
 	return firstErr
 }
 

--- a/lib/kind/localregistry/registry.go
+++ b/lib/kind/localregistry/registry.go
@@ -331,10 +331,25 @@ func (f *Registry) pullManifest(ctx context.Context, ns, repo, ref, k string) er
 	}
 	f.mu.Unlock()
 
-	// A tag-agnostic repo override wins over the upstream for every tag of that
-	// repo: materialize the local image under the exact ref the node asked for.
-	// This is what lets a build be swapped in for an image whose tag isn't known
-	// ahead of time (e.g. an operator picks the version at deploy time).
+	// The in-memory map is only a fast path. The authoritative "do I already
+	// have this?" is the internal store itself — which also covers manifests
+	// put there out-of-band: a shell override pushed with `docker push`/crane,
+	// or content from a previous process. If it's there, serve it and do NOT
+	// pull through, so an override is never clobbered by the upstream (this is
+	// what makes a pushed override stick, even under imagePullPolicy: Always).
+	if f.manifestExistsInternal(ctx, ns, repo, ref) {
+		f.mu.Lock()
+		f.cached[k] = true
+		f.mu.Unlock()
+		return nil
+	}
+
+	// A tag-agnostic repo override stands in for the upstream for every tag of a
+	// matching repo: materialize the local image under the exact ref the node
+	// asked for. Checked AFTER the internal store so an explicit or shell-pushed
+	// override (or content from a previous process) still wins — this only
+	// replaces the upstream pull-through below. Lets a build be swapped in for an
+	// image whose tag isn't known ahead of time (an operator picks it at deploy).
 	f.mu.Lock()
 	override := f.repoOverrides[repoLeaf(repo)]
 	f.mu.Unlock()
@@ -347,19 +362,6 @@ func (f *Registry) pullManifest(ctx context.Context, ns, repo, ref, k string) er
 		f.cached[k] = true
 		f.mu.Unlock()
 		f.log.Info("repo override", "upstream", joinRef("", ns, repo, ref), "internal", internal)
-		return nil
-	}
-
-	// The in-memory map is only a fast path. The authoritative "do I already
-	// have this?" is the internal store itself — which also covers manifests
-	// put there out-of-band: a shell override pushed with `docker push`/crane,
-	// or content from a previous process. If it's there, serve it and do NOT
-	// pull through, so an override is never clobbered by the upstream (this is
-	// what makes a pushed override stick, even under imagePullPolicy: Always).
-	if f.manifestExistsInternal(ctx, ns, repo, ref) {
-		f.mu.Lock()
-		f.cached[k] = true
-		f.mu.Unlock()
 		return nil
 	}
 

--- a/lib/kind/localregistry/registry.go
+++ b/lib/kind/localregistry/registry.go
@@ -57,6 +57,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/crane"
 	"github.com/google/go-containerregistry/pkg/name"
 	ggcrregistry "github.com/google/go-containerregistry/pkg/registry"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/google/go-containerregistry/pkg/v1/types"
 	"golang.org/x/sync/singleflight"
@@ -124,6 +125,11 @@ type Registry struct {
 	// nodes and pods, and without dedup each one would spawn its own
 	// full pull-through.
 	sf singleflight.Group
+
+	// repoOverrides maps a repository leaf (last path segment, e.g. "calico")
+	// to a local image served for EVERY ns/tag of that repo — a tag-agnostic
+	// override (see OverrideRepoFromDaemon), applied lazily in pullManifest.
+	repoOverrides map[string]v1.Image
 }
 
 // detachContext returns a context whose values are inherited from parent
@@ -165,10 +171,11 @@ func Start(ctx context.Context, cfg Config) (*Registry, error) {
 	}
 
 	f := &Registry{
-		cfg:      cfg,
-		log:      log.With("component", "kind-mirror"),
-		keychain: keychain,
-		cached:   map[string]bool{},
+		cfg:           cfg,
+		log:           log.With("component", "kind-mirror"),
+		keychain:      keychain,
+		cached:        map[string]bool{},
+		repoOverrides: map[string]v1.Image{},
 	}
 
 	// Internal store: disk-backed blobs (persist across runs), in-memory
@@ -319,6 +326,25 @@ func (f *Registry) pullManifest(ctx context.Context, ns, repo, ref, k string) er
 		return nil
 	}
 	f.mu.Unlock()
+
+	// A tag-agnostic repo override wins over the upstream for every tag of that
+	// repo: materialize the local image under the exact ref the node asked for.
+	// This is what lets a build be swapped in for an image whose tag isn't known
+	// ahead of time (e.g. an operator picks the version at deploy time).
+	f.mu.Lock()
+	override := f.repoOverrides[repoLeaf(repo)]
+	f.mu.Unlock()
+	if override != nil {
+		internal := joinRef(f.internalHost, safeNS(ns), repo, ref)
+		if err := crane.Push(override, internal, f.pushOpts(ctx)...); err != nil {
+			return fmt.Errorf("store repo override %s: %w", internal, err)
+		}
+		f.mu.Lock()
+		f.cached[k] = true
+		f.mu.Unlock()
+		f.log.Info("repo override", "upstream", joinRef("", ns, repo, ref), "internal", internal)
+		return nil
+	}
 
 	// The in-memory map is only a fast path. The authoritative "do I already
 	// have this?" is the internal store itself — which also covers manifests

--- a/lib/kind/localregistry/registry_test.go
+++ b/lib/kind/localregistry/registry_test.go
@@ -140,6 +140,44 @@ func TestOverrideBeatsUpstream(t *testing.T) {
 	}
 }
 
+// TestRepoOverrideServesEveryTag proves a tag-agnostic repo override (the
+// pre-load path, registered before any specific tag is known) is served for
+// EVERY tag of a matching repository — including a tag never pushed upstream —
+// and that it does not leak to a non-matching repo leaf. The override is set
+// directly here; OverrideRepoFromDaemon's only extra step is `docker save`,
+// which a unit test can't exercise hermetically.
+func TestRepoOverrideServesEveryTag(t *testing.T) {
+	host, srv := startUpstream(t)
+	pushRandom(t, host, "tigera/calico:v1")            // a real upstream tag
+	otherImg := pushRandom(t, host, "tigera/other:v1") // an unrelated repo
+
+	override, err := random.Image(4096, 2) // distinct content
+	if err != nil {
+		t.Fatalf("random.Image: %v", err)
+	}
+
+	f := startRegistry(t)
+	f.mu.Lock()
+	f.repoOverrides["calico"] = override
+	f.mu.Unlock()
+
+	// A non-matching repo leaf still comes from upstream — the override must not
+	// leak to it.
+	if got, want := manifestDigestVia(t, f.Addr(), host, "tigera/other", "v1"), mustDigest(t, otherImg); got != want {
+		t.Errorf("tigera/other served %s, want upstream %s (override leaked to a non-matching repo)", got, want)
+	}
+
+	// Kill the upstream: the override must be served without contacting it, for
+	// both an upstream-known tag and a tag that was never pushed.
+	srv.Close()
+	want := mustDigest(t, override)
+	for _, ref := range []string{"v1", "v999-never-pushed"} {
+		if got := manifestDigestVia(t, f.Addr(), host, "tigera/calico", ref); got != want {
+			t.Errorf("tigera/calico:%s served %s, want override %s", ref, got, want)
+		}
+	}
+}
+
 // TestShellPushOverride proves the no-code override path: pushing an image to
 // the facade under the upstream host as the first path segment — exactly what
 //

--- a/lib/kind/localregistry/registry_test.go
+++ b/lib/kind/localregistry/registry_test.go
@@ -178,6 +178,59 @@ func TestRepoOverrideServesEveryTag(t *testing.T) {
 	}
 }
 
+// TestRepoOverrideYieldsToExistingContent proves a tag-agnostic repo override
+// does NOT clobber content already in the internal store (an explicit or
+// shell-pushed override, or content from a previous process) -- that would break
+// the "an existing override beats upstream" contract. The repo override only
+// stands in for the upstream pull-through, so it applies to tags the store
+// doesn't already answer.
+func TestRepoOverrideYieldsToExistingContent(t *testing.T) {
+	f := startRegistry(t)
+
+	// A shell-pushed exact override for one tag of a matching-leaf repo.
+	shellImg, err := random.Image(2048, 3)
+	if err != nil {
+		t.Fatalf("random.Image: %v", err)
+	}
+	_, port, err := net.SplitHostPort(f.Addr())
+	if err != nil {
+		t.Fatalf("split addr: %v", err)
+	}
+	if err := crane.Push(shellImg, "127.0.0.1:"+port+"/example.com/team/calico:v1", crane.Insecure); err != nil {
+		t.Fatalf("shell push: %v", err)
+	}
+
+	// A repo override for the same leaf ("calico"), with distinct content.
+	repoImg, err := random.Image(4096, 2)
+	if err != nil {
+		t.Fatalf("random.Image: %v", err)
+	}
+	f.mu.Lock()
+	f.repoOverrides["calico"] = repoImg
+	f.mu.Unlock()
+
+	// The shell-pushed tag serves the shell push, not the repo override.
+	if got, want := manifestDigestVia(t, f.Addr(), "example.com", "team/calico", "v1"), mustDigest(t, shellImg); got != want {
+		t.Errorf("v1 served %s, want shell push %s (repo override clobbered existing content)", got, want)
+	}
+	// A different, never-pushed tag of the same repo still gets the repo override.
+	if got, want := manifestDigestVia(t, f.Addr(), "example.com", "team/calico", "v2-new"), mustDigest(t, repoImg); got != want {
+		t.Errorf("v2-new served %s, want repo override %s", got, want)
+	}
+}
+
+// TestOverrideRepoFromDaemonRejectsBadLeaf guards the leaf contract: a
+// multi-segment or empty leaf is rejected up front (it would silently never
+// match a repository's last segment), before any docker save.
+func TestOverrideRepoFromDaemonRejectsBadLeaf(t *testing.T) {
+	f := startRegistry(t)
+	for _, leaf := range []string{"", "tigera/calico"} {
+		if err := f.OverrideRepoFromDaemon(context.Background(), leaf, "irrelevant:latest"); err == nil {
+			t.Errorf("OverrideRepoFromDaemon(leaf=%q) = nil, want error", leaf)
+		}
+	}
+}
+
 // TestShellPushOverride proves the no-code override path: pushing an image to
 // the facade under the upstream host as the first path segment — exactly what
 //


### PR DESCRIPTION
`OverrideFromDaemon` pins one exact upstream ref to a local build. Some callers need to swap a local build in for an image whose exact tag isn't known ahead of time — e.g. an operator picks the version at deploy time, and the target workload doesn't exist yet to read the tag from.

### Tag-agnostic repo override

`OverrideRepoFromDaemon(leaf, localDockerRef)` serves the local image for **every** pull whose repository leaf (last path segment) equals `leaf`, regardless of registry host or tag. The override is materialized lazily in `pullManifest` under whatever ref the node actually requests, so it can be registered *before any pull* — pre-loaded onto a cluster whose workloads come up later. A repo override wins over pull-through for its leaf; the existing exact-ref overrides (`Override` / `OverrideFromDaemon`) are unchanged.

### Daemon-tarball lifetime fix

`crane.Load` returns a **lazy** `v1.Image` that reads the `docker save` tarball on demand — at `crane.Push` (serve) time — so removing the tarball right after loading broke any override that was actually served (`open …kind-mirror-*.tar: no such file or directory`). It only bit an override that a node actually pulled: an exact `OverrideFromDaemon`, or a repo override once a matching image was requested.

`loadDaemonImage` now returns the tarball path and never removes it itself: `OverrideFromDaemon` removes it after `Override` (which fully consumes the image via `crane.Push`) returns; `OverrideRepoFromDaemon` keeps it for the registry's lifetime (the image is served lazily on later pulls) and `Stop` removes the tracked tarballs.

### Testing

`go test ./lib/kind/localregistry/` — `TestRepoOverrideServesEveryTag` covers the tag-agnostic serve (including a tag never pushed upstream) and non-leak to a non-matching repo leaf. The tarball-lifetime fix was found and verified against a live kind cluster serving a locally-built image for an operator-deployed unified ref.

**Release note:**
```release-note
NONE
```

**AI assistance:** Written and tested with Claude Code (Anthropic).
