### PR TITLE
Move the operator's non-amd64 builds off the CI critical path

### DIFF
--- a/.semaphore/semaphore-scheduled-builds.yml
+++ b/.semaphore/semaphore-scheduled-builds.yml
@@ -1777,6 +1777,28 @@ blocks:
         always:
           commands:
             - 'test-results publish --ignore-missing ./report/*.xml --suite-prefix="$TEST_SUITE_PREFIX" --name "Operator" || true'
+  - name: "Operator: multi-arch build"
+    # The operator has no cgo and no build constraints, so cross-compiling the
+    # binary is the whole of the per-arch coverage. `make cd` and the release
+    # build assemble the images.
+    run:
+      when: "true"
+    dependencies:
+      - Prerequisites
+    task:
+      prologue:
+        commands:
+          - cd operator
+      jobs:
+        - name: "Operator: build multi-arch binaries"
+          matrix:
+            - env_var: ARCH
+              values:
+                - arm64
+                - ppc64le
+                - s390x
+          commands:
+            - ../.semaphore/run-and-monitor build-$ARCH.log make build ARCH=$ARCH
   - name: "Operator FV"
     run:
       when: "true"

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -6057,6 +6057,51 @@ blocks:
         always:
           commands:
             - 'test-results publish --ignore-missing ./report/*.xml --suite-prefix="$TEST_SUITE_PREFIX" --name "Operator" || true'
+  - name: "Operator: multi-arch build"
+    # The operator has no cgo and no build constraints, so cross-compiling the
+    # binary is the whole of the per-arch coverage. `make cd` and the release
+    # build assemble the images.
+    run:
+      when: >-
+        change_in(['/.semaphore/semaphore.yml.d/01-preamble.yml',
+        '/.semaphore/semaphore.yml.d/02-global_job_config.yml',
+        '/.semaphore/semaphore.yml.d/03-promotions.yml',
+        '/.semaphore/semaphore.yml.d/09-blocks.yml',
+        '/.semaphore/semaphore.yml.d/99-after_pipeline.yml',
+        '/.semaphore/semaphore.yml.d/blocks/20-operator.yml',
+        '/api/admission/*.go',
+        '/api/config/crd/*.go',
+        '/hack/test/certs/',
+        '/lib.Makefile',
+        '/libcalico-go/config/crd/*.go',
+        '/metadata.mk',
+        '/operator/**'],
+        {pipeline_file: 'ignore', exclude: ['/**/*.md',
+        '/**/.gitignore',
+        '/**/AUTHORS*',
+        '/**/CONTRIBUTING*',
+        '/**/DEVELOPER_GUIDE*',
+        '/**/LICENSE*',
+        '/**/README*',
+        '/**/SECURITY.md',
+        '/api/**/*_test.go',
+        '/libcalico-go/**/*_test.go']})
+    dependencies:
+      - Prerequisites
+    task:
+      prologue:
+        commands:
+          - cd operator
+      jobs:
+        - name: "Operator: build multi-arch binaries"
+          matrix:
+            - env_var: ARCH
+              values:
+                - arm64
+                - ppc64le
+                - s390x
+          commands:
+            - ../.semaphore/run-and-monitor build-$ARCH.log make build ARCH=$ARCH
   - name: "Operator FV"
     run:
       when: >-

--- a/.semaphore/semaphore.yml.d/blocks/20-operator.yml
+++ b/.semaphore/semaphore.yml.d/blocks/20-operator.yml
@@ -21,6 +21,29 @@
         commands:
           - 'test-results publish --ignore-missing ./report/*.xml --suite-prefix="$TEST_SUITE_PREFIX" --name "Operator" || true'
 
+- name: "Operator: multi-arch build"
+  # The operator has no cgo and no build constraints, so cross-compiling the
+  # binary is the whole of the per-arch coverage. `make cd` and the release
+  # build assemble the images.
+  run:
+    when: "${CHANGE_IN(operator)}"
+  dependencies:
+    - Prerequisites
+  task:
+    prologue:
+      commands:
+        - cd operator
+    jobs:
+      - name: "Operator: build multi-arch binaries"
+        matrix:
+          - env_var: ARCH
+            values:
+              - arm64
+              - ppc64le
+              - s390x
+        commands:
+          - ../.semaphore/run-and-monitor build-$ARCH.log make build ARCH=$ARCH
+
 - name: "Operator FV"
   run:
     when: "${CHANGE_IN(operator)}"

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -279,8 +279,9 @@ foss-checks:
 .PHONY: ci
 ## Run what CI runs
 # Not `test`, which lib.Makefile defines as `ut fv st`. The FV block runs the
-# kind suite on its own.
-ci: clean format-check validate-gen-versions static-checks image-all fmt vet ut gen-files fix-changed dirty-check test-crds
+# kind suite on its own. amd64 only here; the "Operator: multi-arch build"
+# block covers the other arches.
+ci: clean format-check validate-gen-versions static-checks image fmt vet ut gen-files fix-changed dirty-check test-crds
 
 # This repository is public and the Enterprise CRDs come from one that is not,
 # so only the core half is checked here. The Enterprise generated files are


### PR DESCRIPTION
The operator's `make ci` runs `image-all`, so the Operator block builds the image for all four arches in sequence, and on a recent master run about 7.5 of the job's 21 minutes went to arm64, ppc64le and s390x (each from a cold Go cache, since `clean` runs first). The operator is first-party pure Go with no cgo, no build constraints and no arch-suffixed files, so a per-arch run only ever catches a cross-compile break. This drops `make ci` to the amd64 image and adds an "Operator: multi-arch build" block that cross-compiles the other three binaries in parallel, the way the envoy blocks already do; `make cd` and the release build are untouched and still cover all four arches.

Related: [CORE-13548](https://tigera.atlassian.net/browse/CORE-13548)

**Release note:**
```release-note
None
```

**AI assistance:** Claude Code (Opus 5) measured the per-arch CI cost and wrote the Makefile and Semaphore block changes.


[CORE-13548]: https://tigera.atlassian.net/browse/CORE-13548?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ