### PR TITLE
Key BPF route wireguard tunnelled flag off the manager's own IP family

### DIFF
--- a/felix/dataplane/linux/bpf_route_mgr.go
+++ b/felix/dataplane/linux/bpf_route_mgr.go
@@ -143,6 +143,13 @@ func newBPFRouteManager(config *Config, maps *bpfmap.IPMaps, ipFamily proto.IPVe
 		dirtyCIDRs.Add(cidr)
 	}
 
+	// Wireguard is configured per address family; a route only belongs to the
+	// family this manager serves, so consult that family's setting alone.
+	wgEnabled := config.Wireguard.Enabled
+	if ipFamily == proto.IPVersion_IPV6 {
+		wgEnabled = config.Wireguard.EnabledV6
+	}
+
 	m := &bpfRouteManager{
 		myNodename:        config.Hostname,
 		cidrToRoute:       map[ip.CIDR]*proto.RouteUpdate{},
@@ -165,7 +172,7 @@ func newBPFRouteManager(config *Config, maps *bpfmap.IPMaps, ipFamily proto.IPVe
 
 		opReporter: opReporter,
 
-		wgEnabled:         config.Wireguard.Enabled || config.Wireguard.EnabledV6,
+		wgEnabled:         wgEnabled,
 		ipFamily:          ipFamily,
 		svcLoopPrevention: config.ServiceLoopPrevention,
 	}

--- a/felix/dataplane/linux/bpf_route_mgr_test.go
+++ b/felix/dataplane/linux/bpf_route_mgr_test.go
@@ -1,0 +1,89 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package intdataplane
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/projectcalico/calico/felix/bpf/bpfmap"
+	"github.com/projectcalico/calico/felix/bpf/routes"
+	"github.com/projectcalico/calico/felix/ip"
+	"github.com/projectcalico/calico/felix/proto"
+	"github.com/projectcalico/calico/felix/wireguard"
+	"github.com/projectcalico/calico/lib/logrusr"
+)
+
+var _ = Describe("BPF route manager", func() {
+	// remoteWorkloadFlags programs a remote-workload route in a no-encap pool and
+	// returns the flags the manager computed for it.
+	remoteWorkloadFlags := func(ipFamily proto.IPVersion, wgV4, wgV6 bool) routes.Flags {
+		config := &Config{
+			Hostname: "node-local",
+			Wireguard: wireguard.Config{
+				Enabled:   wgV4,
+				EnabledV6: wgV6,
+			},
+		}
+		m := newBPFRouteManager(config, &bpfmap.IPMaps{}, ipFamily, logrusr.NewSummarizer("test"))
+
+		dst := "10.0.1.0/26"
+		nodeIP := "172.16.0.2"
+		if ipFamily == proto.IPVersion_IPV6 {
+			dst = "fdcc:10:1::/122"
+			nodeIP = "fdcc:172:16::2"
+		}
+
+		m.onRouteUpdate(&proto.RouteUpdate{
+			Types:       proto.RouteType_REMOTE_WORKLOAD,
+			IpPoolType:  proto.IPPoolType_NO_ENCAP,
+			Dst:         dst,
+			DstNodeName: "node-remote",
+			DstNodeIp:   nodeIP,
+		})
+
+		route := m.calculateRoute(ip.MustParseCIDROrIP(dst))
+		Expect(route).NotTo(BeNil())
+		return route.Flags()
+	}
+
+	// Wireguard is enabled per address family, so the tunnelled flag must follow
+	// the family the route belongs to, not either family's setting.
+	It("should only flag remote workloads tunnelled for the family wireguard is enabled for", func() {
+		By("enabling wireguard for IPv4 only")
+		Expect(remoteWorkloadFlags(proto.IPVersion_IPV4, true, false) & routes.FlagTunneled).
+			To(Equal(routes.FlagTunneled))
+		Expect(remoteWorkloadFlags(proto.IPVersion_IPV6, true, false) & routes.FlagTunneled).
+			To(BeZero())
+
+		By("enabling wireguard for IPv6 only")
+		Expect(remoteWorkloadFlags(proto.IPVersion_IPV4, false, true) & routes.FlagTunneled).
+			To(BeZero())
+		Expect(remoteWorkloadFlags(proto.IPVersion_IPV6, false, true) & routes.FlagTunneled).
+			To(Equal(routes.FlagTunneled))
+
+		By("disabling wireguard for both families")
+		Expect(remoteWorkloadFlags(proto.IPVersion_IPV4, false, false) & routes.FlagTunneled).
+			To(BeZero())
+		Expect(remoteWorkloadFlags(proto.IPVersion_IPV6, false, false) & routes.FlagTunneled).
+			To(BeZero())
+
+		By("enabling wireguard for both families")
+		Expect(remoteWorkloadFlags(proto.IPVersion_IPV4, true, true) & routes.FlagTunneled).
+			To(Equal(routes.FlagTunneled))
+		Expect(remoteWorkloadFlags(proto.IPVersion_IPV6, true, true) & routes.FlagTunneled).
+			To(Equal(routes.FlagTunneled))
+	})
+})


### PR DESCRIPTION
`newBPFRouteManager` is constructed once per address family, but it derived `wgEnabled` from `config.Wireguard.Enabled || config.Wireguard.EnabledV6`. On a dual-stack cluster with wireguard enabled for one family only, *every* remote-workload route of the **other** family was flagged `routes.FlagTunneled` — permanently, on a family that is never encrypted and never routed through a wireguard device.

That flag is not cosmetic. The BPF dataplane reads it as "this destination needs an encapsulating egress" (`cali_rt_needs_tunnel_egress` = tunneled && !same_subnet), so on a native/no-encap pool it claims an encap egress for a destination the kernel routes natively over a plain NIC. Nothing about wireguard state ever reaches the BPF routes map, so the disagreement never converges. It only bites a native/no-encap pool with a cross-subnet destination: in a VXLAN or IPIP pool `FlagTunneled` is true for real reasons and the kernel does route via the tunnel device.

The fix is to consult the manager's own `ipFamily` — `Wireguard.Enabled` for v4, `Wireguard.EnabledV6` for v6.

This is part 1 of CORE-13520. Part 2 of that ticket — that the flag is set for every remote-workload route with no check that the destination node actually has a wireguard key — is deliberately **not** in this PR: it needs a design call on why wireguard sets `FlagTunneled` at all, and plumbing per-peer key state into the route manager is a real change. The ticket stays open for it.

Found while reviewing #13637 (the CORE-13438 fix).

**Testing:** new UT `bpf_route_mgr_test.go` covers all four wireguard on/off combinations across both families. Verified it fails against the old expression (mutation-tested) and passes with the fix.

CORE-13520

**Release note:**
```release-note
Fixed the eBPF dataplane flagging remote workload routes as tunnelled for an address family that does not have WireGuard enabled, on dual-stack clusters with WireGuard enabled for one family only.
```

**AI assistance:** Claude Code wrote the fix and the unit test.