### PR TITLE
Set the JSON content type before writing the response status

### DIFF
--- a/lib/httpmachinery/pkg/apiutil/handler.go
+++ b/lib/httpmachinery/pkg/apiutil/handler.go
@@ -107,14 +107,18 @@ func parseRequestParams[RequestParams any](ctx apicontext.Context, cfg RouterCon
 	return params
 }
 
-func writeJSONResponse(w http.ResponseWriter, src any) {
+// writeJSONResponse writes src as the JSON body of a response with the given
+// status. It owns the status write because the content type has to be set
+// first: once WriteHeader has run, net/http ignores later header changes and
+// labels the response by sniffing the body instead.
+func writeJSONResponse(w http.ResponseWriter, status int, src any) {
 	w.Header().Set(header.ContentType, header.ApplicationJSON)
+	w.WriteHeader(status)
 	if err := json.NewEncoder(w).Encode(src); err != nil {
 		log.Error("Failed to encode response.", "error", err)
 	}
 }
 
 func writeJSONError(w http.ResponseWriter, status int, message string) {
-	w.WriteHeader(status)
-	writeJSONResponse(w, ErrorResponse{Error: message})
+	writeJSONResponse(w, status, ErrorResponse{Error: message})
 }

--- a/lib/httpmachinery/pkg/apiutil/handler_test.go
+++ b/lib/httpmachinery/pkg/apiutil/handler_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/projectcalico/calico/lib/httpmachinery/pkg/apiutil"
 	apicontext "github.com/projectcalico/calico/lib/httpmachinery/pkg/context"
+	"github.com/projectcalico/calico/lib/httpmachinery/pkg/header"
 	"github.com/projectcalico/calico/lib/httpmachinery/pkg/testutil"
 )
 
@@ -174,4 +175,61 @@ func TestJSONListErrorResponse(t *testing.T) {
 	Expect(testutil.MustUnmarshal[apiutil.ErrorResponse](t, w.Body.Bytes())).To(Equal(&apiutil.ErrorResponse{
 		Error: "Internal Server Error",
 	}))
+}
+
+// TestResponseContentType covers every response declaring its content type. The
+// header has to be set before the status is written: once WriteHeader has run,
+// net/http ignores later header changes and sniffs the body instead, labelling
+// a large JSON body text/plain. Reading it back off Result rather than Header is
+// what makes the ordering observable.
+func TestResponseContentType(t *testing.T) {
+	setupTest(t)
+
+	type Request struct {
+		ReqField string `urlQuery:"reqField"`
+		Page     int    `urlQuery:"page"`
+	}
+	type Response struct {
+		RespField string `json:"rspField"`
+	}
+
+	list := apiutil.NewJSONListOrEventStreamHandler(func(ctx apicontext.Context, params Request) apiutil.ListOrStreamResponse[Response] {
+		return apiutil.NewListOrStreamResponse[Response]().SetStatus(http.StatusOK).
+			SendList(apiutil.ListMeta{TotalPages: 1}, []Response{{RespField: "foo"}})
+	})
+	stream := apiutil.NewJSONListOrEventStreamHandler(func(ctx apicontext.Context, params Request) apiutil.ListOrStreamResponse[Response] {
+		return apiutil.NewListOrStreamResponse[Response]().SetStatus(http.StatusOK).
+			SendStream(func(yield func(r Response) bool) { yield(Response{RespField: "foo"}) })
+	})
+	streamErr := apiutil.NewJSONListOrEventStreamHandler(func(ctx apicontext.Context, params Request) apiutil.ListOrStreamResponse[Response] {
+		return apiutil.NewListOrStreamResponse[Response]().SetStatus(http.StatusBadRequest).SetError("bad request")
+	})
+	listErr := apiutil.NewJSONListHandler(func(ctx apicontext.Context, params Request) apiutil.ListResponse[Response] {
+		return apiutil.NewListResponse[Response]().SetStatus(http.StatusInternalServerError).SetError("internal server error")
+	})
+
+	for _, tc := range []struct {
+		name        string
+		serve       func(cfg apiutil.RouterConfig, w http.ResponseWriter, r *http.Request)
+		query       string
+		contentType string
+	}{
+		{"json list", list.ServeHTTP, "reqField=value", header.ApplicationJSON},
+		{"json error", streamErr.ServeHTTP, "reqField=value", header.ApplicationJSON},
+		{"json list handler error", listErr.ServeHTTP, "reqField=value", header.ApplicationJSON},
+		// A request the handler never sees, answered by the decoder.
+		{"request decoding error", list.ServeHTTP, "page=notanumber", header.ApplicationJSON},
+		{"event stream", stream.ServeHTTP, "reqField=value", header.TextEventStream},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			r, err := http.NewRequest(http.MethodGet, "foobar?"+tc.query, nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			tc.serve(apiutil.NewNOOPRouterConfig(), w, r)
+
+			Expect(w.Result().Header.Get(header.ContentType)).To(Equal(tc.contentType),
+				"the content type must be set before the status is written")
+		})
+	}
 }

--- a/lib/httpmachinery/pkg/apiutil/response.go
+++ b/lib/httpmachinery/pkg/apiutil/response.go
@@ -176,8 +176,7 @@ type jsonListResponseWriter[Body any] struct {
 }
 
 func (rs *jsonListResponseWriter[Body]) WriteResponse(ctx apicontext.Context, status int, w http.ResponseWriter) error {
-	w.WriteHeader(status)
-	writeJSONResponse(w, rs.items)
+	writeJSONResponse(w, status, rs.items)
 	return nil
 }
 
@@ -187,7 +186,6 @@ type jsonErrorResponseWriter struct {
 }
 
 func (rs *jsonErrorResponseWriter) WriteResponse(ctx apicontext.Context, status int, w http.ResponseWriter) error {
-	w.WriteHeader(status)
-	writeJSONResponse(w, ErrorResponse{Error: rs.error})
+	writeJSONResponse(w, status, ErrorResponse{Error: rs.error})
 	return nil
 }


### PR DESCRIPTION
## Description

Every JSON response from `lib/httpmachinery` now declares `application/json`.

`net/http` ignores header changes once `WriteHeader` has run, so `writeJSONResponse` set the content type too late and the response was labelled by content sniffing instead. A 1MB flow list went out as `text/plain; charset=utf-8`, which is also the wrong side of any compressible-type allowlist, so response compression could never apply to it.

Three writers had the ordering wrong: `jsonListResponseWriter`, `jsonErrorResponseWriter`, and `writeJSONError`, which answers a request whose params fail to decode. Rather than patch each call site, `writeJSONResponse` now takes the status and writes it itself after setting the content type, so no call site can get the order wrong. `eventStreamResponseWriter` already ordered the two correctly and is unchanged.

Split out of the whisker flow logs work so it can be reviewed on its own.

## Testing

`TestResponseContentType` covers the list, error, list-handler-error, request-decoding-error and event-stream paths. It reads the header back off `Result()` rather than `Header()`, which is what makes the ordering observable: `httptest.ResponseRecorder` snapshots the headers when `WriteHeader` runs, so a late `Set` is invisible there but still lands in `Header()`. Confirmed the test fails with the fix reverted and passes with it. The whisker-backend unit and FV suites pass unchanged.

**Release note:**
```release-note
Whisker flow API responses are now labelled application/json rather than text/plain.
```

**AI assistance:** Claude Code wrote the fix, the test and this description; the change was reviewed by the author.
