### PR TITLE
Disable git's terminal prompt in builds

### DIFF
--- a/lib.Makefile
+++ b/lib.Makefile
@@ -408,6 +408,10 @@ DOCKER_BUILD=docker buildx build --load --platform=linux/$(ARCH) $(DOCKER_PULL) 
 	--build-arg GIT_VERSION=$(GIT_VERSION) \
 	--build-arg UBI_IMAGE=$(UBI_IMAGE)
 
+# Fail a clone that needs credentials instead of blocking on git's terminal
+# prompt, which hangs a CI job until the pipeline timeout.
+export GIT_TERMINAL_PROMPT ?= 0
+
 DOCKER_RUN_PRIV_NET := mkdir -p $(REPO_ROOT)/.go-pkg-cache bin $(GOMOD_CACHE) && \
 	docker run --rm \
 		--init \
@@ -415,6 +419,7 @@ DOCKER_RUN_PRIV_NET := mkdir -p $(REPO_ROOT)/.go-pkg-cache bin $(GOMOD_CACHE) &&
 		$(DOCKER_GIT_WORKTREE_ARGS) \
 		-e LOCAL_USER_ID=$(LOCAL_USER_ID) \
 		-e GOCACHE=/go-cache \
+		-e GIT_TERMINAL_PROMPT=$(GIT_TERMINAL_PROMPT) \
 		$(GOARCH_FLAGS) \
 		-e GOPATH=/go \
 		-e OS=$(BUILDOS) \


### PR DESCRIPTION
When GitHub refuses an anonymous clone, git falls back to prompting for a username and blocks on it. Nothing answers on a CI agent, so the build sits until the pipeline timeout kills the whole workflow - four PRs lost close to four hours each to this on Sept 2.

Setting GIT_TERMINAL_PROMPT=0 makes those clones fail in seconds instead; lib.Makefile exports it to every component that includes it and passes it into the build container, which also covers the libbpf clone in felix.

**Release note:**
```release-note
None
```

**AI assistance:** Claude Code

By opening this PR you take responsibility for every line in it, and you agree to explain the change yourself during review rather than routing review comments back through an agent. See [AI_POLICY.md](../AI_POLICY.md).
