### PR TITLE
[v3.33] Felix FV: drop the racy setup assertions in the IPIP/BIRD route tests

### DIFF
--- a/felix/fv/ipip_bird_routes_test.go
+++ b/felix/fv/ipip_bird_routes_test.go
@@ -137,11 +137,11 @@ var _ = infrastructure.DatastoreDescribe(
 			dest, gw := match[1], match[2]
 
 			// Stand in for the route the old BIRD left behind for the same destination: same
-			// next hop and device, but BIRD's protocol.
+			// next hop and device, but BIRD's protocol.  Exec fails the test if the kernel
+			// rejects this, which is the only check available: Felix can reclaim the route
+			// within milliseconds, so nothing here can reliably observe it in place first.
 			felixes[0].Exec("ip", "route", "replace", dest, "via", gw,
 				"dev", dataplanedefs.IPIPIfaceName, "onlink", "proto", birdRouteProto)
-			Expect(tunl0Routes()).To(ContainSubstring("proto "+birdRouteProto),
-				"test setup did not install a BIRD-protocol route")
 
 			// Felix owns it, so it takes it back.  It must end up replaced rather than simply
 			// removed: this is a destination the cluster needs a route to.
@@ -156,8 +156,6 @@ var _ = infrastructure.DatastoreDescribe(
 			// replace it with.  Without the ownership rule nothing would ever clean this up.
 			felixes[0].Exec("ip", "route", "add", birdStrayCIDR, "via", felixes[1].IP,
 				"dev", dataplanedefs.IPIPIfaceName, "onlink", "proto", birdRouteProto)
-			Expect(tunl0Routes()).To(ContainSubstring(birdStrayCIDR),
-				"test setup did not install a BIRD-protocol route")
 
 			Eventually(tunl0Routes, "30s", "500ms").ShouldNot(ContainSubstring(birdStrayCIDR),
 				"Felix did not remove BIRD's stale route")


### PR DESCRIPTION
**Cherry-pick history**
- Pick onto **release-v3.33**: projectcalico/calico#13708

Fixes the flake reported as [IPIP/BIRD route race — Felix reclaims route before single-shot assertion can see it](https://fv-guru.tools.tigera.net/signatures/6a8763f605a40f5ea24b94fd) (untracked in fv-guru; 5 occurrences across 6 branches since 2026-08-20, one on a protected branch).

**Release note:**
```release-note
None
```

**AI assistance:** Claude Code helped diagnose the race and write this change.

## The race

`ipip_bird_routes_test.go` sets `FELIX_ROUTEREFRESHINTERVAL=1` so the tests don't take 90s waiting for Felix's default resync. Two tests then install a BIRD-protocol route and assert, in a *separate* `docker exec`, that it is present — before waiting for Felix to take it back or remove it.

Felix reclaims the route as soon as its next resync sees it. When that lands inside the ~100ms the second exec takes, the assertion fails with `test setup did not install a BIRD-protocol route` — blaming the setup for the product doing precisely what the test goes on to verify.

From the logs of one instance:

| time | event |
|---|---|
| `20:05:07.377` | test runs `ip route replace … proto bird` |
| `20:05:07.443` | Felix loads the route from the kernel, `Protocol=bird` |
| `20:05:07.444` | Felix replaces it back, `Protocol=80` |
| `20:05:07.480` | the assertion finally reads the table, sees `proto 80`, fails |

Felix won by 36ms and behaved correctly throughout.

With a 1s resync interval and a ~100ms exposure, the expected failure rate is roughly 10% per run, which matches the observed cadence — this will keep firing.

## Why removing the assertions is the right fix rather than narrowing the window

Collapsing the mutation and the check into a single `exec` would shrink the race to a few milliseconds, but not eliminate it. There is no timing-independent way to observe a route whose removal is the behaviour under test, so the assertion has to go.

It costs nothing:

- `Exec` → `utils.Run` → `run(checkNoError: true)` → `gomega.ExpectWithOffset(2, err).NotTo(HaveOccurred())`, so a route the kernel rejects **already** fails the test. That is the race-free check, and it is already in place.
- Neither test can now pass vacuously. `should take back a route to a destination it wants` derives `dest` and `gw` by matching Felix's own route out of the same helper, which proves the helper reads the right device before anything is changed. `should remove a route to a destination it does not want` shares one interface-name constant between the route it adds and the table it reads, so a wrong device would fail the add.

The third `It` and the second `Describe` are untouched — they only use `Consistently` and were never exposed.

## Testing

`gofmt` clean; no `Expect(` remains in the file. I have not run the FV suite against this: a passing run cannot demonstrate the absence of a race, and the argument here is structural — after this change neither test contains an assertion whose outcome depends on timing.

I have added a comment at the replace site explaining why there is no intermediate check, because its absence otherwise reads as an oversight and re-adding it would reintroduce the flake.

