### PR TITLE
Add response compression to lib/httpmachinery

### DIFF
--- a/cmd/deps.txt
+++ b/cmd/deps.txt
@@ -102,7 +102,7 @@ github.com/json-iterator/go v1.1.12
 github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0
 github.com/kelseyhightower/envconfig v1.4.0
 github.com/kelseyhightower/memkv v0.1.1
-github.com/klauspost/compress v1.19.0
+github.com/klauspost/compress v1.20.0
 github.com/klauspost/cpuid/v2 v2.2.10
 github.com/kylelemons/godebug v1.1.0
 github.com/leodido/go-urn v1.4.0

--- a/cni-plugin/deps.txt
+++ b/cni-plugin/deps.txt
@@ -52,7 +52,7 @@ github.com/jinzhu/copier v0.4.0
 github.com/json-iterator/go v1.1.12
 github.com/juju/errors v1.0.0
 github.com/kelseyhightower/envconfig v1.4.0
-github.com/klauspost/compress v1.19.0
+github.com/klauspost/compress v1.20.0
 github.com/leodido/go-urn v1.4.0
 github.com/mcuadros/go-version v0.0.0-20190830083331-035f6764e8d2
 github.com/mdlayher/netlink v1.11.2

--- a/go.mod
+++ b/go.mod
@@ -322,7 +322,7 @@ require (
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/josharian/native v1.1.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
-	github.com/klauspost/compress v1.19.0 // indirect
+	github.com/klauspost/compress v1.20.0 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.10 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/lann/builder v0.0.0-20180802200727-47ae307949d0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -634,8 +634,8 @@ github.com/kelseyhightower/memkv v0.1.1 h1:O7n2MB8cdrwb4UmyyXS2tVETc2DR7KlJRihRg
 github.com/kelseyhightower/memkv v0.1.1/go.mod h1:uIeINg0Dy2aioPWSdga9VnueJjfSvul2dW7o758NxO4=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
-github.com/klauspost/compress v1.19.0 h1:sXLILfc9jV2QYWkzFOPWStmcUVH2RHEB1JCdY2oVvCQ=
-github.com/klauspost/compress v1.19.0/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
+github.com/klauspost/compress v1.20.0 h1:a3C1ke2ohxFymNlb2HWAHjDeKCI90scRskErZkR0ezA=
+github.com/klauspost/compress v1.20.0/go.mod h1:LUdAzn7YLVvxLpc7y3V1m40wESHTgc1422pwwBSKYuI=
 github.com/klauspost/cpuid/v2 v2.2.10 h1:tBs3QSyvjDyFTq3uoc/9xFpCuOsJQFNPiAhYdw2skhE=
 github.com/klauspost/cpuid/v2 v2.2.10/go.mod h1:hqwkgyIinND0mEev00jJYCxPNVRVXFQeu1XKlok6oO0=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=

--- a/lib/httpmachinery/go.mod
+++ b/lib/httpmachinery/go.mod
@@ -3,10 +3,12 @@ module github.com/projectcalico/calico/lib/httpmachinery
 go 1.27.0
 
 require (
+	github.com/go-chi/chi/v5 v5.3.0
 	github.com/go-playground/form v3.1.4+incompatible
 	github.com/go-playground/validator/v10 v10.30.2
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/mux v1.8.1
+	github.com/klauspost/compress v1.20.0
 	github.com/onsi/gomega v1.39.1
 	github.com/projectcalico/calico/lib/std v0.0.0-00010101000000-000000000000
 	github.com/stretchr/testify v1.11.1

--- a/lib/httpmachinery/go.sum
+++ b/lib/httpmachinery/go.sum
@@ -4,6 +4,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/gabriel-vasile/mimetype v1.4.13 h1:46nXokslUBsAJE/wMsp5gtO500a4F3Nkz9Ufpk2AcUM=
 github.com/gabriel-vasile/mimetype v1.4.13/go.mod h1:d+9Oxyo1wTzWdyVUPMmXFvp4F9tea18J8ufA774AB3s=
+github.com/go-chi/chi/v5 v5.3.0 h1:halUjDxhshgXHMrao5bB8eNBXo/rnzwr8m5m36glehM=
+github.com/go-chi/chi/v5 v5.3.0/go.mod h1:R+tYY2hNuVUUjxoPtqUdgBqevM9s9njzkTLutVsOCto=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-playground/assert/v2 v2.2.0 h1:JvknZsQTYeFEAhQwI4qEt9cyV5ONwRHC+lYKSsYSR8s=
@@ -26,6 +28,8 @@ github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
 github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=
+github.com/klauspost/compress v1.20.0 h1:a3C1ke2ohxFymNlb2HWAHjDeKCI90scRskErZkR0ezA=
+github.com/klauspost/compress v1.20.0/go.mod h1:LUdAzn7YLVvxLpc7y3V1m40wESHTgc1422pwwBSKYuI=
 github.com/leodido/go-urn v1.4.0 h1:WT9HwE9SGECu3lg4d/dIA+jxlljEa1/ffXKmRjqdmIQ=
 github.com/leodido/go-urn v1.4.0/go.mod h1:bvxc+MVxLKB4z00jd1z+Dvzr47oO32F/QSNjSBOlFxI=
 github.com/onsi/ginkgo/v2 v2.28.0 h1:Rrf+lVLmtlBIKv6KrIGJCjyY8N36vDVcutbGJkyqjJc=

--- a/lib/httpmachinery/pkg/compression/compression.go
+++ b/lib/httpmachinery/pkg/compression/compression.go
@@ -1,0 +1,87 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package compression negotiates response compression for the HTTP servers in
+// this repository.
+package compression
+
+import (
+	"compress/flate"
+	"fmt"
+	"io"
+	"net/http"
+
+	chimiddleware "github.com/go-chi/chi/v5/middleware"
+	"github.com/klauspost/compress/zstd"
+)
+
+// compressibleTypes are the content types worth compressing: the JSON these
+// servers return in bulk, its newline-delimited form for bulk and streaming
+// bodies, and the CSV the dashboards export. Each repeats its field names on
+// every record, so it shrinks by one to two orders of magnitude.
+//
+// text/event-stream is deliberately absent. A compressed event stream does
+// still deliver per event, because every Flush reaches the client as a complete
+// block, but an intermediary that buffers one would stall it. That trade
+// belongs to whoever wants it rather than arriving as a side effect here.
+var compressibleTypes = []string{
+	"application/json",
+	"application/x-ndjson",
+	"text/csv",
+}
+
+// zstdWindowSize bounds a pooled encoder's memory. JSON gains almost nothing
+// from a larger window.
+const zstdWindowSize = 1 << 20
+
+// NewResponseCompressor returns middleware that compresses a response when the
+// client offers an encoding for it and the response declares a compressible
+// content type. Encodings are preferred in the order zstd, gzip, deflate; a
+// client that offers none of them, or asks for identity, gets the response
+// unchanged, as does a response that already carries a Content-Encoding.
+//
+// A handler has to set its content type before writing its status, or net/http
+// labels the response by sniffing the body and this middleware sees no type to
+// match against.
+//
+// The plain func type keeps this package free of the rest of the library, so a
+// server that only wants compression does not take on the request codec too.
+func NewResponseCompressor() func(http.Handler) http.Handler {
+	compressor := chimiddleware.NewCompressor(flate.DefaultCompression, compressibleTypes...)
+
+	// NewCompressor already registered gzip and deflate. SetEncoder prepends, so
+	// naming zstd here makes it the preferred encoding. chi pools encoders that
+	// implement Reset(io.Writer), which zstd's does, so an encoder's window is
+	// reused across responses rather than rebuilt per request.
+	compressor.SetEncoder("zstd", newZstdEncoder)
+
+	return compressor.Handler
+}
+
+// newZstdEncoder builds the encoder chi hands each compressible response.
+//
+// It panics rather than returning nil on error, even though chi's EncoderFunc
+// documents nil as the failure signal: chi does not guard against a nil
+// encoder, so nil would surface either as a lost pool (SetEncoder's type
+// assertion for Reset(io.Writer) fails and zstd is registered unpooled) or as a
+// nil writer panicking mid-response. The options are constants, so a failure
+// means a broken build of this package, and SetEncoder calls this once eagerly:
+// the panic lands at startup, not in front of a caller.
+func newZstdEncoder(w io.Writer, _ int) io.Writer {
+	zw, err := zstd.NewWriter(w, zstd.WithEncoderConcurrency(1), zstd.WithWindowSize(zstdWindowSize))
+	if err != nil {
+		panic(fmt.Sprintf("compression: zstd encoder options are invalid: %v", err))
+	}
+	return zw
+}

--- a/lib/httpmachinery/pkg/compression/compression_test.go
+++ b/lib/httpmachinery/pkg/compression/compression_test.go
@@ -145,7 +145,7 @@ func TestRoundTripsTheBody(t *testing.T) {
 
 		gr, err := gzip.NewReader(rsp.Body)
 		Expect(err).NotTo(HaveOccurred())
-		defer gr.Close()
+		defer func() { _ = gr.Close() }()
 		decoded, err := io.ReadAll(gr)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(string(decoded)).To(Equal(body))
@@ -241,12 +241,12 @@ func TestStreamsEachFlush(t *testing.T) {
 			req.Header.Set("Accept-Encoding", tc.acceptEncoding)
 			rsp, err := (&http.Transport{DisableCompression: true}).RoundTrip(req)
 			Expect(err).NotTo(HaveOccurred())
-			defer rsp.Body.Close()
+			defer func() { _ = rsp.Body.Close() }()
 			Expect(rsp.Header.Get("Content-Encoding")).To(Equal(tc.acceptEncoding))
 
 			decoded, err := tc.open(rsp.Body)
 			Expect(err).NotTo(HaveOccurred())
-			defer decoded.Close()
+			defer func() { _ = decoded.Close() }()
 
 			// The first event must arrive before the handler is released to
 			// write the second.

--- a/lib/httpmachinery/pkg/compression/compression_test.go
+++ b/lib/httpmachinery/pkg/compression/compression_test.go
@@ -1,0 +1,273 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package compression_test
+
+import (
+	"compress/gzip"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/klauspost/compress/zstd"
+	. "github.com/onsi/gomega"
+
+	"github.com/projectcalico/calico/lib/httpmachinery/pkg/compression"
+	"github.com/projectcalico/calico/lib/httpmachinery/pkg/header"
+)
+
+// body is large and repetitive, the way a page of flows is: compression only
+// kicks in past chi's minimum size, and the repetition is what makes the ratio
+// worth having.
+var body = `{"items":[` + strings.Repeat(`{"source_name":"client","dest_name":"server","protocol":"tcp"},`, 500) + `{}]}`
+
+// serve runs the middleware over a handler that writes body with contentType,
+// and returns the recorded response.
+func serve(t *testing.T, acceptEncoding, contentType string) *http.Response {
+	t.Helper()
+
+	handler := compression.NewResponseCompressor()(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if contentType != "" {
+			w.Header().Set(header.ContentType, contentType)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, body)
+	}))
+
+	r := httptest.NewRequest(http.MethodGet, "/flows", nil)
+	if acceptEncoding != "" {
+		r.Header.Set("Accept-Encoding", acceptEncoding)
+	}
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+	return w.Result()
+}
+
+func TestNegotiatesEncoding(t *testing.T) {
+	RegisterTestingT(t)
+
+	for _, tc := range []struct {
+		name           string
+		acceptEncoding string
+		expected       string
+	}{
+		// zstd is preferred over the gzip and deflate chi registers itself.
+		{"chrome offers everything", "gzip, deflate, br, zstd", "zstd"},
+		{"zstd only", "zstd", "zstd"},
+		{"older browser, gzip only", "gzip, deflate", "gzip"},
+		{"deflate only", "deflate", "deflate"},
+		// Nothing we serve: the response goes out unchanged rather than in an
+		// encoding the client did not ask for.
+		{"brotli only, which we do not serve", "br", ""},
+		{"identity", "identity", ""},
+		{"no header at all", "", ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			RegisterTestingT(t)
+			rsp := serve(t, tc.acceptEncoding, header.ApplicationJSON)
+			Expect(rsp.Header.Get("Content-Encoding")).To(Equal(tc.expected))
+		})
+	}
+}
+
+func TestCompressesOnlyCompressibleTypes(t *testing.T) {
+	RegisterTestingT(t)
+
+	for _, tc := range []struct {
+		name        string
+		contentType string
+		compressed  bool
+	}{
+		{"json", header.ApplicationJSON, true},
+		// The charset parameter must not defeat the match.
+		{"json without charset", "application/json", true},
+		{"ndjson", "application/x-ndjson", true},
+		{"csv", "text/csv", true},
+		{"csv with charset", "text/csv; charset=utf-8", true},
+		// An event stream is left alone: an intermediary that buffered a
+		// compressed one would stall it.
+		{"event stream", header.TextEventStream, false},
+		{"plain text", "text/plain; charset=utf-8", false},
+		// Without the fix that sets the content type before the status, this is
+		// what a JSON handler looks like to the compressor.
+		{"no content type declared", "", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			RegisterTestingT(t)
+			rsp := serve(t, "zstd, gzip", tc.contentType)
+			if tc.compressed {
+				Expect(rsp.Header.Get("Content-Encoding")).NotTo(BeEmpty())
+			} else {
+				Expect(rsp.Header.Get("Content-Encoding")).To(BeEmpty())
+			}
+		})
+	}
+}
+
+func TestRoundTripsTheBody(t *testing.T) {
+	RegisterTestingT(t)
+
+	t.Run("zstd", func(t *testing.T) {
+		RegisterTestingT(t)
+		rsp := serve(t, "zstd", header.ApplicationJSON)
+		Expect(rsp.Header.Get("Content-Encoding")).To(Equal("zstd"))
+
+		raw, err := io.ReadAll(rsp.Body)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(len(raw)).To(BeNumerically("<", len(body)/10), "repetitive JSON should shrink by more than 10x")
+
+		zr, err := zstd.NewReader(strings.NewReader(string(raw)))
+		Expect(err).NotTo(HaveOccurred())
+		defer zr.Close()
+		decoded, err := io.ReadAll(zr)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(decoded)).To(Equal(body))
+	})
+
+	t.Run("gzip", func(t *testing.T) {
+		RegisterTestingT(t)
+		rsp := serve(t, "gzip", header.ApplicationJSON)
+		Expect(rsp.Header.Get("Content-Encoding")).To(Equal("gzip"))
+
+		gr, err := gzip.NewReader(rsp.Body)
+		Expect(err).NotTo(HaveOccurred())
+		defer gr.Close()
+		decoded, err := io.ReadAll(gr)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(decoded)).To(Equal(body))
+	})
+}
+
+// A stale Content-Length would describe the uncompressed body and truncate the
+// response at the client.
+func TestDropsContentLengthWhenCompressing(t *testing.T) {
+	RegisterTestingT(t)
+
+	handler := compression.NewResponseCompressor()(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set(header.ContentType, header.ApplicationJSON)
+		w.Header().Set("Content-Length", "9999")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, body)
+	}))
+
+	r := httptest.NewRequest(http.MethodGet, "/flows", nil)
+	r.Header.Set("Accept-Encoding", "zstd")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+
+	rsp := w.Result()
+	Expect(rsp.Header.Get("Content-Encoding")).To(Equal("zstd"))
+	Expect(rsp.Header.Get("Content-Length")).To(BeEmpty())
+}
+
+// A handler that encoded its own body owns the encoding; double-compressing it
+// would corrupt it.
+func TestLeavesAnAlreadyEncodedResponseAlone(t *testing.T) {
+	RegisterTestingT(t)
+
+	handler := compression.NewResponseCompressor()(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set(header.ContentType, header.ApplicationJSON)
+		w.Header().Set("Content-Encoding", "gzip")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, body)
+	}))
+
+	r := httptest.NewRequest(http.MethodGet, "/flows", nil)
+	r.Header.Set("Accept-Encoding", "zstd")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+
+	rsp := w.Result()
+	Expect(rsp.Header.Get("Content-Encoding")).To(Equal("gzip"))
+	raw, err := io.ReadAll(rsp.Body)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(string(raw)).To(Equal(body), "the body must pass through untouched")
+}
+
+// A stream is only useful if each event reaches the client as the handler
+// flushes it, rather than sitting in the encoder until the response ends. The
+// handler here writes one event, waits until the client has read it, then
+// writes a second; a swallowed flush would block the first read forever.
+func TestStreamsEachFlush(t *testing.T) {
+	RegisterTestingT(t)
+
+	for _, tc := range []struct {
+		name           string
+		acceptEncoding string
+		contentType    string
+		open           func(io.Reader) (io.ReadCloser, error)
+	}{
+		{"zstd json", "zstd", "application/json", openZstd},
+		{"gzip json", "gzip", "application/json", func(r io.Reader) (io.ReadCloser, error) { return gzip.NewReader(r) }},
+		{"zstd ndjson", "zstd", "application/x-ndjson", openZstd},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			RegisterTestingT(t)
+
+			read := make(chan struct{})
+			handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set(header.ContentType, tc.contentType)
+				for i := 1; i <= 2; i++ {
+					_, _ = fmt.Fprintf(w, `{"event":%d}`+"\n", i)
+					w.(http.Flusher).Flush()
+					if i == 1 {
+						select {
+						case <-read:
+						case <-r.Context().Done():
+							return
+						}
+					}
+				}
+			})
+			server := httptest.NewServer(compression.NewResponseCompressor()(handler))
+			defer server.Close()
+
+			req, err := http.NewRequest(http.MethodGet, server.URL, nil)
+			Expect(err).NotTo(HaveOccurred())
+			req.Header.Set("Accept-Encoding", tc.acceptEncoding)
+			rsp, err := (&http.Transport{DisableCompression: true}).RoundTrip(req)
+			Expect(err).NotTo(HaveOccurred())
+			defer rsp.Body.Close()
+			Expect(rsp.Header.Get("Content-Encoding")).To(Equal(tc.acceptEncoding))
+
+			decoded, err := tc.open(rsp.Body)
+			Expect(err).NotTo(HaveOccurred())
+			defer decoded.Close()
+
+			// The first event must arrive before the handler is released to
+			// write the second.
+			first := make([]byte, len(`{"event":1}`)+1)
+			_, err = io.ReadFull(decoded, first)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(first)).To(Equal(`{"event":1}` + "\n"))
+			close(read)
+
+			rest, err := io.ReadAll(decoded)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(rest)).To(Equal(`{"event":2}` + "\n"))
+		})
+	}
+}
+
+// openZstd adapts a zstd decoder to the ReadCloser the streaming test wants.
+func openZstd(r io.Reader) (io.ReadCloser, error) {
+	zr, err := zstd.NewReader(r)
+	if err != nil {
+		return nil, err
+	}
+	return zr.IOReadCloser(), nil
+}

--- a/lib/httpmachinery/pkg/server/options.go
+++ b/lib/httpmachinery/pkg/server/options.go
@@ -19,6 +19,8 @@ import (
 	"crypto/x509"
 	"net/http"
 	"os"
+
+	"github.com/projectcalico/calico/lib/httpmachinery/pkg/apiutil"
 )
 
 // Option is a common format for New() options
@@ -27,6 +29,16 @@ type Option func(*httpServer) error
 func WithInternalServer(internalSrv *http.Server) Option {
 	return func(srv *httpServer) error {
 		srv.srv = internalSrv
+		return nil
+	}
+}
+
+// WithMiddleware wraps every endpoint the server registers, outside any
+// middleware an endpoint declares for itself. Use it for concerns that belong
+// to the whole server, such as response compression.
+func WithMiddleware(middleware ...apiutil.MiddlewareFunc) Option {
+	return func(srv *httpServer) error {
+		srv.middleware = append(srv.middleware, middleware...)
 		return nil
 	}
 }

--- a/lib/httpmachinery/pkg/server/server.go
+++ b/lib/httpmachinery/pkg/server/server.go
@@ -40,6 +40,7 @@ type httpServer struct {
 	addr        string
 	shutdownCtx context.Context
 	serverErrs  chan error
+	middleware  []apiutil.MiddlewareFunc
 }
 
 type Router interface {
@@ -60,7 +61,7 @@ func NewHTTPServer(router Router, apis []apiutil.Endpoint, options ...Option) (H
 
 	srv.srv.Addr = srv.addr
 	srv.srv.TLSConfig = srv.tlsConfig
-	srv.srv.Handler = router.RegisterAPIs(apis)
+	srv.srv.Handler = router.RegisterAPIs(apis, srv.middleware...)
 
 	return srv, nil
 }

--- a/lib/httpmachinery/pkg/server/server_test.go
+++ b/lib/httpmachinery/pkg/server/server_test.go
@@ -1,0 +1,67 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server_test
+
+import (
+	"net/http"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/projectcalico/calico/lib/httpmachinery/pkg/apiutil"
+	"github.com/projectcalico/calico/lib/httpmachinery/pkg/server"
+)
+
+// recordingRouter captures what NewHTTPServer hands its router.
+type recordingRouter struct {
+	apis       []apiutil.Endpoint
+	middleware []apiutil.MiddlewareFunc
+}
+
+func (r *recordingRouter) RegisterAPIs(apis []apiutil.Endpoint, middleware ...apiutil.MiddlewareFunc) http.Handler {
+	r.apis = apis
+	r.middleware = middleware
+	return http.NotFoundHandler()
+}
+
+// Server-wide middleware is useless unless the server passes it to the router,
+// which is the whole path between WithMiddleware and a wrapped endpoint.
+func TestWithMiddlewareReachesTheRouter(t *testing.T) {
+	RegisterTestingT(t)
+
+	first := apiutil.MiddlewareFunc(func(next http.Handler) http.Handler { return next })
+	second := apiutil.MiddlewareFunc(func(next http.Handler) http.Handler { return next })
+
+	router := &recordingRouter{}
+	_, err := server.NewHTTPServer(router, nil,
+		server.WithAddr("127.0.0.1:0"),
+		server.WithMiddleware(first),
+		server.WithMiddleware(second),
+	)
+	Expect(err).NotTo(HaveOccurred())
+
+	// Both calls contribute, in the order given, so a caller can add middleware
+	// from more than one place.
+	Expect(router.middleware).To(HaveLen(2))
+}
+
+func TestNoMiddlewareByDefault(t *testing.T) {
+	RegisterTestingT(t)
+
+	router := &recordingRouter{}
+	_, err := server.NewHTTPServer(router, nil, server.WithAddr("127.0.0.1:0"))
+	Expect(err).NotTo(HaveOccurred())
+	Expect(router.middleware).To(BeEmpty())
+}

--- a/node/deps.txt
+++ b/node/deps.txt
@@ -82,7 +82,7 @@ github.com/json-iterator/go v1.1.12
 github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0
 github.com/kelseyhightower/envconfig v1.4.0
 github.com/kelseyhightower/memkv v0.1.1
-github.com/klauspost/compress v1.19.0
+github.com/klauspost/compress v1.20.0
 github.com/klauspost/cpuid/v2 v2.2.10
 github.com/leodido/go-urn v1.4.0
 github.com/lithammer/dedent v1.1.0

--- a/operator/deps.txt
+++ b/operator/deps.txt
@@ -93,7 +93,7 @@ github.com/joeshaw/multierror v0.0.0-20140124173710-69b34d4ec901
 github.com/josharian/intern v1.0.0
 github.com/json-iterator/go v1.1.12
 github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.7.7
-github.com/klauspost/compress v1.19.0
+github.com/klauspost/compress v1.20.0
 github.com/lann/builder v0.0.0-20180802200727-47ae307949d0
 github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0
 github.com/lib/pq v1.12.3

--- a/release/deps.txt
+++ b/release/deps.txt
@@ -37,7 +37,7 @@ github.com/google/uuid v1.6.0
 github.com/googleapis/enterprise-certificate-proxy v0.3.14
 github.com/googleapis/gax-go/v2 v2.21.0
 github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674
-github.com/klauspost/compress v1.19.0
+github.com/klauspost/compress v1.20.0
 github.com/opencontainers/go-digest v1.0.0
 github.com/opencontainers/image-spec v1.1.1
 github.com/projectcalico/calico


### PR DESCRIPTION
## Description

Adds negotiated response compression to `lib/httpmachinery`, so any server built on it can serve zstd, gzip or deflate to a client that asks. Nothing is wired to it in this PR; whisker-backend picks it up in #12879, where a 1.7MB page of flows measured on a cluster becomes 19KB.

- `compression.NewResponseCompressor` wraps chi's compressor with zstd registered ahead of the gzip and deflate chi provides, for `application/json`, `application/x-ndjson` and `text/csv`. It returns a plain `func(http.Handler) http.Handler` so a server that only wants compression does not take on the request codec too.
- The zstd encoder panics on invalid options rather than returning nil, which chi documents as the failure signal but does not guard: a nil would surface as a lost encoder pool or a nil writer mid-response. The options are constants and `SetEncoder` calls it once at startup, so the panic lands there, not in front of a caller.
- `NewHTTPServer` never passed middleware to `RegisterAPIs`, so the middleware parameter on the `Router` interface was unreachable. `server.WithMiddleware` now supplies it, wrapping every endpoint outside any middleware the endpoint declares for itself.
- `text/event-stream` is deliberately outside the allowlist. A compressed event stream still delivers per event, but an intermediary that buffered one would stall it, and that trade should be made on purpose rather than arriving as a side effect.
- klauspost/compress moves to v1.20.0, which is what bumps five `deps.txt` files.

## Testing

`compression_test.go` covers every negotiation shape a browser sends (Chrome's full header, zstd-only, gzip-only, deflate-only, br-only, identity, no header), content-type matching including the charset parameter and CSV, zstd and gzip round-trips, `Content-Length` removal, an already-encoded response passing through, and per-flush streaming over a real server. `server_test.go` covers `WithMiddleware` reaching the router.

**Release note:**
```release-note
None
```

**AI assistance:** Claude Code wrote the middleware, the tests and this description; the change was reviewed by the author.
