### PR TITLE
fix(release): make image publishing safe to re-run

### DIFF
--- a/cmd/calico/Makefile
+++ b/cmd/calico/Makefile
@@ -112,7 +112,10 @@ release-build: .release-$(VERSION).created
 
 ## Pushes the combined calico image to the registries.
 .PHONY: release-publish
-release-publish: release-prereqs .release-$(VERSION).published
-.release-$(VERSION).published:
-	$(MAKE) push-images-to-registries push-manifests IMAGETAG=$(VERSION) RELEASE=$(RELEASE) CONFIRM=$(CONFIRM)
-	touch $@
+# The registry decides the skip, so a fresh checkout answers like one that pushed.
+release-publish: release-prereqs bin/crane
+	@if $(REPO_ROOT)/hack/image-published $(CRANE_CMD) "$(DEV_REGISTRIES)" "$(BUILD_IMAGES)" "$(VERSION)"; then \
+		echo "$(BUILD_IMAGES):$(VERSION) is already published, skipping"; \
+	else \
+		$(MAKE) push-images-to-registries push-manifests IMAGETAG=$(VERSION) RELEASE=$(RELEASE) CONFIRM=$(CONFIRM); \
+	fi

--- a/cmd/calico/Makefile
+++ b/cmd/calico/Makefile
@@ -113,7 +113,7 @@ release-build: .release-$(VERSION).created
 ## Pushes the combined calico image to the registries.
 .PHONY: release-publish
 release-publish: release-prereqs bin/crane
-	@if $(REPO_ROOT)/hack/image-published $(CRANE_CMD) "$(DEV_REGISTRIES)" "$(BUILD_IMAGES)" "$(VERSION)"; then \
+	@if $(REPO_ROOT)/hack/image-published $(CRANE_CMD) "$(DEV_REGISTRIES)" "$(BUILD_IMAGES)" "$(VERSION)" "$(VALIDARCHES)"; then \
 		echo "$(BUILD_IMAGES):$(VERSION) is already published, skipping"; \
 	else \
 		$(MAKE) push-images-to-registries push-manifests IMAGETAG=$(VERSION) RELEASE=$(RELEASE) CONFIRM=$(CONFIRM); \

--- a/cmd/calico/Makefile
+++ b/cmd/calico/Makefile
@@ -102,7 +102,7 @@ cd: image-all cd-common
 # Release
 ###############################################################################
 ## Produces a clean build of the combined calico image at the specified version.
-.PHONY: release-build
+.PHONY: release-build release-publish
 release-build: .release-$(VERSION).created
 .release-$(VERSION).created:
 	$(MAKE) clean image-all RELEASE=true
@@ -112,7 +112,6 @@ release-build: .release-$(VERSION).created
 
 ## Pushes the combined calico image to the registries.
 .PHONY: release-publish
-# The registry decides the skip, so a fresh checkout answers like one that pushed.
 release-publish: release-prereqs bin/crane
 	@if $(REPO_ROOT)/hack/image-published $(CRANE_CMD) "$(DEV_REGISTRIES)" "$(BUILD_IMAGES)" "$(VERSION)"; then \
 		echo "$(BUILD_IMAGES):$(VERSION) is already published, skipping"; \

--- a/hack/image-published
+++ b/hack/image-published
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2026 Tigera, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# image-published CRANE REGISTRIES IMAGES TAG
+#
+# Exits 0 when every registry/image:TAG resolves, 1 when any is absent or
+# unreadable. A failed lookup exits 1: republishing beats a wrong skip.
+
+set -u
+
+crane=${1:?usage: image-published CRANE REGISTRIES IMAGES TAG}
+registries=${2:?}
+images=${3:?}
+tag=${4:?}
+
+: "${CRANE_LOOKUP_RETRIES:=3}"
+: "${CRANE_LOOKUP_RETRY_DELAY:=3}"
+
+# resolved reports whether an image tag exists, retrying to ride out a flaky
+# registry. "MANIFEST_UNKNOWN" is a real answer, so it returns without retrying.
+resolved() {
+	local image=$1 attempt=1 out
+	while :; do
+		if out=$("$crane" digest "$image" 2>&1); then
+			return 0
+		fi
+		if printf '%s' "$out" | grep -qiE 'MANIFEST_UNKNOWN|NAME_UNKNOWN|not found|404'; then
+			return 1
+		fi
+		if [ "$attempt" -ge "$CRANE_LOOKUP_RETRIES" ]; then
+			echo "WARNING: could not check ${image} after ${attempt} attempts, assuming not published: ${out}" >&2
+			return 1
+		fi
+		attempt=$((attempt + 1))
+		sleep "$CRANE_LOOKUP_RETRY_DELAY"
+	done
+}
+
+for registry in $registries; do
+	for image in $images; do
+		resolved "${registry}/${image}:${tag}" || exit 1
+	done
+done

--- a/hack/image-published
+++ b/hack/image-published
@@ -14,10 +14,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# image-published CRANE REGISTRIES IMAGES TAG
+# image-published CRANE REGISTRIES IMAGES TAG [ARCHES]
 #
-# Exits 0 when every registry/image:TAG resolves, 1 when any is absent or
+# Exits 0 when TAG and every TAG-ARCH resolve, 1 when any is absent or
 # unreadable. A failed lookup exits 1: republishing beats a wrong skip.
+#
+# The bare tag alone is not enough: the amd64 push writes it before the other
+# arches have finished, so it is present while the release is incomplete.
 
 set -u
 
@@ -25,6 +28,7 @@ crane=${1:?usage: image-published CRANE REGISTRIES IMAGES TAG}
 registries=${2:?}
 images=${3:?}
 tag=${4:?}
+arches=${5:-}
 
 : "${CRANE_LOOKUP_RETRIES:=3}"
 : "${CRANE_LOOKUP_RETRY_DELAY:=3}"
@@ -52,5 +56,8 @@ resolved() {
 for registry in $registries; do
 	for image in $images; do
 		resolved "${registry}/${image}:${tag}" || exit 1
+		for arch in $arches; do
+			resolved "${registry}/${image}:${tag}-${arch}" || exit 1
+		done
 	done
 done

--- a/istio/Makefile
+++ b/istio/Makefile
@@ -198,7 +198,7 @@ release-build: .release-$(VERSION).created
 
 .PHONY: release-publish
 release-publish: release-prereqs bin/crane
-	@if $(REPO_ROOT)/hack/image-published $(CRANE_CMD) "$(DEV_REGISTRIES)" "$(BUILD_IMAGES)" "$(VERSION)"; then \
+	@if $(REPO_ROOT)/hack/image-published $(CRANE_CMD) "$(DEV_REGISTRIES)" "$(BUILD_IMAGES)" "$(VERSION)" "$(VALIDARCHES)"; then \
 		echo "$(BUILD_IMAGES):$(VERSION) is already published, skipping"; \
 	else \
 		$(MAKE) push-images-to-registries push-manifests IMAGETAG=$(VERSION) RELEASE=$(RELEASE) CONFIRM=$(CONFIRM); \

--- a/istio/Makefile
+++ b/istio/Makefile
@@ -197,8 +197,10 @@ release-build: .release-$(VERSION).created
 	touch $@
 
 .PHONY: release-publish
-release-publish: release-prereqs .release-$(VERSION).published
-
-.release-$(VERSION).published:
-	$(MAKE) push-images-to-registries push-manifests IMAGETAG=$(VERSION) RELEASE=$(RELEASE) CONFIRM=$(CONFIRM)
-	touch $@
+# The registry decides the skip, so a fresh checkout answers like one that pushed.
+release-publish: release-prereqs bin/crane
+	@if $(REPO_ROOT)/hack/image-published $(CRANE_CMD) "$(DEV_REGISTRIES)" "$(BUILD_IMAGES)" "$(VERSION)"; then \
+		echo "$(BUILD_IMAGES):$(VERSION) is already published, skipping"; \
+	else \
+		$(MAKE) push-images-to-registries push-manifests IMAGETAG=$(VERSION) RELEASE=$(RELEASE) CONFIRM=$(CONFIRM); \
+	fi

--- a/istio/Makefile
+++ b/istio/Makefile
@@ -187,7 +187,7 @@ cd: image-all cd-common
 ###############################################################################
 # Release
 ###############################################################################
-.PHONY: release-build
+.PHONY: release-build release-publish
 release-build: .release-$(VERSION).created
 
 .release-$(VERSION).created:
@@ -197,7 +197,6 @@ release-build: .release-$(VERSION).created
 	touch $@
 
 .PHONY: release-publish
-# The registry decides the skip, so a fresh checkout answers like one that pushed.
 release-publish: release-prereqs bin/crane
 	@if $(REPO_ROOT)/hack/image-published $(CRANE_CMD) "$(DEV_REGISTRIES)" "$(BUILD_IMAGES)" "$(VERSION)"; then \
 		echo "$(BUILD_IMAGES):$(VERSION) is already published, skipping"; \

--- a/lib.Makefile
+++ b/lib.Makefile
@@ -1482,12 +1482,15 @@ CRANE_URL = https://github.com/google/go-containerregistry/releases/download/$(C
 
 .PHONY: bin/crane
 bin/crane: $(REPO_ROOT)/bin/crane
+# Moved into place last: a half-extracted binary looks complete to make.
 $(REPO_ROOT)/bin/crane:
 	$(info ::: Downloading crane from $(CRANE_URL))
 	@mkdir -p $(REPO_ROOT)/bin
-	@curl -sSfL --retry 5 --retry-all-errors -o /tmp/calico-crane.tar.gz $(CRANE_URL)
-	@tar xz -C $(REPO_ROOT)/bin -f /tmp/calico-crane.tar.gz crane
-	@rm -f /tmp/calico-crane.tar.gz
+	@tmp=$$(mktemp -d) && trap 'rm -rf "$$tmp"' EXIT && \
+		curl -sSfL --retry 5 --retry-all-errors -o "$$tmp/crane.tar.gz" $(CRANE_URL) && \
+		tar xz -C "$$tmp" -f "$$tmp/crane.tar.gz" crane && \
+		chmod +x "$$tmp/crane" && \
+		mv "$$tmp/crane" $@
 
 ###############################################################################
 # Common functions for launching a local Kubernetes control plane.

--- a/lib.Makefile
+++ b/lib.Makefile
@@ -1486,11 +1486,11 @@ bin/crane: $(REPO_ROOT)/bin/crane
 $(REPO_ROOT)/bin/crane:
 	$(info ::: Downloading crane from $(CRANE_URL))
 	@mkdir -p $(REPO_ROOT)/bin
-	@tmp=$$(mktemp -d) && trap 'rm -rf "$$tmp"' EXIT && \
+	@tmp=$$(mktemp -d $(REPO_ROOT)/bin/.crane.XXXXXX) && trap 'rm -rf "$$tmp"' EXIT && \
 		curl -sSfL --retry 5 --retry-all-errors -o "$$tmp/crane.tar.gz" $(CRANE_URL) && \
 		tar xz -C "$$tmp" -f "$$tmp/crane.tar.gz" crane && \
 		chmod +x "$$tmp/crane" && \
-		mv "$$tmp/crane" $@
+		mv "$$tmp/crane" "$@"
 
 ###############################################################################
 # Common functions for launching a local Kubernetes control plane.

--- a/node/Makefile
+++ b/node/Makefile
@@ -434,6 +434,7 @@ release-windows-archive: release-prereqs
 	$(MAKE) build-windows-archive WINDOWS_ARCHIVE_TAG=$(VERSION)
 
 ## Pushes a github release and release artifacts produced by `make release-build`.
+.PHONY: release-publish release-publish-linux release-publish-windows
 release-publish: release-publish-linux release-publish-windows
 
 release-publish-linux: release-prereqs bin/crane

--- a/node/Makefile
+++ b/node/Makefile
@@ -434,15 +434,14 @@ release-windows-archive: release-prereqs
 	$(MAKE) build-windows-archive WINDOWS_ARCHIVE_TAG=$(VERSION)
 
 ## Pushes a github release and release artifacts produced by `make release-build`.
-release-publish: release-prereqs .release-$(VERSION).published
-.release-$(VERSION).published:
-	# Push node images.
-	$(MAKE) push-images-to-registries push-manifests IMAGETAG=$(VERSION) RELEASE=$(RELEASE) CONFIRM=$(CONFIRM)
-
-	# Push Windows images.
-	$(MAKE) release-windows IMAGETAG=$(VERSION) CONFIRM=$(CONFIRM)
-
-	touch $@
+# The registry decides the skip, so a fresh checkout answers like one that pushed.
+release-publish: release-prereqs bin/crane
+	@if $(REPO_ROOT)/hack/image-published $(CRANE_CMD) "$(DEV_REGISTRIES)" "$(BUILD_IMAGES)" "$(VERSION)"; then \
+		echo "$(BUILD_IMAGES):$(VERSION) is already published, skipping"; \
+	else \
+		$(MAKE) push-images-to-registries push-manifests IMAGETAG=$(VERSION) RELEASE=$(RELEASE) CONFIRM=$(CONFIRM); \
+		$(MAKE) release-windows IMAGETAG=$(VERSION) CONFIRM=$(CONFIRM); \
+	fi
 
 # WARNING: Only run this target if this release is the latest stable release. Do NOT
 # run this target for alpha / beta / release candidate builds, or patches to earlier Calico versions.

--- a/node/Makefile
+++ b/node/Makefile
@@ -438,7 +438,7 @@ release-windows-archive: release-prereqs
 release-publish: release-publish-linux release-publish-windows
 
 release-publish-linux: release-prereqs bin/crane
-	@if $(REPO_ROOT)/hack/image-published $(CRANE_CMD) "$(DEV_REGISTRIES)" "$(BUILD_IMAGES)" "$(VERSION)"; then \
+	@if $(REPO_ROOT)/hack/image-published $(CRANE_CMD) "$(DEV_REGISTRIES)" "$(BUILD_IMAGES)" "$(VERSION)" "$(VALIDARCHES)"; then \
 		echo "$(BUILD_IMAGES):$(VERSION) is already published, skipping"; \
 	else \
 		$(MAKE) push-images-to-registries push-manifests IMAGETAG=$(VERSION) RELEASE=$(RELEASE) CONFIRM=$(CONFIRM); \

--- a/node/Makefile
+++ b/node/Makefile
@@ -434,12 +434,19 @@ release-windows-archive: release-prereqs
 	$(MAKE) build-windows-archive WINDOWS_ARCHIVE_TAG=$(VERSION)
 
 ## Pushes a github release and release artifacts produced by `make release-build`.
-# The registry decides the skip, so a fresh checkout answers like one that pushed.
-release-publish: release-prereqs bin/crane
+release-publish: release-publish-linux release-publish-windows
+
+release-publish-linux: release-prereqs bin/crane
 	@if $(REPO_ROOT)/hack/image-published $(CRANE_CMD) "$(DEV_REGISTRIES)" "$(BUILD_IMAGES)" "$(VERSION)"; then \
 		echo "$(BUILD_IMAGES):$(VERSION) is already published, skipping"; \
 	else \
 		$(MAKE) push-images-to-registries push-manifests IMAGETAG=$(VERSION) RELEASE=$(RELEASE) CONFIRM=$(CONFIRM); \
+	fi
+
+release-publish-windows: release-prereqs bin/crane
+	@if $(REPO_ROOT)/hack/image-published $(CRANE_CMD) "$(DEV_REGISTRIES)" "$(WINDOWS_IMAGE)" "$(VERSION)"; then \
+		echo "$(WINDOWS_IMAGE):$(VERSION) is already published, skipping"; \
+	else \
 		$(MAKE) release-windows IMAGETAG=$(VERSION) CONFIRM=$(CONFIRM); \
 	fi
 

--- a/third_party/cni-plugins/Makefile
+++ b/third_party/cni-plugins/Makefile
@@ -180,7 +180,10 @@ release-build: .release-$(VERSION).created
 	$(MAKE) retag-build-images-with-registries IMAGETAG=latest RELEASE=true
 	touch $@
 
-release-publish: release-prereqs .release-$(VERSION).published
-.release-$(VERSION).published:
-	$(MAKE) push-images-to-registries push-manifests IMAGETAG=$(VERSION) RELEASE=$(RELEASE) CONFIRM=$(CONFIRM)
-	touch $@
+# The registry decides the skip, so a fresh checkout answers like one that pushed.
+release-publish: release-prereqs bin/crane
+	@if $(REPO_ROOT)/hack/image-published $(CRANE_CMD) "$(DEV_REGISTRIES)" "$(BUILD_IMAGES)" "$(VERSION)"; then \
+		echo "$(BUILD_IMAGES):$(VERSION) is already published, skipping"; \
+	else \
+		$(MAKE) push-images-to-registries push-manifests IMAGETAG=$(VERSION) RELEASE=$(RELEASE) CONFIRM=$(CONFIRM); \
+	fi

--- a/third_party/cni-plugins/Makefile
+++ b/third_party/cni-plugins/Makefile
@@ -171,7 +171,7 @@ ci: ut image-content-addressed
 .PHONY: cd
 cd: image-all cd-common
 
-.PHONY: release-build
+.PHONY: release-build release-publish
 release-build: .release-$(VERSION).created
 .release-$(VERSION).created:
 	$(MAKE) clean image-all RELEASE=true
@@ -180,7 +180,6 @@ release-build: .release-$(VERSION).created
 	$(MAKE) retag-build-images-with-registries IMAGETAG=latest RELEASE=true
 	touch $@
 
-# The registry decides the skip, so a fresh checkout answers like one that pushed.
 release-publish: release-prereqs bin/crane
 	@if $(REPO_ROOT)/hack/image-published $(CRANE_CMD) "$(DEV_REGISTRIES)" "$(BUILD_IMAGES)" "$(VERSION)"; then \
 		echo "$(BUILD_IMAGES):$(VERSION) is already published, skipping"; \

--- a/third_party/cni-plugins/Makefile
+++ b/third_party/cni-plugins/Makefile
@@ -181,7 +181,7 @@ release-build: .release-$(VERSION).created
 	touch $@
 
 release-publish: release-prereqs bin/crane
-	@if $(REPO_ROOT)/hack/image-published $(CRANE_CMD) "$(DEV_REGISTRIES)" "$(BUILD_IMAGES)" "$(VERSION)"; then \
+	@if $(REPO_ROOT)/hack/image-published $(CRANE_CMD) "$(DEV_REGISTRIES)" "$(BUILD_IMAGES)" "$(VERSION)" "$(VALIDARCHES)"; then \
 		echo "$(BUILD_IMAGES):$(VERSION) is already published, skipping"; \
 	else \
 		$(MAKE) push-images-to-registries push-manifests IMAGETAG=$(VERSION) RELEASE=$(RELEASE) CONFIRM=$(CONFIRM); \

--- a/third_party/envoy-gateway/Makefile
+++ b/third_party/envoy-gateway/Makefile
@@ -85,7 +85,7 @@ ci: image
 
 cd: image-all cd-common
 
-.PHONY: release-build
+.PHONY: release-build release-publish
 release-build: .release-$(VERSION).created
 .release-$(VERSION).created:
 	$(MAKE) clean image-all RELEASE=true
@@ -94,7 +94,6 @@ release-build: .release-$(VERSION).created
 	$(MAKE) retag-build-images-with-registries IMAGETAG=latest RELEASE=true
 	touch $@
 
-# The registry decides the skip, so a fresh checkout answers like one that pushed.
 release-publish: release-prereqs bin/crane
 	@if $(REPO_ROOT)/hack/image-published $(CRANE_CMD) "$(DEV_REGISTRIES)" "$(BUILD_IMAGES)" "$(VERSION)"; then \
 		echo "$(BUILD_IMAGES):$(VERSION) is already published, skipping"; \

--- a/third_party/envoy-gateway/Makefile
+++ b/third_party/envoy-gateway/Makefile
@@ -95,7 +95,7 @@ release-build: .release-$(VERSION).created
 	touch $@
 
 release-publish: release-prereqs bin/crane
-	@if $(REPO_ROOT)/hack/image-published $(CRANE_CMD) "$(DEV_REGISTRIES)" "$(BUILD_IMAGES)" "$(VERSION)"; then \
+	@if $(REPO_ROOT)/hack/image-published $(CRANE_CMD) "$(DEV_REGISTRIES)" "$(BUILD_IMAGES)" "$(VERSION)" "$(VALIDARCHES)"; then \
 		echo "$(BUILD_IMAGES):$(VERSION) is already published, skipping"; \
 	else \
 		$(MAKE) push-images-to-registries push-manifests IMAGETAG=$(VERSION) RELEASE=$(RELEASE) CONFIRM=$(CONFIRM); \

--- a/third_party/envoy-gateway/Makefile
+++ b/third_party/envoy-gateway/Makefile
@@ -94,7 +94,10 @@ release-build: .release-$(VERSION).created
 	$(MAKE) retag-build-images-with-registries IMAGETAG=latest RELEASE=true
 	touch $@
 
-release-publish: release-prereqs .release-$(VERSION).published
-.release-$(VERSION).published:
-	$(MAKE) push-images-to-registries push-manifests IMAGETAG=$(VERSION) RELEASE=$(RELEASE) CONFIRM=$(CONFIRM)
-	touch $@
+# The registry decides the skip, so a fresh checkout answers like one that pushed.
+release-publish: release-prereqs bin/crane
+	@if $(REPO_ROOT)/hack/image-published $(CRANE_CMD) "$(DEV_REGISTRIES)" "$(BUILD_IMAGES)" "$(VERSION)"; then \
+		echo "$(BUILD_IMAGES):$(VERSION) is already published, skipping"; \
+	else \
+		$(MAKE) push-images-to-registries push-manifests IMAGETAG=$(VERSION) RELEASE=$(RELEASE) CONFIRM=$(CONFIRM); \
+	fi

--- a/third_party/envoy-proxy/Makefile
+++ b/third_party/envoy-proxy/Makefile
@@ -70,7 +70,7 @@ release-build: .release-$(VERSION).created
 	touch $@
 
 release-publish: release-prereqs bin/crane
-	@if $(REPO_ROOT)/hack/image-published $(CRANE_CMD) "$(DEV_REGISTRIES)" "$(BUILD_IMAGES)" "$(VERSION)"; then \
+	@if $(REPO_ROOT)/hack/image-published $(CRANE_CMD) "$(DEV_REGISTRIES)" "$(BUILD_IMAGES)" "$(VERSION)" "$(VALIDARCHES)"; then \
 		echo "$(BUILD_IMAGES):$(VERSION) is already published, skipping"; \
 	else \
 		$(MAKE) push-images-to-registries push-manifests IMAGETAG=$(VERSION) RELEASE=$(RELEASE) CONFIRM=$(CONFIRM); \

--- a/third_party/envoy-proxy/Makefile
+++ b/third_party/envoy-proxy/Makefile
@@ -60,7 +60,7 @@ ci: image
 
 cd: image-all cd-common
 
-.PHONY: release-build
+.PHONY: release-build release-publish
 release-build: .release-$(VERSION).created
 .release-$(VERSION).created:
 	$(MAKE) clean image-all RELEASE=true
@@ -69,7 +69,6 @@ release-build: .release-$(VERSION).created
 	$(MAKE) retag-build-images-with-registries IMAGETAG=latest RELEASE=true
 	touch $@
 
-# The registry decides the skip, so a fresh checkout answers like one that pushed.
 release-publish: release-prereqs bin/crane
 	@if $(REPO_ROOT)/hack/image-published $(CRANE_CMD) "$(DEV_REGISTRIES)" "$(BUILD_IMAGES)" "$(VERSION)"; then \
 		echo "$(BUILD_IMAGES):$(VERSION) is already published, skipping"; \

--- a/third_party/envoy-proxy/Makefile
+++ b/third_party/envoy-proxy/Makefile
@@ -69,7 +69,10 @@ release-build: .release-$(VERSION).created
 	$(MAKE) retag-build-images-with-registries IMAGETAG=latest RELEASE=true
 	touch $@
 
-release-publish: release-prereqs .release-$(VERSION).published
-.release-$(VERSION).published:
-	$(MAKE) push-images-to-registries push-manifests IMAGETAG=$(VERSION) RELEASE=$(RELEASE) CONFIRM=$(CONFIRM)
-	touch $@
+# The registry decides the skip, so a fresh checkout answers like one that pushed.
+release-publish: release-prereqs bin/crane
+	@if $(REPO_ROOT)/hack/image-published $(CRANE_CMD) "$(DEV_REGISTRIES)" "$(BUILD_IMAGES)" "$(VERSION)"; then \
+		echo "$(BUILD_IMAGES):$(VERSION) is already published, skipping"; \
+	else \
+		$(MAKE) push-images-to-registries push-manifests IMAGETAG=$(VERSION) RELEASE=$(RELEASE) CONFIRM=$(CONFIRM); \
+	fi

--- a/third_party/envoy-ratelimit/Makefile
+++ b/third_party/envoy-ratelimit/Makefile
@@ -77,7 +77,7 @@ ci: image
 
 cd: image-all cd-common
 
-.PHONY: release-build
+.PHONY: release-build release-publish
 release-build: .release-$(VERSION).created
 .release-$(VERSION).created:
 	$(MAKE) clean image-all RELEASE=true
@@ -86,7 +86,6 @@ release-build: .release-$(VERSION).created
 	$(MAKE) retag-build-images-with-registries IMAGETAG=latest RELEASE=true
 	touch $@
 
-# The registry decides the skip, so a fresh checkout answers like one that pushed.
 release-publish: release-prereqs bin/crane
 	@if $(REPO_ROOT)/hack/image-published $(CRANE_CMD) "$(DEV_REGISTRIES)" "$(BUILD_IMAGES)" "$(VERSION)"; then \
 		echo "$(BUILD_IMAGES):$(VERSION) is already published, skipping"; \

--- a/third_party/envoy-ratelimit/Makefile
+++ b/third_party/envoy-ratelimit/Makefile
@@ -87,7 +87,7 @@ release-build: .release-$(VERSION).created
 	touch $@
 
 release-publish: release-prereqs bin/crane
-	@if $(REPO_ROOT)/hack/image-published $(CRANE_CMD) "$(DEV_REGISTRIES)" "$(BUILD_IMAGES)" "$(VERSION)"; then \
+	@if $(REPO_ROOT)/hack/image-published $(CRANE_CMD) "$(DEV_REGISTRIES)" "$(BUILD_IMAGES)" "$(VERSION)" "$(VALIDARCHES)"; then \
 		echo "$(BUILD_IMAGES):$(VERSION) is already published, skipping"; \
 	else \
 		$(MAKE) push-images-to-registries push-manifests IMAGETAG=$(VERSION) RELEASE=$(RELEASE) CONFIRM=$(CONFIRM); \

--- a/third_party/envoy-ratelimit/Makefile
+++ b/third_party/envoy-ratelimit/Makefile
@@ -86,7 +86,10 @@ release-build: .release-$(VERSION).created
 	$(MAKE) retag-build-images-with-registries IMAGETAG=latest RELEASE=true
 	touch $@
 
-release-publish: release-prereqs .release-$(VERSION).published
-.release-$(VERSION).published:
-	$(MAKE) push-images-to-registries push-manifests IMAGETAG=$(VERSION) RELEASE=$(RELEASE) CONFIRM=$(CONFIRM)
-	touch $@
+# The registry decides the skip, so a fresh checkout answers like one that pushed.
+release-publish: release-prereqs bin/crane
+	@if $(REPO_ROOT)/hack/image-published $(CRANE_CMD) "$(DEV_REGISTRIES)" "$(BUILD_IMAGES)" "$(VERSION)"; then \
+		echo "$(BUILD_IMAGES):$(VERSION) is already published, skipping"; \
+	else \
+		$(MAKE) push-images-to-registries push-manifests IMAGETAG=$(VERSION) RELEASE=$(RELEASE) CONFIRM=$(CONFIRM); \
+	fi

--- a/whisker/Makefile
+++ b/whisker/Makefile
@@ -82,7 +82,10 @@ release-build: .release-$(VERSION).created
 	$(MAKE) retag-build-images-with-registries RELEASE=true IMAGETAG=latest
 	touch $@
 
-release-publish: release-prereqs .release-$(VERSION).published
-.release-$(VERSION).published:
-	$(MAKE) push-images-to-registries push-manifests IMAGETAG=$(VERSION) RELEASE=$(RELEASE) CONFIRM=$(CONFIRM)
-	touch $@
+# The registry decides the skip, so a fresh checkout answers like one that pushed.
+release-publish: release-prereqs bin/crane
+	@if $(REPO_ROOT)/hack/image-published $(CRANE_CMD) "$(DEV_REGISTRIES)" "$(BUILD_IMAGES)" "$(VERSION)"; then \
+		echo "$(BUILD_IMAGES):$(VERSION) is already published, skipping"; \
+	else \
+		$(MAKE) push-images-to-registries push-manifests IMAGETAG=$(VERSION) RELEASE=$(RELEASE) CONFIRM=$(CONFIRM); \
+	fi

--- a/whisker/Makefile
+++ b/whisker/Makefile
@@ -82,7 +82,7 @@ release-build: .release-$(VERSION).created
 	$(MAKE) retag-build-images-with-registries RELEASE=true IMAGETAG=latest
 	touch $@
 
-# The registry decides the skip, so a fresh checkout answers like one that pushed.
+.PHONY: release-publish
 release-publish: release-prereqs bin/crane
 	@if $(REPO_ROOT)/hack/image-published $(CRANE_CMD) "$(DEV_REGISTRIES)" "$(BUILD_IMAGES)" "$(VERSION)"; then \
 		echo "$(BUILD_IMAGES):$(VERSION) is already published, skipping"; \

--- a/whisker/Makefile
+++ b/whisker/Makefile
@@ -84,7 +84,7 @@ release-build: .release-$(VERSION).created
 
 .PHONY: release-publish
 release-publish: release-prereqs bin/crane
-	@if $(REPO_ROOT)/hack/image-published $(CRANE_CMD) "$(DEV_REGISTRIES)" "$(BUILD_IMAGES)" "$(VERSION)"; then \
+	@if $(REPO_ROOT)/hack/image-published $(CRANE_CMD) "$(DEV_REGISTRIES)" "$(BUILD_IMAGES)" "$(VERSION)" "$(VALIDARCHES)"; then \
 		echo "$(BUILD_IMAGES):$(VERSION) is already published, skipping"; \
 	else \
 		$(MAKE) push-images-to-registries push-manifests IMAGETAG=$(VERSION) RELEASE=$(RELEASE) CONFIRM=$(CONFIRM); \


### PR DESCRIPTION
Re-running a publish is now safe: each component asks the registry whether its images are already there, so a resumed or repeated release skips only what actually landed and a fresh clone reaches the same answer as the machine that pushed. A lookup that keeps failing publishes rather than skipping, since republishing is wasteful but a wrong skip ships nothing. This replaces per-checkout stamp files, which recorded that a step ran rather than that images arrived — a dry run could leave one behind and silence the real publish that followed.

`bin/crane` also installs reliably now. A failed extract used to leave a partial binary at the final path, which make then treated as up to date forever after; the download stages in a temp dir and moves into place only on success. Note this cannot repair a binary that is already broken, so anyone currently stuck needs `rm bin/crane` once.

The `find -name '.*.published*' -delete` clean rules are left in place as dead code, so the diff stays on the targets that changed.

**Release note:**
```release-note
None
```

**AI assistance:** Claude Code — investigation, implementation, and testing.
