### PR TITLE
[v3.33] release: fix hashrelease disk exhaustion during e2e build

### DIFF
--- a/release/pkg/manager/calico/manager.go
+++ b/release/pkg/manager/calico/manager.go
@@ -341,6 +341,22 @@ func (r *CalicoManager) Build() error {
 			logrus.Info("Skipping building windows archive")
 		}
 
+		// Free transient disk before the multi-arch e2e build. Tagged component and
+		// operator images are still needed by PublishRelease, and the Go module
+		// cache is still needed to compile e2e, so only the build cache, dangling
+		// layers, and the already-consumed operator build cache are reclaimed here.
+		r.logDiskUsage("before e2e disk reclaim")
+		for _, c := range [][]string{
+			{"docker", "builder", "prune", "-af"},
+			{"docker", "image", "prune", "-f"},
+			{"rm", "-rf", filepath.Join(r.tmpDir, "operator", ".go-pkg-cache")},
+		} {
+			if out, err := r.runner.Run(c[0], c[1:], nil); err != nil {
+				logrus.WithError(err).Warnf("disk reclaim %q failed: %s", strings.Join(c, " "), out)
+			}
+		}
+		r.logDiskUsage("after e2e disk reclaim")
+
 		// Build multi-arch e2e test binaries and copy them into the output directory.
 		if r.e2eBinaries {
 			if err = r.buildE2EBinaries(); err != nil {
@@ -1232,10 +1248,11 @@ func (r *CalicoManager) buildReleaseTar() error {
 func (r *CalicoManager) buildE2EBinaries() error {
 	logrus.Info("Building multi-arch e2e test binaries")
 	e2eDir := filepath.Join(r.repoRoot, "e2e")
-	env := append(os.Environ(), fmt.Sprintf("VERSION=%s", r.calicoVersion))
-	if len(r.architectures) > 0 {
-		env = append(env, fmt.Sprintf("VALIDARCHES=%s", strings.Join(r.architectures, " ")))
-	}
+	// Only amd64 and arm64 e2e test binaries are consumed by test cycles: runners
+	// select the binary by their own node arch, and there are no ppc64le/s390x e2e
+	// runners. Building all four exhausts the release agent's disk, so restrict to
+	// the two architectures we actually ship.
+	env := append(os.Environ(), fmt.Sprintf("VERSION=%s", r.calicoVersion), "VALIDARCHES=amd64 arm64")
 	out, err := r.makeInDirectoryWithOutput(e2eDir, "build-all", env...)
 	if err != nil {
 		logrus.Error(out)
@@ -1264,6 +1281,24 @@ func (r *CalicoManager) buildE2EBinaries() error {
 		logrus.Infof("Staged e2e binary: %s", entry.Name())
 	}
 	return nil
+}
+
+// logDiskUsage prints disk and docker usage for hashrelease build diagnostics,
+// so disk pressure can be sized from the job log without SSH access to the agent.
+func (r *CalicoManager) logDiskUsage(stage string) {
+	logrus.Infof("=== disk usage: %s ===", stage)
+	for _, c := range [][]string{
+		{"df", "-h", "/"},
+		{"docker", "system", "df", "-v"},
+		{"docker", "images", "--format", "{{.Size}}\t{{.Repository}}:{{.Tag}}"},
+	} {
+		out, err := r.runner.Run(c[0], c[1:], nil)
+		if err != nil {
+			logrus.WithError(err).Warnf("disk usage diagnostic %q failed", strings.Join(c, " "))
+			continue
+		}
+		logrus.Infof("$ %s\n%s", strings.Join(c, " "), out)
+	}
 }
 
 func (r *CalicoManager) buildBinaries() error {

--- a/release/pkg/manager/calico/manager.go
+++ b/release/pkg/manager/calico/manager.go
@@ -343,23 +343,13 @@ func (r *CalicoManager) Build() error {
 
 		// Build multi-arch e2e test binaries and copy them into the output directory.
 		if r.e2eBinaries {
-			// Temporary disk relief before the e2e build until hashreleases are
-			// split into per-component jobs: reclaim build cache, dangling layers,
-			// and the spent operator cache (tagged images and module cache needed).
-			r.logDiskUsage("before e2e disk reclaim")
-			for _, c := range [][]string{
-				{"docker", "builder", "prune", "-af"},
-				{"docker", "image", "prune", "-f"},
-				{"rm", "-rf", filepath.Join(r.tmpDir, r.operatorRepo, ".go-pkg-cache")},
-			} {
-				if out, err := r.runner.Run(c[0], c[1:], nil); err != nil {
-					logrus.WithError(err).Warnf("disk reclaim %q failed: %s", strings.Join(c, " "), out)
+			if arches := e2eArchitectures(r.architectures); len(arches) == 0 {
+				logrus.Warnf("e2e binaries requested but none of %v is a supported e2e arch (amd64/arm64); skipping", r.architectures)
+			} else {
+				r.reclaimDiskBeforeE2E()
+				if err = r.buildE2EBinaries(arches); err != nil {
+					return err
 				}
-			}
-			r.logDiskUsage("after e2e disk reclaim")
-
-			if err = r.buildE2EBinaries(); err != nil {
-				return err
 			}
 		} else {
 			logrus.Info("Skipping building e2e test binaries")
@@ -1248,22 +1238,46 @@ func (r *CalicoManager) buildReleaseTar() error {
 // e2e runners and only cost build time and disk.
 var e2eSupportedArches = []string{"amd64", "arm64"}
 
-func (r *CalicoManager) buildE2EBinaries() error {
-	logrus.Info("Building multi-arch e2e test binaries")
-	e2eDir := filepath.Join(r.repoRoot, "e2e")
-	// Restrict to supported arches via ARCHES, not VALIDARCHES: lib.Makefile
-	// assigns VALIDARCHES with `=`, so it ignores the env.
-	var e2eArches []string
-	for _, arch := range r.architectures {
+// e2eArchitectures returns the e2e-supported subset of the configured arches.
+// An empty configured set means "all arches" (the tooling-wide convention) and
+// resolves to all supported e2e arches.
+func e2eArchitectures(configured []string) []string {
+	if len(configured) == 0 {
+		return slices.Clone(e2eSupportedArches)
+	}
+	var arches []string
+	for _, arch := range configured {
 		if slices.Contains(e2eSupportedArches, arch) {
-			e2eArches = append(e2eArches, arch)
+			arches = append(arches, arch)
 		}
 	}
-	if len(e2eArches) == 0 {
-		logrus.Info("No amd64/arm64 in the configured architectures; skipping e2e test binaries")
-		return nil
+	return arches
+}
+
+// reclaimDiskBeforeE2E frees transient disk before the multi-arch e2e build.
+// Temporary until hashreleases are split into per-component jobs: reclaim build
+// cache, dangling layers, and the spent operator cache (tagged images and the
+// module cache are still needed).
+func (r *CalicoManager) reclaimDiskBeforeE2E() {
+	r.logDiskUsage("before e2e disk reclaim")
+	for _, c := range [][]string{
+		{"docker", "builder", "prune", "-af"},
+		{"docker", "image", "prune", "-f"},
+		{"rm", "-rf", filepath.Join(r.tmpDir, r.operatorRepo, ".go-pkg-cache")},
+	} {
+		if out, err := r.runner.Run(c[0], c[1:], nil); err != nil {
+			logrus.WithError(err).Warnf("disk reclaim %q failed: %s", strings.Join(c, " "), out)
+		}
 	}
-	env := append(os.Environ(), fmt.Sprintf("VERSION=%s", r.calicoVersion), "ARCHES="+strings.Join(e2eArches, " "))
+	r.logDiskUsage("after e2e disk reclaim")
+}
+
+func (r *CalicoManager) buildE2EBinaries(arches []string) error {
+	logrus.Info("Building multi-arch e2e test binaries")
+	e2eDir := filepath.Join(r.repoRoot, "e2e")
+	// Restrict the build via ARCHES, not VALIDARCHES: lib.Makefile assigns
+	// VALIDARCHES with `=`, so it ignores the env.
+	env := append(os.Environ(), fmt.Sprintf("VERSION=%s", r.calicoVersion), "ARCHES="+strings.Join(arches, " "))
 	out, err := r.makeInDirectoryWithOutput(e2eDir, "build-all", env...)
 	if err != nil {
 		logrus.Error(out)

--- a/release/pkg/manager/calico/manager.go
+++ b/release/pkg/manager/calico/manager.go
@@ -341,24 +341,25 @@ func (r *CalicoManager) Build() error {
 			logrus.Info("Skipping building windows archive")
 		}
 
-		// Free transient disk before the multi-arch e2e build. Tagged component and
-		// operator images are still needed by PublishRelease, and the Go module
-		// cache is still needed to compile e2e, so only the build cache, dangling
-		// layers, and the already-consumed operator build cache are reclaimed here.
-		r.logDiskUsage("before e2e disk reclaim")
-		for _, c := range [][]string{
-			{"docker", "builder", "prune", "-af"},
-			{"docker", "image", "prune", "-f"},
-			{"rm", "-rf", filepath.Join(r.tmpDir, "operator", ".go-pkg-cache")},
-		} {
-			if out, err := r.runner.Run(c[0], c[1:], nil); err != nil {
-				logrus.WithError(err).Warnf("disk reclaim %q failed: %s", strings.Join(c, " "), out)
-			}
-		}
-		r.logDiskUsage("after e2e disk reclaim")
-
 		// Build multi-arch e2e test binaries and copy them into the output directory.
 		if r.e2eBinaries {
+			// Free transient disk before the multi-arch e2e build. Tagged component
+			// and operator images are still needed by PublishRelease, and the Go
+			// module cache is still needed to compile e2e, so only the build cache,
+			// dangling layers, and the already-consumed operator build cache are
+			// reclaimed here.
+			r.logDiskUsage("before e2e disk reclaim")
+			for _, c := range [][]string{
+				{"docker", "builder", "prune", "-af"},
+				{"docker", "image", "prune", "-f"},
+				{"rm", "-rf", filepath.Join(r.tmpDir, "operator", ".go-pkg-cache")},
+			} {
+				if out, err := r.runner.Run(c[0], c[1:], nil); err != nil {
+					logrus.WithError(err).Warnf("disk reclaim %q failed: %s", strings.Join(c, " "), out)
+				}
+			}
+			r.logDiskUsage("after e2e disk reclaim")
+
 			if err = r.buildE2EBinaries(); err != nil {
 				return err
 			}
@@ -1289,7 +1290,7 @@ func (r *CalicoManager) logDiskUsage(stage string) {
 	logrus.Infof("=== disk usage: %s ===", stage)
 	for _, c := range [][]string{
 		{"df", "-h", "/"},
-		{"docker", "system", "df", "-v"},
+		{"docker", "system", "df"},
 		{"docker", "images", "--format", "{{.Size}}\t{{.Repository}}:{{.Tag}}"},
 	} {
 		out, err := r.runner.Run(c[0], c[1:], nil)

--- a/release/pkg/manager/calico/manager.go
+++ b/release/pkg/manager/calico/manager.go
@@ -352,7 +352,7 @@ func (r *CalicoManager) Build() error {
 			for _, c := range [][]string{
 				{"docker", "builder", "prune", "-af"},
 				{"docker", "image", "prune", "-f"},
-				{"rm", "-rf", filepath.Join(r.tmpDir, "operator", ".go-pkg-cache")},
+				{"rm", "-rf", filepath.Join(r.tmpDir, r.operatorRepo, ".go-pkg-cache")},
 			} {
 				if out, err := r.runner.Run(c[0], c[1:], nil); err != nil {
 					logrus.WithError(err).Warnf("disk reclaim %q failed: %s", strings.Join(c, " "), out)
@@ -1249,11 +1249,23 @@ func (r *CalicoManager) buildReleaseTar() error {
 func (r *CalicoManager) buildE2EBinaries() error {
 	logrus.Info("Building multi-arch e2e test binaries")
 	e2eDir := filepath.Join(r.repoRoot, "e2e")
-	// Only amd64 and arm64 e2e test binaries are consumed by test cycles: runners
-	// select the binary by their own node arch, and there are no ppc64le/s390x e2e
-	// runners. Building all four exhausts the release agent's disk, so restrict to
-	// the two architectures we actually ship.
-	env := append(os.Environ(), fmt.Sprintf("VERSION=%s", r.calicoVersion), "VALIDARCHES=amd64 arm64")
+	// e2e test binaries are only consumed on amd64 and arm64: test runners pick
+	// the binary matching their own node arch, and there are no ppc64le/s390x e2e
+	// runners. Building every configured arch also exhausts the release agent's
+	// disk. Build the intersection of the configured and the supported arches.
+	// The set is controlled via ARCHES, not VALIDARCHES: lib.Makefile assigns
+	// VALIDARCHES with `=`, so it ignores the environment.
+	var e2eArches []string
+	for _, arch := range r.architectures {
+		if arch == "amd64" || arch == "arm64" {
+			e2eArches = append(e2eArches, arch)
+		}
+	}
+	if len(e2eArches) == 0 {
+		logrus.Info("No amd64/arm64 in the configured architectures; skipping e2e test binaries")
+		return nil
+	}
+	env := append(os.Environ(), fmt.Sprintf("VERSION=%s", r.calicoVersion), "ARCHES="+strings.Join(e2eArches, " "))
 	out, err := r.makeInDirectoryWithOutput(e2eDir, "build-all", env...)
 	if err != nil {
 		logrus.Error(out)

--- a/release/pkg/manager/calico/manager.go
+++ b/release/pkg/manager/calico/manager.go
@@ -343,11 +343,9 @@ func (r *CalicoManager) Build() error {
 
 		// Build multi-arch e2e test binaries and copy them into the output directory.
 		if r.e2eBinaries {
-			// Free transient disk before the multi-arch e2e build. Tagged component
-			// and operator images are still needed by PublishRelease, and the Go
-			// module cache is still needed to compile e2e, so only the build cache,
-			// dangling layers, and the already-consumed operator build cache are
-			// reclaimed here.
+			// Temporary disk relief before the e2e build until hashreleases are
+			// split into per-component jobs: reclaim build cache, dangling layers,
+			// and the spent operator cache (tagged images and module cache needed).
 			r.logDiskUsage("before e2e disk reclaim")
 			for _, c := range [][]string{
 				{"docker", "builder", "prune", "-af"},
@@ -1246,18 +1244,15 @@ func (r *CalicoManager) buildReleaseTar() error {
 	return nil
 }
 
-// e2eSupportedArches are the architectures e2e test runners actually consume:
-// runners pick the binary matching their own node arch, and there are no
-// ppc64le/s390x e2e runners. Building the other arches only wastes time and
-// exhausts the release agent's disk.
+// e2eSupportedArches are the arches e2e runners consume; ppc64le/s390x have no
+// e2e runners and only cost build time and disk.
 var e2eSupportedArches = []string{"amd64", "arm64"}
 
 func (r *CalicoManager) buildE2EBinaries() error {
 	logrus.Info("Building multi-arch e2e test binaries")
 	e2eDir := filepath.Join(r.repoRoot, "e2e")
-	// Build the intersection of the configured and the supported arches. The set
-	// is controlled via ARCHES, not VALIDARCHES: lib.Makefile assigns VALIDARCHES
-	// with `=`, so it ignores the environment.
+	// Restrict to supported arches via ARCHES, not VALIDARCHES: lib.Makefile
+	// assigns VALIDARCHES with `=`, so it ignores the env.
 	var e2eArches []string
 	for _, arch := range r.architectures {
 		if slices.Contains(e2eSupportedArches, arch) {
@@ -1299,8 +1294,7 @@ func (r *CalicoManager) buildE2EBinaries() error {
 	return nil
 }
 
-// logDiskUsage prints disk and docker usage for hashrelease build diagnostics,
-// so disk pressure can be sized from the job log without SSH access to the agent.
+// logDiskUsage logs disk/docker usage so pressure can be sized from the job log.
 func (r *CalicoManager) logDiskUsage(stage string) {
 	logrus.Infof("=== disk usage: %s ===", stage)
 	for _, c := range [][]string{

--- a/release/pkg/manager/calico/manager.go
+++ b/release/pkg/manager/calico/manager.go
@@ -1246,18 +1246,21 @@ func (r *CalicoManager) buildReleaseTar() error {
 	return nil
 }
 
+// e2eSupportedArches are the architectures e2e test runners actually consume:
+// runners pick the binary matching their own node arch, and there are no
+// ppc64le/s390x e2e runners. Building the other arches only wastes time and
+// exhausts the release agent's disk.
+var e2eSupportedArches = []string{"amd64", "arm64"}
+
 func (r *CalicoManager) buildE2EBinaries() error {
 	logrus.Info("Building multi-arch e2e test binaries")
 	e2eDir := filepath.Join(r.repoRoot, "e2e")
-	// e2e test binaries are only consumed on amd64 and arm64: test runners pick
-	// the binary matching their own node arch, and there are no ppc64le/s390x e2e
-	// runners. Building every configured arch also exhausts the release agent's
-	// disk. Build the intersection of the configured and the supported arches.
-	// The set is controlled via ARCHES, not VALIDARCHES: lib.Makefile assigns
-	// VALIDARCHES with `=`, so it ignores the environment.
+	// Build the intersection of the configured and the supported arches. The set
+	// is controlled via ARCHES, not VALIDARCHES: lib.Makefile assigns VALIDARCHES
+	// with `=`, so it ignores the environment.
 	var e2eArches []string
 	for _, arch := range r.architectures {
-		if arch == "amd64" || arch == "arm64" {
+		if slices.Contains(e2eSupportedArches, arch) {
 			e2eArches = append(e2eArches, arch)
 		}
 	}

--- a/release/pkg/manager/calico/manager_test.go
+++ b/release/pkg/manager/calico/manager_test.go
@@ -588,38 +588,57 @@ func TestPublishContainerImagesBranchTag(t *testing.T) {
 }
 
 // TestBuildE2EBinariesRestrictsArchitectures asserts the hashrelease e2e build
-// is pinned to the architectures consumed by test cycles (amd64, arm64). This
-// keeps ppc64le/s390x out of the build so it does not exhaust the release
-// agent's disk.
+// is limited to the architectures consumed by test cycles (amd64, arm64), the
+// intersection of the configured arches and the supported set. The restriction
+// must go through ARCHES: lib.Makefile assigns VALIDARCHES with `=`, so passing
+// VALIDARCHES via the environment is a no-op.
 func TestBuildE2EBinariesRestrictsArchitectures(t *testing.T) {
-	repoRoot := t.TempDir()
-	// Stage a built e2e binary so the post-build hard-link step succeeds.
-	e2eBinDir := filepath.Join(repoRoot, "e2e", "bin", "k8s")
-	if err := os.MkdirAll(e2eBinDir, 0o755); err != nil {
-		t.Fatalf("setup: %v", err)
+	tests := []struct {
+		name          string
+		architectures []string
+		wantArches    string
+	}{
+		{"default four arches drop ppc64le/s390x", []string{"amd64", "arm64", "ppc64le", "s390x"}, "amd64 arm64"},
+		{"narrowed build keeps only its supported arch", []string{"arm64"}, "arm64"},
 	}
-	if err := os.WriteFile(filepath.Join(e2eBinDir, "e2e-linux-amd64.test"), []byte("x"), 0o644); err != nil {
-		t.Fatalf("setup: %v", err)
-	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repoRoot := t.TempDir()
+			// Stage a built e2e binary so the post-build hard-link step succeeds.
+			e2eBinDir := filepath.Join(repoRoot, "e2e", "bin", "k8s")
+			if err := os.MkdirAll(e2eBinDir, 0o755); err != nil {
+				t.Fatalf("setup: %v", err)
+			}
+			if err := os.WriteFile(filepath.Join(e2eBinDir, "e2e-linux-amd64.test"), []byte("x"), 0o644); err != nil {
+				t.Fatalf("setup: %v", err)
+			}
 
-	f := newFakeRunner()
-	r := &CalicoManager{
-		runner:        f,
-		repoRoot:      repoRoot,
-		outputDir:     t.TempDir(),
-		calicoVersion: "v3.33.0-0.dev-1-gabcdef123456",
-	}
+			f := newFakeRunner()
+			r := &CalicoManager{
+				runner:        f,
+				repoRoot:      repoRoot,
+				outputDir:     t.TempDir(),
+				calicoVersion: "v3.33.0-0.dev-1-gabcdef123456",
+				architectures: tt.architectures,
+			}
 
-	if err := r.buildE2EBinaries(); err != nil {
-		t.Fatalf("buildE2EBinaries() unexpected error: %v", err)
-	}
+			if err := r.buildE2EBinaries(); err != nil {
+				t.Fatalf("buildE2EBinaries() unexpected error: %v", err)
+			}
 
-	makePrefix := "make -C " + filepath.Join(repoRoot, "e2e") + " build-all"
-	env := f.envFor(makePrefix)
-	if env == nil {
-		t.Fatalf("e2e build-all was not run (calls: %v)", f.calls)
-	}
-	if !slices.Contains(env, "VALIDARCHES=amd64 arm64") {
-		t.Errorf("e2e build-all env = %v, want it to contain VALIDARCHES=amd64 arm64", env)
+			makePrefix := "make -C " + filepath.Join(repoRoot, "e2e") + " build-all"
+			env := f.envFor(makePrefix)
+			if env == nil {
+				t.Fatalf("e2e build-all was not run (calls: %v)", f.calls)
+			}
+			if !slices.Contains(env, "ARCHES="+tt.wantArches) {
+				t.Errorf("e2e build-all env = %v, want it to contain ARCHES=%s", env, tt.wantArches)
+			}
+			for _, e := range env {
+				if strings.HasPrefix(e, "VALIDARCHES=") {
+					t.Errorf("e2e build-all should not set VALIDARCHES (lib.Makefile ignores it): %s", e)
+				}
+			}
+		})
 	}
 }

--- a/release/pkg/manager/calico/manager_test.go
+++ b/release/pkg/manager/calico/manager_test.go
@@ -587,58 +587,75 @@ func TestPublishContainerImagesBranchTag(t *testing.T) {
 	}
 }
 
-// TestBuildE2EBinariesRestrictsArchitectures asserts the hashrelease e2e build
-// is limited to the architectures consumed by test cycles (amd64, arm64), the
-// intersection of the configured arches and the supported set. The restriction
-// must go through ARCHES: lib.Makefile assigns VALIDARCHES with `=`, so passing
-// VALIDARCHES via the environment is a no-op.
-func TestBuildE2EBinariesRestrictsArchitectures(t *testing.T) {
+// TestE2EArchitectures covers the supported-arch intersection: an empty set
+// means "all" (the tooling-wide convention), the four-arch default drops
+// ppc64le/s390x, a narrowed build keeps only its supported arches, and an
+// unsupported-only set yields none.
+func TestE2EArchitectures(t *testing.T) {
 	tests := []struct {
-		name          string
-		architectures []string
-		wantArches    string
+		name       string
+		configured []string
+		want       []string
 	}{
-		{"default four arches drop ppc64le/s390x", []string{"amd64", "arm64", "ppc64le", "s390x"}, "amd64 arm64"},
-		{"narrowed build keeps only its supported arch", []string{"arm64"}, "arm64"},
+		{"empty means all supported", nil, []string{"amd64", "arm64"}},
+		{"default four arches drop ppc64le/s390x", []string{"amd64", "arm64", "ppc64le", "s390x"}, []string{"amd64", "arm64"}},
+		{"narrowed build keeps only its supported arch", []string{"arm64"}, []string{"arm64"}},
+		{"unsupported-only yields none", []string{"ppc64le", "s390x"}, nil},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			repoRoot := t.TempDir()
-			// Stage a built e2e binary so the post-build hard-link step succeeds.
-			e2eBinDir := filepath.Join(repoRoot, "e2e", "bin", "k8s")
-			if err := os.MkdirAll(e2eBinDir, 0o755); err != nil {
-				t.Fatalf("setup: %v", err)
-			}
-			if err := os.WriteFile(filepath.Join(e2eBinDir, "e2e-linux-amd64.test"), []byte("x"), 0o644); err != nil {
-				t.Fatalf("setup: %v", err)
-			}
-
-			f := newFakeRunner()
-			r := &CalicoManager{
-				runner:        f,
-				repoRoot:      repoRoot,
-				outputDir:     t.TempDir(),
-				calicoVersion: "v3.33.0-0.dev-1-gabcdef123456",
-				architectures: tt.architectures,
-			}
-
-			if err := r.buildE2EBinaries(); err != nil {
-				t.Fatalf("buildE2EBinaries() unexpected error: %v", err)
-			}
-
-			makePrefix := "make -C " + filepath.Join(repoRoot, "e2e") + " build-all"
-			env := f.envFor(makePrefix)
-			if env == nil {
-				t.Fatalf("e2e build-all was not run (calls: %v)", f.calls)
-			}
-			if !slices.Contains(env, "ARCHES="+tt.wantArches) {
-				t.Errorf("e2e build-all env = %v, want it to contain ARCHES=%s", env, tt.wantArches)
-			}
-			for _, e := range env {
-				if strings.HasPrefix(e, "VALIDARCHES=") {
-					t.Errorf("e2e build-all should not set VALIDARCHES (lib.Makefile ignores it): %s", e)
-				}
+			if got := e2eArchitectures(tt.configured); !slices.Equal(got, tt.want) {
+				t.Errorf("e2eArchitectures(%v) = %v, want %v", tt.configured, got, tt.want)
 			}
 		})
+	}
+}
+
+// TestBuildE2EBinariesUsesARCHES asserts the e2e build is restricted through
+// ARCHES, not VALIDARCHES (lib.Makefile assigns VALIDARCHES with `=`, so passing
+// it via the environment is a no-op).
+func TestBuildE2EBinariesUsesARCHES(t *testing.T) {
+	repoRoot := t.TempDir()
+	// Stage a built e2e binary so the post-build hard-link step succeeds.
+	e2eBinDir := filepath.Join(repoRoot, "e2e", "bin", "k8s")
+	if err := os.MkdirAll(e2eBinDir, 0o755); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(e2eBinDir, "e2e-linux-amd64.test"), []byte("x"), 0o644); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	f := newFakeRunner()
+	r := &CalicoManager{
+		runner:        f,
+		repoRoot:      repoRoot,
+		outputDir:     t.TempDir(),
+		calicoVersion: "v3.33.0-0.dev-1-gabcdef123456",
+	}
+
+	if err := r.buildE2EBinaries([]string{"amd64", "arm64"}); err != nil {
+		t.Fatalf("buildE2EBinaries() unexpected error: %v", err)
+	}
+
+	makePrefix := "make -C " + filepath.Join(repoRoot, "e2e") + " build-all"
+	env := f.envFor(makePrefix)
+	if env == nil {
+		t.Fatalf("e2e build-all was not run (calls: %v)", f.calls)
+	}
+	// Only inspect the arch env vars: env also carries os.Environ(), which can
+	// hold secrets that must not be printed on failure.
+	var archEnv []string
+	for _, e := range env {
+		if strings.HasPrefix(e, "ARCHES=") || strings.HasPrefix(e, "VALIDARCHES=") {
+			archEnv = append(archEnv, e)
+		}
+	}
+	if !slices.Contains(archEnv, "ARCHES=amd64 arm64") {
+		t.Errorf("e2e build-all arch env = %v, want ARCHES=amd64 arm64", archEnv)
+	}
+	for _, e := range archEnv {
+		if strings.HasPrefix(e, "VALIDARCHES=") {
+			t.Errorf("e2e build-all should not set VALIDARCHES (lib.Makefile ignores it): %s", e)
+		}
 	}
 }

--- a/release/pkg/manager/calico/manager_test.go
+++ b/release/pkg/manager/calico/manager_test.go
@@ -16,6 +16,8 @@ package calico
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"slices"
 	"strings"
 	"testing"
@@ -582,5 +584,42 @@ func TestPublishContainerImagesBranchTag(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestBuildE2EBinariesRestrictsArchitectures asserts the hashrelease e2e build
+// is pinned to the architectures consumed by test cycles (amd64, arm64). This
+// keeps ppc64le/s390x out of the build so it does not exhaust the release
+// agent's disk.
+func TestBuildE2EBinariesRestrictsArchitectures(t *testing.T) {
+	repoRoot := t.TempDir()
+	// Stage a built e2e binary so the post-build hard-link step succeeds.
+	e2eBinDir := filepath.Join(repoRoot, "e2e", "bin", "k8s")
+	if err := os.MkdirAll(e2eBinDir, 0o755); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(e2eBinDir, "e2e-linux-amd64.test"), []byte("x"), 0o644); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	f := newFakeRunner()
+	r := &CalicoManager{
+		runner:        f,
+		repoRoot:      repoRoot,
+		outputDir:     t.TempDir(),
+		calicoVersion: "v3.33.0-0.dev-1-gabcdef123456",
+	}
+
+	if err := r.buildE2EBinaries(); err != nil {
+		t.Fatalf("buildE2EBinaries() unexpected error: %v", err)
+	}
+
+	makePrefix := "make -C " + filepath.Join(repoRoot, "e2e") + " build-all"
+	env := f.envFor(makePrefix)
+	if env == nil {
+		t.Fatalf("e2e build-all was not run (calls: %v)", f.calls)
+	}
+	if !slices.Contains(env, "VALIDARCHES=amd64 arm64") {
+		t.Errorf("e2e build-all env = %v, want it to contain VALIDARCHES=amd64 arm64", env)
 	}
 }


### PR DESCRIPTION
### Description

The v3.33 hashrelease build fails with `No space left on device`. The build compiles the e2e test binaries for all four architectures (amd64, arm64, ppc64le, s390x) in a single job, after the operator and all ~20 component images (x4 arches) are already on the agent's disk. That final step pushes the `f1-standard-4` agent (65 GB, the largest-disk hosted machine) past its limit.

This change:

- **Restricts the e2e test binaries to amd64 + arm64.** Only those two are consumed by test cycles (the runners download the binary matching their own node arch, and there are no ppc64le/s390x e2e runners). Historically these were never built for ppc64le/s390x anyway, so this restores prior behavior. Confirmed with QA.
- **Reclaims transient disk before the e2e step.** Prunes the BuildKit build cache, dangling layers, and the already-consumed operator build cache. Tagged component/operator images (needed by `PublishRelease`) and the Go module cache (needed to compile e2e) are left intact.
- **Logs disk and docker usage** around the reclaim, so future disk pressure can be sized from the job log (SSH attach to the agent is blocked by the secret-guard).

The container images themselves are unchanged: they still build and ship for all four architectures.

### Release Note

```release-note
None
```

### Reminder for the reviewer

- [ ] Forward-port to `master` so the fix is not lost on the next branch cut.