### PR TITLE
Publish the e2e test images when they change on master

### DIFF
--- a/.semaphore/push-images/e2e-test.yml
+++ b/.semaphore/push-images/e2e-test.yml
@@ -16,6 +16,9 @@ global_job_config:
       - echo $QUAY_TOKEN | docker login --username "$QUAY_USER" --password-stdin quay.io
       - checkout
       - ssh-add ~/.ssh/id_rsa
+      # The published tag is the branch name, taken from the environment rather
+      # than from git, matching the other push-images pipelines.
+      - export BRANCH_NAME=$SEMAPHORE_GIT_BRANCH
 blocks:
   - name: Publish e2e test utility images
     dependencies: []

--- a/.semaphore/push-images/e2e-test.yml
+++ b/.semaphore/push-images/e2e-test.yml
@@ -16,8 +16,6 @@ global_job_config:
       - echo $QUAY_TOKEN | docker login --username "$QUAY_USER" --password-stdin quay.io
       - checkout
       - ssh-add ~/.ssh/id_rsa
-      # The published tag is the branch name, taken from the environment rather
-      # than from git, matching the other push-images pipelines.
       - export BRANCH_NAME=$SEMAPHORE_GIT_BRANCH
 blocks:
   - name: Publish e2e test utility images

--- a/.semaphore/semaphore-scheduled-builds.yml
+++ b/.semaphore/semaphore-scheduled-builds.yml
@@ -225,9 +225,6 @@ promotions:
     pipeline_file: license-scanning/fossa-scan.yml
     auto_promote:
       when: "branch =~ 'master|release-.*'"
-  # Auto-fires (unlike the component pushes above) because the e2e lanes pull
-  # these images by branch tag at test time, so a merge that changes one and does
-  # not publish it leaves every lane running the previous build.
   - name: Push E2E images
     pipeline_file: push-images/e2e-test.yml
     auto_promote:

--- a/.semaphore/semaphore-scheduled-builds.yml
+++ b/.semaphore/semaphore-scheduled-builds.yml
@@ -225,8 +225,14 @@ promotions:
     pipeline_file: license-scanning/fossa-scan.yml
     auto_promote:
       when: "branch =~ 'master|release-.*'"
+  # Auto-fires (unlike the component pushes above) because the e2e lanes pull
+  # these images by branch tag at test time, so a merge that changes one and does
+  # not publish it leaves every lane running the previous build.
   - name: Push E2E images
     pipeline_file: push-images/e2e-test.yml
+    auto_promote:
+      when: >-
+        branch =~ 'master|release-.*' and change_in('/e2e/images/', {pipeline_file: 'ignore', default_branch: 'master', exclude: ['/**/README.md', '/**/DESIGN.md']})
   - name: Push istio images
     pipeline_file: push-images/istio.yml
   # Auto-fires (unlike the component pushes above) because this is a build-time

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -225,9 +225,6 @@ promotions:
     pipeline_file: license-scanning/fossa-scan.yml
     auto_promote:
       when: "branch =~ 'master|release-.*'"
-  # Auto-fires (unlike the component pushes above) because the e2e lanes pull
-  # these images by branch tag at test time, so a merge that changes one and does
-  # not publish it leaves every lane running the previous build.
   - name: Push E2E images
     pipeline_file: push-images/e2e-test.yml
     auto_promote:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -225,8 +225,14 @@ promotions:
     pipeline_file: license-scanning/fossa-scan.yml
     auto_promote:
       when: "branch =~ 'master|release-.*'"
+  # Auto-fires (unlike the component pushes above) because the e2e lanes pull
+  # these images by branch tag at test time, so a merge that changes one and does
+  # not publish it leaves every lane running the previous build.
   - name: Push E2E images
     pipeline_file: push-images/e2e-test.yml
+    auto_promote:
+      when: >-
+        branch =~ 'master|release-.*' and change_in('/e2e/images/', {pipeline_file: 'ignore', default_branch: 'master', exclude: ['/**/README.md', '/**/DESIGN.md']})
   - name: Push istio images
     pipeline_file: push-images/istio.yml
   # Auto-fires (unlike the component pushes above) because this is a build-time

--- a/.semaphore/semaphore.yml.d/03-promotions.yml
+++ b/.semaphore/semaphore.yml.d/03-promotions.yml
@@ -64,9 +64,6 @@ promotions:
     pipeline_file: license-scanning/fossa-scan.yml
     auto_promote:
       when: "branch =~ 'master|release-.*'"
-  # Auto-fires (unlike the component pushes above) because the e2e lanes pull
-  # these images by branch tag at test time, so a merge that changes one and does
-  # not publish it leaves every lane running the previous build.
   - name: Push E2E images
     pipeline_file: push-images/e2e-test.yml
     auto_promote:

--- a/.semaphore/semaphore.yml.d/03-promotions.yml
+++ b/.semaphore/semaphore.yml.d/03-promotions.yml
@@ -64,8 +64,13 @@ promotions:
     pipeline_file: license-scanning/fossa-scan.yml
     auto_promote:
       when: "branch =~ 'master|release-.*'"
+  # Auto-fires (unlike the component pushes above) because the e2e lanes pull
+  # these images by branch tag at test time, so a merge that changes one and does
+  # not publish it leaves every lane running the previous build.
   - name: Push E2E images
     pipeline_file: push-images/e2e-test.yml
+    auto_promote:
+      when: "branch =~ 'master|release-.*' and change_in('/e2e/images/', {pipeline_file: 'ignore', default_branch: 'master', exclude: ['/**/README.md', '/**/DESIGN.md']})"
   - name: Push istio images
     pipeline_file: push-images/istio.yml
   # Auto-fires (unlike the component pushes above) because this is a build-time

--- a/e2e/images/rapidclient/Makefile
+++ b/e2e/images/rapidclient/Makefile
@@ -5,7 +5,10 @@ PACKAGE_NAME=github.com/projectcalico/calico/e2e/images/rapidclient
 include ../../../lib.Makefile
 
 QUAY_REGISTRY ?= quay.io/tigeradev
-TAG_NAME ?= $(shell git branch --show-current)
+
+# BRANCH_NAME is what CI exports; the git fallback is for local builds, where a
+# detached HEAD yields an empty string and publish stops rather than pushing ":".
+TAG_NAME ?= $(or $(BRANCH_NAME),$(shell git branch --show-current))
 
 # Architectures the published manifest list must cover. arm64 is required: the
 # packet-size server runs on arm64 clusters (e.g. azr-aks ARM), and an amd64-only
@@ -48,7 +51,7 @@ image: bin/rapidclient-$(ARCH)
 		-f Dockerfile -t $(IMAGE):$(TAG_NAME) .
 
 # publish builds all architectures into a single manifest list and pushes it.
-publish: $(addprefix bin/rapidclient-,$(ARCHES))
+publish: var-require-all-TAG_NAME $(addprefix bin/rapidclient-,$(ARCHES))
 	docker buildx build --platform=$(shell echo $(ARCHES) | sed 's/ /,/g; s,[^,]*,linux/&,g') \
 		--push --pull -f Dockerfile -t $(IMAGE):$(TAG_NAME) .
 	# Guard against silently regressing to a single-arch image (the original bug):


### PR DESCRIPTION
The packet-size e2e specs have been failing on every platform since late June, 1,174 failed cases on master in the last four days alone. The server pod exits immediately, because the published rapidclient image predates the server mode those specs need (#13105) and nothing republished it.

Publishing only ever happened from the "Push E2E images" button, so a merge that changed the image left the lanes running the previous build. This makes that pipeline auto-fire on master and release branches when anything under `e2e/images/` changes.

Two smaller fixes in the same area:

- The pipeline now takes the tag from the branch in the environment, like every other push-images pipeline, rather than reading it out of git.
- Publishing with no tag fails instead of pushing an image tagged with the empty string.

Related: [CORE-13575](https://tigera.atlassian.net/browse/CORE-13575)

```release-note
None
```


[CORE-13575]: https://tigera.atlassian.net/browse/CORE-13575?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ