### PR TITLE
[v3.32] Read BGP enablement from the Installation spec

### DIFF
--- a/e2e/pkg/utils/installation.go
+++ b/e2e/pkg/utils/installation.go
@@ -53,9 +53,9 @@ func UsesCalicoIPAM(cli ctrlclient.Client) bool {
 // networking enabled. Lanes whose clusters run in another networking mode should exclude
 // the RequiresBGP label instead of running these tests.
 func RequireBGPEnabled(cli ctrlclient.Client) {
-	installation := GetInstallation(cli)
-	if installation == nil {
-		framework.Failf("No Installation resource; is this cluster operator managed?")
+	installation := &operatorv1.Installation{}
+	if err := cli.Get(context.Background(), ctrlclient.ObjectKey{Name: "default"}, installation); err != nil {
+		framework.Failf("Error querying the Installation resource: %v", err)
 	}
 	network := installation.Spec.CalicoNetwork
 	if network == nil || network.BGP == nil || *network.BGP != operatorv1.BGPEnabled {

--- a/e2e/pkg/utils/installation.go
+++ b/e2e/pkg/utils/installation.go
@@ -34,16 +34,6 @@ func GetInstallation(cli ctrlclient.Client) *operatorv1.Installation {
 	return installation
 }
 
-// InstallationConfig returns the defaulted installation config the operator publishes on the
-// status. Nil if the cluster isn't operator managed, or if the operator hasn't reconciled yet.
-func InstallationConfig(cli ctrlclient.Client) *operatorv1.InstallationSpec {
-	installation := GetInstallation(cli)
-	if installation == nil {
-		return nil
-	}
-	return installation.Status.Computed
-}
-
 // UsesCalicoIPAM reports whether the cluster uses Calico IPAM. If the operator
 // Installation resource is available, it checks the configured IPAM type.
 // Returns true if Calico IPAM is in use or if the IPAM type cannot be determined
@@ -63,11 +53,11 @@ func UsesCalicoIPAM(cli ctrlclient.Client) bool {
 // networking enabled. Lanes whose clusters run in another networking mode should exclude
 // the RequiresBGP label instead of running these tests.
 func RequireBGPEnabled(cli ctrlclient.Client) {
-	config := InstallationConfig(cli)
-	if config == nil {
-		framework.Failf("No computed configuration on the Installation; is this cluster operator managed?")
+	installation := GetInstallation(cli)
+	if installation == nil {
+		framework.Failf("No Installation resource; is this cluster operator managed?")
 	}
-	network := config.CalicoNetwork
+	network := installation.Spec.CalicoNetwork
 	if network == nil || network.BGP == nil || *network.BGP != operatorv1.BGPEnabled {
 		framework.Failf("BGP is not enabled in this cluster, so the lane should exclude the RequiresBGP label")
 	}


### PR DESCRIPTION
Follow-on to the BGP precondition backport.

`RequireBGPEnabled` read `Status.Computed`, which the operator paired with this branch (operator v1.42) writes only in the last lines of a successful reconcile, after an `IsAvailable` early return. It is empty during bringup and on any degraded pass, so the precondition would fail on clusters that do have BGP. Master publishes the computed config ahead of the early returns, which is why the check is safe there and not here.

Reads `Spec.CalicoNetwork.BGP` instead, which is populated whenever the Installation exists. The `RequiresBGP` label and the lane filtering are unchanged.

```release-note
None
```