### PR TITLE
Fix the envtest asset marker, the cri-streaming require line, and the metrics HTTPS log level

### DIFF
--- a/felix/daemon/daemon.go
+++ b/felix/daemon/daemon.go
@@ -747,7 +747,7 @@ configRetry:
 					configParams.PrometheusMetricsCAFile,
 				)
 				// The server retries internally, so it only returns on failure.
-				log.Info("Error starting metrics https server.", err)
+				log.WithError(err).Error("Error starting metrics https server.")
 			}()
 		} else {
 			log.Info("Starting metrics http server.")

--- a/go.mod
+++ b/go.mod
@@ -387,7 +387,7 @@ require (
 	k8s.io/controller-manager v0.37.0 // indirect
 	k8s.io/cri-api v0.37.0 // indirect
 	k8s.io/cri-client v0.37.0 // indirect
-	k8s.io/cri-streaming v0.0.0 // indirect
+	k8s.io/cri-streaming v0.37.0 // indirect
 	k8s.io/csi-translation-lib v0.37.0 // indirect
 	k8s.io/dynamic-resource-allocation v0.37.0 // indirect
 	k8s.io/kms v0.37.0 // indirect

--- a/lib.Makefile
+++ b/lib.Makefile
@@ -1846,7 +1846,10 @@ ENVTEST_CONTAINER_DIR := /go/src/github.com/projectcalico/calico/hack/test/envte
 ifneq ($(OS),Windows_NT)
 ENVTEST_K8S_VERSION ?= $(shell echo $(K8S_VERSION) | sed 's/^v//' | cut -d. -f1,2).x
 endif
-ENVTEST_ASSETS_MARKER := $(ENVTEST_DIR)/.envtest-$(ENVTEST_K8S_VERSION)
+# Key the marker off the full K8S_VERSION rather than the minor wildcard. The
+# fallback below stores its assets under k8s/<full version>-<os>-<arch>, so a
+# bump inside one minor (rc to GA, say) has to force a fresh setup.
+ENVTEST_ASSETS_MARKER := $(ENVTEST_DIR)/.envtest-$(K8S_VERSION:v%=%)
 
 ## Download envtest binaries (kube-apiserver, etcd, kubectl) for use by tests that use controller-runtime envtest.
 .PHONY: setup-envtest

--- a/typha/pkg/daemon/daemon.go
+++ b/typha/pkg/daemon/daemon.go
@@ -377,7 +377,7 @@ func (t *TyphaDaemon) Start(cxt context.Context) {
 					t.ConfigParams.PrometheusMetricsCAFile,
 				)
 				// The server retries internally, so it only returns on failure.
-				log.Info("Error starting metrics https server.", err)
+				log.WithError(err).Error("Error starting metrics https server.")
 			}()
 		} else {
 			log.Info("Starting metrics http server.")


### PR DESCRIPTION
Three small fixes, all surfaced by a review of the downstream pick of #13613.

### `lib.Makefile`: the envtest marker missed a version bump within a minor

`ENVTEST_ASSETS_MARKER` was keyed on the minor wildcard (`.envtest-1.37.x`), but
the fallback path that assembles a bundle when no published one exists stores
its assets under the **full** version:

```make
d=$(ENVTEST_CONTAINER_DIR)/k8s/$(K8S_VERSION:v%=%)-$(BUILDOS)-$(BUILDARCH)
```

So the marker did not track what the assets were keyed by. Moving `K8S_VERSION`
within a minor — `v1.37.0-rc.1` to `v1.37.0`, say — left the marker satisfied,
`make setup-envtest` did nothing, and envtest carried on running against the
rc binaries.

CI never saw this because it starts from a clean workspace every run. It bites a
developer with a warm tree across a bump, silently.

Keying the marker on `K8S_VERSION` fixes it. The recipe already begins with
`rm -f $(ENVTEST_DIR)/.envtest-*`, so stale markers are cleaned up on the next
run.

### `go.mod`: cri-streaming named a version that does not exist

`k8s.io/kubernetes` requires every one of its staging modules at a `v0.0.0`
placeholder and resolves them with local-directory replaces. Those replaces do
not carry to anyone importing it, so consumers supply their own — and raise the
require lines to the release version alongside them.

`cri-streaming` was the only staging module still left at the placeholder, and
so the only require line here naming a version that cannot be resolved:

```
$ go list -m k8s.io/cri-streaming@v0.0.0
go: k8s.io/cri-streaming@v0.0.0: invalid version: unknown revision v0.0.0
```

`cloud-provider` and `mount-utils` have exactly the same shape in the module
graph — kubernetes' placeholder plus our own require line — and both read
`v0.37.0`. The replace decides what gets built either way and `go.sum` already
carried `v0.37.0` only, so nothing changes for the build. This just stops one
line out of ~25 reading differently from its neighbours.

### felix, typha: a failed metrics HTTPS server logged at Info

```go
// The server retries internally, so it only returns on failure.
log.Info("Error starting metrics https server.", err)
```

`ServePrometheusMetricsHTTPS` retries internally and returns only when it cannot
serve at all, so — as the comment right above it says — this is an error, not an
Info. Passing `err` as a bare argument also runs it through `fmt.Sprint`, which
adds a separator only when neither operand is a string, so the two ran together:

```
"Error starting metrics https server.tls: bad cert"
```

`log.WithError(err).Error(...)` puts the error in its own field and logs it at a
level that gets noticed.

### Testing

`make -C felix bin/calico-felix-amd64` builds, and `typha/pkg/daemon` builds.
`make -n setup-envtest` resolves the marker to `.envtest-1.37.0` where it
previously resolved to `.envtest-1.37.x`. `make mod-tidy` leaves the go.mod
change in place and `make check-go-mod` is clean.

**Release note:**
```release-note
None
```

**AI assistance:** This PR was written in part with the assistance of generative AI.

By opening this PR you take responsibility for every line in it, and you agree to explain the change yourself during review rather than routing review comments back through an agent. See [AI_POLICY.md](../AI_POLICY.md).
