### PR TITLE
[release-v3.31] fix(felix): stop SetConntrackCounters short-circuiting the bytes update

### DIFF
--- a/felix/collector/stats.go
+++ b/felix/collector/stats.go
@@ -480,9 +480,13 @@ func (d *Data) ConntrackBytesCounterReverse() counter.Counter {
 }
 
 // Set In Counters' values to packets and bytes. Use the SetConntrackCounters* methods
-// when the source if packets/bytes are absolute values.
+// when the packet/byte counts are absolute values.
 func (d *Data) SetConntrackCounters(packets int, bytes int) {
-	if d.conntrackPktsCtr.Set(packets) && d.conntrackBytesCtr.Set(bytes) {
+	// Evaluate both counters before testing them: && would skip the bytes update whenever the
+	// packet count happens to be unchanged.
+	pktsChanged := d.conntrackPktsCtr.Set(packets)
+	bytesChanged := d.conntrackBytesCtr.Set(bytes)
+	if pktsChanged || bytesChanged {
 		d.setDirtyFlag()
 	}
 	d.IsConnection = true
@@ -523,7 +527,11 @@ func (d *Data) VerdictFound() bool {
 // Set In Counters' values to packets and bytes. Use the SetConntrackCounters* methods
 // when the source if packets/bytes are absolute values.
 func (d *Data) SetConntrackCountersReverse(packets int, bytes int) {
-	if d.conntrackPktsCtrReverse.Set(packets) && d.conntrackBytesCtrReverse.Set(bytes) {
+	// Evaluate both counters before testing them: && would skip the bytes update whenever the
+	// packet count happens to be unchanged.
+	pktsChanged := d.conntrackPktsCtrReverse.Set(packets)
+	bytesChanged := d.conntrackBytesCtrReverse.Set(bytes)
+	if pktsChanged || bytesChanged {
 		d.setDirtyFlag()
 	}
 	d.IsConnection = true

--- a/felix/collector/stats_test.go
+++ b/felix/collector/stats_test.go
@@ -379,3 +379,47 @@ var _ = Describe("Rule Trace", func() {
 	})
 
 })
+
+var _ = Describe("Conntrack counters", func() {
+	var data *collector.Data
+
+	BeforeEach(func() {
+		var src, dst [16]byte
+		copy(src[:], net.ParseIP("127.0.0.1").To16())
+		copy(dst[:], net.ParseIP("127.1.1.1").To16())
+		data = collector.NewData(*tuple.New(src, dst, 6, 12345, 80), nil, nil)
+
+		data.SetConntrackCounters(10, 1000)
+		data.SetConntrackCountersReverse(20, 2000)
+
+		// Data starts out dirty and holding deltas from the sets above; clear both so the
+		// assertions below only see the effect of the update under test.
+		data.ClearConnDirtyFlag()
+	})
+
+	// The byte counter must be updated even when the packet count happens to be unchanged.
+	Describe("a bytes-only update", func() {
+		It("should be recorded in the forward direction", func() {
+			data.SetConntrackCounters(10, 1500)
+			bytesCtr := data.ConntrackBytesCounter()
+			Expect(bytesCtr.Absolute()).To(Equal(1500))
+			Expect(bytesCtr.Delta()).To(Equal(500))
+			Expect(data.IsDirty()).To(BeTrue())
+		})
+		It("should be recorded in the reverse direction", func() {
+			data.SetConntrackCountersReverse(20, 2500)
+			bytesCtr := data.ConntrackBytesCounterReverse()
+			Expect(bytesCtr.Absolute()).To(Equal(2500))
+			Expect(bytesCtr.Delta()).To(Equal(500))
+			Expect(data.IsDirty()).To(BeTrue())
+		})
+	})
+
+	Describe("an unchanged update", func() {
+		It("should leave the data clean", func() {
+			data.SetConntrackCounters(10, 1000)
+			data.SetConntrackCountersReverse(20, 2000)
+			Expect(data.IsDirty()).To(BeFalse())
+		})
+	})
+})


### PR DESCRIPTION
Partial backport of #13410 onto `release-v3.31`.

Only one of the two fixes in #13410 applies to this branch:

- **Backported:** `SetConntrackCounters` / `SetConntrackCountersReverse` combined the two counter updates with `&&`, which short-circuits — the byte counter was not updated at all whenever the packet count happened to be unchanged, and the dirty flag was set only when *both* counters moved. Both are now evaluated and the results OR'd.
- **Not applicable:** the `replaceRuleID` staged-ness fix. This branch calls `model.PolicyIsStaged(rid.Name)`, which is name-based and correct; the bug was introduced later by the switch to the kind-based `model.KindIsStaged`, so v3.31 never reports a staged policy as the verdict.

Carries the two conntrack-counter specs from #13410, adapted to this branch's test file. Verified they fail (2 failures) with the fix reverted and pass with it. `go test ./felix/collector/` passes.

```release-note
Fixed the flow-log collector skipping a conntrack byte-count update when the packet count was unchanged, which could under-report bytes for a flow that expired in that window.
```