### PR TITLE
release: restrict hashrelease e2e binaries to consumed arches and reclaim disk

### DIFF
--- a/release/pkg/manager/calico/manager.go
+++ b/release/pkg/manager/calico/manager.go
@@ -348,6 +348,20 @@ func (r *CalicoManager) Build() error {
 
 		// Build multi-arch e2e test binaries and copy them into the output directory.
 		if r.e2eBinaries {
+			// Free transient disk before the multi-arch e2e build. Tagged component
+			// and operator images are still needed by PublishRelease, so only the
+			// build cache and dangling layers are reclaimed here.
+			r.logDiskUsage("before e2e disk reclaim")
+			for _, c := range [][]string{
+				{"docker", "builder", "prune", "-af"},
+				{"docker", "image", "prune", "-f"},
+			} {
+				if out, err := r.runner.Run(c[0], c[1:], nil); err != nil {
+					logrus.WithError(err).Warnf("disk reclaim %q failed: %s", strings.Join(c, " "), out)
+				}
+			}
+			r.logDiskUsage("after e2e disk reclaim")
+
 			if err = r.buildE2EBinaries(); err != nil {
 				return err
 			}
@@ -1228,13 +1242,29 @@ func (r *CalicoManager) buildReleaseTar() error {
 	return nil
 }
 
+// e2eSupportedArches are the architectures e2e test runners actually consume:
+// runners pick the binary matching their own node arch, and there are no
+// ppc64le/s390x e2e runners. Building the other arches only wastes time and
+// exhausts the release agent's disk.
+var e2eSupportedArches = []string{"amd64", "arm64"}
+
 func (r *CalicoManager) buildE2EBinaries() error {
 	logrus.Info("Building multi-arch e2e test binaries")
 	e2eDir := filepath.Join(r.repoRoot, "e2e")
-	env := append(os.Environ(), fmt.Sprintf("VERSION=%s", r.calicoVersion))
-	if len(r.architectures) > 0 {
-		env = append(env, fmt.Sprintf("VALIDARCHES=%s", strings.Join(r.architectures, " ")))
+	// Build the intersection of the configured and the supported arches. The set
+	// is controlled via ARCHES, not VALIDARCHES: lib.Makefile assigns VALIDARCHES
+	// with `=`, so it ignores the environment.
+	var e2eArches []string
+	for _, arch := range r.architectures {
+		if slices.Contains(e2eSupportedArches, arch) {
+			e2eArches = append(e2eArches, arch)
+		}
 	}
+	if len(e2eArches) == 0 {
+		logrus.Info("No amd64/arm64 in the configured architectures; skipping e2e test binaries")
+		return nil
+	}
+	env := append(os.Environ(), fmt.Sprintf("VERSION=%s", r.calicoVersion), "ARCHES="+strings.Join(e2eArches, " "))
 	out, err := r.makeInDirectoryWithOutput(e2eDir, "build-all", env...)
 	if err != nil {
 		logrus.Error(out)
@@ -1263,6 +1293,24 @@ func (r *CalicoManager) buildE2EBinaries() error {
 		logrus.Infof("Staged e2e binary: %s", entry.Name())
 	}
 	return nil
+}
+
+// logDiskUsage prints disk and docker usage for hashrelease build diagnostics,
+// so disk pressure can be sized from the job log without SSH access to the agent.
+func (r *CalicoManager) logDiskUsage(stage string) {
+	logrus.Infof("=== disk usage: %s ===", stage)
+	for _, c := range [][]string{
+		{"df", "-h", "/"},
+		{"docker", "system", "df"},
+		{"docker", "images", "--format", "{{.Size}}\t{{.Repository}}:{{.Tag}}"},
+	} {
+		out, err := r.runner.Run(c[0], c[1:], nil)
+		if err != nil {
+			logrus.WithError(err).Warnf("disk usage diagnostic %q failed", strings.Join(c, " "))
+			continue
+		}
+		logrus.Infof("$ %s\n%s", strings.Join(c, " "), out)
+	}
 }
 
 func (r *CalicoManager) buildBinaries() error {

--- a/release/pkg/manager/calico/manager.go
+++ b/release/pkg/manager/calico/manager.go
@@ -348,9 +348,9 @@ func (r *CalicoManager) Build() error {
 
 		// Build multi-arch e2e test binaries and copy them into the output directory.
 		if r.e2eBinaries {
-			// Free transient disk before the multi-arch e2e build. Tagged component
-			// and operator images are still needed by PublishRelease, so only the
-			// build cache and dangling layers are reclaimed here.
+			// Temporary disk relief before the e2e build until hashreleases are
+			// split into per-component jobs: reclaim build cache and dangling layers
+			// (tagged images are still needed by PublishRelease).
 			r.logDiskUsage("before e2e disk reclaim")
 			for _, c := range [][]string{
 				{"docker", "builder", "prune", "-af"},
@@ -1242,18 +1242,15 @@ func (r *CalicoManager) buildReleaseTar() error {
 	return nil
 }
 
-// e2eSupportedArches are the architectures e2e test runners actually consume:
-// runners pick the binary matching their own node arch, and there are no
-// ppc64le/s390x e2e runners. Building the other arches only wastes time and
-// exhausts the release agent's disk.
+// e2eSupportedArches are the arches e2e runners consume; ppc64le/s390x have no
+// e2e runners and only cost build time and disk.
 var e2eSupportedArches = []string{"amd64", "arm64"}
 
 func (r *CalicoManager) buildE2EBinaries() error {
 	logrus.Info("Building multi-arch e2e test binaries")
 	e2eDir := filepath.Join(r.repoRoot, "e2e")
-	// Build the intersection of the configured and the supported arches. The set
-	// is controlled via ARCHES, not VALIDARCHES: lib.Makefile assigns VALIDARCHES
-	// with `=`, so it ignores the environment.
+	// Restrict to supported arches via ARCHES, not VALIDARCHES: lib.Makefile
+	// assigns VALIDARCHES with `=`, so it ignores the env.
 	var e2eArches []string
 	for _, arch := range r.architectures {
 		if slices.Contains(e2eSupportedArches, arch) {
@@ -1295,8 +1292,7 @@ func (r *CalicoManager) buildE2EBinaries() error {
 	return nil
 }
 
-// logDiskUsage prints disk and docker usage for hashrelease build diagnostics,
-// so disk pressure can be sized from the job log without SSH access to the agent.
+// logDiskUsage logs disk/docker usage so pressure can be sized from the job log.
 func (r *CalicoManager) logDiskUsage(stage string) {
 	logrus.Infof("=== disk usage: %s ===", stage)
 	for _, c := range [][]string{

--- a/release/pkg/manager/calico/manager_test.go
+++ b/release/pkg/manager/calico/manager_test.go
@@ -16,6 +16,8 @@ package calico
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"slices"
 	"strings"
 	"testing"
@@ -659,6 +661,51 @@ func TestPublishContainerImagesBranchTag(t *testing.T) {
 				if got, want := f.count("make -C"), 2*len(imageReleaseDirs)+len(windowsReleaseDirs); got != want {
 					t.Errorf("make invocations = %d, want %d (calls: %v)", got, want, f.calls)
 				}
+			}
+		})
+	}
+}
+
+// TestBuildE2EBinariesRestrictsArchitectures asserts the hashrelease e2e build
+// is limited to the architectures consumed by test cycles (amd64, arm64), the
+// intersection of the configured arches and e2eSupportedArches. The restriction
+// must go through ARCHES: lib.Makefile assigns VALIDARCHES with `=`, so passing
+// VALIDARCHES via the environment is a no-op.
+func TestBuildE2EBinariesRestrictsArchitectures(t *testing.T) {
+	tests := []struct {
+		name          string
+		architectures []string
+		wantArches    string
+	}{
+		{"default four arches drop ppc64le/s390x", []string{"amd64", "arm64", "ppc64le", "s390x"}, "amd64 arm64"},
+		{"narrowed build keeps only its supported arch", []string{"arm64"}, "arm64"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repoRoot := t.TempDir()
+			// Stage a built e2e binary so the post-build hard-link step succeeds.
+			e2eBinDir := filepath.Join(repoRoot, "e2e", "bin", "k8s")
+			require.NoError(t, os.MkdirAll(e2eBinDir, 0o755))
+			require.NoError(t, os.WriteFile(filepath.Join(e2eBinDir, "e2e-linux-amd64.test"), []byte("x"), 0o644))
+
+			f := newFakeRunner()
+			r := &CalicoManager{
+				runner:        f,
+				repoRoot:      repoRoot,
+				outputDir:     t.TempDir(),
+				calicoVersion: "v3.34.0-0.dev-1-gabcdef123456",
+				architectures: tt.architectures,
+			}
+
+			require.NoError(t, r.buildE2EBinaries())
+
+			makePrefix := "make -C " + filepath.Join(repoRoot, "e2e") + " build-all"
+			env := f.envFor(makePrefix)
+			require.NotNil(t, env, "e2e build-all was not run (calls: %v)", f.calls)
+			require.Contains(t, env, "ARCHES="+tt.wantArches)
+			for _, e := range env {
+				require.False(t, strings.HasPrefix(e, "VALIDARCHES="),
+					"e2e build-all should not set VALIDARCHES (lib.Makefile ignores it): %s", e)
 			}
 		})
 	}


### PR DESCRIPTION
### Description

Master-side counterpart of #13731 (which fixed this on `release-v3.33`). The hashrelease build compiles the e2e test binaries for every configured architecture on a single agent and runs out of disk during that final step.

This change:

- **Restricts the e2e build to the architectures test cycles consume (amd64, arm64).** Runners download the binary matching their own node arch, and there are no ppc64le/s390x e2e runners (confirmed with QA). The supported set is a named `e2eSupportedArches` var so it's discoverable.
- **Drives the restriction through `ARCHES`, not `VALIDARCHES`.** `lib.Makefile` assigns `VALIDARCHES` with `=`, which overrides the environment, so passing `VALIDARCHES` via env was a no-op and all four arches were still built. This is a latent bug on master too. It builds the intersection of the configured and supported arches, so a narrowed `--architecture` is still honored.
- **Reclaims transient disk before the e2e build** (`docker builder prune -af`, `docker image prune -f`), leaving tagged images (needed by publish) and the Go module cache intact.
- **Logs disk/docker usage** around the reclaim so disk pressure can be sized from the job log.

Container images still build for all four architectures; only the e2e test binaries are restricted.

Differences from the v3.33 PR: the operator-cache reclaim line from #13731 is omitted here because master's operator build path differs (it builds under the calico dir via `WithCalicoDirectory`, not `tmpDir/operator`, and has no `operatorRepo` field). The build-cache prune covers the bulk of the reclaim.

### Release Note

```release-note
None
```