### PR TITLE
Fix operator design doc links in operator/CLAUDE.md

### DIFF
--- a/operator/CLAUDE.md
+++ b/operator/CLAUDE.md
@@ -78,10 +78,10 @@ Read the relevant doc before working in these areas:
 
 | Task | Read |
 |------|------|
-| Architecture & design rationale (the "why") | [`docs/principles.md`](../docs/principles.md) |
-| API design & changing CRD types in `api/v1` (principles, conventions, checklist) | [`docs/api_design.md`](../docs/api_design.md) |
-| Developer workflow, code generation, cherry-picks | [`docs/dev_guidelines.md`](../docs/dev_guidelines.md) |
-| Common dev procedures (run, test, debug) | [`docs/common_tasks.md`](../docs/common_tasks.md) |
+| Architecture & design rationale (the "why") | [`docs/principles.md`](docs/principles.md) |
+| API design & changing CRD types in `api/v1` (principles, conventions, checklist) | [`docs/api_design.md`](docs/api_design.md) |
+| Developer workflow, code generation, cherry-picks | [`docs/dev_guidelines.md`](docs/dev_guidelines.md) |
+| Common dev procedures (run, test, debug) | [`docs/common_tasks.md`](docs/common_tasks.md) |
 
 ## Build Environment
 - Tests and builds run in a containerized environment (`calico/go-build`) by default


### PR DESCRIPTION
The four design doc links in `operator/CLAUDE.md` kept a `../` prefix from the standalone operator repo, where `CLAUDE.md` sat a level above `docs/`. From its position in the monorepo they resolve to a repo-root `docs/` that does not exist, so nothing following them lands on `operator/docs/principles.md` and friends.

I checked the other 27 relative links across the repo's `CLAUDE.md` files and every one of them resolves, as do the bare paths that `operator/CLAUDE.md` calls out in its Key Packages list.

Related: [CORE-13542](https://tigera.atlassian.net/browse/CORE-13542)

**Release note:**
```release-note
None
```

**AI assistance:** Claude Code found the broken links and made the edit.


[CORE-13542]: https://tigera.atlassian.net/browse/CORE-13542?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ