### PR TITLE
Widen the focused WireGuard EKS Calico CNI e2e lane

### DIFF
--- a/.argoci/cron/e2e-iptables.yaml
+++ b/.argoci/cron/e2e-iptables.yaml
@@ -730,7 +730,7 @@ steps:
       - name: CNI_PLUGIN
         value: Calico
       - name: E2E_TEST_CONFIG
-        value: e2e/config/wireguard.yaml
+        value: e2e/config/iptables/eks-xtables-encap-wireguard-aws.yaml
       - name: ENABLE_WIREGUARD
         value: "true"
       - name: INSTALLER

--- a/.semaphore/end-to-end/pipelines/iptables.yml
+++ b/.semaphore/end-to-end/pipelines/iptables.yml
@@ -664,6 +664,8 @@ blocks:
           env_vars:
             - name: CNI_PLUGIN
               value: AmazonVPC
+            - name: E2E_TEST_CONFIG
+              value: e2e/config/wireguard.yaml
 
         - name: kdd (Calico CNI)
           execution_time_limit:
@@ -685,6 +687,8 @@ blocks:
             # - [It] "DNS should provide DNS for services"
             # - [It] "DNS should provide DNS for the cluster"
             # See details: https://docs.tigera.io/calico/latest/getting-started/kubernetes/managed-public-cloud/eks#install-eks-with-calico-networking:~:text=Calico%20networking%20cannot,on%20this%20setting.
+            - name: E2E_TEST_CONFIG
+              value: e2e/config/iptables/eks-xtables-encap-wireguard-aws.yaml
       env_vars:
         - name: AWS_K8S_CNI_VERSION
           value: "NA"
@@ -698,8 +702,6 @@ blocks:
           value: "true"
         - name: ENABLE_WIREGUARD
           value: "true"
-        - name: E2E_TEST_CONFIG
-          value: e2e/config/wireguard.yaml
 
   # This is the old every-other-week tests
   - name: Distro support

--- a/e2e/config/iptables/eks-xtables-encap-wireguard-aws.yaml
+++ b/e2e/config/iptables/eks-xtables-encap-wireguard-aws.yaml
@@ -1,0 +1,13 @@
+# Copyright (c) 2026 Tigera, Inc. All rights reserved.
+#
+# iptables: xtables dataplane, Calico CNI, encapsulated, no external node, AWS,
+# on EKS, WireGuard on.
+#
+# Selection scope comes from eks-xtables-encap-aws.yaml, which the arm64 smoke
+# lane also uses.
+
+extends: eks-xtables-encap-aws.yaml
+
+enable:
+  - label: Feature:Wireguard
+    reason: "ENABLE_WIREGUARD is set on this lane"

--- a/e2e/config/iptables/eks-xtables-encap-wireguard-aws.yaml
+++ b/e2e/config/iptables/eks-xtables-encap-wireguard-aws.yaml
@@ -3,11 +3,44 @@
 # iptables: xtables dataplane, Calico CNI, encapsulated, no external node, AWS,
 # on EKS, WireGuard on.
 #
-# Selection scope comes from eks-xtables-encap-aws.yaml, which the arm64 smoke
-# lane also uses.
+# Selection scope comes from eks-xtables-encap-aws.yaml; the exclusions below
+# are what a manual run of this lane could not pass.
 
 extends: eks-xtables-encap-aws.yaml
 
 enable:
   - label: Feature:Wireguard
     reason: "ENABLE_WIREGUARD is set on this lane"
+
+exclude:
+  labels:
+    - label: RequiresBGP
+      reason: "helmerator installs this cluster with VXLAN pools and no BGP, so BIRD is not running"
+
+  namePatterns:
+    - pattern: 'should encrypt traffic with ambient mode and enforce Calico NetworkPolicy'
+      reason: "ambient mode does not enforce the deny here; the sibling UDP spec passes, so the label stays in"
+
+    - group: "needs the multi-mode rapidclient server image, which is only side-loaded into kind and gcp-kubeadm clusters"
+      patterns:
+        - 'Packet.Size.Verification'
+
+    - group: "a host-network client cannot reach a ClusterIP or NodePort here; the other nine scenarios pass"
+      patterns:
+        - 'scenario-4:'
+        - 'scenario-10:'
+        - 'scenario-12:'
+
+    - group: "host endpoint egress policy does not drop the connection on this cluster, so these specs see traffic they expect to be blocked"
+      patterns:
+        - 'egress-0-2 ApplyOnForward='
+        - 'egress-0C2 ApplyOnForward='
+        - 'egress-0N2 ApplyOnForward='
+        - 'egress-1-2 ApplyOnForward=true'
+        - 'egress-1C2 ApplyOnForward=true'
+        - 'egress-1N2 ApplyOnForward=true'
+        - 'egress-2N2 ApplyOnForward=true'
+        - 'ingress-2-1 ApplyOnForward=true'
+
+    - pattern: 'should limit concurrent connections with QoS annotations'
+      reason: "the connection limit is not enforced on this cluster"

--- a/e2e/testsets/index.txt
+++ b/e2e/testsets/index.txt
@@ -52,7 +52,7 @@
 .argoci/cron/e2e-iptables.yaml | focused-wireguard-e2e-aks-w-azure-cni | wireguard | 1
 .argoci/cron/e2e-iptables.yaml | focused-wireguard-e2e-aks-with-calico-cni | wireguard | 1
 .argoci/cron/e2e-iptables.yaml | focused-wireguard-e2e-eks-kdd-aws-cni | wireguard | 1
-.argoci/cron/e2e-iptables.yaml | focused-wireguard-e2e-eks-kdd-calico-cni | iptables/eks-xtables-encap-wireguard-aws | 207
+.argoci/cron/e2e-iptables.yaml | focused-wireguard-e2e-eks-kdd-calico-cni | iptables/eks-xtables-encap-wireguard-aws | 181
 .argoci/cron/e2e-iptables.yaml | ipvs | iptables/xtables-v3crd | 224
 .argoci/cron/e2e-iptables.yaml | k8s-beta-runs | iptables/xtables-manifest | 218
 .argoci/cron/e2e-iptables.yaml | k8s-distros | iptables/xtables | 228
@@ -166,7 +166,7 @@
 .semaphore/end-to-end/pipelines/iptables.yml | Focused WireGuard E2E (AKS w/ Azure CNI) / kdd | wireguard | 1
 .semaphore/end-to-end/pipelines/iptables.yml | Focused WireGuard E2E (AKS with Calico CNI) / kdd | wireguard | 1
 .semaphore/end-to-end/pipelines/iptables.yml | Focused WireGuard E2E (EKS) / kdd (AWS CNI) | wireguard | 1
-.semaphore/end-to-end/pipelines/iptables.yml | Focused WireGuard E2E (EKS) / kdd (Calico CNI) | iptables/eks-xtables-encap-wireguard-aws | 207
+.semaphore/end-to-end/pipelines/iptables.yml | Focused WireGuard E2E (EKS) / kdd (Calico CNI) | iptables/eks-xtables-encap-wireguard-aws | 181
 .semaphore/end-to-end/pipelines/iptables.yml | IPVS / ipvs | iptables/xtables-v3crd | 224
 .semaphore/end-to-end/pipelines/iptables.yml | KubeVirt e2e tests / KubeVirt IP persistence and live migration | gcp/kubevirt | 9
 .semaphore/end-to-end/pipelines/iptables.yml | Migration / Flannel migration | iptables/xtables-manifest | 218

--- a/e2e/testsets/index.txt
+++ b/e2e/testsets/index.txt
@@ -52,7 +52,7 @@
 .argoci/cron/e2e-iptables.yaml | focused-wireguard-e2e-aks-w-azure-cni | wireguard | 1
 .argoci/cron/e2e-iptables.yaml | focused-wireguard-e2e-aks-with-calico-cni | wireguard | 1
 .argoci/cron/e2e-iptables.yaml | focused-wireguard-e2e-eks-kdd-aws-cni | wireguard | 1
-.argoci/cron/e2e-iptables.yaml | focused-wireguard-e2e-eks-kdd-calico-cni | wireguard | 1
+.argoci/cron/e2e-iptables.yaml | focused-wireguard-e2e-eks-kdd-calico-cni | iptables/eks-xtables-encap-wireguard-aws | 207
 .argoci/cron/e2e-iptables.yaml | ipvs | iptables/xtables-v3crd | 224
 .argoci/cron/e2e-iptables.yaml | k8s-beta-runs | iptables/xtables-manifest | 218
 .argoci/cron/e2e-iptables.yaml | k8s-distros | iptables/xtables | 228
@@ -166,7 +166,7 @@
 .semaphore/end-to-end/pipelines/iptables.yml | Focused WireGuard E2E (AKS w/ Azure CNI) / kdd | wireguard | 1
 .semaphore/end-to-end/pipelines/iptables.yml | Focused WireGuard E2E (AKS with Calico CNI) / kdd | wireguard | 1
 .semaphore/end-to-end/pipelines/iptables.yml | Focused WireGuard E2E (EKS) / kdd (AWS CNI) | wireguard | 1
-.semaphore/end-to-end/pipelines/iptables.yml | Focused WireGuard E2E (EKS) / kdd (Calico CNI) | wireguard | 1
+.semaphore/end-to-end/pipelines/iptables.yml | Focused WireGuard E2E (EKS) / kdd (Calico CNI) | iptables/eks-xtables-encap-wireguard-aws | 207
 .semaphore/end-to-end/pipelines/iptables.yml | IPVS / ipvs | iptables/xtables-v3crd | 224
 .semaphore/end-to-end/pipelines/iptables.yml | KubeVirt e2e tests / KubeVirt IP persistence and live migration | gcp/kubevirt | 9
 .semaphore/end-to-end/pipelines/iptables.yml | Migration / Flannel migration | iptables/xtables-manifest | 218

--- a/e2e/testsets/index.txt
+++ b/e2e/testsets/index.txt
@@ -52,7 +52,7 @@
 .argoci/cron/e2e-iptables.yaml | focused-wireguard-e2e-aks-w-azure-cni | wireguard | 1
 .argoci/cron/e2e-iptables.yaml | focused-wireguard-e2e-aks-with-calico-cni | wireguard | 1
 .argoci/cron/e2e-iptables.yaml | focused-wireguard-e2e-eks-kdd-aws-cni | wireguard | 1
-.argoci/cron/e2e-iptables.yaml | focused-wireguard-e2e-eks-kdd-calico-cni | iptables/eks-xtables-encap-wireguard-aws | 181
+.argoci/cron/e2e-iptables.yaml | focused-wireguard-e2e-eks-kdd-calico-cni | iptables/eks-xtables-encap-wireguard-aws | 189
 .argoci/cron/e2e-iptables.yaml | ipvs | iptables/xtables-v3crd | 224
 .argoci/cron/e2e-iptables.yaml | k8s-beta-runs | iptables/xtables-manifest | 218
 .argoci/cron/e2e-iptables.yaml | k8s-distros | iptables/xtables | 228
@@ -166,7 +166,7 @@
 .semaphore/end-to-end/pipelines/iptables.yml | Focused WireGuard E2E (AKS w/ Azure CNI) / kdd | wireguard | 1
 .semaphore/end-to-end/pipelines/iptables.yml | Focused WireGuard E2E (AKS with Calico CNI) / kdd | wireguard | 1
 .semaphore/end-to-end/pipelines/iptables.yml | Focused WireGuard E2E (EKS) / kdd (AWS CNI) | wireguard | 1
-.semaphore/end-to-end/pipelines/iptables.yml | Focused WireGuard E2E (EKS) / kdd (Calico CNI) | iptables/eks-xtables-encap-wireguard-aws | 181
+.semaphore/end-to-end/pipelines/iptables.yml | Focused WireGuard E2E (EKS) / kdd (Calico CNI) | iptables/eks-xtables-encap-wireguard-aws | 189
 .semaphore/end-to-end/pipelines/iptables.yml | IPVS / ipvs | iptables/xtables-v3crd | 224
 .semaphore/end-to-end/pipelines/iptables.yml | KubeVirt e2e tests / KubeVirt IP persistence and live migration | gcp/kubevirt | 9
 .semaphore/end-to-end/pipelines/iptables.yml | Migration / Flannel migration | iptables/xtables-manifest | 218

--- a/e2e/testsets/sets/iptables/eks-xtables-encap-wireguard-aws.txt
+++ b/e2e/testsets/sets/iptables/eks-xtables-encap-wireguard-aws.txt
@@ -23,13 +23,21 @@
 [sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC NetworkPolicy should deny creation by a user without tier GET access [Conformance]
 [sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC NetworkPolicy should deny creation by a user without tier policy access
 [sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC NetworkPolicy should deny update by a user without tier GET access
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC collection delete should allow a collection delete by a user with full tier RBAC
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC collection delete should deny a collection delete by a user without tier policy access [Conformance]
 [sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC default tier should not allow deleting the default tier
 [sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC default tier should not allow updating the default tier
 [sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC list via tier RBAC [RequiresCalicoAPIServer] should allow listing policies in the permitted tier
 [sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC list via tier RBAC [RequiresCalicoAPIServer] should deny listing when user lacks tier policy access
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC namespace-scoped tier access should confine a namespaced tier grant to its own namespace [Conformance]
 [sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC old-style vs new-style name disambiguation [RequiresCalicoAPIServer] should independently authorize bare and tier-prefixed policy names
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC operator-rendered passthrough [RequiresOperator] should grant the tiered policy write verbs and no read verbs in v3 CRD mode
 [sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC read-only access should allow reading but deny writing for a read-only user [Conformance]
 [sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC resource-name exact match [RequiresCalicoAPIServer] should allow access to the named policy but deny access to others
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC staged policies should allow staged global policy writes by a user with full tier RBAC
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC staged policies should allow staged policy writes by a user with full tier RBAC [Conformance]
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC staged policies should deny staged global policy creation by a user without tier GET access
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC staged policies should deny staged policy creation by a user without tier GET access [Conformance]
 [sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC tier isolation should restrict a user to only their permitted tier [Conformance]
 [sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath ClusterIP access scenario-0C0: pod0 -> clusterIP -> pod0 (loopback)
 [sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath ClusterIP access scenario-0C1: pod0 -> clusterIP -> pod1 (same node)

--- a/e2e/testsets/sets/iptables/eks-xtables-encap-wireguard-aws.txt
+++ b/e2e/testsets/sets/iptables/eks-xtables-encap-wireguard-aws.txt
@@ -31,16 +31,6 @@
 [sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC read-only access should allow reading but deny writing for a read-only user [Conformance]
 [sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC resource-name exact match [RequiresCalicoAPIServer] should allow access to the named policy but deny access to others
 [sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC tier isolation should restrict a user to only their permitted tier [Conformance]
-[sig-calico] [Team:CORE] [Feature:BGPPeer] [RequiresBGP] [Category:Networking] BGP password should enforce BGP password authentication [Serial]
-[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Packet Size Verification with different packet sizes using UDP and TCP host to nodeport, different nodes
-[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Packet Size Verification with different packet sizes using UDP and TCP host to pod, different nodes
-[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Packet Size Verification with different packet sizes using UDP and TCP host to service, different nodes
-[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Packet Size Verification with different packet sizes using UDP and TCP pod to nodeport, different nodes
-[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Packet Size Verification with different packet sizes using UDP and TCP pod to nodeport, same node
-[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Packet Size Verification with different packet sizes using UDP and TCP pod to pod, different nodes
-[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Packet Size Verification with different packet sizes using UDP and TCP pod to pod, same node
-[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Packet Size Verification with different packet sizes using UDP and TCP pod to service, different nodes
-[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Packet Size Verification with different packet sizes using UDP and TCP pod to service, same node
 [sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath ClusterIP access scenario-0C0: pod0 -> clusterIP -> pod0 (loopback)
 [sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath ClusterIP access scenario-0C1: pod0 -> clusterIP -> pod1 (same node)
 [sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath ClusterIP access scenario-0C2: pod0 -> clusterIP -> pod2 (cross node) [Conformance]
@@ -60,38 +50,25 @@
 [sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath NodePort access scenario-0N10: pod0 -> node1 NodePort -> pod0
 [sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath NodePort access scenario-0N11: pod0 -> node1 NodePort -> pod1 (hairpin)
 [sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath NodePort access scenario-0N12: pod0 -> node1 NodePort -> pod2 (pod on other node)
-[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Ingress Datapath scenario-10: node1 hostNet=true -> node1NodePort
 [sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Ingress Datapath scenario-11: node0 hostNet=false -> node1NodePort
-[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Ingress Datapath scenario-12: node0 hostNet=true -> node1NodePort
 [sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Ingress Datapath scenario-1: svcNode hostNet=false -> clusterIP
 [sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Ingress Datapath scenario-2: svcNode hostNet=true -> clusterIP
 [sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Ingress Datapath scenario-3: node1 hostNet=false -> clusterIP [Conformance]
-[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Ingress Datapath scenario-4: node1 hostNet=true -> clusterIP
 [sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Ingress Datapath scenario-5: svcNode hostNet=false -> svcNodePort
 [sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Ingress Datapath scenario-6: svcNode hostNet=true -> svcNodePort
 [sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Ingress Datapath scenario-7: node1 hostNet=false -> svcNodePort
 [sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Ingress Datapath scenario-8: node1 hostNet=true -> svcNodePort
 [sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Ingress Datapath scenario-9: node1 hostNet=false -> node1NodePort
-[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-0-2 ApplyOnForward=false, egress [Serial]
-[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-0-2 ApplyOnForward=true, egress [Serial]
-[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-0C2 ApplyOnForward=false, egress [Serial]
-[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-0C2 ApplyOnForward=true, egress [Serial]
 [sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-0C3 ApplyOnForward=false, egress [Serial]
 [sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-0C3 ApplyOnForward=true, egress [Serial]
-[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-0N2 ApplyOnForward=false, egress [Serial]
-[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-0N2 ApplyOnForward=true, egress [Serial]
 [sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-0N3 ApplyOnForward=false, egress [Serial]
 [sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-0N3 ApplyOnForward=true, egress [Serial]
 [sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-1-2 ApplyOnForward=false, egress [Serial]
-[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-1-2 ApplyOnForward=true, egress [Serial]
 [sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-1C2 ApplyOnForward=false, egress [Serial]
-[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-1C2 ApplyOnForward=true, egress [Serial]
 [sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-1N2 ApplyOnForward=false, egress [Serial]
-[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-1N2 ApplyOnForward=true, egress [Serial]
 [sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-2N1 ApplyOnForward=false, egress [Serial]
 [sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-2N1 ApplyOnForward=true, egress [Serial]
 [sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath ingress-2-1 ApplyOnForward=false, ingress [Serial]
-[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath ingress-2-1 ApplyOnForward=true, ingress [Serial]
 [sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath ingress-2C0 ApplyOnForward=false, ingress [Serial]
 [sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath ingress-2C0 ApplyOnForward=true, ingress [Serial]
 [sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath ingress-2N1 ApplyOnForward=false, ingress [Serial]
@@ -99,14 +76,12 @@
 [sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath ingress-3-0 ApplyOnForward=false, ingress [Serial]
 [sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath ingress-3-0 ApplyOnForward=true, ingress [Serial]
 [sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath xtables-only [RequiresXtables] egress-2N2 ApplyOnForward=false, egress [Serial]
-[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath xtables-only [RequiresXtables] egress-2N2 ApplyOnForward=true, egress [Serial]
 [sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath xtables-only [RequiresXtables] ingress-2N2 ApplyOnForward=false, ingress [Serial]
 [sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath xtables-only [RequiresXtables] ingress-2N2 ApplyOnForward=true, ingress [Serial]
 [sig-calico] [Team:CORE] [Feature:IPAM] [RequiresCalicoIPAM] [Category:Networking] IPAM GC should garbage-collect leaked IP addresses [Serial]
 [sig-calico] [Team:CORE] [Feature:IPPool] [Category:Operator] [RequiresOperator] [RequiresCalicoCNI] operator IPPool management tests should create and delete IP pools [Serial]
 [sig-calico] [Team:CORE] [Feature:Istio] [Category:Networking] Istio OpenShift Platform Configuration should deploy Istio with correct OpenShift platform configuration [Serial]
 [sig-calico] [Team:CORE] [Feature:Istio] [Category:Networking] [RequiresOperator] Istio Ambient Mode should allow UDP traffic to bypass ztunnel while Calico enforces UDP policy [Serial]
-[sig-calico] [Team:CORE] [Feature:Istio] [Category:Networking] [RequiresOperator] Istio Ambient Mode should encrypt traffic with ambient mode and enforce Calico NetworkPolicy [Serial]
 [sig-calico] [Team:CORE] [Feature:MTU] [Category:Networking] Automatic MTU tests should select the correct MTU for the platform
 [sig-calico] [Team:CORE] [Feature:NetworkPolicy] [Category:Policy] [RunsOnWindows] Calico NetworkPolicy should correctly isolate namespaces [Conformance]
 [sig-calico] [Team:CORE] [Feature:NetworkPolicy] [Category:Policy] [RunsOnWindows] Calico NetworkPolicy should provide a default allow [Conformance]
@@ -118,7 +93,6 @@
 [sig-calico] [Team:CORE] [Feature:NetworkPolicy] [Category:Policy] service network policy Calico service network policy test ServiceMatch policy client egress by service, server ingress by service [Conformance]
 [sig-calico] [Team:CORE] [Feature:OwnerReferences] [Category:Configuration] OwnerReference tests should delete a NetworkSet if its owner has been deleted
 [sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit bandwidth with QoS annotations
-[sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit concurrent connections with QoS annotations
 [sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit packet rate with QoS annotations
 [sig-calico] [Team:CORE] [Feature:Wireguard] [Category:Networking] WireGuard tests should carry pod traffic between nodes over the tunnel
 [sig-network] API Server should have Endpoints and EndpointSlices pointing to API Server [Conformance]

--- a/e2e/testsets/sets/iptables/eks-xtables-encap-wireguard-aws.txt
+++ b/e2e/testsets/sets/iptables/eks-xtables-encap-wireguard-aws.txt
@@ -1,0 +1,207 @@
+[sig-calico] [Team:CORE] [Category:Networking] [Feature:HostPorts] HostPorts tests with host port resources active on :8080 should support Pod HostPorts [Conformance] [Serial]
+[sig-calico] [Team:CORE] [Category:Networking] [Feature:Pods] Pod Termination Grace Period should allow client to reach server while client is terminating [Conformance]
+[sig-calico] [Team:CORE] [Category:Networking] [Feature:Pods] Pod Termination Grace Period should allow pinging a server pod while it is terminating
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Flow-Logs] [RequiresGoldmane] [NoTierPrefix] staged network policy Test presence in flow logs StagedGlobalNetworkPolicy Validate name, tier, action [Conformance]
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Flow-Logs] [RequiresGoldmane] [NoTierPrefix] staged network policy Test presence in flow logs StagedKubernetesNetworkPolicy Validate name, tier, action [Conformance]
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Flow-Logs] [RequiresGoldmane] [NoTierPrefix] staged network policy Test presence in flow logs StagedNetworkPolicy Validate name, tier, action [Conformance]
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Flow-Logs] [RequiresGoldmane] [NoTierPrefix] staged network policy enforcing staged-policies StagedGlobalNetworkPolicy should enforce a deny policy
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Flow-Logs] [RequiresGoldmane] [NoTierPrefix] staged network policy enforcing staged-policies StagedKubernetesNetworkPolicy should enforce a deny policy
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Flow-Logs] [RequiresGoldmane] [NoTierPrefix] staged network policy enforcing staged-policies StagedNetworkPolicy should enforce a deny policy
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Host-Protection] host endpoint tests doNotTrack policy should deny connections to the specified port in a doNotTrack deny policy [Serial]
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Host-Protection] host endpoint tests should allow connections using a named port [Conformance] [Serial]
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Host-Protection] host endpoint tests should allow inbound connections with an allow-all [Serial]
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Host-Protection] host endpoint tests should block all inbound connections by default [Serial]
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-Policy] [RunsOnWindows] Tiered policy tests with a second tier can explicitly pass traffic
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-Policy] [RunsOnWindows] Tiered policy tests with a second tier should enforce a default deny
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-Policy] [RunsOnWindows] Tiered policy tests with a single tier taking precedence over the default tier can pass to the default tier, and allow traffic explicitly. [Conformance]
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] Tiered RBAC with tier-prefixed names should allow create and deny based on tier RBAC with prefixed names
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC GlobalNetworkPolicy should allow creation by a user with full tier RBAC
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC GlobalNetworkPolicy should deny creation by a user without tier access
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC NetworkPolicy should allow creation by a user with full tier RBAC [Conformance]
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC NetworkPolicy should allow deletion by a user with full tier RBAC
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC NetworkPolicy should allow update by a user with full tier RBAC
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC NetworkPolicy should deny creation by a user without tier GET access [Conformance]
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC NetworkPolicy should deny creation by a user without tier policy access
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC NetworkPolicy should deny update by a user without tier GET access
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC default tier should not allow deleting the default tier
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC default tier should not allow updating the default tier
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC list via tier RBAC [RequiresCalicoAPIServer] should allow listing policies in the permitted tier
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC list via tier RBAC [RequiresCalicoAPIServer] should deny listing when user lacks tier policy access
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC old-style vs new-style name disambiguation [RequiresCalicoAPIServer] should independently authorize bare and tier-prefixed policy names
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC read-only access should allow reading but deny writing for a read-only user [Conformance]
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC resource-name exact match [RequiresCalicoAPIServer] should allow access to the named policy but deny access to others
+[sig-calico] [Team:CORE] [Category:Policy] [Feature:Tiered-RBAC] [NoTierPrefix] Tiered RBAC tier isolation should restrict a user to only their permitted tier [Conformance]
+[sig-calico] [Team:CORE] [Feature:BGPPeer] [RequiresBGP] [Category:Networking] BGP password should enforce BGP password authentication [Serial]
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Packet Size Verification with different packet sizes using UDP and TCP host to nodeport, different nodes
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Packet Size Verification with different packet sizes using UDP and TCP host to pod, different nodes
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Packet Size Verification with different packet sizes using UDP and TCP host to service, different nodes
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Packet Size Verification with different packet sizes using UDP and TCP pod to nodeport, different nodes
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Packet Size Verification with different packet sizes using UDP and TCP pod to nodeport, same node
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Packet Size Verification with different packet sizes using UDP and TCP pod to pod, different nodes
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Packet Size Verification with different packet sizes using UDP and TCP pod to pod, same node
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Packet Size Verification with different packet sizes using UDP and TCP pod to service, different nodes
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Packet Size Verification with different packet sizes using UDP and TCP pod to service, same node
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath ClusterIP access scenario-0C0: pod0 -> clusterIP -> pod0 (loopback)
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath ClusterIP access scenario-0C1: pod0 -> clusterIP -> pod1 (same node)
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath ClusterIP access scenario-0C2: pod0 -> clusterIP -> pod2 (cross node) [Conformance]
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath ExternalIP access scenario-0EC0: pod0 -> externalIP Cluster -> pod0
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath ExternalIP access scenario-0EC1: pod0 -> externalIP Cluster -> pod1
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath ExternalIP access scenario-0EC2: pod0 -> externalIP Cluster -> pod2 (other node) [Conformance]
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath ExternalIP access scenario-0EL0: pod0 -> externalIP local-only -> pod0
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath ExternalIP access scenario-0EL1: pod0 -> externalIP local-only -> pod1
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath Host-networked destination scenario-0H1: pod0 -> clusterIP -> host-networked pod1 (same node)
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath Host-networked destination scenario-0H2: pod0 -> clusterIP -> host-networked pod2 (other node)
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath NodePort access scenario-0L00: pod0 -> node0 NodePort local-only -> pod0
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath NodePort access scenario-0L01: pod0 -> node0 NodePort local-only -> pod1
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath NodePort access scenario-0L12: pod0 -> node1 NodePort local-only -> pod2
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath NodePort access scenario-0N00: pod0 -> node0 NodePort -> pod0
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath NodePort access scenario-0N01: pod0 -> node0 NodePort -> pod1 (same node)
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath NodePort access scenario-0N02: pod0 -> node0 NodePort -> pod2 (other node) [Conformance]
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath NodePort access scenario-0N10: pod0 -> node1 NodePort -> pod0
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath NodePort access scenario-0N11: pod0 -> node1 NodePort -> pod1 (hairpin)
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Egress Datapath NodePort access scenario-0N12: pod0 -> node1 NodePort -> pod2 (pod on other node)
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Ingress Datapath scenario-10: node1 hostNet=true -> node1NodePort
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Ingress Datapath scenario-11: node0 hostNet=false -> node1NodePort
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Ingress Datapath scenario-12: node0 hostNet=true -> node1NodePort
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Ingress Datapath scenario-1: svcNode hostNet=false -> clusterIP
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Ingress Datapath scenario-2: svcNode hostNet=true -> clusterIP
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Ingress Datapath scenario-3: node1 hostNet=false -> clusterIP [Conformance]
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Ingress Datapath scenario-4: node1 hostNet=true -> clusterIP
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Ingress Datapath scenario-5: svcNode hostNet=false -> svcNodePort
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Ingress Datapath scenario-6: svcNode hostNet=true -> svcNodePort
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Ingress Datapath scenario-7: node1 hostNet=false -> svcNodePort
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Ingress Datapath scenario-8: node1 hostNet=true -> svcNodePort
+[sig-calico] [Team:CORE] [Feature:Datapath] [Category:Networking] Workload Ingress Datapath scenario-9: node1 hostNet=false -> node1NodePort
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-0-2 ApplyOnForward=false, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-0-2 ApplyOnForward=true, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-0C2 ApplyOnForward=false, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-0C2 ApplyOnForward=true, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-0C3 ApplyOnForward=false, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-0C3 ApplyOnForward=true, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-0N2 ApplyOnForward=false, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-0N2 ApplyOnForward=true, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-0N3 ApplyOnForward=false, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-0N3 ApplyOnForward=true, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-1-2 ApplyOnForward=false, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-1-2 ApplyOnForward=true, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-1C2 ApplyOnForward=false, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-1C2 ApplyOnForward=true, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-1N2 ApplyOnForward=false, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-1N2 ApplyOnForward=true, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-2N1 ApplyOnForward=false, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath egress-2N1 ApplyOnForward=true, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath ingress-2-1 ApplyOnForward=false, ingress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath ingress-2-1 ApplyOnForward=true, ingress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath ingress-2C0 ApplyOnForward=false, ingress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath ingress-2C0 ApplyOnForward=true, ingress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath ingress-2N1 ApplyOnForward=false, ingress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath ingress-2N1 ApplyOnForward=true, ingress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath ingress-3-0 ApplyOnForward=false, ingress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath ingress-3-0 ApplyOnForward=true, ingress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath xtables-only [RequiresXtables] egress-2N2 ApplyOnForward=false, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath xtables-only [RequiresXtables] egress-2N2 ApplyOnForward=true, egress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath xtables-only [RequiresXtables] ingress-2N2 ApplyOnForward=false, ingress [Serial]
+[sig-calico] [Team:CORE] [Feature:Host-Protection] [Category:Networking] Host Endpoint Datapath xtables-only [RequiresXtables] ingress-2N2 ApplyOnForward=true, ingress [Serial]
+[sig-calico] [Team:CORE] [Feature:IPAM] [RequiresCalicoIPAM] [Category:Networking] IPAM GC should garbage-collect leaked IP addresses [Serial]
+[sig-calico] [Team:CORE] [Feature:IPPool] [Category:Operator] [RequiresOperator] [RequiresCalicoCNI] operator IPPool management tests should create and delete IP pools [Serial]
+[sig-calico] [Team:CORE] [Feature:Istio] [Category:Networking] Istio OpenShift Platform Configuration should deploy Istio with correct OpenShift platform configuration [Serial]
+[sig-calico] [Team:CORE] [Feature:Istio] [Category:Networking] [RequiresOperator] Istio Ambient Mode should allow UDP traffic to bypass ztunnel while Calico enforces UDP policy [Serial]
+[sig-calico] [Team:CORE] [Feature:Istio] [Category:Networking] [RequiresOperator] Istio Ambient Mode should encrypt traffic with ambient mode and enforce Calico NetworkPolicy [Serial]
+[sig-calico] [Team:CORE] [Feature:MTU] [Category:Networking] Automatic MTU tests should select the correct MTU for the platform
+[sig-calico] [Team:CORE] [Feature:NetworkPolicy] [Category:Policy] [RunsOnWindows] Calico NetworkPolicy should correctly isolate namespaces [Conformance]
+[sig-calico] [Team:CORE] [Feature:NetworkPolicy] [Category:Policy] [RunsOnWindows] Calico NetworkPolicy should provide a default allow [Conformance]
+[sig-calico] [Team:CORE] [Feature:NetworkPolicy] [Category:Policy] [RunsOnWindows] Calico NetworkPolicy should support a 'deny egress' policy [Conformance]
+[sig-calico] [Team:CORE] [Feature:NetworkPolicy] [Category:Policy] [RunsOnWindows] Calico NetworkPolicy should support namespace selectors [Conformance]
+[sig-calico] [Team:CORE] [Feature:NetworkPolicy] [Category:Policy] [RunsOnWindows] Calico NetworkPolicy should support service account selectors [Conformance]
+[sig-calico] [Team:CORE] [Feature:NetworkPolicy] [Category:Policy] service network policy Calico service network policy test ServiceMatch policy client egress by pod-name, server ingress by service [Conformance]
+[sig-calico] [Team:CORE] [Feature:NetworkPolicy] [Category:Policy] service network policy Calico service network policy test ServiceMatch policy client egress by service, server ingress by pod-name [Conformance]
+[sig-calico] [Team:CORE] [Feature:NetworkPolicy] [Category:Policy] service network policy Calico service network policy test ServiceMatch policy client egress by service, server ingress by service [Conformance]
+[sig-calico] [Team:CORE] [Feature:OwnerReferences] [Category:Configuration] OwnerReference tests should delete a NetworkSet if its owner has been deleted
+[sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit bandwidth with QoS annotations
+[sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit concurrent connections with QoS annotations
+[sig-calico] [Team:CORE] [Feature:QoS] [Category:Networking] QoS Controls should limit packet rate with QoS annotations
+[sig-calico] [Team:CORE] [Feature:Wireguard] [Category:Networking] WireGuard tests should carry pod traffic between nodes over the tunnel
+[sig-network] API Server should have Endpoints and EndpointSlices pointing to API Server [Conformance]
+[sig-network] API Server should provide secure master service [Conformance]
+[sig-network] DNS should support configurable pod DNS nameservers [Conformance]
+[sig-network] EndpointSlice should create Endpoints and EndpointSlices for Pods matching a Service [Conformance]
+[sig-network] EndpointSlice should create and delete EndpointSlices for a Service with a selector that matches no pods [Conformance]
+[sig-network] EndpointSlice should support a Service with multiple endpoint IPs specified in multiple EndpointSlices [Conformance]
+[sig-network] EndpointSlice should support a Service with multiple ports specified in multiple EndpointSlices [Conformance]
+[sig-network] EndpointSlice should support creating EndpointSlice API operations [Conformance]
+[sig-network] EndpointSliceMirroring should mirror a custom Endpoints resource through create update and delete [Conformance]
+[sig-network] Endpoints should test the lifecycle of an Endpoint [Conformance]
+[sig-network] EndpointsController should create Endpoints for Pods matching a Service [Conformance]
+[sig-network] EndpointsController should create and delete Endpoints for a Service with a selector that matches no pods [Conformance]
+[sig-network] HostPort validates that there is no conflict between pods with same hostPort but different hostIP and protocol [LinuxOnly] [Conformance]
+[sig-network] Ingress API should support creating Ingress API operations [Conformance]
+[sig-network] IngressClass API should support creating IngressClass API operations [Conformance]
+[sig-network] Netpol NetworkPolicy between server and client should allow egress access on one named port [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should allow egress access to server in CIDR block [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should allow ingress access from namespace on one named port [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should allow ingress access from updated namespace [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should allow ingress access from updated pod [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should allow ingress access on one named port [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should deny egress from all pods in a namespace [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should deny egress from pods based on PodSelector [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should deny ingress access to updated pod [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should deny ingress from pods on other namespaces [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce egress policy allowing traffic to a server in a different namespace based on PodSelector and NamespaceSelector [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce except clause while egress access to server in CIDR block [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce ingress policy allowing any port traffic to a server on a specific protocol [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce multiple egress policies with egress allow-all policy taking precedence [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce multiple ingress policies with ingress allow-all policy taking precedence [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce multiple, stacked policies with overlapping podSelectors [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce policies to check ingress and egress policies can be controlled independently based on PodSelector [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce policy based on Multiple PodSelectors and NamespaceSelectors [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce policy based on NamespaceSelector with MatchExpressions [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce policy based on NamespaceSelector with MatchExpressions using default ns label [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce policy based on PodSelector and NamespaceSelector [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce policy based on PodSelector or NamespaceSelector [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce policy based on PodSelector with MatchExpressions [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce policy based on Ports [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce policy based on any PodSelectors [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce policy to allow ingress traffic for a target [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce policy to allow ingress traffic from pods in all namespaces [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce policy to allow traffic based on NamespaceSelector with MatchLabels using default ns label [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce policy to allow traffic from pods within server namespace based on PodSelector [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce policy to allow traffic only from a different namespace, based on NamespaceSelector [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce policy to allow traffic only from a pod in a different namespace based on PodSelector and NamespaceSelector [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should enforce updated policy [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should ensure an IP overlapping both IPBlock.CIDR and IPBlock.Except is allowed [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should not allow access by TCP when a policy specifies only UDP [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should not allow all ports if it cannot limit to the requested port [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should not mistakenly treat 'protocol: SCTP' as 'protocol: TCP', even if the plugin doesn't support SCTP [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should properly isolate pods that are selected by a policy allowing SCTP, even if the plugin doesn't support SCTP [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should stop enforcing policies after they are deleted [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should support a 'default-deny-all' policy [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should support a 'default-deny-ingress' policy [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should support allow-all policy [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should support denying of egress traffic on the client side (even if the server explicitly allows this traffic) [Feature:NetworkPolicy]
+[sig-network] Netpol NetworkPolicy between server and client should work with Ingress, Egress specified together [Feature:NetworkPolicy]
+[sig-network] Netpol [LinuxOnly] NetworkPolicy between server and client using UDP should enforce policy based on Ports [Feature:NetworkPolicy]
+[sig-network] Netpol [LinuxOnly] NetworkPolicy between server and client using UDP should enforce policy to allow traffic only from a pod in a different namespace based on PodSelector and NamespaceSelector [Feature:NetworkPolicy]
+[sig-network] Netpol [LinuxOnly] NetworkPolicy between server and client using UDP should support a 'default-deny-ingress' policy [Feature:NetworkPolicy]
+[sig-network] Networking Granular Checks: Pods should function for intra-pod communication: http [Conformance] [NodeConformance]
+[sig-network] Networking Granular Checks: Pods should function for intra-pod communication: udp [Conformance] [NodeConformance]
+[sig-network] Networking Granular Checks: Pods should function for node-pod communication: http [LinuxOnly] [Conformance] [NodeConformance]
+[sig-network] Networking Granular Checks: Pods should function for node-pod communication: udp [LinuxOnly] [Conformance] [NodeConformance]
+[sig-network] Proxy version v1 A set of valid responses are returned for both pod and service ProxyWithPath [Conformance]
+[sig-network] Service endpoints latency should not be very high [Conformance]
+[sig-network] ServiceCIDR and IPAddress API should support IPAddress API operations [Conformance]
+[sig-network] ServiceCIDR and IPAddress API should support ServiceCIDR API operations [Conformance]
+[sig-network] Services should be able to change the type from ClusterIP to ExternalName [Conformance]
+[sig-network] Services should be able to change the type from ExternalName to ClusterIP [Conformance]
+[sig-network] Services should be able to change the type from ExternalName to NodePort [Conformance]
+[sig-network] Services should be able to change the type from NodePort to ExternalName [Conformance]
+[sig-network] Services should be able to create a functioning NodePort service [Conformance]
+[sig-network] Services should be able to switch session affinity for NodePort service [LinuxOnly] [Conformance]
+[sig-network] Services should be able to switch session affinity for service with type clusterIP [LinuxOnly] [Conformance]
+[sig-network] Services should complete a service status lifecycle [Conformance]
+[sig-network] Services should delete a collection of services [Conformance]
+[sig-network] Services should find a service from listing all namespaces [Conformance]
+[sig-network] Services should have session affinity work for NodePort service [LinuxOnly] [Conformance]
+[sig-network] Services should have session affinity work for service with type clusterIP [LinuxOnly] [Conformance]
+[sig-network] Services should serve a basic endpoint from pods [Conformance]
+[sig-network] Services should serve endpoints on same port and different protocols [Conformance]
+[sig-network] Services should serve multiport endpoints from pods [Conformance]


### PR DESCRIPTION
The focused WireGuard EKS lane with Calico CNI spun up a whole EKS cluster to run one spec. This points it at a config that reuses the scope `eks-xtables-encap-aws.yaml` already carries for EKS with Calico CNI, and enables the WireGuard label `base.yaml` excludes. 1 spec becomes 189.

## Description

The exclusions come from running the lane by hand on 2026-08-31: 206 specs ran, 175 passed, and the WireGuard spec was one of them.

| Excluded | Specs | Why |
|---|---|---|
| Packet size verification | 9 | the multi-mode rapidclient image only side-loads into kind and gcp-kubeadm clusters |
| Host endpoint egress scenarios | 11 | policy does not drop the connection; a serial rerun reproduced 8 of 8 |
| Workload ingress scenarios 4, 10 and 12 | 3 | a host-network client cannot reach a ClusterIP or NodePort here |
| BGP | 1 | helmerator installs this cluster with VXLAN pools and no BGP, so BIRD is not running |
| Istio ambient encryption | 1 | the sibling UDP spec passes, so the label stays in |
| QoS connection limit | 1 | not enforced on this cluster |

Note the BGP row. `eks-xtables-encap-aws.yaml` does not exclude that label, so the arm64 smoke lane sharing the scope must be getting BIRD from the operator installer where this lane does not.

Five other specs failed the run and are deliberately not excluded. All five died on connection resets between my machine and the EKS public API endpoint, and Lens puts each of them between 87% and 100% on aws-eks over July and August, so they pass when the runner is inside AWS.

The host endpoint group is the part I am least sure about. Host endpoints should work behind Calico CNI, and Lens has that group at 88.9% across aws-eks for the same two months, so this may be a bug on this particular shape rather than something the shape rules out. No ticket for it yet.

One caveat on all of it: the run covered 181 of these specs on a single day. Eight Tiered-RBAC specs have landed on master since, and they have not run on this shape.

Only the EKS Calico CNI lane changes here. The EKS AWS CNI lane and the two AKS lanes still run one spec apiece.

Related: CORE-13368

```release-note
None
```

**AI assistance:** Claude Code drove the manual run, classified the failures, and drafted the config.

