### PR TITLE
Build the operator image behind an .image.created marker

### DIFF
--- a/.semaphore/load-cached-images
+++ b/.semaphore/load-cached-images
@@ -8,15 +8,11 @@ set -euo pipefail
 ARCH=${ARCH:-amd64}
 REPO_ROOT=$(git rev-parse --show-toplevel)
 
-# load_image NAME GCS_TAR MARKER [MARKER_GCS_PATH]
-#
-# MARKER is touched, or fetched from MARKER_GCS_PATH when the rebuild gate
-# compares the marker's content rather than its mtime.
+# load_image NAME GCS_TAR MARKER
 load_image() {
     local name=$1
     local gcs_path=$2
     local marker=$3
-    local marker_gcs_path=${4:-}
 
     if ! gcloud storage cp "${GCS_WORKFLOW_DIR}/${gcs_path}" "/tmp/${gcs_path}" 2>/dev/null; then
         echo "No cached ${name} image found, will build from source."
@@ -31,19 +27,11 @@ load_image() {
 
     if [ -n "$marker" ]; then
         mkdir -p "$(dirname "$marker")"
-        if [ -n "$marker_gcs_path" ]; then
-            gcloud storage cp "${GCS_WORKFLOW_DIR}/${marker_gcs_path}" "$marker"
-        else
-            touch "$marker"
-        fi
+        touch "$marker"
     fi
 }
 
-load_image "calico/calico"  "calico-image.tar.zst"  "${REPO_ROOT}/cmd/calico/.image.created-${ARCH}"
-load_image "calico/node"    "node-image.tar.zst"    "${REPO_ROOT}/node/.image.created-${ARCH}"
-load_image "calico/whisker" "whisker-image.tar.zst" "${REPO_ROOT}/whisker/.image.created-${ARCH}"
-
-# The operator's rebuild gate is hack/dev-build.sh's record of the inputs the
-# image was built from, so the stamp travels with the tarball. A stamp that
-# does not match this tree still just triggers a rebuild.
-load_image "tigera/operator" "operator-image.tar.zst" "${REPO_ROOT}/.dev-stamps/operator.inputs" "operator.inputs"
+load_image "calico/calico"   "calico-image.tar.zst"   "${REPO_ROOT}/cmd/calico/.image.created-${ARCH}"
+load_image "calico/node"     "node-image.tar.zst"     "${REPO_ROOT}/node/.image.created-${ARCH}"
+load_image "calico/whisker"  "whisker-image.tar.zst"  "${REPO_ROOT}/whisker/.image.created-${ARCH}"
+load_image "tigera/operator" "operator-image.tar.zst" "${REPO_ROOT}/operator/.image.created-${ARCH}"

--- a/.semaphore/semaphore-scheduled-builds.yml
+++ b/.semaphore/semaphore-scheduled-builds.yml
@@ -593,21 +593,9 @@ blocks:
             - zstd -3 --rm /tmp/whisker-image.tar
             - gcloud storage cp /tmp/whisker-image.tar.zst "${GCS_WORKFLOW_DIR}/whisker-image.tar.zst"
   - name: "Build: operator image"
-    # The operator image the kind lanes deploy. Unlike the other component
-    # images it bakes in the references it will install
+    # The operator image bakes in the references it will install
     # (localhost:5000/calico/<name>:test-build), so this producer builds it
-    # through the same `make kind-operator-image` its consumers run and every
-    # kind lane can share the one tarball.
-    #
-    # hack/dev-build.sh gates the rebuild on a record of the inputs the image was
-    # built from, not on a marker file, so that stamp ships alongside the
-    # tarball for load-cached-images to restore. Upload it first: a tarball
-    # without its stamp would fail the consumer's untolerated gcloud cp.
-    #
-    # Consumers ("E2E tests (KinD)", "KubeVirt live migration (KIND)") list this
-    # block in their `dependencies:`, so CHANGE_IN_WITH_DEPENDENTS() folds their
-    # triggers into the arg below — this block's own inputs, the operator's Go
-    # closure plus the versions file build-operator.sh reads.
+    # through the same `make kind-operator-image` its consumers run.
     run:
       when: "true"
     dependencies: []
@@ -623,7 +611,6 @@ blocks:
         - name: "Build and cache operator image"
           commands:
             - make kind-operator-image
-            - gcloud storage cp .dev-stamps/operator.inputs "${GCS_WORKFLOW_DIR}/operator.inputs"
             - docker save localhost:5000/calico/operator:test-build -o /tmp/operator-image.tar
             - zstd -3 --rm /tmp/operator-image.tar
             - gcloud storage cp /tmp/operator-image.tar.zst "${GCS_WORKFLOW_DIR}/operator-image.tar.zst"

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -1854,21 +1854,9 @@ blocks:
             - zstd -3 --rm /tmp/whisker-image.tar
             - gcloud storage cp /tmp/whisker-image.tar.zst "${GCS_WORKFLOW_DIR}/whisker-image.tar.zst"
   - name: "Build: operator image"
-    # The operator image the kind lanes deploy. Unlike the other component
-    # images it bakes in the references it will install
+    # The operator image bakes in the references it will install
     # (localhost:5000/calico/<name>:test-build), so this producer builds it
-    # through the same `make kind-operator-image` its consumers run and every
-    # kind lane can share the one tarball.
-    #
-    # hack/dev-build.sh gates the rebuild on a record of the inputs the image was
-    # built from, not on a marker file, so that stamp ships alongside the
-    # tarball for load-cached-images to restore. Upload it first: a tarball
-    # without its stamp would fail the consumer's untolerated gcloud cp.
-    #
-    # Consumers ("E2E tests (KinD)", "KubeVirt live migration (KIND)") list this
-    # block in their `dependencies:`, so CHANGE_IN_WITH_DEPENDENTS() folds their
-    # triggers into the arg below — this block's own inputs, the operator's Go
-    # closure plus the versions file build-operator.sh reads.
+    # through the same `make kind-operator-image` its consumers run.
     run:
       when: >-
         change_in(['/.semaphore/semaphore.yml.d/01-preamble.yml',
@@ -2049,6 +2037,7 @@ blocks:
         '/lib/std/uniquelabels/*.go',
         '/lib/std/uniquestr/*.go',
         '/libcalico-go/config/*.go',
+        '/libcalico-go/config/crd',
         '/libcalico-go/config/crd/*.go',
         '/libcalico-go/lib/apiconfig/*.go',
         '/libcalico-go/lib/apis/crd.projectcalico.org/v1/scheme/*.go',
@@ -2129,6 +2118,8 @@ blocks:
         '/operator/',
         '/operator/api/v1/*.go',
         '/operator/cmd/*.go',
+        '/operator/config',
+        '/operator/deploy/crds',
         '/operator/hack/gen-versions/*.go',
         '/operator/hack/release/*.go',
         '/operator/hack/release/internal/command/*.go',
@@ -2183,6 +2174,7 @@ blocks:
         '/operator/pkg/controller/utils/*.go',
         '/operator/pkg/controller/utils/imageset/*.go',
         '/operator/pkg/controller/whisker/*.go',
+        '/operator/pkg/crds',
         '/operator/pkg/crds/*.go',
         '/operator/pkg/crypto/*.go',
         '/operator/pkg/ctrlruntime/*.go',
@@ -2273,6 +2265,7 @@ blocks:
         '/operator/pkg/render/nonclusterhost/*.go',
         '/operator/pkg/render/tiers/*.go',
         '/operator/pkg/render/webhooks/*.go',
+        '/operator/pkg/render/whisker',
         '/operator/pkg/render/whisker/*.go',
         '/operator/pkg/tls/*.go',
         '/operator/pkg/tls/certificatemanagement/*.go',
@@ -2382,7 +2375,6 @@ blocks:
         - name: "Build and cache operator image"
           commands:
             - make kind-operator-image
-            - gcloud storage cp .dev-stamps/operator.inputs "${GCS_WORKFLOW_DIR}/operator.inputs"
             - docker save localhost:5000/calico/operator:test-build -o /tmp/operator-image.tar
             - zstd -3 --rm /tmp/operator-image.tar
             - gcloud storage cp /tmp/operator-image.tar.zst "${GCS_WORKFLOW_DIR}/operator-image.tar.zst"

--- a/.semaphore/semaphore.yml.d/blocks/10-prerequisites.yml
+++ b/.semaphore/semaphore.yml.d/blocks/10-prerequisites.yml
@@ -345,21 +345,9 @@
           - zstd -3 --rm /tmp/whisker-image.tar
           - gcloud storage cp /tmp/whisker-image.tar.zst "${GCS_WORKFLOW_DIR}/whisker-image.tar.zst"
 - name: "Build: operator image"
-  # The operator image the kind lanes deploy. Unlike the other component
-  # images it bakes in the references it will install
+  # The operator image bakes in the references it will install
   # (localhost:5000/calico/<name>:test-build), so this producer builds it
-  # through the same `make kind-operator-image` its consumers run and every
-  # kind lane can share the one tarball.
-  #
-  # hack/dev-build.sh gates the rebuild on a record of the inputs the image was
-  # built from, not on a marker file, so that stamp ships alongside the
-  # tarball for load-cached-images to restore. Upload it first: a tarball
-  # without its stamp would fail the consumer's untolerated gcloud cp.
-  #
-  # Consumers ("E2E tests (KinD)", "KubeVirt live migration (KIND)") list this
-  # block in their `dependencies:`, so CHANGE_IN_WITH_DEPENDENTS() folds their
-  # triggers into the arg below — this block's own inputs, the operator's Go
-  # closure plus the versions file build-operator.sh reads.
+  # through the same `make kind-operator-image` its consumers run.
   run:
     when: "${CHANGE_IN_WITH_DEPENDENTS(operator,non-go:/operator/,non-go:/hack/test/kind/infra/calico_versions.yml)}"
   dependencies: []
@@ -375,7 +363,6 @@
       - name: "Build and cache operator image"
         commands:
           - make kind-operator-image
-          - gcloud storage cp .dev-stamps/operator.inputs "${GCS_WORKFLOW_DIR}/operator.inputs"
           - docker save localhost:5000/calico/operator:test-build -o /tmp/operator-image.tar
           - zstd -3 --rm /tmp/operator-image.tar
           - gcloud storage cp /tmp/operator-image.tar.zst "${GCS_WORKFLOW_DIR}/operator-image.tar.zst"

--- a/Makefile
+++ b/Makefile
@@ -180,8 +180,7 @@ $(CHART_DESTINATION)/projectcalico.org.v3-$(GIT_VERSION).tgz: bin/helm $(shell f
 # optionally push to a remote registry.
 #
 # Images are only re-tagged / re-pushed when their docker image ID changes,
-# and the operator is only rebuilt when its inputs change. This makes repeated
-# runs fast when only one component has been modified.
+# which makes repeated runs fast when only one component has been modified.
 #
 # Usage:
 #   make image                                              # build + tag as calico/<name>:<version>
@@ -205,19 +204,11 @@ image:
 	  ARCH="$(ARCH)" \
 	  STAMP_DIR="$(DEV_STAMP_DIR)" \
 	  $(REPO_ROOT)/hack/dev-build.sh --tag
-	$(MAKE) operator-image
 	@echo "image complete"
 
 .PHONY: operator-image
 ## Build the operator image with the dev registry's component references baked in.
-operator-image:
-	@STAMP_DIR="$(DEV_STAMP_DIR)" \
-	  KIND_INFRA_DIR="$(KIND_INFRA_DIR)" \
-	  REPO_ROOT="$(REPO_ROOT)" \
-	  DEV_IMAGE_TAG="$(DEV_IMAGE_TAG)" \
-	  DEV_IMAGE_REGISTRY="$(DEV_IMAGE_REGISTRY)" \
-	  DEV_IMAGE_PATH="$(DEV_IMAGE_PATH)" \
-	  $(REPO_ROOT)/hack/dev-build.sh --operator
+operator-image: $(REPO_ROOT)/operator/.image.created-$(ARCH)
 
 .PHONY: push
 ## Push all tagged images to the remote registry.

--- a/hack/dev-build.sh
+++ b/hack/dev-build.sh
@@ -20,7 +20,6 @@
 #
 # Usage:
 #   dev-build.sh --tag         Tag locally-built images for the dev registry
-#   dev-build.sh --operator    Build the operator image if inputs changed
 #   dev-build.sh --push        Push dev-tagged images to the registry
 #
 # Environment (--tag):
@@ -29,14 +28,6 @@
 #   DEV_IMAGE_TAG    - Tag to apply
 #   ARCH             - Architecture suffix for source tags
 #   STAMP_DIR        - Directory for stamp files
-#
-# Environment (--operator):
-#   STAMP_DIR          - Directory for stamp files
-#   KIND_INFRA_DIR     - Path to hack/test/kind/infra/
-#   REPO_ROOT          - Path to the root of this repo
-#   DEV_IMAGE_TAG      - Tag for the operator image
-#   DEV_IMAGE_REGISTRY - Registry for the operator image
-#   DEV_IMAGE_PATH     - Path within the registry
 #
 # Environment (--push):
 #   DEV_IMAGES - Space-separated target image refs to push
@@ -54,32 +45,6 @@ tag() {
     done
 
     echo "Tagged $(echo $CALICO_IMAGES | wc -w) images as ${DEV_IMAGE_PREFIX}/*:${DEV_IMAGE_TAG}"
-}
-
-# Build the operator image if its inputs (tag, registry, source, versions)
-# have changed since the last run.
-operator() {
-    mkdir -p "$STAMP_DIR"
-    versions_hash=$(md5sum "${KIND_INFRA_DIR}/calico_versions.yml" | cut -d' ' -f1)
-    # Untracked files under operator/ are invisible here, so a brand-new source
-    # file wants an explicit rebuild.
-    operator_hash=$( { git -C "$REPO_ROOT" rev-parse HEAD:operator
-                       git -C "$REPO_ROOT" diff HEAD -- operator; } | md5sum | cut -d' ' -f1)
-    cur_inputs="${DEV_IMAGE_TAG}:${DEV_IMAGE_REGISTRY}:${DEV_IMAGE_PATH}:${operator_hash}:${versions_hash}"
-    stamp="${STAMP_DIR}/operator.inputs"
-    prev_inputs=$(cat "$stamp" 2>/dev/null || echo "")
-
-    if [ "$cur_inputs" = "$prev_inputs" ]; then
-        echo "Operator unchanged (inputs match)"
-    else
-        echo "Building operator (inputs changed)..."
-        cd "$KIND_INFRA_DIR"
-        DEV_IMAGE_TAG="$DEV_IMAGE_TAG" \
-            DEV_IMAGE_REGISTRY="$DEV_IMAGE_REGISTRY" \
-            DEV_IMAGE_PATH="$DEV_IMAGE_PATH" \
-            ./build-operator.sh
-        echo "$cur_inputs" > "$stamp"
-    fi
 }
 
 # Push dev-tagged images to the remote registry. Skips images whose
@@ -108,11 +73,10 @@ push() {
 }
 
 case "${1:-}" in
-    --tag)      tag ;;
-    --operator) operator ;;
-    --push)     push ;;
+    --tag)  tag ;;
+    --push) push ;;
     *)
-        echo "Usage: $0 --tag | --operator | --push" >&2
+        echo "Usage: $0 --tag | --push" >&2
         exit 1
         ;;
 esac

--- a/hack/image-exists
+++ b/hack/image-exists
@@ -14,19 +14,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# image-exists STAMP_FILE
+# image-exists STAMP_FILE [EXPECTED_REF]
 #
-# Prints MISSING-IMAGE on stdout when STAMP_FILE records an image ref that
-# Docker doesn't have locally. Used as a Make prereq via $(shell) so a
-# pruned image forces the stamp's rule to re-run even when the stamp's
-# mtime is fresh.
+# Prints MISSING-IMAGE when the stamp's recorded image ref is absent from
+# Docker or differs from EXPECTED_REF. Used as a Make prereq via $(shell), so
+# either case forces the stamp's rule to re-run.
 
 set -u
 
-stamp=${1:?usage: image-exists STAMP_FILE}
+stamp=${1:?usage: image-exists STAMP_FILE [EXPECTED_REF]}
+expected=${2:-}
 
 [ -f "$stamp" ] || exit 0
 img=$(cat "$stamp")
 [ -n "$img" ] || exit 0
+if [ -n "$expected" ] && [ "$img" != "$expected" ]; then
+    echo MISSING-IMAGE
+    exit 0
+fi
 docker image inspect "$img" >/dev/null 2>&1 && exit 0
 echo MISSING-IMAGE

--- a/lib.Makefile
+++ b/lib.Makefile
@@ -1691,6 +1691,21 @@ helm: bin/helm
 bin/helm: bin/.helm-updated-$(HELM_VERSION)
 
 ###############################################################################
+# Dev image build variables. Used by the root Makefile's image and push
+# targets, and by the operator image marker below.
+###############################################################################
+DEV_IMAGE_PATH ?= calico
+DEV_IMAGE_TAG ?= $(GIT_VERSION)
+DEV_IMAGE_REGISTRY ?= docker.io
+DEV_STAMP_DIR := $(REPO_ROOT)/.dev-stamps
+
+# Map calico/<name>:test-build → $(DEV_IMAGE_REGISTRY)/$(DEV_IMAGE_PATH)/<name>:$(DEV_IMAGE_TAG)
+# filter-registry strips "docker.io/" since Docker Hub doesn't use it in image refs.
+DEV_IMAGE_PREFIX = $(if $(filter docker.io,$(DEV_IMAGE_REGISTRY)),$(DEV_IMAGE_PATH),$(DEV_IMAGE_REGISTRY)/$(DEV_IMAGE_PATH))
+DEV_CALICO_IMAGES = $(foreach img,$(KIND_CALICO_IMAGES),$(DEV_IMAGE_PREFIX)/$(subst calico/,,$(firstword $(subst :, ,$(img)))):$(DEV_IMAGE_TAG))
+DEV_OPERATOR_IMAGE = $(DEV_IMAGE_PREFIX)/operator:$(DEV_IMAGE_TAG)
+
+###############################################################################
 # Common functions for setting up a kind cluster with Calico for testing.
 ###############################################################################
 KIND_INFRA_DIR := $(REPO_ROOT)/hack/test/kind/infra
@@ -1719,6 +1734,7 @@ KIND_IMAGE_MARKERS = \
 	$(REPO_ROOT)/whisker/.image.created-$(ARCH) \
 	$(REPO_ROOT)/cmd/calico/.image.created-$(ARCH) \
 	$(REPO_ROOT)/key-cert-provisioner/.image.created-$(ARCH) \
+	$(REPO_ROOT)/operator/.image.created-$(ARCH) \
 	$(REPO_ROOT)/third_party/envoy-gateway/.envoy-gateway.created-$(ARCH) \
 	$(REPO_ROOT)/third_party/envoy-proxy/.envoy-proxy.created-$(ARCH) \
 	$(REPO_ROOT)/third_party/envoy-ratelimit/.envoy-ratelimit.created-$(ARCH) \
@@ -1773,6 +1789,19 @@ $(REPO_ROOT)/key-cert-provisioner/.image.created-$(ARCH): \
 	rm -f $@
 	$(MAKE) -C $(REPO_ROOT)/key-cert-provisioner image
 	echo "test-signer:latest-$(ARCH)" > $@
+
+# The operator bakes the component refs it installs into the image, so
+# image-exists gets the expected ref: a changed DEV_IMAGE_* triple must
+# rebuild even though the recorded image still exists.
+$(REPO_ROOT)/operator/.image.created-$(ARCH): \
+    $(shell $(REPO_ROOT)/hack/image-exists $(REPO_ROOT)/operator/.image.created-$(ARCH) $(DEV_OPERATOR_IMAGE)) \
+    $(call local-deps-go-files,operator) $(KIND_INFRA_DIR)/calico_versions.yml
+	rm -f $@
+	DEV_IMAGE_TAG=$(DEV_IMAGE_TAG) \
+	  DEV_IMAGE_REGISTRY=$(DEV_IMAGE_REGISTRY) \
+	  DEV_IMAGE_PATH=$(DEV_IMAGE_PATH) \
+	  $(KIND_INFRA_DIR)/build-operator.sh
+	echo "$(DEV_OPERATOR_IMAGE)" > $@
 
 # Envoy components: the third_party/envoy-* sub-makes use their own marker
 # names (.envoy-<comp>.created-$(ARCH)). The sub-make handles fetching
@@ -1929,20 +1958,6 @@ $(ENVTEST_MIN_ASSETS_MARKER):
 		'go run sigs.k8s.io/controller-runtime/tools/setup-envtest@latest \
 		use --bin-dir $(ENVTEST_CONTAINER_DIR) -p path $(ENVTEST_MIN_K8S_VERSION)'
 	touch $@
-
-###############################################################################
-# Dev image build variables. Targets that use these are in the root Makefile.
-###############################################################################
-DEV_IMAGE_PATH ?= calico
-DEV_IMAGE_TAG ?= $(GIT_VERSION)
-DEV_IMAGE_REGISTRY ?= docker.io
-DEV_STAMP_DIR := $(REPO_ROOT)/.dev-stamps
-
-# Map calico/<name>:test-build → $(DEV_IMAGE_REGISTRY)/$(DEV_IMAGE_PATH)/<name>:$(DEV_IMAGE_TAG)
-# filter-registry strips "docker.io/" since Docker Hub doesn't use it in image refs.
-DEV_IMAGE_PREFIX = $(if $(filter docker.io,$(DEV_IMAGE_REGISTRY)),$(DEV_IMAGE_PATH),$(DEV_IMAGE_REGISTRY)/$(DEV_IMAGE_PATH))
-DEV_CALICO_IMAGES = $(foreach img,$(KIND_CALICO_IMAGES),$(DEV_IMAGE_PREFIX)/$(subst calico/,,$(firstword $(subst :, ,$(img)))):$(DEV_IMAGE_TAG))
-DEV_OPERATOR_IMAGE = $(DEV_IMAGE_PREFIX)/operator:$(DEV_IMAGE_TAG)
 
 ###############################################################################
 # Common functions for launching a local etcd instance.


### PR DESCRIPTION
Review follow-up on #13740, which merged with three comments open. All three are addressed here.

## Description

The operator was the one image whose rebuild gate was not an `.image.created-$(ARCH)` marker. It gets one here, plus an optional expected-ref argument to `hack/image-exists`, so a changed `DEV_IMAGE_TAG` forces a rebuild even when the recorded image is still present locally. That is the one case a plain marker would miss.

Dropped along with the old gate:

- `.dev-stamps/operator.inputs` and the `--operator` path through `hack/dev-build.sh`
- the fourth `load_image` parameter and its GCS fetch in `.semaphore/load-cached-images`
- the `operator.inputs` upload from the producer block

The other two comments:

- The producer block's comment is cut to the one claim a reader needs.
- `BUILD_CACHE_GROUP: calico` stays. The operator has no module of its own since the monorepo import, so it builds in the root module: `go list -deps ./operator/pkg/...` is 1523 packages against 1587 for `./felix/...`, with 940 shared. 33 of the 35 blocks that set the variable use `calico`, the operator blocks included; the two that differ are Check Go and the Gateway API conformance lane.

Checked by hand on a fresh build, a no-op re-run, a pruned image, and a changed tag.

Related: [CORE-13556](https://tigera.atlassian.net/browse/CORE-13556)

```release-note
None
```

**AI assistance:** Claude Code wrote the marker rule, the `hack/image-exists` change, and the CI cleanup.


[CORE-13556]: https://tigera.atlassian.net/browse/CORE-13556?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ