### PR TITLE
Gate the KubeVirt IP persistence suite on real KubeVirt

### DIFF
--- a/e2e/pkg/tests/kubevirt/ip_persistence.go
+++ b/e2e/pkg/tests/kubevirt/ip_persistence.go
@@ -50,6 +50,7 @@ import (
 var _ = describe.CalicoDescribe(
 	describe.WithTeam(describe.Core),
 	describe.WithFeature("KubeVirt"),
+	describe.RequiresRealKubeVirt(),
 	describe.WithCategory(describe.Networking),
 	"KubeVirt IP persistence",
 	func() {

--- a/e2e/pkg/tests/kubevirt/labels_test.go
+++ b/e2e/pkg/tests/kubevirt/labels_test.go
@@ -67,6 +67,48 @@ func TestEveryKubeVirtSuiteDeclaresTheKubeVirtFeature(t *testing.T) {
 	}
 }
 
+// The Feature label does not say which kind of KubeVirt a suite needs, and the
+// lanes that run one kind exclude the other, so a suite declaring neither runs
+// where it cannot pass.
+func TestEveryKubeVirtSuiteDeclaresTheKubeVirtItNeeds(t *testing.T) {
+	fset := token.NewFileSet()
+	paths, err := filepath.Glob("*.go")
+	if err != nil {
+		t.Fatalf("listing the KubeVirt suites: %v", err)
+	}
+	var checked int
+	for _, path := range paths {
+		if strings.HasSuffix(path, "_test.go") {
+			continue
+		}
+		f, err := parser.ParseFile(fset, path, nil, 0)
+		if err != nil {
+			t.Fatalf("parsing %s: %v", path, err)
+		}
+		ast.Inspect(f, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok || !isDescribeCall(call, "CalicoDescribe") {
+				return true
+			}
+			checked++
+			for _, arg := range call.Args {
+				inner, ok := arg.(*ast.CallExpr)
+				if !ok {
+					continue
+				}
+				if isDescribeCall(inner, "RequiresRealKubeVirt") || isDescribeCall(inner, "RequiresMockVirt") {
+					return true
+				}
+			}
+			t.Errorf("%s: suite declares neither RequiresRealKubeVirt nor RequiresMockVirt", fset.Position(call.Pos()))
+			return true
+		})
+	}
+	if checked == 0 {
+		t.Fatal("found no KubeVirt suites, so this guard checks nothing")
+	}
+}
+
 // isDescribeCall reports whether the call is describe.<name>(...).
 func isDescribeCall(call *ast.CallExpr, name string) bool {
 	sel, ok := call.Fun.(*ast.SelectorExpr)

--- a/e2e/testsets/sets/gcp/kubevirt.txt
+++ b/e2e/testsets/sets/gcp/kubevirt.txt
@@ -1,9 +1,9 @@
-[sig-calico] [Team:CORE] [Feature:KubeVirt] [Category:Networking] KubeVirt IP persistence should assign static IP via annotation and preserve it across migration
-[sig-calico] [Team:CORE] [Feature:KubeVirt] [Category:Networking] KubeVirt IP persistence should preserve VM IP across VMI recreation (reboot)
-[sig-calico] [Team:CORE] [Feature:KubeVirt] [Category:Networking] KubeVirt IP persistence should preserve VM IP across pod recreation
-[sig-calico] [Team:CORE] [Feature:KubeVirt] [Category:Networking] KubeVirt IP persistence should preserve VM IP address across live migration
-[sig-calico] [Team:CORE] [Feature:KubeVirt] [Category:Networking] KubeVirt IP persistence should promote target pod to active IPAM owner after migration
-[sig-calico] [Team:CORE] [Feature:KubeVirt] [Category:Networking] KubeVirt IP persistence should release IPAM handle when VM is deleted
+[sig-calico] [Team:CORE] [Feature:KubeVirt] [RequiresRealKubeVirt] [Category:Networking] KubeVirt IP persistence should assign static IP via annotation and preserve it across migration
+[sig-calico] [Team:CORE] [Feature:KubeVirt] [RequiresRealKubeVirt] [Category:Networking] KubeVirt IP persistence should preserve VM IP across VMI recreation (reboot)
+[sig-calico] [Team:CORE] [Feature:KubeVirt] [RequiresRealKubeVirt] [Category:Networking] KubeVirt IP persistence should preserve VM IP across pod recreation
+[sig-calico] [Team:CORE] [Feature:KubeVirt] [RequiresRealKubeVirt] [Category:Networking] KubeVirt IP persistence should preserve VM IP address across live migration
+[sig-calico] [Team:CORE] [Feature:KubeVirt] [RequiresRealKubeVirt] [Category:Networking] KubeVirt IP persistence should promote target pod to active IPAM owner after migration
+[sig-calico] [Team:CORE] [Feature:KubeVirt] [RequiresRealKubeVirt] [Category:Networking] KubeVirt IP persistence should release IPAM handle when VM is deleted
 [sig-calico] [Team:CORE] [Feature:KubeVirt] [RequiresRealKubeVirt] [Category:Networking] KubeVirt live migration eBGP external client [ExternalNode] should maintain TCP connection from eBGP external client across two consecutive migrations
 [sig-calico] [Team:CORE] [Feature:KubeVirt] [RequiresRealKubeVirt] [Category:Networking] KubeVirt live migration should maintain TCP connection over iBGP across two consecutive live migrations
 [sig-calico] [Team:CORE] [Feature:KubeVirt] [RequiresRealKubeVirt] [Category:Networking] KubeVirt live migration should prefer the local workload route on the migration target node


### PR DESCRIPTION
The IP persistence suite creates and migrates VirtualMachine resources, but it declared no capability label, so nothing stopped a lane without KubeVirt from selecting it. The sibling live-migration suite in the same package has always carried `RequiresRealKubeVirt`.

The unit test in that package checked that every suite declares the KubeVirt feature. It now also checks that each one says which kind of KubeVirt it needs, real or MockVirt, since the lanes that run one exclude the other.

No lane's selection changes: the only set that picked these specs up already provides real KubeVirt.

Related: [CORE-13577](https://tigera.atlassian.net/browse/CORE-13577)

```release-note
None
```


[CORE-13577]: https://tigera.atlassian.net/browse/CORE-13577?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ