### PR TITLE
[v3.31] Read BGP enablement from the Installation status

### DIFF
--- a/e2e/pkg/describe/describe.go
+++ b/e2e/pkg/describe/describe.go
@@ -79,6 +79,12 @@ func WithFeature(feature string) any {
 }
 
 // WithWindows marks tests that can run on clusters with Windows nodes.
+// RequiresBGP marks tests that need the cluster to run in BGP networking mode. Lanes on
+// clusters using another mode exclude them via --ginkgo.skip=RequiresBGP.
+func RequiresBGP() any {
+	return framework.WithLabel("RequiresBGP")
+}
+
 func WithWindows() any {
 	return framework.WithLabel("RunsOnWindows")
 }

--- a/e2e/pkg/tests/bgp/export.go
+++ b/e2e/pkg/tests/bgp/export.go
@@ -21,7 +21,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	v3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
-	v1 "github.com/tigera/operator/api/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -35,6 +34,7 @@ var _ = describe.CalicoDescribe(
 	describe.WithTeam(describe.Core),
 	describe.WithFeature("BGPPeer"),
 	describe.WithCategory(describe.Networking),
+	describe.RequiresBGP(),
 	"BGP export tests",
 	func() {
 		// Define variables common across all tests.
@@ -61,14 +61,7 @@ var _ = describe.CalicoDescribe(
 			// We need a minimum of two nodes for BGP peering tests.
 			utils.RequireNodeCount(f, 2)
 
-			// Make sure the cluster is in BGP mode by querying the Installation resource. The tests in this file
-			// all require BGP, and all require Calico be installed by the operator.
-			installation := &v1.Installation{}
-			err = cli.Get(context.Background(), ctrlclient.ObjectKey{Name: "default"}, installation)
-			Expect(err).NotTo(HaveOccurred(), "Error querying Installation resource")
-			Expect(installation.Spec.CalicoNetwork).NotTo(BeNil(), "CalicoNetwork is not configured in the Installation")
-			Expect(installation.Spec.CalicoNetwork.BGP).NotTo(BeNil(), "BGP is not enabled in the cluster")
-			Expect(*installation.Spec.CalicoNetwork.BGP).To(Equal(v1.BGPEnabled), "BGP is not enabled in the cluster")
+			utils.RequireBGPEnabled(cli)
 
 			// Ensure full mesh BGP is functioning before each test.
 			restoreBGPConfig = ensureInitialBGPConfig(cli)

--- a/e2e/pkg/tests/bgp/peers.go
+++ b/e2e/pkg/tests/bgp/peers.go
@@ -21,7 +21,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	v3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
-	v1 "github.com/tigera/operator/api/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -37,6 +36,7 @@ var _ = describe.CalicoDescribe(
 	describe.WithTeam(describe.Core),
 	describe.WithFeature("BGPPeer"),
 	describe.WithCategory(describe.Networking),
+	describe.RequiresBGP(),
 	"BGPPeer",
 	func() {
 		// Define variables common across all tests.
@@ -63,14 +63,7 @@ var _ = describe.CalicoDescribe(
 			// We need a minimum of two nodes for BGP peering tests.
 			utils.RequireNodeCount(f, 2)
 
-			// Make sure the cluster is in BGP mode by querying the Installation resource. The tests in this file
-			// all require BGP, and all require Calico be installed by the operator.
-			installation := &v1.Installation{}
-			err = cli.Get(context.Background(), ctrlclient.ObjectKey{Name: "default"}, installation)
-			Expect(err).NotTo(HaveOccurred(), "Error querying Installation resource")
-			Expect(installation.Spec.CalicoNetwork).NotTo(BeNil(), "CalicoNetwork is not configured in the Installation")
-			Expect(installation.Spec.CalicoNetwork.BGP).NotTo(BeNil(), "BGP is not enabled in the cluster")
-			Expect(*installation.Spec.CalicoNetwork.BGP).To(Equal(v1.BGPEnabled), "BGP is not enabled in the cluster")
+			utils.RequireBGPEnabled(cli)
 
 			// Ensure full mesh BGP is functioning before each test.
 			restoreBGPConfig = ensureInitialBGPConfig(cli)

--- a/e2e/pkg/tests/bgp/route_reflector.go
+++ b/e2e/pkg/tests/bgp/route_reflector.go
@@ -23,7 +23,6 @@ import (
 	. "github.com/onsi/gomega"
 	v3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
 	"github.com/projectcalico/api/pkg/lib/numorstring"
-	v1 "github.com/tigera/operator/api/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -39,6 +38,7 @@ var _ = describe.CalicoDescribe(
 	describe.WithTeam(describe.Core),
 	describe.WithFeature("BGPPeer"),
 	describe.WithCategory(describe.Networking),
+	describe.RequiresBGP(),
 	describe.WithDisruptive(),
 	"Route reflectors",
 	func() {
@@ -67,14 +67,7 @@ var _ = describe.CalicoDescribe(
 			// We need a minimum of two nodes for BGP peering tests.
 			utils.RequireNodeCount(f, 3)
 
-			// Make sure the cluster is in BGP mode by querying the Installation resource. The tests in this file
-			// all require BGP, and all require Calico be installed by the operator.
-			installation := &v1.Installation{}
-			err = cli.Get(context.Background(), ctrlclient.ObjectKey{Name: "default"}, installation)
-			Expect(err).NotTo(HaveOccurred(), "Error querying Installation resource")
-			Expect(installation.Spec.CalicoNetwork).NotTo(BeNil(), "CalicoNetwork is not configured in the Installation")
-			Expect(installation.Spec.CalicoNetwork.BGP).NotTo(BeNil(), "BGP is not enabled in the cluster")
-			Expect(*installation.Spec.CalicoNetwork.BGP).To(Equal(v1.BGPEnabled), "BGP is not enabled in the cluster")
+			utils.RequireBGPEnabled(cli)
 
 			// Ensure full mesh BGP is functioning before each test.
 			restoreBGPConfig = ensureInitialBGPConfig(cli)

--- a/e2e/pkg/tests/networking/ipip.go
+++ b/e2e/pkg/tests/networking/ipip.go
@@ -23,7 +23,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	v3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
-	v1 "github.com/tigera/operator/api/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/kubernetes/test/e2e/framework"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -39,6 +38,7 @@ var _ = describe.CalicoDescribe(
 	describe.WithTeam(describe.Core),
 	describe.WithFeature("IPIP"),
 	describe.WithCategory(describe.Networking),
+	describe.RequiresBGP(),
 	"IP-in-IP tests",
 	func() {
 		// Define variables common across all tests.
@@ -71,14 +71,7 @@ var _ = describe.CalicoDescribe(
 			// We need a minimum of two nodes for BGP peering tests.
 			utils.RequireNodeCount(f, 2)
 
-			// Make sure the cluster is in BGP mode by querying the Installation resource. The tests in this file
-			// all require BGP, and all require Calico be installed by the operator.
-			installation := &v1.Installation{}
-			err = cli.Get(context.Background(), ctrlclient.ObjectKey{Name: "default"}, installation)
-			Expect(err).NotTo(HaveOccurred(), "Error querying Installation resource")
-			Expect(installation.Spec.CalicoNetwork).NotTo(BeNil(), "CalicoNetwork is not configured in the Installation")
-			Expect(installation.Spec.CalicoNetwork.BGP).NotTo(BeNil(), "BGP is not enabled in the cluster")
-			Expect(*installation.Spec.CalicoNetwork.BGP).To(Equal(v1.BGPEnabled), "BGP is not enabled in the cluster")
+			utils.RequireBGPEnabled(cli)
 
 			// Create an IP pool for the test.
 			poolName = conncheck.GenerateRandomName("ipip-pool")

--- a/e2e/pkg/utils/installation.go
+++ b/e2e/pkg/utils/installation.go
@@ -1,0 +1,59 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"context"
+
+	operatorv1 "github.com/tigera/operator/api/v1"
+	"k8s.io/kubernetes/test/e2e/framework"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// GetInstallation returns the operator Installation resource if available.
+// Returns nil if the Installation resource cannot be retrieved (e.g., on
+// manifest-based installs where the operator CRD may not exist).
+func GetInstallation(cli ctrlclient.Client) *operatorv1.Installation {
+	installation := &operatorv1.Installation{}
+	err := cli.Get(context.Background(), ctrlclient.ObjectKey{Name: "default"}, installation)
+	if err != nil {
+		return nil
+	}
+	return installation
+}
+
+// InstallationConfig returns the defaulted installation config the operator publishes on the
+// status. Nil if the cluster isn't operator managed, or if the operator hasn't reconciled yet.
+func InstallationConfig(cli ctrlclient.Client) *operatorv1.InstallationSpec {
+	installation := GetInstallation(cli)
+	if installation == nil {
+		return nil
+	}
+	return installation.Status.Computed
+}
+
+// RequireBGPEnabled fails the test unless the operator installed the cluster with BGP
+// networking enabled. Lanes whose clusters run in another networking mode should exclude
+// the RequiresBGP label instead of running these tests.
+func RequireBGPEnabled(cli ctrlclient.Client) {
+	config := InstallationConfig(cli)
+	if config == nil {
+		framework.Failf("No computed configuration on the Installation; is this cluster operator managed?")
+	}
+	network := config.CalicoNetwork
+	if network == nil || network.BGP == nil || *network.BGP != operatorv1.BGPEnabled {
+		framework.Failf("BGP is not enabled in this cluster, so the lane should exclude the RequiresBGP label")
+	}
+}


### PR DESCRIPTION
Backport of the code half of https://github.com/projectcalico/calico/pull/13586 to release-v3.31.

The BGP suites read BGP enablement off the Installation spec, but the operator publishes the fields it defaults on the status, so the precondition fails on clusters that do have BGP. `RequireBGPEnabled` reads the status instead, and names the label a lane should exclude when the cluster runs in another mode.

v3.31 has 106 BGPPeer cases at 0% and 72 IP-in-IP cases at 25% over the last week.

This is a port rather than a pick. release-v3.31 has no `e2e/pkg/utils/installation.go` and no `e2e/testsets/`, so the helpers are written here and the generated test sets are left out.

The unit test that master pairs with this change is also left out: release-v3.31 has no `ut` target in `e2e/Makefile` and no job that runs the e2e unit tests, so it would never execute. `make -C e2e build` passes.

```release-note
None
```