### PR TITLE
Track bundled third-party image versions with Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -47,6 +47,37 @@
       "depNameTemplate": "calico/base",
       "datasourceTemplate": "docker",
       "versioningTemplate": "regex:^(?<compatibility>ubi\\d+)-(?<patch>\\d+)$"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^third_party\\/envoy-gateway\\/Makefile$/"],
+      "matchStrings": ["ENVOY_GATEWAY_VERSION=v(?<currentValue>\\d+\\.\\d+\\.\\d+)"],
+      "depNameTemplate": "envoyproxy/gateway",
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^v(?<version>.*)$"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^third_party\\/envoy-proxy\\/Makefile$/"],
+      "matchStrings": ["ENVOYBINARY_IMAGE \\?= quay\\.io\\/tigera\\/envoybinary:(?<currentValue>v\\d+\\.\\d+\\.\\d+-[0-9a-f]+)"],
+      "depNameTemplate": "quay.io/tigera/envoybinary",
+      "datasourceTemplate": "docker",
+      "versioningTemplate": "regex:^v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-(?<build>[0-9a-f]+)$"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^third_party\\/envoy-ratelimit\\/Makefile$/"],
+      "matchStrings": ["ENVOY_RATELIMIT_VERSION=(?<currentDigest>[0-9a-f]{8,40})"],
+      "depNameTemplate": "https://github.com/envoyproxy/ratelimit",
+      "currentValueTemplate": "main",
+      "datasourceTemplate": "git-refs"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^istio\\/Makefile$/"],
+      "matchStrings": ["ISTIO_VERSION \\?= (?<currentValue>\\d+\\.\\d+\\.\\d+)"],
+      "depNameTemplate": "istio/istio",
+      "datasourceTemplate": "github-releases"
     }
   ],
   "packageRules": [
@@ -97,6 +128,19 @@
         "fileFilters": ["**/deps.txt"],
         "executionMode": "branch"
       }
+    },
+    {
+      "description": "Bundled third-party images: off by default, so a newly added release branch never picks them up implicitly",
+      "matchDepNames": ["envoyproxy/gateway", "quay.io/tigera/envoybinary", "https://github.com/envoyproxy/ratelimit", "istio/istio"],
+      "enabled": false
+    },
+    {
+      "description": "Bundled third-party images: patch updates only, master only, grouped into a single PR. Digest is listed because envoy-ratelimit is pinned to a commit, so its updates arrive as digests rather than versions; minor and major stay blocked by the rule above, since those need patch rebases and API/RBAC review",
+      "matchDepNames": ["envoyproxy/gateway", "quay.io/tigera/envoybinary", "https://github.com/envoyproxy/ratelimit", "istio/istio"],
+      "matchBaseBranches": ["master"],
+      "matchUpdateTypes": ["patch", "digest"],
+      "enabled": true,
+      "groupName": "third-party-images"
     }
   ]
 }

--- a/third_party/envoy-gateway/Makefile
+++ b/third_party/envoy-gateway/Makefile
@@ -34,10 +34,9 @@ $(ENVOY_GATEWAY_DOWNLOADED):
 # 	For each valid patch file, it applies the patch to the envoy-gateway directory using patch -p1.
 	for patch in patches/*.patch; do \
 		if [ -f "$$patch" ]; then \
-			patch -d envoy-gateway -p1 < "$$patch"; \
+			patch -d envoy-gateway -p1 < "$$patch" || exit 1; \
 		fi; \
-	done; \
-
+	done
 	touch $@
 
 .PHONY: build

--- a/third_party/envoy-ratelimit/Makefile
+++ b/third_party/envoy-ratelimit/Makefile
@@ -32,9 +32,9 @@ $(ENVOY_RATELIMIT_DOWNLOADED):
 # 	For each valid patch file, it applies the patch to the envoy-ratelimit directory using patch -p1.
 	for patch in patches/*.patch; do \
 		if [ -f "$$patch" ]; then \
-			patch -d envoy-ratelimit -p1 < "$$patch"; \
+			patch -d envoy-ratelimit -p1 < "$$patch" || exit 1; \
 		fi; \
-	done; \
+	done
 	touch $@
 
 .PHONY: build


### PR DESCRIPTION
Brings the four bundled third-party image pins under Renovate, the same way `K8S_VERSION` and `CALICO_BASE_VER` are already handled. They are bumped entirely by hand today.

| Component | Pin | Datasource |
|---|---|---|
| envoy-gateway | `ENVOY_GATEWAY_VERSION` | `github-releases` on `envoyproxy/gateway` |
| envoy-proxy | `ENVOYBINARY_IMAGE` | `docker` on `quay.io/tigera/envoybinary`, regex versioning for the `v<semver>-<sha>` tag |
| envoy-ratelimit | `ENVOY_RATELIMIT_VERSION` | `git-refs` on `envoyproxy/ratelimit` (pinned to a commit, so updates are digests) |
| istio | `ISTIO_VERSION` | `github-releases` on `istio/istio` |

Scoped conservatively for a first pass: **patch updates only** (minor and major stay blocked by the existing rule — those need the bundled patches rebased and, for envoy-gateway, API/RBAC review), **`master` only**, and grouped into a single `third-party-images` PR kept out of the existing `dependency-updates` group so a failure here cannot block the go and k8s bumps that merge cleanly today. The set is disabled by default and re-enabled for `master`, so adding a future release branch to `baseBranchPatterns` cannot start bumping these images implicitly.

### What this does and does not do

It does **not** regenerate the CVE dependency patches under `patches/`. A version bump whose patch no longer applies will fail its component build, which is intended for this pass: the PR reports that an update exists and CI shows what still has to be done by hand. Regenerating those patches automatically is a larger piece of work and is not attempted here.

The second commit is what makes that reliable. Both `envoy-gateway` and `envoy-ratelimit` apply their patches in a shell `for` loop whose exit status is only the final iteration's, and in `envoy-ratelimit` the loop is joined to `touch $@` by a line continuation, so the sentinel is stamped even when the last patch fails. Today a failed `patch -p1` can leave a partially patched tree and a green build.

### Testing

No test is added — this is CI configuration plus a Makefile failure-path fix, neither of which is reachable from a unit test. Verified directly instead:

- All four regexes extract the expected `currentValue`/`currentDigest` from the real Makefiles.
- `renovate-config-validator` (renovate@43, the version pinned in `.semaphore/renovate.yml`) passes; confirmed the check is meaningful by feeding it a bogus key and watching it fail.
- Regex versioning on the `envoybinary` tag orders correctly and classifies `1.38.3 -> 1.38.4` as patch and `-> 1.39.0` as minor. Arch-suffixed tags (`…-arm64`, `…-amd64`) are correctly rejected as invalid versions.
- `quay.io/tigera/envoybinary` tags are publicly listable, so the docker datasource resolves without credentials.
- Makefile fix: with a deliberately failing first patch, the old form exits 0 and stamps the sentinel; the new form exits non-zero and does not.

Against the live datasources, the first PR would propose envoy-gateway `v1.8.2 -> v1.8.4`, istio `1.29.4 -> 1.29.7`, and an envoy-ratelimit digest bump. envoy-proxy would propose nothing, since the only newer tag is a minor.

### Follow-ups, not in this PR

- A `RENOVATE_DRY_RUN=full` run on the Semaphore job to confirm extraction against the real repo before the first live PR.
- A rebuild of `envoybinary` at the *same* Envoy version but a new build SHA does not compare greater, so Renovate will not offer it. That is a real gap for CVE remediation specifically.
- `ISTIO_VERSION` drives three fetches (istio tarball, ztunnel tarball, `istio/proxyv2` image); Renovate cannot express "only if the tag exists in all three".

**Release note:**
```release-note
None
```

**AI assistance:** Claude Code (Opus 5) — drafted the Renovate config and ran the verification above; reviewed and edited by me.

By opening this PR you take responsibility for every line in it, and you agree to explain the change yourself during review rather than routing review comments back through an agent. See [AI_POLICY.md](../AI_POLICY.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
