### PR TITLE
e2e: Wait for tiered RBAC grants to take effect in the e2e setup hooks

### DIFF
--- a/e2e/pkg/tests/policy/tiered_rbac.go
+++ b/e2e/pkg/tests/policy/tiered_rbac.go
@@ -25,6 +25,7 @@ import (
 	. "github.com/onsi/gomega"
 	v3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
 	"github.com/sirupsen/logrus"
+	authorizationv1 "k8s.io/api/authorization/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -183,6 +184,9 @@ var _ = describe.CalicoDescribe(
 				_, err := f.ClientSet.RbacV1().RoleBindings(f.Namespace.Name).Create(ctx, &setup.nsBindings[i], metav1.CreateOptions{})
 				Expect(err).NotTo(HaveOccurred(), "failed to create RoleBinding %s", setup.nsBindings[i].Name)
 			}
+
+			By("Waiting for the RBAC grants to take effect")
+			waitForTieredRBAC(ctx, f.ClientSet, setup)
 		})
 
 		Context("NetworkPolicy", func() {
@@ -1221,6 +1225,96 @@ func buildTieredRBACResources(testTier, otherTier, suffix, namespace string, exp
 	return setup
 }
 
+// waitForTieredRBAC blocks until the API server's authorizer honours every
+// binding in setup.
+func waitForTieredRBAC(ctx context.Context, cs kubernetes.Interface, setup tieredRBACSetup) {
+	probes := tieredRBACProbes(setup)
+	Eventually(func() error {
+		return checkTieredRBACProbes(ctx, cs, probes)
+	}, 30*time.Second, 250*time.Millisecond).Should(Succeed(), "tiered RBAC grants did not take effect")
+}
+
+// tieredRBACProbes returns one SubjectAccessReview per binding subject in
+// setup, each asking for a rule of the bound role. Specs run in parallel and
+// all impersonate the same fixed user names, so another process may already
+// hold a binding for the same user with the same base rules; only the per-spec
+// tier names in ResourceNames prove that this spec's own role and binding have
+// reached the authorizer. A role with no named rule falls back to its first
+// rule.
+func tieredRBACProbes(setup tieredRBACSetup) []*authorizationv1.SubjectAccessReview {
+	rules := make(map[rbacv1.RoleRef][]rbacv1.PolicyRule, len(setup.roles)+len(setup.nsRoles))
+	for _, r := range setup.roles {
+		rules[rbacv1.RoleRef{APIGroup: rbacv1.GroupName, Kind: "ClusterRole", Name: r.Name}] = r.Rules
+	}
+	for _, r := range setup.nsRoles {
+		rules[rbacv1.RoleRef{APIGroup: rbacv1.GroupName, Kind: "Role", Name: r.Name}] = r.Rules
+	}
+
+	var probes []*authorizationv1.SubjectAccessReview
+	for _, b := range setup.bindings {
+		for _, s := range b.Subjects {
+			if p := tieredRBACProbe(s, "", rules[b.RoleRef]); p != nil {
+				probes = append(probes, p)
+			}
+		}
+	}
+	for _, b := range setup.nsBindings {
+		for _, s := range b.Subjects {
+			if p := tieredRBACProbe(s, b.Namespace, rules[b.RoleRef]); p != nil {
+				probes = append(probes, p)
+			}
+		}
+	}
+	return probes
+}
+
+// tieredRBACProbe builds a SubjectAccessReview asking whether subject may
+// exercise one of rules. It returns nil when there is nothing to ask.
+func tieredRBACProbe(subject rbacv1.Subject, namespace string, rules []rbacv1.PolicyRule) *authorizationv1.SubjectAccessReview {
+	if len(rules) == 0 {
+		return nil
+	}
+	rule := rules[0]
+	for _, r := range rules {
+		if len(r.ResourceNames) > 0 {
+			rule = r
+			break
+		}
+	}
+	attrs := &authorizationv1.ResourceAttributes{
+		Namespace: namespace,
+		Verb:      rule.Verbs[0],
+		Group:     rule.APIGroups[0],
+		Resource:  rule.Resources[0],
+	}
+	if len(rule.ResourceNames) > 0 {
+		attrs.Name = rule.ResourceNames[0]
+	}
+	return &authorizationv1.SubjectAccessReview{
+		Spec: authorizationv1.SubjectAccessReviewSpec{
+			ResourceAttributes: attrs,
+			User:               subject.Name,
+		},
+	}
+}
+
+// checkTieredRBACProbes returns an error with the first probe the authorizer still denies,
+// or nil once every probe is allowed.
+func checkTieredRBACProbes(ctx context.Context, cs kubernetes.Interface, probes []*authorizationv1.SubjectAccessReview) error {
+	for _, p := range probes {
+		res, err := cs.AuthorizationV1().SubjectAccessReviews().Create(ctx, p, metav1.CreateOptions{})
+		if err != nil {
+			return err
+		}
+		if !res.Status.Allowed {
+			a := p.Spec.ResourceAttributes
+			return fmt.Errorf("user %s may not yet %s %s %q in namespace %q: %s",
+				p.Spec.User, a.Verb, a.Resource, a.Name, a.Namespace, res.Status.Reason)
+		}
+	}
+	return nil
+}
+
 // hasTieredPolicyWebhook reports whether the tiered policy admission webhook is installed. A
 // manifest install in v3 CRD mode ships it alongside the passthrough ClusterRole.
 func hasTieredPolicyWebhook(ctx context.Context, cs kubernetes.Interface) bool {
@@ -1297,6 +1391,9 @@ var _ = describe.CalicoDescribe(
 
 			By("Creating RBAC resources for test users")
 			setup := buildTieredRBACResources(testTier, otherTier, suffix, f.Namespace.Name, expectPassthrough)
+			// This suite grants only the cluster-scoped roles, so the namespaced
+			// grants must not be created or waited for.
+			setup.nsRoles, setup.nsBindings = nil, nil
 			for i := range setup.roles {
 				_, err := f.ClientSet.RbacV1().ClusterRoles().Create(ctx, &setup.roles[i], metav1.CreateOptions{})
 				Expect(err).NotTo(HaveOccurred())
@@ -1305,6 +1402,9 @@ var _ = describe.CalicoDescribe(
 				_, err := f.ClientSet.RbacV1().ClusterRoleBindings().Create(ctx, &setup.bindings[i], metav1.CreateOptions{})
 				Expect(err).NotTo(HaveOccurred())
 			}
+
+			By("Waiting for the RBAC grants to take effect")
+			waitForTieredRBAC(ctx, f.ClientSet, setup)
 		})
 
 		AfterEach(func() {

--- a/e2e/pkg/tests/policy/tiered_rbac_test.go
+++ b/e2e/pkg/tests/policy/tiered_rbac_test.go
@@ -1,0 +1,191 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package policy
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	authorizationv1 "k8s.io/api/authorization/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+const (
+	probeSuffix    = "rbac-abcde"
+	probeTestTier  = "e2e-rbac-test-" + probeSuffix
+	probeOtherTier = "e2e-rbac-other-" + probeSuffix
+	probeNamespace = "tiered-rbac-1234"
+)
+
+// Every subject of every binding the suite creates gets a probe, and wherever
+// the bound role carries a per-spec name the probe asks for it, so a parallel
+// spec's grant to the same user cannot satisfy the wait.
+func TestTieredRBACProbesCoverEveryBinding(t *testing.T) {
+	g := NewWithT(t)
+
+	setup := buildTieredRBACResources(probeTestTier, probeOtherTier, probeSuffix, probeNamespace, true)
+	probes := tieredRBACProbes(setup)
+
+	var wantProbes int
+	for _, b := range setup.bindings {
+		wantProbes += len(b.Subjects)
+	}
+	for _, b := range setup.nsBindings {
+		wantProbes += len(b.Subjects)
+	}
+	g.Expect(probes).To(HaveLen(wantProbes))
+
+	var namespaced []*authorizationv1.SubjectAccessReview
+	for _, p := range probes {
+		attrs := p.Spec.ResourceAttributes
+		g.Expect(p.Spec.User).NotTo(BeEmpty())
+		g.Expect(attrs.Group).To(Equal("projectcalico.org"))
+		g.Expect(attrs.Verb).NotTo(BeEmpty())
+		g.Expect(attrs.Resource).NotTo(BeEmpty())
+
+		// The watch-no-tier role has no name-scoped rule to prefer.
+		if p.Spec.User == rbacWatchNoTierUser {
+			g.Expect(attrs.Name).To(BeEmpty())
+		} else {
+			g.Expect(attrs.Name).To(ContainSubstring(probeSuffix), "probe for %s should ask for a per-spec name", p.Spec.User)
+		}
+
+		if attrs.Namespace != "" {
+			namespaced = append(namespaced, p)
+		}
+	}
+
+	g.Expect(namespaced).To(HaveLen(1))
+	g.Expect(namespaced[0].Spec.User).To(Equal(rbacNamespacedUser))
+	g.Expect(namespaced[0].Spec.ResourceAttributes.Namespace).To(Equal(probeNamespace))
+	g.Expect(namespaced[0].Spec.ResourceAttributes.Resource).To(Equal("tier.networkpolicies"))
+	g.Expect(namespaced[0].Spec.ResourceAttributes.Name).To(Equal(probeTestTier + ".*"))
+}
+
+func TestTieredRBACProbePrefersNamedRule(t *testing.T) {
+	unnamed := rbacv1.PolicyRule{
+		APIGroups: []string{"projectcalico.org"},
+		Resources: []string{"networkpolicies"},
+		Verbs:     []string{"get", "list"},
+	}
+	named := rbacv1.PolicyRule{
+		APIGroups:     []string{"projectcalico.org"},
+		Resources:     []string{"tiers"},
+		Verbs:         []string{"get"},
+		ResourceNames: []string{probeTestTier},
+	}
+	subject := rbacv1.Subject{Kind: "User", Name: rbacTierAdminUser}
+
+	tests := []struct {
+		name      string
+		giveRules []rbacv1.PolicyRule
+		wantAttrs *authorizationv1.ResourceAttributes
+	}{
+		{
+			name:      "named rule wins over an earlier unnamed one",
+			giveRules: []rbacv1.PolicyRule{unnamed, named},
+			wantAttrs: &authorizationv1.ResourceAttributes{
+				Namespace: probeNamespace,
+				Verb:      "get",
+				Group:     "projectcalico.org",
+				Resource:  "tiers",
+				Name:      probeTestTier,
+			},
+		},
+		{
+			name:      "first rule when none is named",
+			giveRules: []rbacv1.PolicyRule{unnamed},
+			wantAttrs: &authorizationv1.ResourceAttributes{
+				Namespace: probeNamespace,
+				Verb:      "get",
+				Group:     "projectcalico.org",
+				Resource:  "networkpolicies",
+			},
+		},
+		{
+			name: "no rules, no probe",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			got := tieredRBACProbe(subject, probeNamespace, tt.giveRules)
+			if tt.wantAttrs == nil {
+				g.Expect(got).To(BeNil())
+				return
+			}
+			g.Expect(got).NotTo(BeNil())
+			g.Expect(got.Spec.User).To(Equal(rbacTierAdminUser))
+			g.Expect(got.Spec.ResourceAttributes).To(Equal(tt.wantAttrs))
+		})
+	}
+}
+
+func TestCheckTieredRBACProbesReportsFirstDenial(t *testing.T) {
+	g := NewWithT(t)
+
+	allowed := map[string]bool{}
+	cs := fake.NewClientset()
+	cs.PrependReactor("create", "subjectaccessreviews", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		create, ok := action.(k8stesting.CreateAction)
+		if !ok {
+			return true, nil, errors.New("not a create action")
+		}
+		sar, ok := create.GetObject().(*authorizationv1.SubjectAccessReview)
+		if !ok {
+			return true, nil, errors.New("not a SubjectAccessReview")
+		}
+		out := sar.DeepCopy()
+		out.Status.Allowed = allowed[sar.Spec.User]
+		if !out.Status.Allowed {
+			out.Status.Reason = "binding not yet observed"
+		}
+		return true, out, nil
+	})
+
+	probes := tieredRBACProbes(buildTieredRBACResources(probeTestTier, probeOtherTier, probeSuffix, probeNamespace, true))
+	g.Expect(probes).NotTo(BeEmpty())
+
+	err := checkTieredRBACProbes(context.Background(), cs, probes)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring(probes[0].Spec.User))
+	g.Expect(err.Error()).To(ContainSubstring("binding not yet observed"))
+
+	for _, p := range probes {
+		allowed[p.Spec.User] = true
+	}
+	g.Expect(checkTieredRBACProbes(context.Background(), cs, probes)).To(Succeed())
+}
+
+func TestCheckTieredRBACProbesReturnsAPIErrors(t *testing.T) {
+	g := NewWithT(t)
+
+	cs := fake.NewClientset()
+	cs.PrependReactor("create", "subjectaccessreviews", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New("apiserver unavailable")
+	})
+
+	probes := tieredRBACProbes(buildTieredRBACResources(probeTestTier, probeOtherTier, probeSuffix, probeNamespace, true))
+	err := checkTieredRBACProbes(context.Background(), cs, probes)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("apiserver unavailable"))
+}


### PR DESCRIPTION
The tiered RBAC suites create ClusterRoles, ClusterRoleBindings and a Role for their test users and then impersonate those users straight away. The API server's authorizer only sees new RBAC objects once its informers catch up, so the first request occasionally came back 403 ("user cannot get tier").

Poll a SubjectAccessReview per binding until the authorizer allows it. The probe prefers rules scoped by ResourceNames, which carry the per-spec tier names, because specs run in parallel with the same user, so we need to wait on rules specific to the test.

<!-- For any user-visible change, replace TBD with a one-line description. -->
**Release note:**
```release-note
TBD
```

<!-- Replace TBD: say what AI tools helped write this change, or "None". -->
**AI assistance:** Claude Fable
