### PR TITLE
libcalico-go/epstatusfile: close the fsnotify watcher when Add fails

### DIFF
--- a/libcalico-go/lib/epstatusfile/status_file_watcher.go
+++ b/libcalico-go/lib/epstatusfile/status_file_watcher.go
@@ -116,6 +116,13 @@ func (w *FileWatcher) newFsnotifyWatcher() error {
 	err = watcher.Add(w.dir)
 	if err != nil {
 		log.WithError(err).Error("Error adding directory to fsnotify.")
+		// A watcher owns an inotify instance and a goroutine, and the GC
+		// reclaims neither, so it must be closed even though it never watched
+		// anything. runWatcher() retries on every poll tick, so anything left
+		// behind here accumulates for as long as the directory is unwatchable.
+		if closeErr := watcher.Close(); closeErr != nil {
+			log.WithError(closeErr).Info("Ignoring error following close of fsWatcher")
+		}
 		return err
 	}
 

--- a/libcalico-go/lib/epstatusfile/status_file_watcher_test.go
+++ b/libcalico-go/lib/epstatusfile/status_file_watcher_test.go
@@ -139,7 +139,7 @@ func clearDir(dirPath string) {
 // process. Every fsnotify.Watcher owns exactly one.
 func countInotifyFDs() int {
 	entries, err := os.ReadDir("/proc/self/fd")
-	Expect(err).ShouldNot(HaveOccurred())
+	Expect(err).ShouldNot(HaveOccurred(), "cannot count inotify instances without procfs")
 
 	count := 0
 	for _, entry := range entries {

--- a/libcalico-go/lib/epstatusfile/status_file_watcher_test.go
+++ b/libcalico-go/lib/epstatusfile/status_file_watcher_test.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 	"sync"
 	"time"
 
@@ -132,6 +133,27 @@ func clearDir(dirPath string) {
 	}
 
 	log.Infof("Directory %s cleared successfully!", dirPath)
+}
+
+// countInotifyFDs returns the number of inotify instances held open by this
+// process. Every fsnotify.Watcher owns exactly one.
+func countInotifyFDs() int {
+	entries, err := os.ReadDir("/proc/self/fd")
+	Expect(err).ShouldNot(HaveOccurred())
+
+	count := 0
+	for _, entry := range entries {
+		target, err := os.Readlink(filepath.Join("/proc/self/fd", entry.Name()))
+		if err != nil {
+			// The descriptor was closed while we were scanning.
+			continue
+		}
+		if strings.Contains(target, "inotify") {
+			count++
+		}
+	}
+
+	return count
 }
 
 var _ = Describe("Workload endpoint status file watcher test", func() {
@@ -311,5 +333,27 @@ var _ = Describe("Workload endpoint status file watcher test", func() {
 
 		Eventually(haveEvents, "15s", "1s").WithArguments(filePath, []string{"create", "update", "update"}).Should(BeTrue())
 		Eventually(lastInSync).Should(BeTrue())
+	})
+
+	It("should not leak inotify instances while the directory cannot be watched", func() {
+		// A missing directory makes fsnotify's Add fail, which sends the watcher
+		// goroutine round its retry loop once per poll interval.
+		missingDir := filepath.Join(tmpPath, "no-such-dir")
+		w = NewFileWatcherWithShim(missingDir, 100*time.Millisecond, fsnotifyErr.newFsnotifyWatcherShim, fsnotifyActivity)
+		w.SetCallbacks(Callbacks{
+			OnFileCreation: r.OnFileCreate,
+			OnFileUpdate:   r.OnFileUpdate,
+			OnFileDeletion: r.OnFileDeletion,
+			OnInSync:       r.OnInSync,
+		})
+
+		baseline := countInotifyFDs()
+
+		w.Start()
+		defer w.Stop()
+
+		// The retried watcher is closed within the same iteration, so at most one
+		// can be open when we sample.
+		Consistently(countInotifyFDs, "2s", "100ms").Should(BeNumerically("<=", baseline+1))
 	})
 })


### PR DESCRIPTION
`newFsnotifyWatcher()` returned early when fsnotify's `Add` on the watched directory failed, without closing the watcher it had just created. `w.fsWatcher` was still nil at that point, so `closeWatcher()` could not reclaim it either.

Each `fsnotify.Watcher` owns an inotify instance and a `readEvents` goroutine (`backend_inotify.go:147`), and the goroutine holds a reference to the instance, so the GC reclaims neither. `runWatcher()` retries once per poll interval for as long as the directory stays unwatchable, which turns a one-off into an unbounded leak.

The only consumer is confd's local BGP peer watcher (`confd/pkg/backends/calico/local_bgp_peer_watcher.go`), started unconditionally on Linux with a 30s poll interval, watching the `endpoint-status` directory that Felix creates. So while Felix is crash-looping — or permanently, if `EndpointStatusPathPrefix` is set to the empty string — confd leaks **120 inotify instances an hour**, plus a goroutine each. `fs.inotify.max_user_instances` is per-UID and calico-node runs as root in the host user namespace, so exhausting it also stops other root processes on the node from creating inotify instances. That is the part that makes this more than a confd memory leak.

Found while investigating a Felix crash-loop where the endpoint-status directory never got created.

### Testing

New UT points a watcher at a missing directory and asserts the inotify instance count in `/proc/self/fd` stays flat across several poll intervals. Verified both ways with `make -C libcalico-go ut WHAT=lib/epstatusfile`:

- with the fix: 9 of 9 specs pass
- with the fix reverted, test kept: fails on the first retry (`Expected <int>: 2 to be <= <int>: 1`)

**Release note:**
```release-note
Fix an inotify instance and goroutine leak in confd that occurred whenever the endpoint-status directory could not be watched, which could exhaust the node's per-user inotify instance limit.
```

**AI assistance:** Claude Code investigated the leak, wrote the fix and the unit test, and ran the tests.

CORE-13470
