### PR TITLE
ci: stop polling for PR approvals

### DIFF
--- a/.github/workflows/ci-notify.yml
+++ b/.github/workflows/ci-notify.yml
@@ -1,6 +1,15 @@
-# DMs a PR author on Slack when their PR's Semaphore CI finishes, and when
-# someone approves their PR. CI is event-driven off `status`; approvals are
-# polled — see the `schedule` trigger for why they cannot be event-driven.
+# DMs a PR author on Slack when their PR's Semaphore CI finishes. The DM is
+# event-driven off `status`.
+#
+# An approval DM exists too, but only on the manual `workflow_dispatch` path.
+# It cannot be driven by `pull_request_review`: that event is
+# pull-request-scoped, so a fork PR's run gets neither secrets nor variables
+# (measured: "Secret source: None"), and this repo holds any PR-scoped run
+# whose author or triggering actor is not a member for maintainer approval —
+# Copilot reviews nearly every PR, so every review left a held "approve this
+# workflow" run on other contributors' PRs. A repository-level schedule can
+# reach the secrets, but polling hourly for approvals is not worth the cron
+# quota it spends.
 #
 # Opt-in is a repo *variable* (not a secret — Slack member IDs aren't
 # sensitive): CI_NOTIFY_MAP, a comma-separated list of
@@ -22,28 +31,6 @@ name: PR Slack notify
 
 on:
   status: {}
-  # Approval path. Polled, not event-driven, because reacting to
-  # pull_request_review costs everyone else something:
-  #
-  #   * That event is pull-request-scoped — GitHub runs the workflow file from
-  #     refs/pull/N/merge, so a fork PR's run gets neither secrets nor
-  #     variables (measured: "Secret source: None"). Delivery from the event
-  #     itself is impossible, which forced a workflow_run cascade.
-  #   * Worse, this repo requires maintainer approval for any PR-scoped run
-  #     whose PR author or triggering actor is not a member. Copilot reviews
-  #     nearly every PR and is not a member, so every review left a held
-  #     "approve this workflow" run — on other contributors' PRs too, for a
-  #     DM that only serves the opted-in authors.
-  #
-  # A schedule is repository-level: nothing to approve, and it still gets the
-  # secrets and the working `contents: write` the dedup marker needs. Cost is
-  # latency: a cycle, plus GitHub's own delay in starting scheduled runs, which
-  # on this repo measures 31-46 minutes (sampled from sync-generated-files.yml,
-  # whose hourly cron starts at :31 to :46). A finer cron buys nothing against
-  # a delay that size — GitHub drops schedule slots it cannot start — so this
-  # is hourly, and an approval DM should be expected within roughly two hours.
-  schedule:
-    - cron: "0 * * * *"
   # Manual test path: simulate a finished-CI status (or an approval) for a
   # given PR, so the full chain (resolve -> opt-in lookup -> DM) can be
   # exercised on demand without waiting for real CI. Dispatchable only once
@@ -71,8 +58,6 @@ on:
 # duplicate-event burst (minutes), so each run opportunistically prunes
 # markers whose date prefix is more than 2 days old — see "Prune stale dedup
 # markers" — keeping refs/ci-notify/* bounded.
-# The approval poll claims markers in the same namespace, keyed by review id
-# rather than commit, so the same prune covers both.
 
 permissions:
   pull-requests: read
@@ -88,8 +73,8 @@ jobs:
   notify:
     # Fire once when the aggregate Semaphore status reaches a terminal
     # state. Skip 'pending' — that's CI starting/running, not finishing.
-    # Approvals arrive as a workflow_dispatch from the poll job below, which
-    # is also the manual test path (state comes from the input either way).
+    # Approvals arrive only as a manual workflow_dispatch (state comes from
+    # the input either way).
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (github.event.context == 'ci/semaphoreci/pr: Calico' &&
@@ -109,7 +94,7 @@ jobs:
       STATE: ${{ github.event.state || inputs.state }}
       # Status events only — the commit to resolve a PR from, and the commit
       # the dedup marker is named after. Empty on a dispatch, which takes the
-      # PR number from its input and whose marker (if any) the poll claimed.
+      # PR number from its input and claims no marker.
       SHA: ${{ github.event.sha }}
     steps:
       - name: Skip if not configured
@@ -198,10 +183,9 @@ jobs:
             echo "slack_id=$SLACK_ID" >> "$GITHUB_OUTPUT"
           fi
 
-      # Naming only — whether this approval deserves a DM was settled before
-      # the dispatch (by the poll job, or by whoever ran it by hand, which
-      # takes write access). An empty result just means the DM will not name
-      # anyone, so nothing here fails the job.
+      # Naming only — whether this approval deserves a DM was settled by
+      # whoever ran the dispatch, which takes write access. An empty result
+      # just means the DM will not name anyone, so nothing here fails the job.
       - name: Name the approving reviewer
         id: reviewer
         if: >-
@@ -230,8 +214,7 @@ jobs:
       # no concurrency group or serialization required. A non-"already
       # exists" failure fails OPEN (proceeds to send) rather than silently
       # swallowing a real notification on an API hiccup. Status events only:
-      # a dispatched approval was already deduped by the poll job, keyed on
-      # review id, and a manual dispatch is meant to send unconditionally.
+      # a manual dispatch is meant to send unconditionally.
       - name: Claim dedup marker (atomic)
         id: claim
         if: steps.gate.outputs.skip != 'true' && steps.resolve.outputs.skip != 'true' && steps.lookup.outputs.skip != 'true' && github.event_name == 'status'
@@ -460,98 +443,3 @@ jobs:
                   || echo "::notice::could not prune $REF"
               fi
             done
-
-  # Approval poll. Decides *whether* an approval deserves a DM; delivery stays
-  # in the notify job above, reached by workflow_dispatch, so there is exactly
-  # one Slack implementation. workflow_dispatch is one of only two events the
-  # repository's GITHUB_TOKEN may still trigger, so this needs no PAT.
-  poll:
-    if: github.event_name == 'schedule'
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    permissions:
-      pull-requests: read
-      # git ref create (the dedup marker, keyed on review id).
-      contents: write
-      # workflow_dispatch of the notify job.
-      actions: write
-    env:
-      GH_TOKEN: ${{ github.token }}
-      REPO: ${{ github.repository }}
-      CI_NOTIFY_MAP: ${{ vars.CI_NOTIFY_MAP }}
-    steps:
-      - name: DM authors whose PRs gained an approval
-        run: |
-          if [[ -z "$CI_NOTIFY_MAP" ]]; then
-            echo "::notice::CI_NOTIFY_MAP variable missing — nothing to poll for"
-            exit 0
-          fi
-          # Query per opted-in author rather than sweeping every open PR: an
-          # approval on anyone else's PR has no DM to send. Same parsing as the
-          # Slack-ID lookup above, keeping only the login half.
-          LOGINS=$(printf '%s' "$CI_NOTIFY_MAP" \
-            | tr ',' '\n' \
-            | awk -F: '{gsub(/[[:space:]]/, "")} $1 != "" {print $1}')
-
-          # Ignore approvals older than this. Without it, deploying this
-          # workflow — or recovering from an outage — would DM about every
-          # already-approved open PR at once.
-          # It has to comfortably exceed one cycle plus GitHub's start delay
-          # plus a dropped slot, or an approval ages out before any poll sees
-          # it and its DM is lost silently: hourly cron + up to ~46 minutes of
-          # delay puts two consecutive polls as much as ~2h45m apart, so 2
-          # hours (the value while the cron was */15) would now drop DMs.
-          CUTOFF=$(date -u -d '6 hours ago' +%Y-%m-%dT%H:%M:%SZ)
-
-          for LOGIN in $LOGINS; do
-            # review:approved is GitHub's own review-decision filter, so this
-            # returns only PRs that currently carry an approval.
-            # --paginate is safe with this filter: it applies --jq per page,
-            # and one number per line concatenates into the list we want.
-            # An index-into-array filter would not — see the reviews call below.
-            PRS=$(gh api "search/issues?q=repo:$REPO+is:pr+is:open+review:approved+author:$LOGIN&per_page=100" \
-                    --paginate --jq '.items[].number' 2>/dev/null) || true
-            for PR in $PRS; do
-              # The approval that matters is the most recent one from someone
-              # with write access; author_association comes from the same call.
-              # Flat filter + tail -n1, because --paginate applies --jq per
-              # page and an index-into-array filter would emit one row per page.
-              ROW=$(gh api "repos/$REPO/pulls/$PR/reviews?per_page=100" --paginate \
-                --jq '.[] | select(.state == "APPROVED" and (.author_association
-                        | IN("OWNER","MEMBER","COLLABORATOR")))
-                      | "\(.id) \(.user.login) \(.submitted_at)"' 2>/dev/null | tail -n1) || true
-              [[ -z "$ROW" ]] && continue
-              read -r RID RLOGIN RAT <<<"$ROW"
-              # ISO-8601 UTC sorts lexicographically, so '<' compares times.
-              [[ "$RAT" < "$CUTOFF" ]] && continue
-
-              # Claim per review id, not per PR: a second reviewer's approval
-              # is a new event worth a DM, while re-polling the same one is not.
-              REF="refs/ci-notify/$(date -u +%Y%m%d)-review-$RID"
-              set +e
-              ERR=$(gh api "repos/$REPO/git/refs" --method POST \
-                -f ref="$REF" -f sha="$GITHUB_SHA" 2>&1 >/dev/null)
-              RC=$?
-              set -e
-              if [[ $RC -ne 0 ]]; then
-                if [[ "$ERR" != *"Reference already exists"* ]]; then
-                  # Fail CLOSED, unlike the status path: an unclaimed marker
-                  # means the next cycle retries, whereas sending now could
-                  # repeat the DM every 15 minutes forever.
-                  echo "::warning::could not claim $REF ($ERR) — will retry next cycle"
-                fi
-                continue
-              fi
-
-              echo "PR #$PR approved by $RLOGIN (review $RID) — dispatching notify"
-              if ! gh workflow run ci-notify.yml -f pr_number="$PR" -f state=approved; then
-                # Release the claim, or a transient dispatch failure would
-                # suppress this approval's DM for good: every later cycle would
-                # find the marker and skip. Same reasoning as "Release dedup
-                # marker if send failed" in the notify job.
-                echo "::warning::dispatch failed for PR #$PR — releasing $REF so the next cycle retries"
-                gh api "repos/$REPO/git/$REF" --method DELETE >/dev/null 2>&1 \
-                  || echo "::notice::could not release $REF — this approval will not be retried"
-              fi
-            done
-          done


### PR DESCRIPTION
`ci-notify.yml` DMs a PR author on Slack when their Semaphore CI finishes, and when someone approves their PR. The approval half was driven by an hourly `schedule` that searched for fresh approvals and handed off to the notify job by `workflow_dispatch`. It was polled rather than event-driven because `pull_request_review` is pull-request-scoped: a fork PR's run gets neither secrets nor variables, and this repo holds any PR-scoped run whose author or triggering actor is not a member for maintainer approval.

That poll is not worth its cron quota. It spends a scheduled run every hour on a DM that only serves the logins listed in the `CI_NOTIFY_MAP` repo variable, and the poll -> dispatch -> DM hop was never observed to fire on a genuinely new approval.

This drops the `schedule` trigger and the `poll` job, and updates the comments that described the file as having a polled approval path.

Unaffected:

- The **CI-finished DM**, which is event-driven off `status` and is the part that works.
- The **approval DM itself**, still reachable through the existing `workflow_dispatch` input (`state: approved`). Re-enabling later means restoring a trigger, not rewriting the notifier.
- The dedup / prune machinery, which the notify job still owns.

Validated with `actionlint` (clean) and `make yaml-lint` (clean).

**Release note:**
```release-note
TBD
```

**AI assistance:** Claude Code wrote the edit and the description; I reviewed both.

By opening this PR you take responsibility for every line in it, and you agree to explain the change yourself during review rather than routing review comments back through an agent. See [AI_POLICY.md](../AI_POLICY.md).
