### PR TITLE
Give release-v3.33 its own ArgoCI cron slots

### DIFF
--- a/.argoci/cron/e2e-benchmarking.yaml
+++ b/.argoci/cron/e2e-benchmarking.yaml
@@ -2,7 +2,7 @@
 # Migrated from the Semaphore e2e pipeline of the same name — maintained here by hand.
 version: condensed
 generateName: e2e-benchmarking-
-schedule: 0 21 * * 0
+schedule: 0 23 * * 0
 globalPrologue: |
   cd "${CI_HOME}/${CI_GIT_DIR}"
   export ARGO_WORKFLOW_NAME="{{workflow.name}}"

--- a/.argoci/cron/e2e-bpf.yaml
+++ b/.argoci/cron/e2e-bpf.yaml
@@ -2,7 +2,7 @@
 # Migrated from the Semaphore e2e pipeline of the same name — maintained here by hand.
 version: condensed
 generateName: e2e-bpf-
-schedule: 10 21 * * 2
+schedule: 10 23 * * 2
 globalPrologue: |
   cd "${CI_HOME}/${CI_GIT_DIR}"
   export ARGO_WORKFLOW_NAME="{{workflow.name}}"

--- a/.argoci/cron/e2e-certification.yaml
+++ b/.argoci/cron/e2e-certification.yaml
@@ -2,7 +2,7 @@
 # Migrated from the Semaphore e2e pipeline of the same name — maintained here by hand.
 version: condensed
 generateName: e2e-certification-
-schedule: 10 21 * * 1
+schedule: 0 0 31 2 *
 globalPrologue: |
   cd "${CI_HOME}/${CI_GIT_DIR}"
   export ARGO_WORKFLOW_NAME="{{workflow.name}}"

--- a/.argoci/cron/e2e-iptables.yaml
+++ b/.argoci/cron/e2e-iptables.yaml
@@ -2,7 +2,7 @@
 # Migrated from the Semaphore e2e pipeline of the same name — maintained here by hand.
 version: condensed
 generateName: e2e-iptables-
-schedule: 10 21 * * 4
+schedule: 10 23 * * 4
 globalPrologue: |
   cd "${CI_HOME}/${CI_GIT_DIR}"
   export ARGO_WORKFLOW_NAME="{{workflow.name}}"

--- a/.argoci/cron/e2e-nftables.yaml
+++ b/.argoci/cron/e2e-nftables.yaml
@@ -2,7 +2,7 @@
 # Migrated from the Semaphore e2e pipeline of the same name — maintained here by hand.
 version: condensed
 generateName: e2e-nftables-
-schedule: 10 21 * * 1
+schedule: 10 23 * * 1
 globalPrologue: |
   cd "${CI_HOME}/${CI_GIT_DIR}"
   export ARGO_WORKFLOW_NAME="{{workflow.name}}"

--- a/.argoci/cron/e2e-openstack.yaml
+++ b/.argoci/cron/e2e-openstack.yaml
@@ -18,9 +18,11 @@
 # is a strict subset of full-fv, so adds nothing on a weekly cadence.
 version: condensed
 generateName: e2e-openstack-
-# Sundays 17:00 UTC (the handler emits no CronWorkflow timezone, so cron
-# fields are UTC).
-schedule: 0 17 * * 0
+# Feb 31 never fires.  Without the overrides noted above this would install
+# master packages and images, so it would report this branch's name while
+# testing master.  Un-park it once v3.33.0 ships the calico-3.33 PPA and the
+# matching images, adding those overrides at the same time.
+schedule: 0 0 31 2 *
 globalPrologue: |
   cd "${CI_HOME}/${CI_GIT_DIR}"
   export ARGO_WORKFLOW_NAME="{{workflow.name}}"

--- a/.argoci/cron/e2e-patch-verification.yaml
+++ b/.argoci/cron/e2e-patch-verification.yaml
@@ -2,7 +2,7 @@
 # Migrated from the Semaphore e2e pipeline of the same name — maintained here by hand.
 version: condensed
 generateName: e2e-patch-verification-
-schedule: 10 21 * * 3
+schedule: 10 23 * * 3
 globalPrologue: |
   cd "${CI_HOME}/${CI_GIT_DIR}"
   export ARGO_WORKFLOW_NAME="{{workflow.name}}"

--- a/.argoci/cron/e2e-upgrade.yaml
+++ b/.argoci/cron/e2e-upgrade.yaml
@@ -2,7 +2,7 @@
 # Migrated from the Semaphore e2e pipeline of the same name — maintained here by hand.
 version: condensed
 generateName: e2e-upgrade-
-schedule: 10 21 * * 3
+schedule: 10 23 * * 3
 globalPrologue: |
   cd "${CI_HOME}/${CI_GIT_DIR}"
   export ARGO_WORKFLOW_NAME="{{workflow.name}}"

--- a/.argoci/cron/e2e-vpp.yaml
+++ b/.argoci/cron/e2e-vpp.yaml
@@ -2,7 +2,10 @@
 # Migrated from the Semaphore e2e pipeline of the same name — maintained here by hand.
 version: condensed
 generateName: e2e-vpp-
-schedule: 0 16 * * 1,3,5
+# Feb 31 never fires: VPP is not covered on this release branch.  The steps
+# below still pin master and a v3.28 regression matrix, so they would not be
+# testing this branch anyway.  Manual runs stay available via /argoci cron.
+schedule: 0 0 31 2 *
 globalPrologue: |
   cd "${CI_HOME}/${CI_GIT_DIR}"
   export ARGO_WORKFLOW_NAME="{{workflow.name}}"

--- a/.argoci/cron/e2e-windows.yaml
+++ b/.argoci/cron/e2e-windows.yaml
@@ -2,7 +2,7 @@
 # Migrated from the Semaphore e2e pipeline of the same name — maintained here by hand.
 version: condensed
 generateName: e2e-windows-
-schedule: 10 21 * * 5
+schedule: 10 23 * * 5
 globalPrologue: |
   cd "${CI_HOME}/${CI_GIT_DIR}"
   export ARGO_WORKFLOW_NAME="{{workflow.name}}"


### PR DESCRIPTION
When `release-v3.33` was cut it inherited master's `.argoci/cron/*.yaml` verbatim, so every e2e cron on this branch is scheduled in master's slot. Only one of them is actually deployed today — `e2e-iptables-release-v3-33`, which landed by accident because an unrelated PR happened to touch that file — and it has been running head-to-head with `e2e-iptables-master` at Thu 21:10 UTC since 2026-08-20.

This moves the recurring crons onto the 23:xx band already used by `release-v3.31`, which clears master (21:xx) and `release-v3.32` (19:xx). They overlap `release-v3.31` until those runs are retired, which is expected and short-lived.

| cron | was | now |
| --- | --- | --- |
| benchmarking | `0 21 * * 0` | `0 23 * * 0` |
| nftables | `10 21 * * 1` | `10 23 * * 1` |
| bpf | `10 21 * * 2` | `10 23 * * 2` |
| patch-verification | `10 21 * * 3` | `10 23 * * 3` |
| upgrade | `10 21 * * 3` | `10 23 * * 3` |
| iptables | `10 21 * * 4` | `10 23 * * 4` |
| windows | `10 21 * * 5` | `10 23 * * 5` |
| certification | `10 21 * * 1` | `0 0 31 2 *` (parked) |
| openstack | `0 17 * * 0` | `0 0 31 2 *` (parked) |
| vpp | `0 16 * * 1,3,5` | `0 0 31 2 *` (parked) |

`e2e-test.yaml` already carried `0 0 31 2 *` and is unchanged.

Certification is parked to match `release-v3.31` and `release-v3.32`.

openstack and vpp are parked because neither can test this branch yet. The packaged installer defaults to `ppa:project-calico/master` and `calico/{ctl,node}:master`, and neither cron overrides them, so on a release branch they would report this branch's name while testing master. The `calico-3.33` PPA does not exist yet either — it is created at the first release from the branch per `release/RELEASING.md` — so there is nothing branch-specific to install. Both should be un-parked once v3.33.0 ships that PPA and the matching images, adding the `INSTALL_SOURCE` / `CALICOCTL_IMAGE` / `CALICO_NODE_IMAGE` overrides at the same time. vpp additionally still pins `RELEASE_STREAM: master` and a v3.28 regression matrix.

**Testing done:** no functional change beyond `schedule:` values; all 11 cron files confirmed to still parse as YAML, and the seven rescheduled files now carry schedules byte-identical to their `release-v3.31` counterparts.

**Note for whoever merges:** the handler only applies cron files that the merged PR changed, so this deploys 10 of the 11 — `e2e-test.yaml` is unchanged and will not get a CronWorkflow. An empty commit with `[update-cron-workflows]` pushed to `release-v3.33` after merge redeploys all 11 at the branch head and is the safer finish.

**Release note:**
```release-note
NONE
```
