### PR TITLE
Fail gen-versions when a versions file omits a required component

### DIFF
--- a/hack/test/kind/infra/build-operator.sh
+++ b/hack/test/kind/infra/build-operator.sh
@@ -31,7 +31,7 @@ VERSIONS_FILE=$(mktemp /tmp/calico_versions_XXXXXX.yml)
 sed -e "s/test-build/${DEV_IMAGE_TAG}/g" \
     -e "/version:/a\\    registry: ${DEV_IMAGE_REGISTRY}/\n    imagePath: ${DEV_IMAGE_PATH}" \
     "${INFRA_DIR}/calico_versions.yml" > "${VERSIONS_FILE}"
-build/_output/bin/gen-versions -os-versions="${VERSIONS_FILE}" > "${COMPONENTS}"
+build/_output/bin/gen-versions -os-versions="${VERSIONS_FILE}" -out="${COMPONENTS}"
 rm -f "${VERSIONS_FILE}"
 
 make image

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -167,7 +167,7 @@ clean:
 ###############################################################################
 # Tests
 ###############################################################################
-UT_DIR?=./pkg
+UT_DIR?=./pkg ./hack/gen-versions
 FV_DIR?=./test
 GO_TEST_ARGS ?= -count 1
 
@@ -190,7 +190,7 @@ ut: $(ENVOY_GATEWAY_CHART) $(ISTIO_CHART_FILES)
 	$(DOCKER_GO_BUILD) sh -c '$(GIT_CONFIG_SSH) \
 	go install sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.22 && \
 	export KUBEBUILDER_ASSETS=$$(setup-envtest use $(ENVTEST_K8S_VERSION) --bin-dir /tmp/envtest-bins -p path) && \
-	gotestsum --format testname --junitfile report/operator_ut.xml -- $(UT_DIR)/... $(GO_TEST_ARGS) $(GINKGO_FOCUS_ARG)'
+	gotestsum --format testname --junitfile report/operator_ut.xml -- $(addsuffix /...,$(UT_DIR)) $(GO_TEST_ARGS) $(GINKGO_FOCUS_ARG)'
 
 ## Run the functional tests against a local kind cluster.
 fv: kind-cluster-create deploy-crds load-container-images run-fvs kind-cluster-destroy

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -424,10 +424,10 @@ EE_VERSIONS?=config/enterprise_versions.yml
 gen-versions: gen-versions-calico gen-versions-enterprise
 
 gen-versions-calico: $(BINDIR)/gen-versions
-	$(BINDIR)/gen-versions -os-versions=$(OS_VERSIONS) > pkg/components/calico.go
+	$(BINDIR)/gen-versions -os-versions=$(OS_VERSIONS) -out=pkg/components/calico.go
 
 gen-versions-enterprise: $(BINDIR)/gen-versions
-	$(BINDIR)/gen-versions -ee-versions=$(EE_VERSIONS) > pkg/components/enterprise.go
+	$(BINDIR)/gen-versions -ee-versions=$(EE_VERSIONS) -out=pkg/components/enterprise.go
 
 $(BINDIR)/gen-versions: $(shell find ./hack/gen-versions -type f)
 	mkdir -p $(BINDIR)

--- a/operator/hack/gen-versions/calico.go.tpl
+++ b/operator/hack/gen-versions/calico.go.tpl
@@ -19,7 +19,7 @@ package components
 
 var (
 	CalicoRelease string = "{{ .Title }}"
-{{ with index .Components "third-party-cni-plugins" }}
+{{ with required .Components "third-party-cni-plugins" }}
 	ComponentCalicoCNIPlugins = Component{
 		Version:   "{{ .Version }}",
 		Image:     "{{ .Image }}",
@@ -28,7 +28,7 @@ var (
 		variant:   calicoVariant,
 	}
 {{- end }}
-{{ with index .Components "cni-windows" }}
+{{ with required .Components "cni-windows" }}
 	ComponentCalicoCNIWindows = Component{
 		Version:   "{{ .Version }}",
 		Image:     "{{ .Image }}",
@@ -37,7 +37,7 @@ var (
 		variant:   calicoVariant,
 	}
 {{- end }}
-{{ with index .Components.node }}
+{{ with required .Components "node" }}
 	ComponentCalicoNode = Component{
 		Version:   "{{ .Version }}",
 		Image:     "{{ .Image }}",
@@ -46,7 +46,7 @@ var (
 		variant:   calicoVariant,
 	}
 {{- end }}
-{{ with index .Components  "node-windows" }}
+{{ with required .Components "node-windows" }}
 	ComponentCalicoNodeWindows = Component{
 		Version:   "{{ .Version }}",
 		Image:     "{{ .Image }}",
@@ -55,7 +55,7 @@ var (
 		variant:   calicoVariant,
 	}
 {{- end }}
-{{ with index .Components.whisker }}
+{{ with required .Components "whisker" }}
 	ComponentCalicoWhisker = Component{
 		Version:   "{{ .Version }}",
 		Image:     "{{ .Image }}",
@@ -64,7 +64,7 @@ var (
 		variant:   calicoVariant,
 	}
 {{- end }}
-{{ with index .Components "envoy-gateway" }}
+{{ with required .Components "envoy-gateway" }}
 	ComponentCalicoEnvoyGateway = Component{
 		Version:   "{{ .Version }}",
 		Image:     "{{ .Image }}",
@@ -73,7 +73,7 @@ var (
 		variant:   calicoVariant,
 	}
 {{- end }}
-{{ with index .Components "envoy-proxy" }}
+{{ with required .Components "envoy-proxy" }}
 	ComponentCalicoEnvoyProxy = Component{
 		Version:   "{{ .Version }}",
 		Image:     "{{ .Image }}",
@@ -82,7 +82,7 @@ var (
 		variant:   calicoVariant,
 	}
 {{- end }}
-{{ with index .Components "envoy-ratelimit" }}
+{{ with required .Components "envoy-ratelimit" }}
 	ComponentCalicoEnvoyRatelimit = Component{
 		Version:   "{{ .Version }}",
 		Image:     "{{ .Image }}",
@@ -91,7 +91,7 @@ var (
 		variant:   calicoVariant,
 	}
 {{- end }}
-{{ with index .Components "istio-pilot" }}
+{{ with required .Components "istio-pilot" }}
 	ComponentCalicoIstioPilot = Component{
 		Version:   "{{ .Version }}",
 		Image:     "{{ .Image }}",
@@ -100,7 +100,7 @@ var (
 		variant:   calicoVariant,
 	}
 {{- end }}
-{{ with index .Components "istio-install-cni" }}
+{{ with required .Components "istio-install-cni" }}
 	ComponentCalicoIstioInstallCNI = Component{
 		Version:   "{{ .Version }}",
 		Image:     "{{ .Image }}",
@@ -109,7 +109,7 @@ var (
 		variant:   calicoVariant,
 	}
 {{- end }}
-{{ with index .Components "istio-ztunnel" }}
+{{ with required .Components "istio-ztunnel" }}
 	ComponentCalicoIstioZTunnel = Component{
 		Version:   "{{ .Version }}",
 		Image:     "{{ .Image }}",
@@ -118,7 +118,7 @@ var (
 		variant:   calicoVariant,
 	}
 {{- end }}
-{{ with index .Components "istio-proxyv2" }}
+{{ with required .Components "istio-proxyv2" }}
 	ComponentCalicoIstioProxyv2 = Component{
 		Version:   "{{ .Version }}",
 		Image:     "{{ .Image }}",
@@ -127,7 +127,7 @@ var (
 		variant:   calicoVariant,
 	}
 {{- end }}
-{{ with index .Components.calico }}
+{{ with required .Components "calico" }}
 	ComponentCalico = Component{
 		Version:   "{{ .Version }}",
 		Image:     "{{ .Image }}",

--- a/operator/hack/gen-versions/components.go
+++ b/operator/hack/gen-versions/components.go
@@ -16,7 +16,9 @@ package main
 
 import (
 	"fmt"
+	"io"
 	"os"
+	"path/filepath"
 	"strings"
 	"text/template"
 
@@ -167,12 +169,26 @@ func readComponents(versionsPath string) (Release, error) {
 	return cr, nil
 }
 
-func render(tplFile string, vz Release) error {
-	t, err := template.ParseFiles(tplFile)
+func render(w io.Writer, tplFile string, vz Release) error {
+	funcs := template.FuncMap{
+		"required": requiredComponent,
+	}
+
+	name := filepath.Base(tplFile)
+	t, err := template.New(name).Funcs(funcs).Option("missingkey=error").ParseFiles(tplFile)
 	if err != nil {
 		return fmt.Errorf("failed to parse template file file: %v", err)
 	}
-	t.Option("missingkey=error")
 
-	return t.Execute(os.Stdout, vz)
+	return t.Execute(w, vz)
+}
+
+// requiredComponent returns the named component, erroring when the versions file
+// omits it rather than letting the template render an empty image reference.
+func requiredComponent(components Components, key string) (*Component, error) {
+	c, ok := components[key]
+	if !ok || c == nil {
+		return nil, fmt.Errorf("versions file has no entry for required component %q", key)
+	}
+	return c, nil
 }

--- a/operator/hack/gen-versions/components.go
+++ b/operator/hack/gen-versions/components.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"os"
@@ -167,6 +168,17 @@ func readComponents(versionsPath string) (Release, error) {
 	}
 
 	return cr, nil
+}
+
+// renderFile writes the rendered template to path, buffering first so a failed
+// render leaves any existing file alone.
+func renderFile(path, tplFile string, vz Release) error {
+	var buf bytes.Buffer
+	if err := render(&buf, tplFile, vz); err != nil {
+		return err
+	}
+
+	return os.WriteFile(path, buf.Bytes(), 0o644)
 }
 
 func render(w io.Writer, tplFile string, vz Release) error {

--- a/operator/hack/gen-versions/components_test.go
+++ b/operator/hack/gen-versions/components_test.go
@@ -1,0 +1,99 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v2"
+)
+
+func TestRenderRequiresTemplateComponents(t *testing.T) {
+	tests := []struct {
+		name     string
+		tpl      string
+		versions string
+		omit     string
+	}{
+		{
+			name:     "calico",
+			tpl:      osVersionsTpl,
+			versions: "../../config/calico_versions.yml",
+			omit:     "node",
+		},
+		{
+			name:     "enterprise",
+			tpl:      eeVersionsTpl,
+			versions: "../../config/enterprise_versions.yml",
+			omit:     "manager",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			vz, err := GetComponents(tt.versions)
+			if err != nil {
+				t.Fatalf("failed to read %s: %v", tt.versions, err)
+			}
+			if err := render(io.Discard, tt.tpl, vz); err != nil {
+				t.Fatalf("render of %s failed: %v", tt.versions, err)
+			}
+
+			trimmed, err := GetComponents(versionsWithout(t, tt.versions, tt.omit))
+			if err != nil {
+				t.Fatalf("failed to read trimmed versions file: %v", err)
+			}
+			err = render(io.Discard, tt.tpl, trimmed)
+			if err == nil {
+				t.Fatalf("render succeeded with component %q missing", tt.omit)
+			}
+			if !strings.Contains(err.Error(), tt.omit) {
+				t.Errorf("error %q does not name the missing component %q", err, tt.omit)
+			}
+		})
+	}
+}
+
+// versionsWithout writes a copy of a versions file with one component removed and
+// returns its path.
+func versionsWithout(t *testing.T, versionsPath, omit string) string {
+	t.Helper()
+
+	release, err := readComponents(versionsPath)
+	if err != nil {
+		t.Fatalf("failed to read %s: %v", versionsPath, err)
+	}
+	if _, ok := release.Components[omit]; !ok {
+		t.Fatalf("%s has no component %q to remove", versionsPath, omit)
+	}
+	delete(release.Components, omit)
+
+	out, err := yaml.Marshal(release)
+	if err != nil {
+		t.Fatalf("failed to marshal versions: %v", err)
+	}
+
+	path := filepath.Join(t.TempDir(), filepath.Base(versionsPath))
+	if err := os.WriteFile(path, out, 0o644); err != nil {
+		t.Fatalf("failed to write %s: %v", path, err)
+	}
+	return path
+}

--- a/operator/hack/gen-versions/components_test.go
+++ b/operator/hack/gen-versions/components_test.go
@@ -15,7 +15,7 @@
 package main
 
 import (
-	"io"
+	"bytes"
 	"os"
 	"path/filepath"
 	"strings"
@@ -53,20 +53,37 @@ func TestRenderRequiresTemplateComponents(t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed to read %s: %v", tt.versions, err)
 			}
-			if err := render(io.Discard, tt.tpl, vz); err != nil {
+
+			dest := filepath.Join(t.TempDir(), "components.go")
+			if err := renderFile(dest, tt.tpl, vz); err != nil {
 				t.Fatalf("render of %s failed: %v", tt.versions, err)
+			}
+			generated, err := os.ReadFile(dest)
+			if err != nil {
+				t.Fatalf("failed to read %s: %v", dest, err)
+			}
+			if !strings.Contains(string(generated), "package components") {
+				t.Fatalf("%s does not look like generated Go source", dest)
 			}
 
 			trimmed, err := GetComponents(versionsWithout(t, tt.versions, tt.omit))
 			if err != nil {
 				t.Fatalf("failed to read trimmed versions file: %v", err)
 			}
-			err = render(io.Discard, tt.tpl, trimmed)
+			err = renderFile(dest, tt.tpl, trimmed)
 			if err == nil {
 				t.Fatalf("render succeeded with component %q missing", tt.omit)
 			}
 			if !strings.Contains(err.Error(), tt.omit) {
 				t.Errorf("error %q does not name the missing component %q", err, tt.omit)
+			}
+
+			after, err := os.ReadFile(dest)
+			if err != nil {
+				t.Fatalf("failed to read %s: %v", dest, err)
+			}
+			if !bytes.Equal(after, generated) {
+				t.Errorf("failed render overwrote %s", dest)
 			}
 		})
 	}

--- a/operator/hack/gen-versions/enterprise.go.tpl
+++ b/operator/hack/gen-versions/enterprise.go.tpl
@@ -19,7 +19,7 @@ package components
 
 var (
 	EnterpriseRelease string = "{{ .Title }}"
-{{ with index .Components "calico" }}
+{{ with required .Components "calico" }}
 	ComponentTigeraCalico = Component{
 		Version:   "{{ .Version }}",
 		Image:     "{{ .Image }}",
@@ -28,7 +28,7 @@ var (
 		variant:   enterpriseVariant,
 	}
 {{- end }}
-{{ with index .Components "deep-packet-inspection" }}
+{{ with required .Components "deep-packet-inspection" }}
 	ComponentDeepPacketInspection = Component{
 		Version:   "{{ .Version }}",
 		Image:     "{{ .Image }}",
@@ -37,19 +37,19 @@ var (
 		variant:   enterpriseVariant,
 	}
 {{- end }}
-{{ with index .Components "eck-elasticsearch" }}
+{{ with required .Components "eck-elasticsearch" }}
 	ComponentEckElasticsearch = Component{
 		Version: "{{ .Version }}",
 		variant: enterpriseVariant,
 	}
 {{- end }}
-{{ with index .Components "eck-kibana" }}
+{{ with required .Components "eck-kibana" }}
 	ComponentEckKibana = Component{
 		Version: "{{ .Version }}",
 		variant: enterpriseVariant,
 	}
 {{- end }}
-{{ with index .Components "elastic-tsee-installer" }}
+{{ with required .Components "elastic-tsee-installer" }}
 	ComponentElasticTseeInstaller = Component{
 		Version:   "{{ .Version }}",
 		Image:     "{{ .Image }}",
@@ -58,7 +58,7 @@ var (
 		variant:   enterpriseVariant,
 	}
 {{- end }}
-{{ with .Components.elasticsearch }}
+{{ with required .Components "elasticsearch" }}
 	ComponentElasticsearch = Component{
 		Version:   "{{ .Version }}",
 		Image:     "{{ .Image }}",
@@ -67,13 +67,13 @@ var (
 		variant:   enterpriseVariant,
 	}
 {{- end }}
-{{ with index .Components "eck-elasticsearch-operator" }}
+{{ with required .Components "eck-elasticsearch-operator" }}
 	ComponentECKElasticsearchOperator = Component{
 		Version: "{{ .Version }}",
 		variant: enterpriseVariant,
 	}
 {{- end }}
-{{ with index .Components "elasticsearch-operator" }}
+{{ with required .Components "elasticsearch-operator" }}
 	ComponentElasticsearchOperator = Component{
 		Version:   "{{ .Version }}",
 		Image:     "{{ .Image }}",
@@ -82,7 +82,7 @@ var (
 		variant:   enterpriseVariant,
 	}
 {{- end }}
-{{ with index .Components "fluent-bit" }}
+{{ with required .Components "fluent-bit" }}
 	ComponentFluentBit = Component{
 		Version:   "{{ .Version }}",
 		Image:     "{{ .Image }}",
@@ -91,7 +91,7 @@ var (
 		variant:   enterpriseVariant,
 	}
 {{- end }}
-{{ with index .Components "fluent-bit-windows" }}
+{{ with required .Components "fluent-bit-windows" }}
 	ComponentFluentBitWindows = Component{
 		Version:   "{{ .Version }}",
 		Image:     "{{ .Image }}",
@@ -100,7 +100,7 @@ var (
 		variant:   enterpriseVariant,
 	}
 {{- end }}
-{{ with index .Components "intrusion-detection-controller" }}
+{{ with required .Components "intrusion-detection-controller" }}
 	ComponentIntrusionDetectionController = Component{
 		Version:   "{{ .Version }}",
 		Image:     "{{ .Image }}",
@@ -109,7 +109,7 @@ var (
 		variant:   enterpriseVariant,
 	}
 {{- end }}
-{{ with .Components.kibana }}
+{{ with required .Components "kibana" }}
 	ComponentKibana = Component{
 		Version:   "{{ .Version }}",
 		Image:     "{{ .Image }}",
@@ -118,7 +118,7 @@ var (
 		variant:   enterpriseVariant,
 	}
 {{- end }}
-{{ with index .Components "manager" }}
+{{ with required .Components "manager" }}
 	ComponentManager = Component{
 		Version:   "{{ .Version }}",
 		Image:     "{{ .Image }}",
@@ -127,7 +127,7 @@ var (
 		variant:   enterpriseVariant,
 	}
 {{- end }}
-{{ with index .Components "dex" }}
+{{ with required .Components "dex" }}
 	ComponentDex = Component{
 		Version:   "{{ .Version }}",
 		Image:     "{{ .Image }}",
@@ -136,7 +136,7 @@ var (
 		variant:   enterpriseVariant,
 	}
 {{- end }}
-{{ with index .Components "egress-gateway" }}
+{{ with required .Components "egress-gateway" }}
 	ComponentEgressGateway = Component{
 		Version:   "{{ .Version }}",
 		Image:     "{{ .Image }}",
@@ -145,7 +145,7 @@ var (
 		variant:   enterpriseVariant,
 	}
 {{- end }}
-{{ with index .Components "gateway-l7-collector" }}
+{{ with required .Components "gateway-l7-collector" }}
 	ComponentGatewayL7Collector = Component{
 		Version:  "{{ .Version }}",
 		Image:    "{{ .Image }}",
@@ -153,7 +153,7 @@ var (
 		variant:  enterpriseVariant,
 	}
 {{- end }}
-{{ with index .Components "envoy" }}
+{{ with required .Components "envoy" }}
 	ComponentEnvoyProxy = Component{
 		Version:   "{{ .Version }}",
 		Image:     "{{ .Image }}",
@@ -162,7 +162,7 @@ var (
 		variant:   enterpriseVariant,
 	}
 {{- end }}
-{{ with index .Components "dikastes" }}
+{{ with required .Components "dikastes" }}
 	ComponentDikastes = Component{
 		Version:   "{{ .Version }}",
 		Image:     "{{ .Image }}",
@@ -171,13 +171,13 @@ var (
 		variant:   enterpriseVariant,
 	}
 {{- end }}
-{{ with index .Components "coreos-prometheus" }}
+{{ with required .Components "coreos-prometheus" }}
 	ComponentCoreOSPrometheus = Component{
 		Version: "{{ .Version }}",
 		variant: enterpriseVariant,
 	}
 {{- end }}
-{{ with index .Components "prometheus" }}
+{{ with required .Components "prometheus" }}
 	ComponentPrometheus = Component{
 		Version:   "{{ .Version }}",
 		Image:     "{{ .Image }}",
@@ -186,13 +186,13 @@ var (
 		variant:   enterpriseVariant,
 	}
 {{- end }}
-{{ with index .Components "coreos-alertmanager" }}
+{{ with required .Components "coreos-alertmanager" }}
 	ComponentCoreOSAlertmanager = Component{
 		Version: "{{ .Version }}",
 		variant: enterpriseVariant,
 	}
 {{- end }}
-{{ with index .Components "alertmanager" }}
+{{ with required .Components "alertmanager" }}
 	ComponentPrometheusAlertmanager = Component{
 		Version:   "{{ .Version }}",
 		Image:     "{{ .Image }}",
@@ -201,7 +201,7 @@ var (
 		variant:   enterpriseVariant,
 	}
 {{- end }}
-{{ with index .Components "node" }}
+{{ with required .Components "node" }}
 	ComponentTigeraNode = Component{
 		Version:   "{{ .Version }}",
 		Image:     "{{ .Image }}",
@@ -210,7 +210,7 @@ var (
 		variant:   enterpriseVariant,
 	}
 {{- end }}
-{{ with index .Components "node-windows" }}
+{{ with required .Components "node-windows" }}
 	ComponentTigeraNodeWindows = Component{
 		Version:   "{{ .Version }}",
 		Image:     "{{ .Image }}",
@@ -219,7 +219,7 @@ var (
 		variant:   enterpriseVariant,
 	}
 {{- end }}
-{{ with index .Components "tigera-cni-windows" }}
+{{ with required .Components "tigera-cni-windows" }}
 	ComponentTigeraCNIWindows = Component{
 		Version:   "{{ .Version }}",
 		Image:     "{{ .Image }}",
@@ -228,7 +228,7 @@ var (
 		variant:   enterpriseVariant,
 	}
 {{- end }}
-{{ with index .Components "tigera-third-party-cni-plugins" }}
+{{ with required .Components "tigera-third-party-cni-plugins" }}
 	ComponentTigeraCNIPlugins = Component{
 		Version:   "{{ .Version }}",
 		Image:     "{{ .Image }}",
@@ -237,7 +237,7 @@ var (
 		variant:   enterpriseVariant,
 	}
 {{- end }}
-{{ with index .Components "gateway-api-envoy-gateway" }}
+{{ with required .Components "gateway-api-envoy-gateway" }}
 	ComponentGatewayAPIEnvoyGateway = Component{
 		Version:   "{{ .Version }}",
 		Image:     "{{ .Image }}",
@@ -246,7 +246,7 @@ var (
 		variant:   enterpriseVariant,
 	}
 {{- end }}
-{{ with index .Components "gateway-api-envoy-proxy" }}
+{{ with required .Components "gateway-api-envoy-proxy" }}
 	ComponentGatewayAPIEnvoyProxy = Component{
 		Version:   "{{ .Version }}",
 		Image:     "{{ .Image }}",
@@ -255,7 +255,7 @@ var (
 		variant:   enterpriseVariant,
 	}
 {{- end }}
-{{ with index .Components "gateway-api-envoy-ratelimit" }}
+{{ with required .Components "gateway-api-envoy-ratelimit" }}
 	ComponentGatewayAPIEnvoyRatelimit = Component{
 		Version:   "{{ .Version }}",
 		Image:     "{{ .Image }}",
@@ -264,7 +264,7 @@ var (
 		variant:   enterpriseVariant,
 	}
 {{- end }}
-{{ with index .Components "istio-pilot" }}
+{{ with required .Components "istio-pilot" }}
 	ComponentIstioPilot = Component{
 		Version:  "{{ .Version }}",
 		Image:    "{{ .Image }}",
@@ -272,7 +272,7 @@ var (
 		variant:  enterpriseVariant,
 	}
 {{- end }}
-{{ with index .Components "istio-install-cni" }}
+{{ with required .Components "istio-install-cni" }}
 	ComponentIstioInstallCNI = Component{
 		Version:  "{{ .Version }}",
 		Image:    "{{ .Image }}",
@@ -280,7 +280,7 @@ var (
 		variant:  enterpriseVariant,
 	}
 {{- end }}
-{{ with index .Components "istio-ztunnel" }}
+{{ with required .Components "istio-ztunnel" }}
 	ComponentIstioZTunnel = Component{
 		Version:  "{{ .Version }}",
 		Image:    "{{ .Image }}",
@@ -288,7 +288,7 @@ var (
 		variant:  enterpriseVariant,
 	}
 {{- end }}
-{{ with index .Components "istio-proxyv2" }}
+{{ with required .Components "istio-proxyv2" }}
 	ComponentIstioProxyv2 = Component{
 		Version:  "{{ .Version }}",
 		Image:    "{{ .Image }}",

--- a/operator/hack/gen-versions/main.go
+++ b/operator/hack/gen-versions/main.go
@@ -33,6 +33,7 @@ var (
 	eeVersionsPath    string
 	osVersionsPath    string
 	cloudVersionsPath string
+	outPath           string
 )
 
 func main() {
@@ -41,6 +42,7 @@ func main() {
 	flag.StringVar(&eeVersionsPath, "ee-versions", "", "path to enterprise versions file")
 	flag.StringVar(&osVersionsPath, "os-versions", "", "path to calico versions file")
 	flag.StringVar(&cloudVersionsPath, "cloud-versions", "", "path to cloud versions file")
+	flag.StringVar(&outPath, "out", "", "path to write the generated file to, or stdout when unset")
 	flag.Parse()
 
 	if debug {
@@ -63,25 +65,28 @@ func main() {
 
 	switch {
 	case osVersionsPath != "":
-		if err := run(osVersionsPath, filepath.Join(templateDir, osVersionsTpl)); err != nil {
+		if err := run(osVersionsPath, filepath.Join(templateDir, osVersionsTpl), outPath); err != nil {
 			log.Fatalln(err)
 		}
 	case eeVersionsPath != "":
-		if err := run(eeVersionsPath, filepath.Join(templateDir, eeVersionsTpl)); err != nil {
+		if err := run(eeVersionsPath, filepath.Join(templateDir, eeVersionsTpl), outPath); err != nil {
 			log.Fatalln(err)
 		}
 	case cloudVersionsPath != "":
-		if err := run(cloudVersionsPath, filepath.Join(templateDir, cloudVersionsTpl)); err != nil {
+		if err := run(cloudVersionsPath, filepath.Join(templateDir, cloudVersionsTpl), outPath); err != nil {
 			log.Fatalln(err)
 		}
 	}
 }
 
-func run(versionsPath, tpl string) error {
+func run(versionsPath, tpl, outPath string) error {
 	vz, err := GetComponents(versionsPath)
 	if err != nil {
 		return err
 	}
 
-	return render(os.Stdout, tpl, vz)
+	if outPath == "" {
+		return render(os.Stdout, tpl, vz)
+	}
+	return renderFile(outPath, tpl, vz)
 }

--- a/operator/hack/gen-versions/main.go
+++ b/operator/hack/gen-versions/main.go
@@ -83,5 +83,5 @@ func run(versionsPath, tpl string) error {
 		return err
 	}
 
-	return render(tpl, vz)
+	return render(os.Stdout, tpl, vz)
 }


### PR DESCRIPTION
## Description

`with index .Components "x"` guarded every component block, and `index` yields the zero value for a missing key rather than erroring, so a dropped or typo'd component key silently produced an operator that resolves an image named `""` at runtime. The `missingkey=error` option already set here covers only the field-syntax lookups, not the `index` builtin most of the blocks used.

Two halves to the fix:

- Both templates look components up through a `required` function that errors on a missing or empty entry
- `gen-versions` takes its destination as `-out` and buffers the render, since the old shell redirect truncated the target before the tool had read a single component; with no `-out` it still writes to stdout

The committed versions files and the kind dev-build list already satisfy the required set, and the test covering both halves lives in `operator/hack/gen-versions`, a directory the `ut` target now reaches.

Related: [CORE-13544](https://tigera.atlassian.net/browse/CORE-13544)

**Release note:**
```release-note
None
```

**AI assistance:** Claude Code wrote the template, tool, and test changes.


[CORE-13544]: https://tigera.atlassian.net/browse/CORE-13544?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ