### PR TITLE
[v3.33] CORE-13379: Don't sort Felix's live route-table ranges in place

### DIFF
--- a/felix/config/config_params.go
+++ b/felix/config/config_params.go
@@ -1312,7 +1312,8 @@ func (config *Config) RouteTableIndices() []idalloc.IndexRange {
 	} else if config.RouteTableRange != (idalloc.IndexRange{}) {
 		log.Warn("Both `RouteTableRanges` and deprecated `RouteTableRange` options are set. `RouteTableRanges` value will be given precedence.")
 	}
-	return config.RouteTableRanges
+	// Clone so that callers cannot mutate our copy of the config.
+	return slices.Clone(config.RouteTableRanges)
 }
 
 func (config *Config) GetBPFAttachType() v3.BPFAttachOption {

--- a/felix/config/config_params_test.go
+++ b/felix/config/config_params_test.go
@@ -30,6 +30,7 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"github.com/projectcalico/calico/felix/config"
+	"github.com/projectcalico/calico/felix/idalloc"
 	"github.com/projectcalico/calico/felix/testutils"
 	"github.com/projectcalico/calico/libcalico-go/lib/apiconfig"
 	"github.com/projectcalico/calico/libcalico-go/lib/set"
@@ -808,6 +809,28 @@ var _ = DescribeTable("Config validation",
 		"RouteTableRanges": "abcde",
 	}, false),
 )
+
+var _ = Describe("Config RouteTableRanges", func() {
+	// The dataplane driver hands RouteTableIndices() to NewIndexAllocator, which
+	// sorts the ranges it is given.  If that reordered Felix's own copy of the
+	// config, the next config update would re-parse the raw value in its original
+	// order, see a change, and restart Felix - over and over.
+	const rawRanges = "1-250,1000-1500"
+
+	It("should survive the route-table index allocator without looking changed", func() {
+		conf := config.New()
+		changed, err := conf.UpdateFrom(map[string]string{"RouteTableRanges": rawRanges}, config.DatastoreGlobal)
+		Expect(err).To(Succeed())
+		Expect(changed).To(BeTrue())
+
+		idalloc.NewIndexAllocator(conf.RouteTableIndices(), []idalloc.IndexRange{{Min: 253, Max: 255}})
+
+		changed, err = conf.UpdateFrom(map[string]string{"RouteTableRanges": rawRanges}, config.DatastoreGlobal)
+		Expect(err).To(Succeed())
+		Expect(changed).To(BeFalse(),
+			"re-applying identical config reported a change, which would make Felix restart in a loop")
+	})
+})
 
 var _ = DescribeTable("Config InterfaceExclude",
 	func(excludeList string, expected []*regexp.Regexp) {

--- a/felix/idalloc/index_allocator.go
+++ b/felix/idalloc/index_allocator.go
@@ -15,8 +15,9 @@
 package idalloc
 
 import (
+	"cmp"
 	"errors"
-	"sort"
+	"slices"
 
 	"github.com/projectcalico/calico/libcalico-go/lib/set"
 )
@@ -29,19 +30,6 @@ func (r IndexRange) contains(a int) bool {
 	return r.Min <= a && r.Max >= a
 }
 
-// ByMaxIndex sorts collections of IndexRange structs in order of their starting/lower index
-type ByMaxIndex []IndexRange
-
-// Len is the number of indexranges in the collection
-func (i ByMaxIndex) Len() int { return len(i) }
-
-// Less reports whether the element with index a
-// must sort before the element with index b.
-func (i ByMaxIndex) Less(a, b int) bool { return i[a].Max < i[b].Max }
-
-// Swap swaps the elements with indexes a and b.
-func (i ByMaxIndex) Swap(a, b int) { i[a], i[b] = i[b], i[a] }
-
 type IndexAllocator struct {
 	indexStack *stack
 	exclusions []IndexRange
@@ -50,10 +38,11 @@ type IndexAllocator struct {
 // NewIndexAllocator returns an index allocator from the provided indexRanges
 // any indices falling within the specified exclusions will not be returned, even if designated by indexRanges
 func NewIndexAllocator(indexRanges []IndexRange, exclusions []IndexRange) *IndexAllocator {
-	// sort index ranges in descending order of their Max bound
-	if len(indexRanges) > 1 {
-		sort.Sort(sort.Reverse(ByMaxIndex(indexRanges)))
-	}
+	// Sort in descending order of Max bound.  Using Sorted... (not Sort...) to
+	// avoid mutating caller's slice.
+	indexRanges = slices.SortedFunc(slices.Values(indexRanges), func(a, b IndexRange) int {
+		return cmp.Compare(b.Max, a.Max)
+	})
 
 	r := &IndexAllocator{
 		indexStack: &stack{},

--- a/felix/idalloc/index_allocator_test.go
+++ b/felix/idalloc/index_allocator_test.go
@@ -105,5 +105,11 @@ var _ = Describe("IndexAllocator", func() {
 			_, err = r.GrabIndex()
 			Expect(err).To(HaveOccurred())
 		})
+
+		It("should not reorder the caller's slice", func() {
+			ranges := []IndexRange{{Min: 1, Max: 250}, {Min: 1000, Max: 1500}}
+			NewIndexAllocator(ranges, nil)
+			Expect(ranges).To(Equal([]IndexRange{{Min: 1, Max: 250}, {Min: 1000, Max: 1500}}))
+		})
 	})
 })


### PR DESCRIPTION
**Cherry-pick history**
- Pick onto **release-v3.33**: projectcalico/calico#13582

Bug fix.

`idalloc.NewIndexAllocator` sorted the slice it was given, and its only production
caller passes `Config.RouteTableIndices()`, which returned the `Config`'s own
`RouteTableRanges` slice. Felix therefore reordered its live config at dataplane
startup.

Config change detection re-parses the raw values and compares them with
`reflect.DeepEqual`, and `Config.Copy()` is a shallow copy, so the reordered slice
compared unequal to a fresh parse of the same raw string. Felix read that as the
user changing `RouteTableRanges` — which is not in `handledConfigChanges` — and
restarted. The new process did the same thing, giving a restart loop with no config
change at all.

This only bites when `routeTableRanges` holds two or more ranges written in any
order other than descending by max, e.g. `1-250,1000-1500`.

Fix: sort a copy in `NewIndexAllocator`, and clone in `RouteTableIndices()` so no
future caller can corrupt the live config either. Dropping the in-place sort makes
the exported `ByMaxIndex` `sort.Interface` dead code, so it goes away.

**Testing:** two new unit tests — one asserting `NewIndexAllocator` leaves the
caller's slice alone, and one at the level the bug actually bit: apply
`RouteTableRanges: "1-250,1000-1500"`, run it through the allocator, re-apply the
identical raw values, and assert no change is reported. Both fail without the fix
(the second on its "would make Felix restart in a loop" assertion) and pass with it.

**Release note:**
```release-note
Fixed a bug where setting multiple routeTableRanges could cause Felix to restart repeatedly.
```

<details>
<summary><b>Automated Cherry-Pick PR details</b></summary>

- **Original PR ID**: 13582
- **Original Commit SHA**: 0c084bca57
- **Source Repo**: `projectcalico/calico`
- **Target Repo**: `projectcalico/calico`
- **Target Branch**: `release-v3.33`
</details>
