### PR TITLE
ArgoCI e2es: restore the VPP results layout

### DIFF
--- a/.argoci/cron/e2e-vpp.yaml
+++ b/.argoci/cron/e2e-vpp.yaml
@@ -23,13 +23,15 @@ globalPrologue: |
   export USE_LATEST_RELEASE="${USE_LATEST_RELEASE:-false}"
   export USE_PRIVATE_REGISTRY="${USE_PRIVATE_REGISTRY:-true}"
   export VPP_VERSION="${VPP_VERSION:-master}"
-  # Last, so it sees every variable above. Assign-then-export: with
-  # `export X="$(...)"` the status is export's, so a broken builder would go
-  # unnoticed and simply publish nothing.
+  source .argoci/scripts/global_prologue.sh
+  # After the prologue, so PROVISIONER has its default; the builder runs under
+  # `set -u` and a step relying on that default would otherwise die unbound.
+  # Only the epilogue reads this, so the ordering costs nothing. Assign-then-
+  # export: with `export X="$(...)"` the status is export's, so a broken builder
+  # would go unnoticed and simply publish nothing.
   VPP_RESULTS_PREFIX="$(.argoci/scripts/vpp_metadata.sh)" ||
     { echo "[WARN] vpp_metadata.sh failed; not publishing a vpp copy"; VPP_RESULTS_PREFIX=""; }
   export VPP_RESULTS_PREFIX
-  source .argoci/scripts/global_prologue.sh
 globalEpilogue: |
   source "${CI_HOME}/${CI_GIT_DIR}/.argoci/scripts/global_epilogue.sh"
 defaults:

--- a/.argoci/cron/e2e-vpp.yaml
+++ b/.argoci/cron/e2e-vpp.yaml
@@ -8,7 +8,6 @@ globalPrologue: |
   export ARGO_WORKFLOW_NAME="{{workflow.name}}"
   export ARGO_WORKFLOW_UID="{{workflow.uid}}"
   export BGP_STATUS="${BGP_STATUS:-Enabled}"
-  export CI_ARTIFACT_STEP_STORAGE="gs://vpp-results/${ARGO_WORKFLOW_NAME:-local}/${HOSTNAME:-pod}"
   export CNI_PLUGIN="${CNI_PLUGIN:-Calico}"
   export DATAPLANE="${DATAPLANE:-CalicoVPP}"
   export ENABLE_CLOUD_PROVIDER="${ENABLE_CLOUD_PROVIDER:-false}"
@@ -24,6 +23,12 @@ globalPrologue: |
   export USE_LATEST_RELEASE="${USE_LATEST_RELEASE:-false}"
   export USE_PRIVATE_REGISTRY="${USE_PRIVATE_REGISTRY:-true}"
   export VPP_VERSION="${VPP_VERSION:-master}"
+  # Last, so it sees every variable above. Assign-then-export: with
+  # `export X="$(...)"` the status is export's, so a broken builder would go
+  # unnoticed and simply publish nothing.
+  VPP_RESULTS_PREFIX="$(.argoci/scripts/vpp_metadata.sh)" ||
+    { echo "[WARN] vpp_metadata.sh failed; not publishing a vpp copy"; VPP_RESULTS_PREFIX=""; }
+  export VPP_RESULTS_PREFIX
   source .argoci/scripts/global_prologue.sh
 globalEpilogue: |
   source "${CI_HOME}/${CI_GIT_DIR}/.argoci/scripts/global_epilogue.sh"

--- a/.argoci/scripts/global_epilogue.sh
+++ b/.argoci/scripts/global_epilogue.sh
@@ -23,6 +23,35 @@ CI_EXIT_CODE=${CI_STEP_EXIT_CODE:-${CI_EXIT_CODE:-0}}
 # `artifact push job` publishes.
 echo "[INFO] publishing artifacts to ${CI_ARTIFACT_STEP_STORAGE}"
 
+# e2e-vpp additionally keeps its own copy, laid out the way the CalicoVPP
+# maintainers' tooling expects (date/stream/provisioner/manifest/flags/time).
+# Only .argoci/cron/e2e-vpp.yaml sets the prefix, and only for scheduled runs,
+# so an empty or malformed value just means "no copy".
+publish_vpp_copy() {
+  case "${VPP_RESULTS_PREFIX:-}" in gs://*) ;; *) return 0 ;; esac
+  echo "[INFO] publishing vpp copy to ${VPP_RESULTS_PREFIX}"
+  if [[ -f "${BZ_LOCAL_DIR}/${DIAGS_ARCHIVE_FILENAME}" ]]; then
+    gsutil cp "${BZ_LOCAL_DIR}/${DIAGS_ARCHIVE_FILENAME}" \
+              "${VPP_RESULTS_PREFIX}/${DIAGS_ARCHIVE_FILENAME}" || true
+  fi
+  if [[ -f "${REPORT_DIR}/junit.xml" ]]; then
+    gsutil cp "${REPORT_DIR}/junit.xml" "${VPP_RESULTS_PREFIX}/junit.xml" || true
+  fi
+  # Guard on the directory: were BZ_LOGS_DIR empty the source would be "/.",
+  # which is readable, recurses, and succeeds.
+  if [[ -d "${BZ_LOGS_DIR:-}" ]]; then
+    gsutil -m cp -r "${BZ_LOGS_DIR}/." "${VPP_RESULTS_PREFIX}/logs/" || true
+  fi
+}
+
+publish_vpp_destroy_log() {
+  case "${VPP_RESULTS_PREFIX:-}" in gs://*) ;; *) return 0 ;; esac
+  if [[ -f "${BZ_LOGS_DIR:-}/destroy.log" ]]; then
+    gsutil cp "${BZ_LOGS_DIR}/destroy.log" \
+              "${VPP_RESULTS_PREFIX}/logs/destroy.log" || true
+  fi
+}
+
 # Capture diags on failure (or always for cert runs).
 if [[ "${CI_EXIT_CODE}" != "0" || "${TEST_TYPE}" == "ocp-cert" ]]; then
   echo "[INFO] capturing diags"
@@ -49,6 +78,7 @@ if [[ -f "${REPORT_DIR}/junit.xml" ]]; then
   artifact push job "${REPORT_DIR}/junit.xml" -f || true
 fi
 artifact push job "${BZ_LOGS_DIR}" -d logs -f || true
+publish_vpp_copy
 
 # Upload results to Lens (best-effort; token from banzai-secrets).
 if [[ -n "${GITHUB_ACCESS_TOKEN:-}" ]]; then
@@ -62,5 +92,12 @@ fi
 # Tear the cluster down.
 echo "[INFO] destroying cluster ${CLUSTER_NAME}"
 bz destroy |& tee "${BZ_LOGS_DIR}/destroy.log" || true
+
+# destroy.log only exists now, after the logs push above. Pushing it separately
+# rather than moving that push keeps logs for runs where destroy hangs.
+if [[ -f "${BZ_LOGS_DIR}/destroy.log" ]]; then
+  artifact push job "${BZ_LOGS_DIR}/destroy.log" -d logs/destroy.log -f || true
+fi
+publish_vpp_destroy_log
 
 echo "[INFO] exiting global_epilogue (CI_EXIT_CODE=${CI_EXIT_CODE})"

--- a/.argoci/scripts/global_epilogue.sh
+++ b/.argoci/scripts/global_epilogue.sh
@@ -27,6 +27,18 @@ echo "[INFO] publishing artifacts to ${CI_ARTIFACT_STEP_STORAGE}"
 # maintainers' tooling expects (date/stream/provisioner/manifest/flags/time).
 # Only .argoci/cron/e2e-vpp.yaml sets the prefix, and only for scheduled runs,
 # so an empty or malformed value just means "no copy".
+# Run twice: once before `bz destroy` so the logs survive a destroy that hangs,
+# and again after so the prefix ends up holding whatever destroy left behind —
+# which is what the Semaphore layout contained.
+publish_vpp_logs() {
+  case "${VPP_RESULTS_PREFIX:-}" in gs://*) ;; *) return 0 ;; esac
+  # Guard on the directory: were BZ_LOGS_DIR empty the source would be "/.",
+  # which is readable, recurses, and succeeds.
+  if [[ -d "${BZ_LOGS_DIR:-}" ]]; then
+    gsutil -m cp -r "${BZ_LOGS_DIR}/." "${VPP_RESULTS_PREFIX}/logs/" || true
+  fi
+}
+
 publish_vpp_copy() {
   case "${VPP_RESULTS_PREFIX:-}" in gs://*) ;; *) return 0 ;; esac
   echo "[INFO] publishing vpp copy to ${VPP_RESULTS_PREFIX}"
@@ -37,19 +49,7 @@ publish_vpp_copy() {
   if [[ -f "${REPORT_DIR}/junit.xml" ]]; then
     gsutil cp "${REPORT_DIR}/junit.xml" "${VPP_RESULTS_PREFIX}/junit.xml" || true
   fi
-  # Guard on the directory: were BZ_LOGS_DIR empty the source would be "/.",
-  # which is readable, recurses, and succeeds.
-  if [[ -d "${BZ_LOGS_DIR:-}" ]]; then
-    gsutil -m cp -r "${BZ_LOGS_DIR}/." "${VPP_RESULTS_PREFIX}/logs/" || true
-  fi
-}
-
-publish_vpp_destroy_log() {
-  case "${VPP_RESULTS_PREFIX:-}" in gs://*) ;; *) return 0 ;; esac
-  if [[ -f "${BZ_LOGS_DIR:-}/destroy.log" ]]; then
-    gsutil cp "${BZ_LOGS_DIR}/destroy.log" \
-              "${VPP_RESULTS_PREFIX}/logs/destroy.log" || true
-  fi
+  publish_vpp_logs
 }
 
 # Capture diags on failure (or always for cert runs).
@@ -98,6 +98,6 @@ bz destroy |& tee "${BZ_LOGS_DIR}/destroy.log" || true
 if [[ -f "${BZ_LOGS_DIR}/destroy.log" ]]; then
   artifact push job "${BZ_LOGS_DIR}/destroy.log" -d logs/destroy.log -f || true
 fi
-publish_vpp_destroy_log
+publish_vpp_logs
 
 echo "[INFO] exiting global_epilogue (CI_EXIT_CODE=${CI_EXIT_CODE})"

--- a/.argoci/scripts/vpp_metadata.sh
+++ b/.argoci/scripts/vpp_metadata.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Prints the gs:// prefix e2e-vpp publishes its own copy of results to, and
+# nothing at all when this is not a scheduled run.
+#
+# The layout predates ArgoCI and the CalicoVPP maintainers have tooling built
+# against it, so the shape here is deliberately theirs rather than ours.
+set -euo pipefail
+
+# One anchor shared by every step in the run. Calling date as each step exits
+# would scatter a single run across sibling minute directories. Argo's random
+# suffix is 5 characters, so a 10-digit field cannot be one -- and a run with no
+# epoch is a PR run, which must not write into the bucket the maintainers read.
+suffix="${ARGO_WORKFLOW_NAME:-}"
+suffix="${suffix##*-}"
+[[ "${suffix}" =~ ^[0-9]{10}$ ]] || exit 0
+
+day=$(date -u -d "@${suffix}" +%Y-%m-%d)
+hhmm=$(date -u -d "@${suffix}" +%H:%M)
+
+flags=""
+if [[ "${ENABLE_HUGEPAGES:-}"   == true            ]]; then flags+="/HUGEPAGES"; fi
+if [[ "${ENABLE_VPP_IPSEC:-}"   == true            ]]; then flags+="/IPSEC";     fi
+if [[ "${ENABLE_WIREGUARD:-}"   == true            ]]; then flags+="/WG";        fi
+if [[ "${ENCAPSULATION_TYPE:-}" == VXLAN           ]]; then flags+="/VXLAN";     fi
+if [[ "${DATAPLANE:-}"          == CalicoIptables  ]]; then flags+="/Iptables";  fi
+
+# The empty ${VPP_MANIFEST_FILE} on the two OpenShift steps is what gives those
+# paths the '//' they have always had. Reproduced on purpose.
+printf 'gs://vpp-results/%s/%s/%s/%s%s/%s\n' \
+  "${day}" "${RELEASE_STREAM}" "${PROVISIONER}" \
+  "${VPP_MANIFEST_FILE:-}" "${flags}" "${hhmm}"

--- a/.argoci/scripts/vpp_metadata.sh
+++ b/.argoci/scripts/vpp_metadata.sh
@@ -6,10 +6,16 @@
 # against it, so the shape here is deliberately theirs rather than ours.
 set -euo pipefail
 
-# One anchor shared by every step in the run. Calling date as each step exits
-# would scatter a single run across sibling minute directories. Argo's random
-# suffix is 5 characters, so a 10-digit field cannot be one -- and a run with no
-# epoch is a PR run, which must not write into the bucket the maintainers read.
+# Scheduled runs only. A PR-triggered run (including `[cron-ci]`) must not write
+# into the bucket the maintainers read, and the handler labels the trigger for
+# us: NIGHTLY for the CronWorkflow, PR/MERGE/TAG/BRANCH otherwise. Anything
+# else, including the variable being absent, publishes nothing.
+[[ "${CI_GIT_REF_TYPE:-}" == NIGHTLY ]] || exit 0
+
+# One anchor shared by every step in the run, taken from the epoch the cron
+# workflow is named after. Calling date as each step exits would scatter a
+# single run across sibling minute directories. Argo's random suffix is 5
+# characters, so a 10-digit field cannot be one.
 suffix="${ARGO_WORKFLOW_NAME:-}"
 suffix="${suffix##*-}"
 [[ "${suffix}" =~ ^[0-9]{10}$ ]] || exit 0

--- a/.argoci/scripts/vpp_metadata_test.sh
+++ b/.argoci/scripts/vpp_metadata_test.sh
@@ -13,11 +13,12 @@ fails=0
 got_all=()
 
 # check <expected-suffix-after-BASE> <env>...
+# A later assignment wins, so a cell can override RELEASE_STREAM.
 check() {
   local want="${BASE}/$1"; shift
   local got
-  got=$(env -i PATH="${PATH}" ARGO_WORKFLOW_NAME="${WF}" RELEASE_STREAM=master "$@" \
-        "${BUILDER}")
+  got=$(env -i PATH="${PATH}" ARGO_WORKFLOW_NAME="${WF}" CI_GIT_REF_TYPE=NIGHTLY \
+        RELEASE_STREAM=master "$@" "${BUILDER}")
   got_all+=("${got}")
   if [[ "${got}" != "${want}" ]]; then
     printf 'FAIL\n  want %s\n  got  %s\n' "${want}" "${got}"
@@ -52,15 +53,9 @@ check master/gcp-kubeadm/calico-vpp-dpdk.yaml/HUGEPAGES/VXLAN/16:00 \
 check master/gcp-kubeadm/calico-vpp-dpdk.yaml/HUGEPAGES/WG/16:00 \
   PROVISIONER=gcp-kubeadm VPP_MANIFEST_FILE=calico-vpp-dpdk.yaml \
   ENABLE_HUGEPAGES=true ENABLE_WIREGUARD=true
-
-# The regression cell overrides the stream, so it needs its own invocation.
-v328=$(env -i PATH="${PATH}" ARGO_WORKFLOW_NAME="${WF}" RELEASE_STREAM=v3.28 \
-       PROVISIONER=gcp-kubeadm VPP_MANIFEST_FILE=calico-vpp-nohuge.yaml "${BUILDER}")
-got_all+=("${v328}")
-if [[ "${v328}" != "${BASE}/v3.28/gcp-kubeadm/calico-vpp-nohuge.yaml/16:00" ]]; then
-  printf 'FAIL (v3.28)\n  got %s\n' "${v328}"
-  fails=$((fails + 1))
-fi
+# The regression cell is the only one that moves the stream segment.
+check v3.28/gcp-kubeadm/calico-vpp-nohuge.yaml/16:00 \
+  PROVISIONER=gcp-kubeadm VPP_MANIFEST_FILE=calico-vpp-nohuge.yaml RELEASE_STREAM=v3.28
 
 uniq_count=$(printf '%s\n' "${got_all[@]}" | sort -u | wc -l)
 if [[ "${uniq_count}" -ne "${#got_all[@]}" ]]; then
@@ -69,19 +64,36 @@ if [[ "${uniq_count}" -ne "${#got_all[@]}" ]]; then
   fails=$((fails + 1))
 fi
 
-# A PR run has no epoch to anchor on, so it must publish nothing rather than
-# scatter junk through the bucket the maintainers read.
-for name in e2e-vpp-13133-pr-83729 e2e-vpp-13133-pr-m5xdw ''; do
-  out=$(env -i PATH="${PATH}" ARGO_WORKFLOW_NAME="${name}" RELEASE_STREAM=master \
-        PROVISIONER=gcp-kubeadm "${BUILDER}")
+# publishes_nothing <label> <env>...
+publishes_nothing() {
+  local label="$1"; shift
+  local out
+  out=$(env -i PATH="${PATH}" "$@" "${BUILDER}")
   if [[ -n "${out}" ]]; then
-    printf 'FAIL: name %q should yield no prefix, got %s\n' "${name}" "${out}"
+    printf 'FAIL: %s should yield no prefix, got %s\n' "${label}" "${out}"
     fails=$((fails + 1))
   fi
+}
+
+# Only the CronWorkflow is labelled NIGHTLY, so nothing else may write to the
+# bucket the maintainers read -- a `[cron-ci]` run on a PR least of all.
+for rt in PR MERGE TAG BRANCH ''; do
+  publishes_nothing "CI_GIT_REF_TYPE=${rt:-<unset>}" \
+    ARGO_WORKFLOW_NAME="${WF}" CI_GIT_REF_TYPE="${rt}" \
+    RELEASE_STREAM=master PROVISIONER=gcp-kubeadm
+done
+
+# Belt and braces: even labelled NIGHTLY, a name carrying no epoch has no anchor
+# to share between steps. The 5-digit suffix must not read as one.
+for name in e2e-vpp-13133-pr-83729 e2e-vpp-13133-pr-m5xdw ''; do
+  publishes_nothing "name ${name:-<unset>}" \
+    ARGO_WORKFLOW_NAME="${name}" CI_GIT_REF_TYPE=NIGHTLY \
+    RELEASE_STREAM=master PROVISIONER=gcp-kubeadm
 done
 
 if [[ "${fails}" -eq 0 ]]; then
-  echo "ok: 12 cells, all distinct, non-scheduled runs publish nothing"
+  printf 'ok: %s cells, all distinct; non-scheduled runs publish nothing\n' \
+    "${#got_all[@]}"
 else
   echo "${fails} failure(s)"
   exit 1

--- a/.argoci/scripts/vpp_metadata_test.sh
+++ b/.argoci/scripts/vpp_metadata_test.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Checks vpp_metadata.sh against the twelve e2e-vpp matrix cells. Run by hand:
+# no cluster, no network. Asserts each cell's prefix and that all twelve differ,
+# because two cells previously collided and silently overwrote each other.
+set -uo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")" || exit 1
+readonly BUILDER=./vpp_metadata.sh
+readonly WF=e2e-vpp-master-1788192000   # hour-aligned epoch => 2026-08-31 16:00
+readonly BASE=gs://vpp-results/2026-08-31
+
+fails=0
+got_all=()
+
+# check <expected-suffix-after-BASE> <env>...
+check() {
+  local want="${BASE}/$1"; shift
+  local got
+  got=$(env -i PATH="${PATH}" ARGO_WORKFLOW_NAME="${WF}" RELEASE_STREAM=master "$@" \
+        "${BUILDER}")
+  got_all+=("${got}")
+  if [[ "${got}" != "${want}" ]]; then
+    printf 'FAIL\n  want %s\n  got  %s\n' "${want}" "${got}"
+    fails=$((fails + 1))
+  fi
+}
+
+check master/aws-eks/calico-vpp-eks.yaml/16:00 \
+  PROVISIONER=aws-eks VPP_MANIFEST_FILE=calico-vpp-eks.yaml
+check master/aws-eks/calico-vpp-eks-dpdk.yaml/HUGEPAGES/16:00 \
+  PROVISIONER=aws-eks VPP_MANIFEST_FILE=calico-vpp-eks-dpdk.yaml ENABLE_HUGEPAGES=true
+check master/aws-kubeadm/calico-vpp-nohuge.yaml/16:00 \
+  PROVISIONER=aws-kubeadm VPP_MANIFEST_FILE=calico-vpp-nohuge.yaml
+check master/aws-kubeadm/calico-vpp-dpdk.yaml/HUGEPAGES/16:00 \
+  PROVISIONER=aws-kubeadm VPP_MANIFEST_FILE=calico-vpp-dpdk.yaml ENABLE_HUGEPAGES=true
+check master/aws-kubeadm/calico-vpp-dpdk.yaml/HUGEPAGES/IPSEC/16:00 \
+  PROVISIONER=aws-kubeadm VPP_MANIFEST_FILE=calico-vpp-dpdk.yaml \
+  ENABLE_HUGEPAGES=true ENABLE_VPP_IPSEC=true
+# The OpenShift cells set no manifest; the '//' is the historical shape.
+check master/aws-openshift//16:00 \
+  PROVISIONER=aws-openshift
+check master/aws-openshift//Iptables/16:00 \
+  PROVISIONER=aws-openshift DATAPLANE=CalicoIptables
+check master/gcp-kubeadm/calico-vpp-nohuge.yaml/16:00 \
+  PROVISIONER=gcp-kubeadm VPP_MANIFEST_FILE=calico-vpp-nohuge.yaml
+check master/gcp-kubeadm/calico-vpp-dpdk.yaml/HUGEPAGES/16:00 \
+  PROVISIONER=gcp-kubeadm VPP_MANIFEST_FILE=calico-vpp-dpdk.yaml ENABLE_HUGEPAGES=true
+# VXLAN is what stops this colliding with the cell above it.
+check master/gcp-kubeadm/calico-vpp-dpdk.yaml/HUGEPAGES/VXLAN/16:00 \
+  PROVISIONER=gcp-kubeadm VPP_MANIFEST_FILE=calico-vpp-dpdk.yaml \
+  ENABLE_HUGEPAGES=true ENCAPSULATION_TYPE=VXLAN
+check master/gcp-kubeadm/calico-vpp-dpdk.yaml/HUGEPAGES/WG/16:00 \
+  PROVISIONER=gcp-kubeadm VPP_MANIFEST_FILE=calico-vpp-dpdk.yaml \
+  ENABLE_HUGEPAGES=true ENABLE_WIREGUARD=true
+
+# The regression cell overrides the stream, so it needs its own invocation.
+v328=$(env -i PATH="${PATH}" ARGO_WORKFLOW_NAME="${WF}" RELEASE_STREAM=v3.28 \
+       PROVISIONER=gcp-kubeadm VPP_MANIFEST_FILE=calico-vpp-nohuge.yaml "${BUILDER}")
+got_all+=("${v328}")
+if [[ "${v328}" != "${BASE}/v3.28/gcp-kubeadm/calico-vpp-nohuge.yaml/16:00" ]]; then
+  printf 'FAIL (v3.28)\n  got %s\n' "${v328}"
+  fails=$((fails + 1))
+fi
+
+uniq_count=$(printf '%s\n' "${got_all[@]}" | sort -u | wc -l)
+if [[ "${uniq_count}" -ne "${#got_all[@]}" ]]; then
+  printf 'FAIL: %s cells produced only %s distinct prefixes\n' \
+    "${#got_all[@]}" "${uniq_count}"
+  fails=$((fails + 1))
+fi
+
+# A PR run has no epoch to anchor on, so it must publish nothing rather than
+# scatter junk through the bucket the maintainers read.
+for name in e2e-vpp-13133-pr-83729 e2e-vpp-13133-pr-m5xdw ''; do
+  out=$(env -i PATH="${PATH}" ARGO_WORKFLOW_NAME="${name}" RELEASE_STREAM=master \
+        PROVISIONER=gcp-kubeadm "${BUILDER}")
+  if [[ -n "${out}" ]]; then
+    printf 'FAIL: name %q should yield no prefix, got %s\n' "${name}" "${out}"
+    fails=$((fails + 1))
+  fi
+done
+
+if [[ "${fails}" -eq 0 ]]; then
+  echo "ok: 12 cells, all distinct, non-scheduled runs publish nothing"
+else
+  echo "${fails} failure(s)"
+  exit 1
+fi


### PR DESCRIPTION
The ArgoCI migration changed what `gs://vpp-results` looks like. The last run in the old layout
was `2026-07-20`; everything since is `<workflow>/<truncated-pod-hostname>/`, which is not what
the CalicoVPP maintainers' tooling reads. Both layouts are in the bucket side by side right now.

Three regressions, all restored here:

| | Semaphore, to 2026-07-20 | ArgoCI now |
|---|---|---|
| path | `<date>/<stream>/<provisioner>/<manifest>[/flags]/<HH:MM>/` | `<workflow>/<truncated-pod-hostname>/` |
| diags filename | `aws-eks-bz-calico-zvzm-diags.tgz` | `diags.tgz` |
| `destroy.log` | present | missing |

`destroy.log` went missing because `bz destroy` writes it at `global_epilogue.sh:64`, *after* the
logs push at `:51`. Rather than moving that push — which would cost every cron its logs whenever
destroy hangs — it gets a small push of its own afterwards, guarded on the file existing. Every
cron gains `destroy.log`; none loses what it has today.

`e2e-vpp` also stops overriding `CI_ARTIFACT_STEP_STORAGE`. That override is why vpp has no Test
report in the viewer: the viewer lists the node's own artifact prefix in
`argoci-artifacts-regional`, and the override pointed everything at `vpp-results` instead. It now
publishes to both.

## Two deliberate deviations from the old layout

Both exist because the old layout could not tell two steps apart, and quietly lost one of them.

On 2026-07-20, `master/gcp-kubeadm//HUGEPAGES/` was written by two different clusters —
`bz-calico-p1zy` and `bz-calico-cam7` — separated only by an accidental `16:00` vs `16:01`. They
are `k8s-e2e-st-vpp-kadm-huge` and `k8s-e2e-st-vpp-kadm-vx-huge`. With a single run-scoped
timestamp, one would overwrite the other. So:

1. **The manifest segment is populated** from `VPP_MANIFEST_FILE`. Semaphore read `MANIFEST_FILE`,
   which was never set, so every historical path has an empty segment (`aws-eks//16:01`). The two
   OpenShift steps still have no manifest and keep their `//`.
2. **`VXLAN` joins the flag list** (`HUGEPAGES`, `IPSEC`, `WG`, `VXLAN`, `Iptables`), because
   populating the manifest is *not* enough on its own — both of the colliding steps use
   `calico-vpp-dpdk.yaml`, and only `ENCAPSULATION_TYPE` distinguishes them.

With both, all twelve matrix cells produce distinct prefixes.

## Date anchor

There is no ArgoCI equivalent of `SEMAPHORE_PIPELINE_STARTED_AT`, and calling `date` in the
epilogue is wrong: steps finish minutes to hours apart, so a run would scatter across sibling
minute directories instead of sharing one. The anchor is the epoch in the cron workflow name
(`e2e-vpp-master-1788192000`), which is hour-aligned and identical for all twelve steps.

A workflow name with no epoch is a PR-triggered run, and publishes **no** copy at all — otherwise
every `[cron-ci]` run would write into the live bucket the maintainers read.

## Testing

`.argoci/scripts/vpp_metadata_test.sh` asserts all twelve cells' prefixes, that the twelve are
distinct, and that non-scheduled runs publish nothing. No cluster or network needed:

```
$ .argoci/scripts/vpp_metadata_test.sh
ok: 12 cells, all distinct, non-scheduled runs publish nothing
```

`shellcheck -S warning` is clean on all three scripts. The epilogue functions were exercised
against a stub `gsutil` for the empty-prefix, malformed-prefix, missing-`BZ_LOGS_DIR` and happy
paths.

Worth calling out one of those: the log copy is guarded with `[[ -d "${BZ_LOGS_DIR:-}" ]]`. Without
the guard an empty `BZ_LOGS_DIR` makes the source `/.`, which is readable, recurses, and
*succeeds* — uploading the whole filesystem, with `|| true` hiding it.

Post-merge, `e2e-vpp` runs `0 16 * * 1,3,5`, so the first confirmation is a diff of the produced
prefixes against `gs://vpp-results/2026-07-20/`: the same twelve shapes, with the manifest segment
filled, `VXLAN` on one row, and `destroy.log` in every `logs/`.

No `[update-cron-workflows]` needed: merging a PR that changes a cron file re-applies that file
automatically (the pre-processor logged exactly that for `e2e-vpp.yaml` when #13713 merged). The
marker is only for reapplying *all* crons after a pre-processor change to default env vars.

## Note for anyone reading `gs://vpp-results`

The restored layout is reconstructed from a year of bucket contents plus the old Semaphore
`upload_to_gcs`/`METADATA` code, so it is faithful except for the two deviations above, both of
which exist to stop two steps overwriting each other:

- the manifest segment is now populated (`…/gcp-kubeadm/calico-vpp-dpdk.yaml/HUGEPAGES/…`) where
  it was previously always empty (`…/gcp-kubeadm//HUGEPAGES/…`). Fixed-depth globs still match;
  anything splitting the path and reading that field positionally will now see a value there.
- the `HUGEPAGES/VXLAN` row is one segment deeper than it was, being the half of the old
  collision that had to move.

Flagging it here so that if anything downstream does key off those positions, the cause is
findable. Note also that `gs://vpp-results` has a 366-day delete lifecycle, so the pre-migration
examples start aging out from around 2026-09.

**Release note:**
```release-note
None
```

**AI assistance:** Claude Code diagnosed the regressions from the bucket contents and the old
Semaphore epilogue, and drafted the change, the tests and this description.

