### PR TITLE
[BPF] Keep pre-existing forwarded flows alive when switching to eBPF

### DIFF
--- a/felix/dataplane/linux/int_dataplane.go
+++ b/felix/dataplane/linux/int_dataplane.go
@@ -2244,6 +2244,21 @@ func (d *InternalDataplane) setUpIptablesBPF() {
 					Comment: []string{"From ", dataplanedefs.BPFOutDev, " device, mark verified, accept."},
 				},
 			)
+
+			// A flow that pre-dates BPF and is forwarded between two host interfaces
+			// matches none of the accepts above, so a DROP policy on FORWARD would kill
+			// it. Linux conntrack vetted it, which is the same signal INPUT trusts.
+			// Must stay after the to-workload jumps so that workload destinations keep
+			// going through the dispatch chain.
+			fwdRules = append(fwdRules,
+				generictables.Rule{
+					Match: d.newMatch().
+						MarkMatchesWithMask(tcdefs.MarkSeenFallThrough, tcdefs.MarkSeenFallThroughMask).
+						ConntrackState("ESTABLISHED,RELATED"),
+					Action:  d.actions.Allow(),
+					Comment: []string{"Accept forwarded packets from flows that pre-date BPF."},
+				},
+			)
 		}
 
 		t.InsertOrAppendRules("INPUT", inputRules)

--- a/felix/dataplane/linux/int_dataplane.go
+++ b/felix/dataplane/linux/int_dataplane.go
@@ -2245,11 +2245,8 @@ func (d *InternalDataplane) setUpIptablesBPF() {
 				},
 			)
 
-			// A flow that pre-dates BPF and is forwarded between two host interfaces
-			// matches none of the accepts above, so a DROP policy on FORWARD would kill
-			// it. Linux conntrack vetted it, which is the same signal INPUT trusts.
-			// Must stay after the to-workload jumps so that workload destinations keep
-			// going through the dispatch chain.
+			// Forwarded between two host interfaces, so matched by none of the accepts
+			// above. Linux conntrack vetted it, the same signal INPUT trusts.
 			fwdRules = append(fwdRules,
 				generictables.Rule{
 					Match: d.newMatch().

--- a/felix/fv/bpf_test.go
+++ b/felix/fv/bpf_test.go
@@ -5574,6 +5574,106 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 				It("should keep a connection up between hosts and local workloads when BPF is enabled", func() {
 					verifyConnectivityWhileEnablingBPF(hostW[0], w[0][0])
 				})
+
+				// Connections through a service must survive the switch too.  kube-proxy
+				// does not run in the FV, so we install the DNAT it would have written,
+				// in the chains Felix deletes on the switch.  The connection has to
+				// outlive that deletion: the DNAT binding lives in the Linux conntrack
+				// entry, not in the rule.
+				//
+				// Pinned to one matrix point to keep the cost down.  Neither DSR nor the
+				// tunnel affects the pod-to-ClusterIP path.
+				if testOpts.dsr && testOpts.tunnel == "none" {
+					const (
+						migrationSvcIP   = "10.101.0.99"
+						migrationSvcPort = 8090
+					)
+
+					installKubeProxyService := func(felix *infrastructure.Felix, backend *workload.Workload) {
+						target := net.JoinHostPort(backend.IP, backend.Ports)
+						if NFTMode() {
+							felix.Exec("nft", "add", "table", "ip", "kube-proxy")
+							felix.Exec("nft", "add", "chain", "ip", "kube-proxy", "services",
+								"{ type nat hook prerouting priority dstnat ; }")
+							felix.Exec("nft", "add", "rule", "ip", "kube-proxy", "services",
+								"ip", "daddr", migrationSvcIP, "tcp", "dport", fmt.Sprint(migrationSvcPort),
+								"dnat", "to", target)
+							return
+						}
+						felix.Exec("iptables", "-w", "10", "-W", "100000", "-t", "nat",
+							"-N", "KUBE-SERVICES")
+						felix.Exec("iptables", "-w", "10", "-W", "100000", "-t", "nat",
+							"-A", "KUBE-SERVICES", "-d", migrationSvcIP, "-p", "tcp",
+							"--dport", fmt.Sprint(migrationSvcPort),
+							"-j", "DNAT", "--to-destination", target)
+						felix.Exec("iptables", "-w", "10", "-W", "100000", "-t", "nat",
+							"-I", "PREROUTING", "-j", "KUBE-SERVICES")
+					}
+
+					// Marker that Felix's kube-proxy cleanup takes away, and the
+					// command that shows whether it is still there.
+					kubeProxyMarker := "KUBE-SERVICES"
+					dumpRulesCmd := []string{"iptables-save", "-t", "nat"}
+					if NFTMode() {
+						kubeProxyMarker = "kube-proxy"
+						dumpRulesCmd = []string{"nft", "list", "ruleset"}
+					}
+					dumpRules := func(felix *infrastructure.Felix) func() string {
+						return func() string {
+							out, _ := felix.ExecOutput(dumpRulesCmd...)
+							return out
+						}
+					}
+
+					verifySvcConnectivityWhileEnablingBPF := func(client, backend *workload.Workload) {
+						By("Creating the service")
+						testSvc := k8sService("migration-svc", migrationSvcIP, backend,
+							migrationSvcPort, 8055, 0, testOpts.protocol)
+						k8sClient := infra.(*infrastructure.K8sDatastoreInfra).K8sClient
+						_, err := k8sClient.CoreV1().Services(testSvc.Namespace).Create(
+							context.Background(), testSvc, metav1.CreateOptions{})
+						Expect(err).NotTo(HaveOccurred())
+						Eventually(checkSvcEndpoints(k8sClient, testSvc), "10s").Should(Equal(1),
+							"Service endpoints didn't get created? Is controller-manager happy?")
+
+						By("Installing the rules kube-proxy would have written")
+						installKubeProxyService(tc.Felixes[0], backend)
+						// Also proves the dump command works, so that the check for
+						// their removal below cannot pass vacuously.
+						Expect(dumpRules(tc.Felixes[0])()).To(ContainSubstring(kubeProxyMarker))
+
+						By("Starting persistent connection via the service")
+						pc = client.StartPersistentConnection(migrationSvcIP, migrationSvcPort,
+							workload.PersistentConnectionOpts{
+								MonitorConnectivity: true,
+								Timeout:             60 * time.Second,
+							})
+
+						By("having initial connectivity", expectPongs)
+						By("enabling BPF mode", enableBPF) // Waits for BPF programs to be installed
+						By("removing the kube-proxy rules", func() {
+							Eventually(dumpRules(tc.Felixes[0]), "30s", "1s").
+								ShouldNot(ContainSubstring(kubeProxyMarker))
+						})
+						By("still having connectivity on the existing connection", expectPongs)
+
+						By("having connectivity on a new connection via the service", func() {
+							cc.ResetExpectations()
+							cc.Expect(Some, client, TargetIP(migrationSvcIP),
+								ExpectWithPorts(uint16(migrationSvcPort)))
+							cc.CheckConnectivity()
+							cc.ResetExpectations()
+						})
+					}
+
+					It("should keep a connection to a service with a local backend up when BPF is enabled", func() {
+						verifySvcConnectivityWhileEnablingBPF(w[0][1], w[0][0])
+					})
+
+					It("should keep a connection to a service with a remote backend up when BPF is enabled", func() {
+						verifySvcConnectivityWhileEnablingBPF(w[0][1], w[1][0])
+					})
+				}
 			}
 		})
 

--- a/felix/fv/bpf_test.go
+++ b/felix/fv/bpf_test.go
@@ -5582,8 +5582,9 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 				// entry, not in the rule.
 				//
 				// Pinned to one matrix point to keep the cost down.  Neither DSR nor the
-				// tunnel affects the pod-to-ClusterIP path.
-				if testOpts.dsr && testOpts.tunnel == "none" {
+				// tunnel affects the pod-to-ClusterIP path.  The addresses and the rules
+				// below are v4, hence the explicit IPv6 exclusion.
+				if testOpts.dsr && !testOpts.ipv6 && testOpts.tunnel == "none" {
 					const (
 						migrationSvcIP   = "10.101.0.99"
 						migrationSvcPort = 8090
@@ -5618,19 +5619,15 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 						kubeProxyMarker = "kube-proxy"
 						dumpRulesCmd = []string{"nft", "list", "ruleset"}
 					}
-					dumpRules := func(felix *infrastructure.Felix) func() string {
-						return func() string {
-							out, _ := felix.ExecOutput(dumpRulesCmd...)
-							return out
-						}
-					}
-
 					verifySvcConnectivityWhileEnablingBPF := func(client, backend *workload.Workload) {
 						By("Creating the service")
+						// Must agree with the DNAT target below, which uses the same port.
+						backendPort, err := strconv.Atoi(backend.Ports)
+						Expect(err).NotTo(HaveOccurred())
 						testSvc := k8sService("migration-svc", migrationSvcIP, backend,
-							migrationSvcPort, 8055, 0, testOpts.protocol)
+							migrationSvcPort, backendPort, 0, testOpts.protocol)
 						k8sClient := infra.(*infrastructure.K8sDatastoreInfra).K8sClient
-						_, err := k8sClient.CoreV1().Services(testSvc.Namespace).Create(
+						_, err = k8sClient.CoreV1().Services(testSvc.Namespace).Create(
 							context.Background(), testSvc, metav1.CreateOptions{})
 						Expect(err).NotTo(HaveOccurred())
 						Eventually(checkSvcEndpoints(k8sClient, testSvc), "10s").Should(Equal(1),
@@ -5640,7 +5637,8 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 						installKubeProxyService(tc.Felixes[0], backend)
 						// Also proves the dump command works, so that the check for
 						// their removal below cannot pass vacuously.
-						Expect(dumpRules(tc.Felixes[0])()).To(ContainSubstring(kubeProxyMarker))
+						Expect(tc.Felixes[0].ExecOutputFn(dumpRulesCmd...)()).
+							To(ContainSubstring(kubeProxyMarker))
 
 						By("Starting persistent connection via the service")
 						pc = client.StartPersistentConnection(migrationSvcIP, migrationSvcPort,
@@ -5652,7 +5650,7 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 						By("having initial connectivity", expectPongs)
 						By("enabling BPF mode", enableBPF) // Waits for BPF programs to be installed
 						By("removing the kube-proxy rules", func() {
-							Eventually(dumpRules(tc.Felixes[0]), "30s", "1s").
+							Eventually(tc.Felixes[0].ExecOutputFn(dumpRulesCmd...), "30s", "1s").
 								ShouldNot(ContainSubstring(kubeProxyMarker))
 						})
 						By("still having connectivity on the existing connection", expectPongs)

--- a/felix/fv/bpf_test.go
+++ b/felix/fv/bpf_test.go
@@ -5671,6 +5671,65 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 					It("should keep a connection to a service with a remote backend up when BPF is enabled", func() {
 						verifySvcConnectivityWhileEnablingBPF(w[0][1], w[1][0])
 					})
+
+					// External client -> NodePort.  With a backend on another node the
+					// forwarded legs enter and leave on the same host interface, which is
+					// the case that matched none of the BPF-mode FORWARD accepts.
+					verifyNodePortWhileEnablingBPF := func(backend *workload.Workload) {
+						const (
+							npSvcIP  = "10.101.0.98"
+							nodePort = 30333
+						)
+						backendPort, err := strconv.Atoi(backend.Ports)
+						Expect(err).NotTo(HaveOccurred())
+
+						By("Creating the NodePort service")
+						testSvc := k8sService("migration-np", npSvcIP, backend,
+							migrationSvcPort, backendPort, int32(nodePort), testOpts.protocol)
+						k8sClient := infra.(*infrastructure.K8sDatastoreInfra).K8sClient
+						_, err = k8sClient.CoreV1().Services(testSvc.Namespace).Create(
+							context.Background(), testSvc, metav1.CreateOptions{})
+						Expect(err).NotTo(HaveOccurred())
+						Eventually(checkSvcEndpoints(k8sClient, testSvc), "10s").Should(Equal(1))
+
+						By("Installing the NodePort rules kube-proxy would have written")
+						f := tc.Felixes[0]
+						target := net.JoinHostPort(backend.IP, backend.Ports)
+						f.Exec("iptables", "-w", "10", "-W", "100000", "-t", "nat", "-N", "KUBE-SERVICES")
+						f.Exec("iptables", "-w", "10", "-W", "100000", "-t", "nat", "-A", "KUBE-SERVICES",
+							"-m", "addrtype", "--dst-type", "LOCAL", "-p", "tcp",
+							"--dport", fmt.Sprint(nodePort), "-j", "DNAT", "--to-destination", target)
+						f.Exec("iptables", "-w", "10", "-W", "100000", "-t", "nat",
+							"-I", "PREROUTING", "-j", "KUBE-SERVICES")
+						// kube-proxy masquerades node port traffic so replies come back via
+						// the ingress node.
+						f.Exec("iptables", "-w", "10", "-W", "100000", "-t", "nat", "-A", "POSTROUTING",
+							"-d", backend.IP, "-p", "tcp", "--dport", backend.Ports, "-j", "MASQUERADE")
+
+						By("Starting persistent connection from the external client to the node port")
+						pc = &PersistentConnection{
+							Runtime:             externalClient,
+							RuntimeName:         externalClient.Name,
+							IP:                  felixIP(0),
+							Port:                nodePort,
+							Protocol:            testOpts.protocol,
+							MonitorConnectivity: true,
+							Timeout:             60 * time.Second,
+						}
+						Expect(pc.Start()).NotTo(HaveOccurred())
+
+						By("having initial connectivity", expectPongs)
+						By("enabling BPF mode", enableBPF)
+						By("still having connectivity on the existing connection", expectPongs)
+					}
+
+					It("should keep an external nodeport connection with a local backend up when BPF is enabled", func() {
+						verifyNodePortWhileEnablingBPF(w[0][0])
+					})
+
+					It("should keep an external nodeport connection with a remote backend up when BPF is enabled", func() {
+						verifyNodePortWhileEnablingBPF(w[1][0])
+					})
 				}
 			}
 		})

--- a/felix/fv/bpf_test.go
+++ b/felix/fv/bpf_test.go
@@ -5581,9 +5581,9 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 				// outlive that deletion: the DNAT binding lives in the Linux conntrack
 				// entry, not in the rule.
 				//
-				// Pinned to one matrix point to keep the cost down.  Neither DSR nor the
-				// tunnel affects the pod-to-ClusterIP path.  The addresses and the rules
-				// below are v4, hence the explicit IPv6 exclusion.
+				// Pinned to one matrix point to keep the cost down; these flows pre-date
+				// BPF so they never take the DSR or tunnel path.  The addresses below are
+				// v4, hence the explicit IPv6 exclusion.
 				if testOpts.dsr && !testOpts.ipv6 && testOpts.tunnel == "none" {
 					const (
 						migrationSvcIP   = "10.101.0.99"
@@ -5692,19 +5692,34 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 						Expect(err).NotTo(HaveOccurred())
 						Eventually(checkSvcEndpoints(k8sClient, testSvc), "10s").Should(Equal(1))
 
+						// The masquerade mimics kube-proxy, which SNATs node port traffic so
+						// that replies come back via the ingress node.  Only the iptables run
+						// reproduces the regression: nftables mode sets the FORWARD policy to
+						// ACCEPT (see infrastructure.Felix), so nothing drops the packet there.
 						By("Installing the NodePort rules kube-proxy would have written")
 						f := tc.Felixes[0]
 						target := net.JoinHostPort(backend.IP, backend.Ports)
-						f.Exec("iptables", "-w", "10", "-W", "100000", "-t", "nat", "-N", "KUBE-SERVICES")
-						f.Exec("iptables", "-w", "10", "-W", "100000", "-t", "nat", "-A", "KUBE-SERVICES",
-							"-m", "addrtype", "--dst-type", "LOCAL", "-p", "tcp",
-							"--dport", fmt.Sprint(nodePort), "-j", "DNAT", "--to-destination", target)
-						f.Exec("iptables", "-w", "10", "-W", "100000", "-t", "nat",
-							"-I", "PREROUTING", "-j", "KUBE-SERVICES")
-						// kube-proxy masquerades node port traffic so replies come back via
-						// the ingress node.
-						f.Exec("iptables", "-w", "10", "-W", "100000", "-t", "nat", "-A", "POSTROUTING",
-							"-d", backend.IP, "-p", "tcp", "--dport", backend.Ports, "-j", "MASQUERADE")
+						if NFTMode() {
+							f.Exec("nft", "add", "table", "ip", "kube-proxy")
+							f.Exec("nft", "add", "chain", "ip", "kube-proxy", "nodeports",
+								"{ type nat hook prerouting priority dstnat ; }")
+							f.Exec("nft", "add", "rule", "ip", "kube-proxy", "nodeports",
+								"fib", "daddr", "type", "local", "tcp", "dport", fmt.Sprint(nodePort),
+								"dnat", "to", target)
+							f.Exec("nft", "add", "chain", "ip", "kube-proxy", "masq",
+								"{ type nat hook postrouting priority srcnat ; }")
+							f.Exec("nft", "add", "rule", "ip", "kube-proxy", "masq",
+								"ip", "daddr", backend.IP, "tcp", "dport", backend.Ports, "masquerade")
+						} else {
+							f.Exec("iptables", "-w", "10", "-W", "100000", "-t", "nat", "-N", "KUBE-SERVICES")
+							f.Exec("iptables", "-w", "10", "-W", "100000", "-t", "nat", "-A", "KUBE-SERVICES",
+								"-m", "addrtype", "--dst-type", "LOCAL", "-p", "tcp",
+								"--dport", fmt.Sprint(nodePort), "-j", "DNAT", "--to-destination", target)
+							f.Exec("iptables", "-w", "10", "-W", "100000", "-t", "nat",
+								"-I", "PREROUTING", "-j", "KUBE-SERVICES")
+							f.Exec("iptables", "-w", "10", "-W", "100000", "-t", "nat", "-A", "POSTROUTING",
+								"-d", backend.IP, "-p", "tcp", "--dport", backend.Ports, "-j", "MASQUERADE")
+						}
 
 						By("Starting persistent connection from the external client to the node port")
 						pc = &PersistentConnection{


### PR DESCRIPTION
Switching the dataplane to eBPF drops pre-existing connections that arrive at a node port and are served by a backend on another node. The connection is silently lost on any node whose filter FORWARD policy is DROP.

A flow that pre-dates eBPF mode is kept alive by the mid-flow fallthrough: the ingress BPF program marks the packet `FALLTHROUGH` and lets it into the stack, Linux conntrack applies the translation it already holds, and the next BPF program allows it on the `CT_ESTABLISHED` mark. In eBPF mode Felix's FORWARD chain accepts bypass-marked traffic, traffic in from `cali+`, and traffic from `bpfout.cali`, and jumps to the workload dispatch chain for traffic out to `cali+`. A node port flow with a remote backend enters and leaves on the same host interface, so it matches none of them, collects the `CT_ESTABLISHED` mark, falls off the end of the chain and hits the DROP policy. Until the switch it was carried by kube-proxy's own `-j KUBE-FORWARD` accept, which Felix deletes as part of its kube-proxy cleanup.

INPUT has carried an accept for exactly this since the mechanism was written — the fallthrough was built for host-terminated flows such as the connection to the API server, and FORWARD only ever got the rule that sets the mark for the next program. This adds the matching accept to FORWARD, placed after the to-workload jumps so that workload destinations keep going through the dispatch chain.

FORWARD needs only the accept, not the reject and deny that follow it in INPUT. INPUT is the last word for host-terminated traffic, so it has to decide the unknown-flow case itself. A forwarded packet always meets a further BPF program on the egress interface, and that program already drops a mid-flow packet Linux conntrack does not know: `tc.c` sets `CALI_ST_SUPPRESS_CT_STATE` on the egress miss and `calico_tc_skb_accepted_entrypoint` returns `TC_ACT_SHOT` for it even when policy allowed. Denying in FORWARD would pre-empt that decision with less information.

Four functional verification specs cover the switch for service traffic, which nothing covered before: a ClusterIP with a local and a remote backend, and a node port with a local and a remote backend. kube-proxy does not run in the FV, so they install the rules it would have written, in the chains Felix deletes on the switch. The node-port-with-remote-backend spec fails without the fix and passes with it.

**Release note:**
```release-note
Fixed a bug where pre-existing connections to a node port with a backend on another node were dropped when the dataplane was switched to eBPF mode.
```

**AI assistance:** Claude Code wrote the test code, found the root cause, and drafted the fix.
