### PR TITLE
Create the stamp dir before writing push stamps

### DIFF
--- a/hack/dev-build.sh
+++ b/hack/dev-build.sh
@@ -50,6 +50,9 @@ tag() {
 # Push dev-tagged images to the remote registry. Skips images whose
 # docker image ID hasn't changed since the last push.
 push() {
+    # The stamp dir is not created anywhere else; a fresh workspace has none.
+    mkdir -p "$STAMP_DIR"
+
     pushed=0
     skipped=0
 


### PR DESCRIPTION
`hack/dev-build.sh --push` writes `${STAMP_DIR}/<img>.pushed-id`, but nothing creates that directory any more. The only `mkdir -p "$STAMP_DIR"` lived in the `--operator` mode that 7b9ff697 removed, and `make image` used to run it before `push`.

With `set -euo pipefail`, the failed write aborts `push` *after* the image has already been uploaded, so `make push` fails on any workspace without a pre-existing `.dev-stamps/` — which is every fresh CI checkout:

```
dev-build.sh: line 67: .../.dev-stamps/localhost_5000_calico_node_test-build.pushed-id: No such file or directory
make[3]: *** [Makefile:216: push] Error 1
make[2]: *** [lib.Makefile:1839: kind-build-images] Error 2
make[1]: *** [Makefile:259: kind-up] Error 2
```

That takes out every kind-based job. On a fresh `master` run today it accounted for 7 of 8 failed jobs: `E2E tests (KinD)` (all four), `E2E tests: Gateway API Conformance`, `KubeVirt live migration (KIND)` and `Node: kind-cluster tests`.

**Testing**

- `bash -n hack/dev-build.sh` passes.
- Reproduced the failure and confirmed the fix in isolation, with a stubbed `docker` on `PATH` and `STAMP_DIR` pointing at a non-existent directory: before, `--push` exits 1 with the exact error above; after, it exits 0 and writes the stamp.
- The read side (`prev_id=$(cat "$stamp" 2>/dev/null || echo "")`) already tolerated a missing dir, so first-run behaviour is unchanged apart from no longer failing.

**Release note:**
```release-note
NONE
```

**AI assistance:** This PR was written in part with the assistance of generative AI, which diagnosed the root cause and wrote the one-line fix.

By opening this PR you take responsibility for every line in it, and you agree to explain the change yourself during review rather than routing review comments back through an agent. See [AI_POLICY.md](../AI_POLICY.md).
