### PR TITLE
[v3.33] Stop running the external node e2e tests on clusters with no external node

### DIFF
--- a/e2e/pkg/tests/hostendpoints/hostendpoints.go
+++ b/e2e/pkg/tests/hostendpoints/hostendpoints.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2017-2025 Tigera, Inc. All rights reserved.
+Copyright (c) 2017-2026 Tigera, Inc. All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -359,15 +359,8 @@ var _ = describe.CalicoDescribe(
 				checker.Execute()
 			})
 
-			It("should deny connections from specified source addresses in a doNotTrack deny policy (DoS mitigation) [ExternalNode]", func() {
-				extClient := externalnode.NewClient()
-				if extClient == nil {
-					if describe.IncludesFocus("ExternalNode") {
-						framework.Failf("External node client not available")
-					} else {
-						Skip("Skipping test that requires an external node")
-					}
-				}
+			It("should deny connections from specified source addresses in a doNotTrack deny policy (DoS mitigation)", describe.WithExternalNode(), func() {
+				extClient := externalnode.MustNewClient()
 
 				// Wrap the external node as a conncheck Client so the probes
 				// go through the standard ConnectionTester machinery.

--- a/e2e/pkg/tests/kubevirt/live_migration.go
+++ b/e2e/pkg/tests/kubevirt/live_migration.go
@@ -181,13 +181,7 @@ var _ = describe.CalicoDescribe(
 				if isMockVirtDeployed(f) {
 					Fail("This test requires real KubeVirt with QEMU-backed VMs for TCP connectivity; MockVirt does not run a guest OS")
 				}
-				tor := externalnode.NewClient()
-				if tor == nil {
-					// The RequiresExternalNode label gates whether this test runs at
-					// all; once selected, missing credentials are a real failure
-					// rather than a self-skip.
-					Fail("External node not configured (set EXT_IP, EXT_KEY, EXT_USER)")
-				}
+				tor := externalnode.MustNewClient()
 
 				ctx, cancel := context.WithTimeout(context.Background(), eBGPDoubleMigrationTimeout)
 				defer cancel()

--- a/e2e/pkg/tests/networking/maglev.go
+++ b/e2e/pkg/tests/networking/maglev.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2025 Tigera, Inc. All rights reserved.
+Copyright (c) 2025-2026 Tigera, Inc. All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -73,10 +73,7 @@ var _ = describe.CalicoDescribe(
 
 		BeforeEach(func() {
 			// Initialize external node for testing
-			extNode = externalnode.NewClient()
-			if extNode == nil {
-				Skip("External node not available - required for Maglev testing")
-			}
+			extNode = externalnode.MustNewClient()
 
 			// Get available nodes for pod distribution
 			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)

--- a/e2e/pkg/tests/networking/packet_size.go
+++ b/e2e/pkg/tests/networking/packet_size.go
@@ -161,9 +161,7 @@ var _ = describe.CalicoDescribe(
 			ct.AddServer(server)
 
 			if clientType == pktClientExt {
-				extClient := externalnode.NewClient()
-				Expect(extClient).NotTo(BeNil(),
-					"external node tests require EXT_IP, EXT_KEY, EXT_USER to be configured")
+				extClient := externalnode.MustNewClient()
 				ct.Deploy()
 				DeferCleanup(ct.Stop)
 

--- a/e2e/pkg/tests/networking/workload_ingress.go
+++ b/e2e/pkg/tests/networking/workload_ingress.go
@@ -517,9 +517,7 @@ var _ = describe.CalicoDescribe(
 			logrus.Infof("Scenario %d (external): dest=%s dataplane=%s expect=%s",
 				s.num, s.dest, dp.Calico, expect)
 
-			extNode := externalnode.NewClient()
-			Expect(extNode).NotTo(BeNil(),
-				"external node scenarios require EXT_IP, EXT_KEY, and EXT_USER to be configured")
+			extNode := externalnode.MustNewClient()
 
 			extIPs := extNode.IPs()
 			Expect(extIPs).NotTo(BeEmpty(), "could not determine external node IP addresses")

--- a/e2e/pkg/utils/externalnode/client.go
+++ b/e2e/pkg/utils/externalnode/client.go
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020-2021 Tigera, Inc. All rights reserved. */
+/* Copyright (c) 2020-2026 Tigera, Inc. All rights reserved. */
 
 package externalnode
 
@@ -13,6 +13,7 @@ import (
 	//nolint:staticcheck // Ignore ST1001: should not use dot imports
 	. "github.com/onsi/gomega"
 	"github.com/sirupsen/logrus"
+	"k8s.io/kubernetes/test/e2e/framework"
 
 	"github.com/projectcalico/calico/e2e/pkg/config"
 	"github.com/projectcalico/calico/e2e/pkg/utils/images"
@@ -38,6 +39,16 @@ func NewClient() *Client {
 		extIP:   config.ExtNodeIP(),
 		extKey:  config.ExtNodeSSHKey(),
 		extUser: config.ExtNodeUsername(),
+	}
+	return client
+}
+
+// MustNewClient returns a client for the external node, failing the test if the
+// cluster has none.
+func MustNewClient() *Client {
+	client := NewClient()
+	if client == nil {
+		framework.Failf("No external node is configured, so the lane should exclude the ExternalNode label")
 	}
 	return client
 }

--- a/e2e/pkg/utils/externalnode/client_test.go
+++ b/e2e/pkg/utils/externalnode/client_test.go
@@ -1,13 +1,30 @@
 // Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package externalnode
 
 import (
+	"io/fs"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/onsi/gomega"
 )
+
+const testsDir = "../../tests"
 
 // The ssh probe returns no addresses when the external node is unreachable, and
 // indexing that empty slice used to panic and take the whole Ginkgo node down.
@@ -38,4 +55,59 @@ func TestIPReturnsFirstDiscoveredAddress(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected failure: %s", err)
 	}
+}
+
+// NewClient returns nil on a cluster with no external node, leaving each caller to
+// decide what that means. MustNewClient fails with the label a lane should exclude.
+func TestTestsUseMustNewClient(t *testing.T) {
+	for _, path := range testFilesCalling(t, "externalnode.NewClient") {
+		t.Errorf("%s: use externalnode.MustNewClient instead of NewClient", path)
+	}
+}
+
+// A test that needs the external node without the label runs on every lane,
+// including the ones whose clusters have no external node.
+func TestTestsNeedingTheExternalNodeCarryTheLabel(t *testing.T) {
+	paths := testFilesCalling(t, "externalnode.MustNewClient")
+	if len(paths) == 0 {
+		t.Fatal("no e2e test calls externalnode.MustNewClient, so this guard checks nothing")
+	}
+	for _, path := range paths {
+		if !fileContains(t, path, "ExternalNode") {
+			t.Errorf("%s: needs the external node but carries no describe.WithExternalNode label", path)
+		}
+	}
+}
+
+// testFilesCalling returns the e2e test files that call the named function.
+func testFilesCalling(t *testing.T, fn string) []string {
+	t.Helper()
+
+	var paths []string
+	err := filepath.WalkDir(testsDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		if fileContains(t, path, fn+"(") {
+			paths = append(paths, path)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking %s: %v", testsDir, err)
+	}
+	return paths
+}
+
+func fileContains(t *testing.T, path, s string) bool {
+	t.Helper()
+
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading %s: %v", path, err)
+	}
+	return strings.Contains(string(contents), s)
 }


### PR DESCRIPTION
Cherry-pick of https://github.com/projectcalico/calico/pull/13588 to release-v3.33.

The external node specs run on lanes with no external node configured, where they fail instead of skipping. Callers move to `MustNewClient`, and the specs carry the `ExternalNode` label so a lane without credentials excludes them.

One conflict in `hostendpoints.go`, where release-v3.33 still had the `describe.IncludesFocus` form of the same check. Resolved in favor of the label.

```release-note
None
```