### PR TITLE
[v3.31] Skip peer-redirect to VM workloads for on-node clients too

### DIFF
--- a/felix/bpf-gpl/tc.c
+++ b/felix/bpf-gpl/tc.c
@@ -689,10 +689,17 @@ syn_force_policy:
 			goto skip_policy;
 		}
 		ctx->state->flags |= CALI_ST_DEST_IS_HOST;
-	} else if (CALI_F_FROM_HEP) {
+	} else if (CALI_F_TO_HOST) {
 		if (cali_rt_flags_skip_ingress_redirect(dest_rt->flags)) {
+			/* The destination workload cannot accept peer-redirected packets;
+			 * bpf_redirect_peer() leaves the L2 header alone, so they reach a
+			 * VM behind a bridge addressed to the veth's MAC rather than the
+			 * guest's, and the guest drops them as PACKET_OTHERHOST.  Record
+			 * it on the conntrack entry so every packet of the flow takes the
+			 * FIB path, which rewrites the destination MAC.  The client may be
+			 * off-host or a workload on this node, so this covers both. */
 			ctx->state->flags |= CALI_ST_SKIP_REDIR_PEER;
-		} else if (!ctx->nat_dest && !cali_rt_is_local(dest_rt)) {
+		} else if (CALI_F_FROM_HEP && !ctx->nat_dest && !cali_rt_is_local(dest_rt)) {
 			/* Disable FIB, let the packet go through the host after it is
 			 * policed. It is ingress into the system and we got a packet, which is
 			 * not for this host, and it wasn't resolved as a service and it is not

--- a/felix/bpf/ut/whitelist_test.go
+++ b/felix/bpf/ut/whitelist_test.go
@@ -171,6 +171,37 @@ func TestSkipIngressRedirect(t *testing.T) {
 		Expect(ctr.Data().B2A.Approved).NotTo(BeTrue())
 		Expect(ctr.Flags() & v4.FlagNoRedirPeer).To(Equal(v4.FlagNoRedirPeer))
 	})
+
+	// A local workload sending to a local workload that opts out of ingress
+	// redirect: the opt-out belongs to the destination, so only the
+	// destination's route carries the flag.
+	resetRTMap(rtMap)
+	rtKey = routes.NewKey(srcV4CIDR).AsBytes()
+	rtVal = routes.NewValueWithIfIndex(routes.FlagsLocalWorkload|routes.FlagInIPAMPool, 1).AsBytes()
+	err = rtMap.Update(rtKey, rtVal)
+	Expect(err).NotTo(HaveOccurred())
+	rtKey = routes.NewKey(dstV4CIDR).AsBytes()
+	rtVal = routes.NewValueWithIfIndex(routes.FlagsLocalWorkload|routes.FlagSkipIngressRedir|routes.FlagInIPAMPool, 2).AsBytes()
+	err = rtMap.Update(rtKey, rtVal)
+	Expect(err).NotTo(HaveOccurred())
+
+	resetCTMap(ctMap)
+
+	skbMark = 0
+	runBpfTest(t, "calico_from_workload_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+		res, err := bpfrun(pktBytes)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.Retval).To(Equal(resTC_ACT_REDIRECT))
+
+		ct, err := conntrack.LoadMapMem(ctMap)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ct).Should(HaveKey(ctKey))
+
+		// Without the flag on the conntrack entry, every packet after the
+		// first would be peer-redirected to the destination with its L2
+		// header unmodified.
+		Expect(ct[ctKey].Flags() & v4.FlagNoRedirPeer).To(Equal(v4.FlagNoRedirPeer))
+	})
 }
 
 func TestAllowEnterHostToWorkload(t *testing.T) {


### PR DESCRIPTION
**Cherry-pick history**
- Pick onto **release-v3.31**: projectcalico/calico#13334 (also picked to release-v3.32 in #13386)

A workload can opt out of ingress peer-redirect — `isVMWorkload` sets it for KubeVirt virt-launcher pods, and ingress bandwidth QoS needs it too. The opt-out was only honoured when the client was off the node.

`bpf_redirect_peer()` does not rewrite the L2 header, so the packet reaches the destination addressed to the host side of the veth. An ordinary pod does not care, because the kernel has already classified the packet as `PACKET_HOST`, but a workload that bridges its veth on to something else does: a KubeVirt VM sees a destination MAC that is not the guest's and drops the frame as `PACKET_OTHERHOST`. The symptom is a TCP connection that opens and then carries no application bytes — the first packet of the flow is conntrack-NEW so it takes the FIB path, which *does* rewrite the destination MAC, and every packet after the flow goes ESTABLISHED takes `bpf_redirect_peer`.

The destination-route check that records `CALI_CT_FLAG_SKIP_REDIR_PEER` on the conntrack entry sat under a `CALI_F_FROM_HEP` gate. A client on the same node creates the conntrack entry in *its own* from-WEP program, and the only other check there looks at the source route — the client, which is not a VM. So neither check fired and the flow kept its fast path. An off-node client was unaffected, which is why this was easy to miss.

The fix gates on `CALI_F_TO_HOST`, which is exactly the two programs that call `try_redirect_to_peer`. `CALI_F_FROM_HEP` moves onto the inner `CALI_ST_SKIP_FIB` branch so that behaviour (#8918) is unchanged, and for from-WEP with a destination that has not opted out nothing changes at all. The Maglev path in the same file already applied this check ungated.

Traffic reaching the VM through a Service is covered as well: the check runs against the post-DNAT route.

`felix/bpf/ut/whitelist_test.go` gains a third sub-case, a local workload sending to a local workload where only the *destination* route carries the flag. It fails without the fix and passes with it; the two existing sub-cases cover the other two client positions.

The `felix/design/bpf-overview.md` hunk from the original PR is dropped here: `felix/design/` does not exist on release-v3.31. That was the only conflict, and #13386 resolved it the same way. `felix/bpf-gpl/tc.c` and the test applied cleanly, and the resulting `tc.c` diff is identical to the one on master.

CORE-13126

**Release note:**
```release-note
Fixed a stalled-connection bug in the eBPF dataplane where a client pod could not exchange data with a VM workload on the same node, because established-flow packets bypassed the destination MAC rewrite.
```
