### PR TITLE
Prune stale YAML in the api, operator and kube-controllers CRD generators

### DIFF
--- a/api/Makefile
+++ b/api/Makefile
@@ -62,6 +62,8 @@ build: gen-files examples
 # Regenerate all files if the gen exes changed or any "types.go" files changed
 .PHONY: gen-files
 gen-files .generate_files: lint-cache-dir clean-generated
+	# Prune stale CRDs, keeping embed.go, which lives with the CRDs it embeds.
+	rm -f config/crd/*.yaml
 	# Generate CRDs using the in-repo Calico-patched controller-gen.
 	$(MAKE) -C $(REPO_ROOT) $(CALICO_CONTROLLER_GEN_BIN)
 	$(DOCKER_RUN) $(CALICO_BUILD) sh -c '$(GIT_CONFIG_SSH) $(CALICO_CONTROLLER_GEN) crd:allowDangerousTypes=true,crdVersions=v1 paths=./pkg/apis/... output:crd:dir=config/crd/'

--- a/kube-controllers/Makefile
+++ b/kube-controllers/Makefile
@@ -47,6 +47,8 @@ check-copyright:
 ###############################################################################
 .PHONY: gen-files
 gen-files:
+	# Prune stale CRDs so one whose Go type is gone leaves the tree too.
+	rm -f pkg/apis/migration/v1/crd/*.yaml
 	$(MAKE) -C $(REPO_ROOT) $(CALICO_CONTROLLER_GEN_BIN)
 	$(DOCKER_RUN) $(CALICO_BUILD) sh -c '$(CALICO_CONTROLLER_GEN) crd paths=./pkg/apis/migration/... output:crd:dir=pkg/apis/migration/v1/crd/'
 	$(DOCKER_RUN) $(CALICO_BUILD) sh -c '$(CALICO_CONTROLLER_GEN) object paths=./pkg/apis/migration/...'

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -488,6 +488,8 @@ deploy: manifests kustomize
 # Generate manifests e.g. CRD
 # Can also generate RBAC and webhooks but that is not enabled currently.
 manifests:
+	# Prune stale CRDs so one whose Go type is gone leaves the tree too.
+	rm -f pkg/crds/operator/*.yaml
 	$(DOCKER_GO_BUILD) sh -c 'controller-gen crd paths="./api/..." output:crd:artifacts:config=pkg/crds/operator'
 	for x in $$(find pkg/crds/operator/*); do sed -i -e '/creationTimestamp: null/d' -e '/^---/d' -e '/^\s*$$/d' $$x; done
 	@docker run --rm --user $(id -u):$(id -g) -v $(CURDIR)/pkg/crds/operator/:/work/crds/operator/ tmknom/prettier --write --parser=yaml /work


### PR DESCRIPTION
The generators for `api/config/crd`, `operator/pkg/crds/operator` and `kube-controllers/pkg/apis/migration/v1/crd` run controller-gen in place with no prune, so a CRD whose Go type gets deleted sticks around forever and `check-dirty` still passes, because the tree stays self-consistent. This adds the `rm -f <dir>/*.yaml` that `libcalico-go`'s `gen-crds` has always had, scoped to `*.yaml` so the `embed.go` that lives with the api CRDs survives.

Checked each of the three by dropping a bogus CRD and deleting a real one, re-running the generator, and confirming the bogus file was pruned, the real one came back, and `git status` was clean.

Related: [CORE-13533](https://tigera.atlassian.net/browse/CORE-13533)

```release-note
None
```

**AI assistance:** Claude Code


[CORE-13533]: https://tigera.atlassian.net/browse/CORE-13533?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ