### PR TITLE
Create the release tmp dir before writing the pinned version file

### DIFF
--- a/release/internal/pinnedversion/pinnedversion.go
+++ b/release/internal/pinnedversion/pinnedversion.go
@@ -196,6 +196,9 @@ func generatePinnedVersionFile(p *CalicoPinnedVersions) error {
 	}
 
 	logrus.WithField("file", pinnedVersionPath).Info("Creating pinned version file")
+	if err := os.MkdirAll(p.Dir, utils.DirPerms); err != nil {
+		return fmt.Errorf("cannot create pinned version directory: %w", err)
+	}
 	pinnedVersionFile, err := os.Create(pinnedVersionPath)
 	if err != nil {
 		return fmt.Errorf("cannot create pinned version file: %w", err)

--- a/release/internal/pinnedversion/pinnedversion_test.go
+++ b/release/internal/pinnedversion/pinnedversion_test.go
@@ -16,6 +16,7 @@ package pinnedversion
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 
 	approvals "github.com/approvals/go-approval-tests"
@@ -99,6 +100,32 @@ func TestImageComponents(t *testing.T) {
 			t.Errorf("expected components to be same, but they differ: %s", diff)
 		}
 	})
+}
+
+func TestGeneratePinnedVersionFileCreatesDir(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "tmp")
+	rootDir, err := command.GitDir()
+	if err != nil {
+		t.Fatalf("failed to get git root dir: %v", err)
+	}
+	p := &CalicoPinnedVersions{
+		Dir:                 dir,
+		RootDir:             rootDir,
+		ReleaseBranchPrefix: "release",
+		OperatorCfg: OperatorConfig{
+			Image:    "tigera/operator",
+			Registry: "docker.io",
+		},
+		releaseName:   "test-release",
+		productBranch: "release-v3.31",
+		versionData:   version.NewHashreleaseVersions(version.New("v3.31.0")),
+	}
+	if err := generatePinnedVersionFile(p); err != nil {
+		t.Fatalf("failed to generate pinned version file: %v", err)
+	}
+	if _, err := os.Stat(PinnedVersionFilePath(dir)); err != nil {
+		t.Fatalf("pinned version file not created: %v", err)
+	}
 }
 
 func TestGeneratePinnedVersionFile(t *testing.T) {


### PR DESCRIPTION
Hashrelease builds have been failing since the operator moved into the monorepo:

```
FATAL Error running app error="failed to generate pinned version file: cannot create pinned version file: open /home/semaphore/calico/release/tmp/pinned_versions.yml: no such file or directory"
```

`release/tmp` used to get created as a side effect of cloning the operator repo into it, which happened just before the pinned version file was written. The monorepo build doesn't clone anything, so nothing makes the directory. This creates it explicitly, and adds a test that points the output directory at a path that doesn't exist yet.

**Release note:**
```release-note
None
```

**AI assistance:** Claude Code found the cause and wrote the fix.
