### PR TITLE
[v3.32] Label the IP-in-IP e2e suite as requiring BGP

### DIFF
--- a/e2e/pkg/describe/describe.go
+++ b/e2e/pkg/describe/describe.go
@@ -85,6 +85,12 @@ func RequiresNoEncap() any {
 	return framework.WithLabel("NoEncap")
 }
 
+// RequiresBGP marks tests that need the cluster to run in BGP networking mode. Lanes on
+// clusters using another mode exclude them via --ginkgo.skip=RequiresBGP.
+func RequiresBGP() any {
+	return framework.WithLabel("RequiresBGP")
+}
+
 // RequiresBGPMesh marks tests that depend on the BGP node-to-node mesh being the sole
 // routing mechanism. These tests disable the mesh and expect connectivity to break, which
 // only works when there's no other routing path (e.g., VXLAN). Skip these on VXLAN clusters

--- a/e2e/pkg/tests/bgp/bgp_password.go
+++ b/e2e/pkg/tests/bgp/bgp_password.go
@@ -23,7 +23,6 @@ import (
 	//nolint:staticcheck // Ignore ST1001: should not use dot imports
 	. "github.com/onsi/gomega"
 	v3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
-	v1 "github.com/tigera/operator/api/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -42,6 +41,7 @@ var _ = describe.CalicoDescribe(
 	describe.WithTeam(describe.Core),
 	describe.WithFeature("BGPPeer"),
 	describe.WithCategory(describe.Networking),
+	describe.RequiresBGP(),
 	describe.WithSerial(),
 	"BGP password",
 	func() {
@@ -63,13 +63,7 @@ var _ = describe.CalicoDescribe(
 			// We need a minimum of two nodes for BGP peering tests.
 			utils.RequireNodeCount(f, 2)
 
-			// Verify BGP is enabled via the Installation resource.
-			installation := &v1.Installation{}
-			err = cli.Get(context.Background(), ctrlclient.ObjectKey{Name: "default"}, installation)
-			Expect(err).NotTo(HaveOccurred(), "Error querying Installation resource")
-			Expect(installation.Spec.CalicoNetwork).NotTo(BeNil(), "CalicoNetwork is not configured in the Installation")
-			Expect(installation.Spec.CalicoNetwork.BGP).NotTo(BeNil(), "BGP is not enabled in the cluster")
-			Expect(*installation.Spec.CalicoNetwork.BGP).To(Equal(v1.BGPEnabled), "BGP is not enabled in the cluster")
+			utils.RequireBGPEnabled(cli)
 
 			// Ensure full mesh BGP is functioning before each test.
 			restoreBGPConfig = ensureInitialBGPConfig(cli)

--- a/e2e/pkg/tests/bgp/export.go
+++ b/e2e/pkg/tests/bgp/export.go
@@ -23,7 +23,6 @@ import (
 	//nolint:staticcheck // Ignore ST1001: should not use dot imports
 	. "github.com/onsi/gomega"
 	v3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
-	v1 "github.com/tigera/operator/api/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -63,14 +62,7 @@ var _ = describe.CalicoDescribe(
 			// We need a minimum of two nodes for BGP peering tests.
 			utils.RequireNodeCount(f, 2)
 
-			// Make sure the cluster is in BGP mode by querying the Installation resource. The tests in this file
-			// all require BGP, and all require Calico be installed by the operator.
-			installation := &v1.Installation{}
-			err = cli.Get(context.Background(), ctrlclient.ObjectKey{Name: "default"}, installation)
-			Expect(err).NotTo(HaveOccurred(), "Error querying Installation resource")
-			Expect(installation.Spec.CalicoNetwork).NotTo(BeNil(), "CalicoNetwork is not configured in the Installation")
-			Expect(installation.Spec.CalicoNetwork.BGP).NotTo(BeNil(), "BGP is not enabled in the cluster")
-			Expect(*installation.Spec.CalicoNetwork.BGP).To(Equal(v1.BGPEnabled), "BGP is not enabled in the cluster")
+			utils.RequireBGPEnabled(cli)
 			requireNonVXLANCluster(cli)
 
 			// Ensure full mesh BGP is functioning before each test.

--- a/e2e/pkg/tests/bgp/peers.go
+++ b/e2e/pkg/tests/bgp/peers.go
@@ -23,7 +23,6 @@ import (
 	//nolint:staticcheck // Ignore ST1001: should not use dot imports
 	. "github.com/onsi/gomega"
 	v3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
-	v1 "github.com/tigera/operator/api/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -65,14 +64,7 @@ var _ = describe.CalicoDescribe(
 			// We need a minimum of two nodes for BGP peering tests.
 			utils.RequireNodeCount(f, 2)
 
-			// Make sure the cluster is in BGP mode by querying the Installation resource. The tests in this file
-			// all require BGP, and all require Calico be installed by the operator.
-			installation := &v1.Installation{}
-			err = cli.Get(context.Background(), ctrlclient.ObjectKey{Name: "default"}, installation)
-			Expect(err).NotTo(HaveOccurred(), "Error querying Installation resource")
-			Expect(installation.Spec.CalicoNetwork).NotTo(BeNil(), "CalicoNetwork is not configured in the Installation")
-			Expect(installation.Spec.CalicoNetwork.BGP).NotTo(BeNil(), "BGP is not enabled in the cluster")
-			Expect(*installation.Spec.CalicoNetwork.BGP).To(Equal(v1.BGPEnabled), "BGP is not enabled in the cluster")
+			utils.RequireBGPEnabled(cli)
 			requireNonVXLANCluster(cli)
 
 			// Ensure full mesh BGP is functioning before each test.

--- a/e2e/pkg/tests/bgp/route_reflector.go
+++ b/e2e/pkg/tests/bgp/route_reflector.go
@@ -25,7 +25,6 @@ import (
 	. "github.com/onsi/gomega"
 	v3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
 	"github.com/projectcalico/api/pkg/lib/numorstring"
-	v1 "github.com/tigera/operator/api/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -41,6 +40,7 @@ var _ = describe.CalicoDescribe(
 	describe.WithTeam(describe.Core),
 	describe.WithFeature("BGPPeer"),
 	describe.WithCategory(describe.Networking),
+	describe.RequiresBGP(),
 	describe.WithDisruptive(),
 	describe.WithSerial(),
 	"Route reflectors",
@@ -67,14 +67,7 @@ var _ = describe.CalicoDescribe(
 			// We need a minimum of two nodes for BGP peering tests.
 			utils.RequireNodeCount(f, 3)
 
-			// Make sure the cluster is in BGP mode by querying the Installation resource. The tests in this file
-			// all require BGP, and all require Calico be installed by the operator.
-			installation := &v1.Installation{}
-			err = cli.Get(context.Background(), ctrlclient.ObjectKey{Name: "default"}, installation)
-			Expect(err).NotTo(HaveOccurred(), "Error querying Installation resource")
-			Expect(installation.Spec.CalicoNetwork).NotTo(BeNil(), "CalicoNetwork is not configured in the Installation")
-			Expect(installation.Spec.CalicoNetwork.BGP).NotTo(BeNil(), "BGP is not enabled in the cluster")
-			Expect(*installation.Spec.CalicoNetwork.BGP).To(Equal(v1.BGPEnabled), "BGP is not enabled in the cluster")
+			utils.RequireBGPEnabled(cli)
 
 			// Ensure full mesh BGP is functioning before each test.
 			restoreBGPConfig = ensureInitialBGPConfig(cli)

--- a/e2e/pkg/tests/networking/ipip.go
+++ b/e2e/pkg/tests/networking/ipip.go
@@ -25,7 +25,6 @@ import (
 	//nolint:staticcheck // Ignore ST1001: should not use dot imports
 	. "github.com/onsi/gomega"
 	v3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
-	v1 "github.com/tigera/operator/api/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/kubernetes/test/e2e/framework"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -42,6 +41,7 @@ var _ = describe.CalicoDescribe(
 	describe.WithFeature("IPIP"),
 	describe.WithCategory(describe.Networking),
 	describe.RequiresNoEncap(),
+	describe.RequiresBGP(),
 	describe.WithSerial(),
 	"IP-in-IP tests",
 	func() {
@@ -72,14 +72,7 @@ var _ = describe.CalicoDescribe(
 			// We need a minimum of two nodes for BGP peering tests.
 			utils.RequireNodeCount(f, 2)
 
-			// Make sure the cluster is in BGP mode by querying the Installation resource. The tests in this file
-			// all require BGP, and all require Calico be installed by the operator.
-			installation := &v1.Installation{}
-			err = cli.Get(context.Background(), ctrlclient.ObjectKey{Name: "default"}, installation)
-			Expect(err).NotTo(HaveOccurred(), "Error querying Installation resource")
-			Expect(installation.Spec.CalicoNetwork).NotTo(BeNil(), "CalicoNetwork is not configured in the Installation")
-			Expect(installation.Spec.CalicoNetwork.BGP).NotTo(BeNil(), "BGP is not enabled in the cluster")
-			Expect(*installation.Spec.CalicoNetwork.BGP).To(Equal(v1.BGPEnabled), "BGP is not enabled in the cluster")
+			utils.RequireBGPEnabled(cli)
 
 			// Create an IP pool for the test.
 			poolName = utils.GenerateRandomName("ipip-pool")

--- a/e2e/pkg/utils/installation.go
+++ b/e2e/pkg/utils/installation.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	operatorv1 "github.com/tigera/operator/api/v1"
+	"k8s.io/kubernetes/test/e2e/framework"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -33,6 +34,16 @@ func GetInstallation(cli ctrlclient.Client) *operatorv1.Installation {
 	return installation
 }
 
+// InstallationConfig returns the defaulted installation config the operator publishes on the
+// status. Nil if the cluster isn't operator managed, or if the operator hasn't reconciled yet.
+func InstallationConfig(cli ctrlclient.Client) *operatorv1.InstallationSpec {
+	installation := GetInstallation(cli)
+	if installation == nil {
+		return nil
+	}
+	return installation.Status.Computed
+}
+
 // UsesCalicoIPAM reports whether the cluster uses Calico IPAM. If the operator
 // Installation resource is available, it checks the configured IPAM type.
 // Returns true if Calico IPAM is in use or if the IPAM type cannot be determined
@@ -46,4 +57,18 @@ func UsesCalicoIPAM(cli ctrlclient.Client) bool {
 		return false
 	}
 	return true
+}
+
+// RequireBGPEnabled fails the test unless the operator installed the cluster with BGP
+// networking enabled. Lanes whose clusters run in another networking mode should exclude
+// the RequiresBGP label instead of running these tests.
+func RequireBGPEnabled(cli ctrlclient.Client) {
+	config := InstallationConfig(cli)
+	if config == nil {
+		framework.Failf("No computed configuration on the Installation; is this cluster operator managed?")
+	}
+	network := config.CalicoNetwork
+	if network == nil || network.BGP == nil || *network.BGP != operatorv1.BGPEnabled {
+		framework.Failf("BGP is not enabled in this cluster, so the lane should exclude the RequiresBGP label")
+	}
 }

--- a/e2e/pkg/utils/installation_test.go
+++ b/e2e/pkg/utils/installation_test.go
@@ -1,0 +1,83 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+
+package utils
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// A suite that requires BGP without the label runs on every lane, including the
+// ones whose clusters use VXLAN, where the precondition fails every case.
+func TestSuitesRequiringBGPCarryTheLabel(t *testing.T) {
+	for _, path := range testFilesCalling(t, "RequireBGPEnabled") {
+		if !fileContains(t, path, "RequiresBGP") {
+			t.Errorf("%s: requires BGP but the suite has no describe.RequiresBGP label", path)
+		}
+	}
+}
+
+// The precondition belongs in RequireBGPEnabled, which names the label a lane
+// should exclude. An inline assertion just reports that BGP is off.
+func TestNoInlineBGPPreconditions(t *testing.T) {
+	fset := token.NewFileSet()
+	err := filepath.WalkDir("../tests", func(path string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() || !strings.HasSuffix(path, ".go") {
+			return err
+		}
+		f, err := parser.ParseFile(fset, path, nil, 0)
+		if err != nil {
+			return err
+		}
+		ast.Inspect(f, func(n ast.Node) bool {
+			sel, ok := n.(*ast.SelectorExpr)
+			if !ok || sel.Sel.Name != "BGP" {
+				return true
+			}
+			if inner, ok := sel.X.(*ast.SelectorExpr); ok && inner.Sel.Name == "CalicoNetwork" {
+				t.Errorf("%s: use utils.RequireBGPEnabled instead of asserting on the Installation", fset.Position(sel.Pos()))
+			}
+			return true
+		})
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking the e2e tests: %v", err)
+	}
+}
+
+func testFilesCalling(t *testing.T, fn string) []string {
+	t.Helper()
+	var matched []string
+	err := filepath.WalkDir("../tests", func(path string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() || !strings.HasSuffix(path, ".go") {
+			return err
+		}
+		if fileContains(t, path, fn+"(") {
+			matched = append(matched, path)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking the e2e tests: %v", err)
+	}
+	if len(matched) == 0 {
+		t.Fatalf("no e2e test calls %s, so this guard checks nothing", fn)
+	}
+	return matched
+}
+
+func fileContains(t *testing.T, path, s string) bool {
+	t.Helper()
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading %s: %v", path, err)
+	}
+	return strings.Contains(string(body), s)
+}


### PR DESCRIPTION
Cherry-pick of https://github.com/projectcalico/calico/pull/13586 to release-v3.32.

The BGP suites read BGP enablement off the Installation spec, but the operator publishes the fields it defaults on the status, so the precondition fails on clusters that do have BGP. `RequireBGPEnabled` reads the status instead, and names the label a lane should exclude when the cluster runs in another mode. A unit test fails any suite that requires BGP without carrying the label.

v3.32 carries most of the failures this reaches: 503 BGPPeer cases at 7.6% and 334 IP-in-IP cases at 15.3% over the last week.

Adapted from the master change:
- Dropped the regenerated files under `e2e/testsets/`, which only exist on master.
- Added `InstallationConfig` and `describe.RequiresBGP`, both of which master already had.
- Kept `requireNonVXLANCluster`, which master has since renamed.

```release-note
None
```