### PR TITLE
release: restrict hashrelease e2e binaries to consumed architectures

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -7424,6 +7424,7 @@ blocks:
         '/api/config/crd/*.go',
         '/hack/test/certs/',
         '/lib.Makefile',
+        '/libcalico-go/config/crd',
         '/libcalico-go/config/crd/*.go',
         '/metadata.mk',
         '/operator/**'],

--- a/release/pkg/manager/calico/manager.go
+++ b/release/pkg/manager/calico/manager.go
@@ -1228,13 +1228,37 @@ func (r *CalicoManager) buildReleaseTar() error {
 	return nil
 }
 
+// e2eSupportedArches are the arches e2e runners consume; ppc64le/s390x have no
+// e2e runners and only cost build time and disk.
+var e2eSupportedArches = []string{"amd64", "arm64"}
+
+// e2eArchitectures returns the e2e-supported subset of the configured arches.
+// An empty configured set means "all arches" (the tooling-wide convention) and
+// resolves to all supported e2e arches.
+func e2eArchitectures(configured []string) []string {
+	if len(configured) == 0 {
+		return slices.Clone(e2eSupportedArches)
+	}
+	var arches []string
+	for _, arch := range configured {
+		if slices.Contains(e2eSupportedArches, arch) {
+			arches = append(arches, arch)
+		}
+	}
+	return arches
+}
+
 func (r *CalicoManager) buildE2EBinaries() error {
+	arches := e2eArchitectures(r.architectures)
+	if len(arches) == 0 {
+		logrus.Warnf("e2e binaries requested but none of %v is a supported e2e arch (amd64/arm64); skipping", r.architectures)
+		return nil
+	}
 	logrus.Info("Building multi-arch e2e test binaries")
 	e2eDir := filepath.Join(r.repoRoot, "e2e")
-	env := append(os.Environ(), fmt.Sprintf("VERSION=%s", r.calicoVersion))
-	if len(r.architectures) > 0 {
-		env = append(env, fmt.Sprintf("VALIDARCHES=%s", strings.Join(r.architectures, " ")))
-	}
+	// Restrict the build via ARCHES, not VALIDARCHES: lib.Makefile assigns
+	// VALIDARCHES with `=`, so it ignores the env.
+	env := append(os.Environ(), fmt.Sprintf("VERSION=%s", r.calicoVersion), "ARCHES="+strings.Join(arches, " "))
 	out, err := r.makeInDirectoryWithOutput(e2eDir, "build-all", env...)
 	if err != nil {
 		logrus.Error(out)

--- a/release/pkg/manager/calico/manager_test.go
+++ b/release/pkg/manager/calico/manager_test.go
@@ -16,6 +16,8 @@ package calico
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"slices"
 	"strings"
 	"testing"
@@ -661,5 +663,66 @@ func TestPublishContainerImagesBranchTag(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestE2EArchitectures covers the supported-arch intersection: an empty set
+// means "all" (the tooling-wide convention), the four-arch default drops
+// ppc64le/s390x, a narrowed build keeps only its supported arches, and an
+// unsupported-only set yields none.
+func TestE2EArchitectures(t *testing.T) {
+	tests := []struct {
+		name       string
+		configured []string
+		want       []string
+	}{
+		{"empty means all supported", nil, []string{"amd64", "arm64"}},
+		{"default four arches drop ppc64le/s390x", []string{"amd64", "arm64", "ppc64le", "s390x"}, []string{"amd64", "arm64"}},
+		{"narrowed build keeps only its supported arch", []string{"arm64"}, []string{"arm64"}},
+		{"unsupported-only yields none", []string{"ppc64le", "s390x"}, nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, e2eArchitectures(tt.configured))
+		})
+	}
+}
+
+// TestBuildE2EBinariesUsesARCHES asserts the e2e build is restricted through
+// ARCHES, not VALIDARCHES (lib.Makefile assigns VALIDARCHES with `=`, so passing
+// it via the environment is a no-op).
+func TestBuildE2EBinariesUsesARCHES(t *testing.T) {
+	repoRoot := t.TempDir()
+	// Stage a built e2e binary so the post-build hard-link step succeeds.
+	e2eBinDir := filepath.Join(repoRoot, "e2e", "bin", "k8s")
+	require.NoError(t, os.MkdirAll(e2eBinDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(e2eBinDir, "e2e-linux-amd64.test"), []byte("x"), 0o644))
+
+	f := newFakeRunner()
+	r := &CalicoManager{
+		runner:        f,
+		repoRoot:      repoRoot,
+		outputDir:     t.TempDir(),
+		calicoVersion: "v3.34.0-0.dev-1-gabcdef123456",
+		architectures: []string{"amd64", "arm64", "ppc64le", "s390x"},
+	}
+
+	require.NoError(t, r.buildE2EBinaries())
+
+	makePrefix := "make -C " + filepath.Join(repoRoot, "e2e") + " build-all"
+	env := f.envFor(makePrefix)
+	require.NotNil(t, env, "e2e build-all was not run (calls: %v)", f.calls)
+	// Only inspect the arch env vars: env also carries os.Environ(), which can
+	// hold secrets that must not be printed on failure.
+	var archEnv []string
+	for _, e := range env {
+		if strings.HasPrefix(e, "ARCHES=") || strings.HasPrefix(e, "VALIDARCHES=") {
+			archEnv = append(archEnv, e)
+		}
+	}
+	require.Contains(t, archEnv, "ARCHES=amd64 arm64")
+	for _, e := range archEnv {
+		require.False(t, strings.HasPrefix(e, "VALIDARCHES="),
+			"e2e build-all should not set VALIDARCHES (lib.Makefile ignores it): %s", e)
 	}
 }


### PR DESCRIPTION
### Description

The hashrelease e2e build passes its arch set via `VALIDARCHES`, but `lib.Makefile` assigns `VALIDARCHES` with `=`, which overrides (ignores) the environment. So the restriction is a **no-op today** and the build always produces all four arches — including `ppc64le`/`s390x` e2e binaries that no runner consumes (runners download the binary matching their own node arch). That wastes build time and disk on every hashrelease.

This routes the restriction through `ARCHES` (the same lever `buildContainerImages` uses) and builds the intersection of the configured arches and the supported set `{amd64, arm64}`:

- An empty configured set keeps the tooling-wide "all arches" meaning (resolves to all supported).
- A build explicitly narrowed to only unsupported arches warns and skips.

Scope is intentionally just the arch restriction. The related disk-exhaustion stopgap on `release-v3.33` (#13731) is temporary and not brought here; the longer-term fix for master is splitting the OSS hashrelease into per-component jobs.

### Release Note

```release-note
None
```