### PR TITLE
[v3.33] Stop running the KubeVirt e2e tests on clusters without KubeVirt

### DIFF
--- a/e2e/pkg/tests/kubevirt/labels_test.go
+++ b/e2e/pkg/tests/kubevirt/labels_test.go
@@ -1,0 +1,78 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubevirt
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Lanes whose clusters have no KubeVirt exclude these suites by the Feature
+// label, so a suite filed under another feature runs everywhere and fails.
+func TestEveryKubeVirtSuiteDeclaresTheKubeVirtFeature(t *testing.T) {
+	fset := token.NewFileSet()
+	paths, err := filepath.Glob("*.go")
+	if err != nil {
+		t.Fatalf("listing the KubeVirt suites: %v", err)
+	}
+	var checked int
+	for _, path := range paths {
+		if strings.HasSuffix(path, "_test.go") {
+			continue
+		}
+		f, err := parser.ParseFile(fset, path, nil, 0)
+		if err != nil {
+			t.Fatalf("parsing %s: %v", path, err)
+		}
+		ast.Inspect(f, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok || !isDescribeCall(call, "CalicoDescribe") {
+				return true
+			}
+			checked++
+			for _, arg := range call.Args {
+				inner, ok := arg.(*ast.CallExpr)
+				if !ok || !isDescribeCall(inner, "WithFeature") {
+					continue
+				}
+				if len(inner.Args) == 0 {
+					continue
+				}
+				if lit, ok := inner.Args[0].(*ast.BasicLit); ok && lit.Value == `"KubeVirt"` {
+					return true
+				}
+			}
+			t.Errorf("%s: suite is not labelled with the KubeVirt feature", fset.Position(call.Pos()))
+			return true
+		})
+	}
+	if checked == 0 {
+		t.Fatal("found no KubeVirt suites, so this guard checks nothing")
+	}
+}
+
+// isDescribeCall reports whether the call is describe.<name>(...).
+func isDescribeCall(call *ast.CallExpr, name string) bool {
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok {
+		return false
+	}
+	pkg, ok := sel.X.(*ast.Ident)
+	return ok && pkg.Name == "describe" && sel.Sel.Name == name
+}

--- a/e2e/pkg/tests/kubevirt/live_migration_mockvirt.go
+++ b/e2e/pkg/tests/kubevirt/live_migration_mockvirt.go
@@ -26,6 +26,7 @@ import (
 	"github.com/sirupsen/logrus"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/test/e2e/framework"
 	kubevirtv1 "kubevirt.io/api/core/v1"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -55,7 +56,7 @@ var _ = describe.CalicoDescribe(
 
 		BeforeEach(func() {
 			if !isMockVirtDeployed(f) {
-				Fail("KubeVirt-MockVirt tests selected but cluster does not have MockVirt deployed")
+				framework.Failf("MockVirt is not deployed in this cluster, so the lane should exclude the RequiresMockVirt label")
 			}
 			// Double migration needs 3 workers: source, first target, second target.
 			utils.RequireNodeCount(f, 3)

--- a/e2e/pkg/tests/kubevirt/utils.go
+++ b/e2e/pkg/tests/kubevirt/utils.go
@@ -31,6 +31,7 @@ import (
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -831,24 +832,39 @@ func pickThirdWorkerNode(ctx context.Context, f *framework.Framework, node1, nod
 	return ""
 }
 
-// isMockVirtDeployed returns true if the cluster is running MockVirt (simulated
-// KubeVirt). Detection checks the KubeVirt CR's simulationMode field, which the
-// MockVirt deploy script patches to true.
+var kubeVirtResource = schema.GroupVersionResource{
+	Group:    "kubevirt.io",
+	Version:  "v1",
+	Resource: "kubevirts",
+}
+
+// isMockVirtDeployed reports whether the cluster runs MockVirt, which the deploy
+// script marks by patching simulationMode on the KubeVirt CR.
 func isMockVirtDeployed(f *framework.Framework) bool {
 	GinkgoHelper()
 	dynClient, err := dynamic.NewForConfig(f.ClientConfig())
 	Expect(err).NotTo(HaveOccurred(), "failed to create dynamic client")
-	kvResource := schema.GroupVersionResource{
-		Group:    "kubevirt.io",
-		Version:  "v1",
-		Resource: "kubevirts",
+	deployed, err := mockVirtDeployed(dynClient)
+	Expect(err).NotTo(HaveOccurred(), "failed to read KubeVirt CR kubevirt/kubevirt")
+	return deployed
+}
+
+// mockVirtDeployed reads simulationMode from the KubeVirt CR. A missing CR, or no
+// KubeVirt CRD at all, reports false rather than an error.
+func mockVirtDeployed(dynClient dynamic.Interface) (bool, error) {
+	obj, err := dynClient.Resource(kubeVirtResource).Namespace("kubevirt").Get(context.Background(), "kubevirt", metav1.GetOptions{})
+	if apierrors.IsNotFound(err) || meta.IsNoMatchError(err) {
+		return false, nil
 	}
-	obj, err := dynClient.Resource(kvResource).Namespace("kubevirt").Get(context.Background(), "kubevirt", metav1.GetOptions{})
-	Expect(err).NotTo(HaveOccurred(), "failed to get KubeVirt CR kubevirt/kubevirt")
+	if err != nil {
+		return false, err
+	}
 	simMode, found, err := unstructured.NestedBool(obj.Object,
 		"spec", "configuration", "developerConfiguration", "simulationMode")
-	Expect(err).NotTo(HaveOccurred(), "failed to read simulationMode from KubeVirt CR")
-	return found && simMode
+	if err != nil {
+		return false, err
+	}
+	return found && simMode, nil
 }
 
 // setupMockVirtEBGPPeering configures eBGP peering between a BIRD container on

--- a/e2e/pkg/tests/kubevirt/utils_test.go
+++ b/e2e/pkg/tests/kubevirt/utils_test.go
@@ -1,0 +1,110 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubevirt
+
+import (
+	"errors"
+	"testing"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+func TestMockVirtDeployed(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		client   dynamic.Interface
+		expected bool
+	}{
+		{
+			name:     "no KubeVirt CRD",
+			client:   clientWithNoKubeVirtCRD(),
+			expected: false,
+		},
+		{
+			name:     "no KubeVirt CR",
+			client:   fakeKubeVirtClient(),
+			expected: false,
+		},
+		{
+			name:     "real KubeVirt",
+			client:   fakeKubeVirtClient(kubeVirtCR(map[string]any{})),
+			expected: false,
+		},
+		{
+			name:     "simulation mode off",
+			client:   fakeKubeVirtClient(kubeVirtCR(map[string]any{"simulationMode": false})),
+			expected: false,
+		},
+		{
+			name:     "MockVirt",
+			client:   fakeKubeVirtClient(kubeVirtCR(map[string]any{"simulationMode": true})),
+			expected: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			deployed, err := mockVirtDeployed(tc.client)
+			if err != nil {
+				t.Fatalf("mockVirtDeployed: %v", err)
+			}
+			if deployed != tc.expected {
+				t.Errorf("mockVirtDeployed = %v, want %v", deployed, tc.expected)
+			}
+		})
+	}
+}
+
+func TestMockVirtDeployedReportsOtherErrors(t *testing.T) {
+	client := fakeKubeVirtClient()
+	client.PrependReactor("get", "kubevirts", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewForbidden(kubeVirtResource.GroupResource(), "kubevirt", errors.New("nope"))
+	})
+	if _, err := mockVirtDeployed(client); err == nil {
+		t.Error("mockVirtDeployed swallowed a Forbidden error from the API server")
+	}
+}
+
+func fakeKubeVirtClient(objs ...runtime.Object) *dynamicfake.FakeDynamicClient {
+	listKinds := map[schema.GroupVersionResource]string{kubeVirtResource: "KubeVirtList"}
+	return dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), listKinds, objs...)
+}
+
+// A cluster with no KubeVirt at all has no kubevirts resource to serve, which the
+// API machinery reports as a no-kind-match rather than a NotFound.
+func clientWithNoKubeVirtCRD() dynamic.Interface {
+	client := fakeKubeVirtClient()
+	client.PrependReactor("get", "kubevirts", func(k8stesting.Action) (bool, runtime.Object, error) {
+		gk := schema.GroupKind{Group: kubeVirtResource.Group, Kind: "KubeVirt"}
+		return true, nil, &meta.NoKindMatchError{GroupKind: gk, SearchedVersions: []string{kubeVirtResource.Version}}
+	})
+	return client
+}
+
+func kubeVirtCR(developerConfiguration map[string]any) *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{}
+	obj.SetGroupVersionKind(kubeVirtResource.GroupVersion().WithKind("KubeVirt"))
+	obj.SetNamespace("kubevirt")
+	obj.SetName("kubevirt")
+	if err := unstructured.SetNestedMap(obj.Object, developerConfiguration, "spec", "configuration", "developerConfiguration"); err != nil {
+		panic(err)
+	}
+	return obj
+}


### PR DESCRIPTION
Cherry-pick of https://github.com/projectcalico/calico/pull/13587 to release-v3.33.

The KubeVirt specs run on lanes with no KubeVirt installed, where they fail instead of skipping. This checks for the KubeVirt CR up front and skips when it is absent.

```release-note
None
```