### PR TITLE
argoci: fail the step when bz init profile fails

### DIFF
--- a/.argoci/scripts/global_prologue.sh
+++ b/.argoci/scripts/global_prologue.sh
@@ -10,7 +10,9 @@
 #   - Semaphore vars (SEMAPHORE_*) become CI_*/ARGO_* equivalents;
 #   - RELEASE_STREAM is derived from the checked-out branch.
 #
-# Sourced (not executed) by the e2e-test template, so no `set -e`/`exit`.
+# Sourced (not executed) by the e2e-test template, so no `set -e`/`exit` — the
+# exceptions are the bz-install and bz-init hard-fails, where nothing later can
+# succeed, so aborting the step is the intended outcome.
 set -o pipefail
 
 echo "[INFO] starting prologue"
@@ -231,8 +233,12 @@ if [[ "${CREATE_WINDOWS_NODES:-false}" == "true" ]] && ! command -v puttygen >/d
 fi
 
 echo "[INFO] initialising bz profile..."
+# A half-initialised directory is not a profile, so provision, diags and destroy
+# would each fail with "is not a cluster profile directory" and bury the real
+# cause. pipefail is set above, so tee cannot mask bz's status.
 ( cd "${HOME}" && bz init profile -n "${BZ_PROFILE_NAME}" --skip-prompt --secretsPath "${HOME}/secrets" ) \
-  |& tee "${BZ_LOGS_DIR}/initialize.log" || true
+  |& tee "${BZ_LOGS_DIR}/initialize.log" \
+  || { echo "[ERROR] bz init profile failed — see initialize.log"; exit 1; }
 mkdir -p "${BZ_LOCAL_DIR}" "${REPORT_DIR}" "${BZ_LOCAL_DIR}/config"
 # bz provision prereq wants the docker auth at <profile>/.local/config/docker_auth.json
 # (the DOCKER_AUTH_FILE env alone does not redirect the prereq check).

--- a/.argoci/scripts/global_prologue.sh
+++ b/.argoci/scripts/global_prologue.sh
@@ -238,7 +238,7 @@ echo "[INFO] initialising bz profile..."
 # cause. pipefail is set above, so tee cannot mask bz's status.
 ( cd "${HOME}" && bz init profile -n "${BZ_PROFILE_NAME}" --skip-prompt --secretsPath "${HOME}/secrets" ) \
   |& tee "${BZ_LOGS_DIR}/initialize.log" \
-  || { echo "[ERROR] bz init profile failed — see initialize.log"; exit 1; }
+  || { echo "[ERROR] bz init profile failed — see ${BZ_LOGS_DIR}/initialize.log"; exit 1; }
 mkdir -p "${BZ_LOCAL_DIR}" "${REPORT_DIR}" "${BZ_LOCAL_DIR}/config"
 # bz provision prereq wants the docker auth at <profile>/.local/config/docker_auth.json
 # (the DOCKER_AUTH_FILE env alone does not redirect the prereq check).


### PR DESCRIPTION
A failed `bz init profile` leaves a directory that is not a profile. `|| true` on line 235 swallowed that, so the step carried on and `bz provision`, `bz diags` and `bz destroy` each failed with `is not a cluster profile directory` — naming the wrong command and burying the real cause.

That is why this looked for weeks like a `bz provision` regression. In the week to 2026-09-04 it was **303 of 498 provision failures (61%)**; excluding the class, the weekly provision pass rate is flat at 90-94% instead of sliding 92.3% -> 81.2%. Provision was never the thing failing.

From a run this morning:

```
[INFO] initialising bz profile...
? Enter the calient helm patch of v3.21 to install: (0) EOF: EOF   <-- init dies
[INFO] starting bz provision...
[ERROR] Unable to perform bz provision: /root/...-488qd is not a cluster profile directory
[ERROR] Unable to perform bz diags:     /root/...-488qd is not a cluster profile directory
[ERROR] Unable to perform bz destroy:   /root/...-488qd is not a cluster profile directory
```

## Change

Replace `|| true` with the hard-fail idiom already used for the bz install a few lines up. `set -o pipefail` is set at the top, so `tee` cannot mask `bz`'s status once the swallow is gone — no `PIPESTATUS` juggling needed.

The header comment said there were no `exit`s; it already had one (the bz-install fail), so I have made it name both.

This is deliberately independent of *why* init failed. Two distinct triggers showed up in one workflow this morning — a prompt `--skip-prompt` does not suppress (12 pods) and `Kubernetes/k8s version is out of AKS support` (5 pods) — and this change surfaces whichever comes next instead of disguising it as a provision failure.

The specific prompt bug is fixed separately in tigera/bz-cli#222. This one stands on its own: without it the next init failure is just as misleading.

Verified with `bash -n`; `shellcheck -S warning` reports only the two pre-existing warnings on other lines (SC1090 line 29, SC2155 line 321).

Same `|| true` exists in tigera/calico-private's copy — will follow via the usual cherry-pick once this lands.