### PR TITLE
[v3.32] argoci: move the OpenShift cells off 4.18/4.19, and export the CI-account cloud env

### DIFF
--- a/.argoci/cron/e2e-iptables.yaml
+++ b/.argoci/cron/e2e-iptables.yaml
@@ -30,18 +30,18 @@ steps:
       - name: PROVISIONER
         value: aws-openshift
     matrix:
-      - name: 4-18-29
+      - name: 4-20-35
         env:
           - name: OPENSHIFT_VERSION
-            value: 4.18.29
-      - name: 4-19-20
+            value: 4.20.35
+      - name: 4-21-30
         env:
           - name: OPENSHIFT_VERSION
-            value: 4.19.20
-      - name: 4-20-6
+            value: 4.21.30
+      - name: 4-22-11
         env:
           - name: OPENSHIFT_VERSION
-            value: 4.20.6
+            value: 4.22.11
     commands: |
       .argoci/scripts/body_standard.sh
   - name: arm64-smoke-tests-aks-arm64

--- a/.argoci/cron/e2e-patch-verification.yaml
+++ b/.argoci/cron/e2e-patch-verification.yaml
@@ -385,7 +385,7 @@ steps:
       - name: IP_FAMILY
         value: ipv4
       - name: OPENSHIFT_VERSION
-        value: 4.18.17
+        value: 4.22.11
       - name: PROVISIONER
         value: aws-openshift
     commands: |

--- a/.argoci/cron/e2e-upgrade.yaml
+++ b/.argoci/cron/e2e-upgrade.yaml
@@ -132,10 +132,10 @@ steps:
       - name: PROVISIONER
         value: aws-openshift
     matrix:
-      - name: 4-19-20-calicoiptables-operator
+      - name: 4-22-11-calicoiptables-operator
         env:
           - name: OPENSHIFT_VERSION
-            value: 4.19.20
+            value: 4.22.11
           - name: DATAPLANE
             value: CalicoIptables
           - name: INSTALLER

--- a/.argoci/scripts/global_prologue.sh
+++ b/.argoci/scripts/global_prologue.sh
@@ -108,6 +108,13 @@ export GOOGLE_ZONE=${GOOGLE_ZONE:-$(gcloud compute zones list --project "${GOOGL
 export GOOGLE_NETWORK=${GOOGLE_NETWORK:-semaphore-autotest}
 export AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION:-us-west-2}
 
+# banzai-core defaults these to the tigera-dev developer account, which the CI
+# IAM user cannot reach: kops 403s on its state store and the OpenShift
+# installer finds no matching Route53 zone.
+export KOPS_STATE_STORE_NAME=${KOPS_STATE_STORE_NAME:-kops-tigera-dev-ci}
+export KOPS_AWS_DNS_ZONE=${KOPS_AWS_DNS_ZONE:-kops.ci.aws.eng.tigera.net}
+export OPENSHIFT_BASE_DOMAIN=${OPENSHIFT_BASE_DOMAIN:-openshift.ci.aws.eng.tigera.net}
+
 # RELEASE_STREAM: release-vX.Y -> vX.Y, else master. BRANCH is passed by the
 # workflow (from the cron's `branch` parameter).
 # Branch comes from the ArgoCI handler (CI_GIT_CLONED_BRANCH); fall back to


### PR DESCRIPTION
The OpenShift e2e cells were pinned to 4.18/4.19/4.20 — **Kubernetes 1.31/1.32/1.33** — while the rest of this branch tests 1.34 and up. The two oldest fail almost every run.

OpenShift and Kubernetes pair 1:1, stated in each release's `release.txt`: 4.20→1.33, 4.21→1.34, 4.22→1.35.

## What changes

| file | was | now |
|---|---|---|
| `e2e-iptables.yaml` | 4.18.29 / 4.19.20 / 4.20.6 | **4.20.35 / 4.21.30 / 4.22.11** |
| `e2e-patch-verification.yaml` | 4.18.17 | **4.22.11** |
| `e2e-upgrade.yaml` | 4.19.20 | **4.22.11** |

Same set as `release-v3.31` (#13782). This branch is documented against Kubernetes 1.34/1.35/1.36, so the 4.20 cell (k8s 1.33) sits one minor below its range — kept deliberately, to hold three cells rather than drop to two, since 1.36 has no GA OpenShift.

Provision failure rate for OSS `aws-openshift` over 14 days, monotonic in the version:

| OpenShift | runs | failed |
|---|---|---|
| 4.18 | 46 | 44 (96%) |
| 4.19 | 32 | 22 (69%) |
| 4.20 | 22 | 16 (73%) |
| 4.21 | 12 | 8 (67%) |
| 4.22 | 4 | **0** |

## Also here: the CI-account exports

Part of that failure rate is not the version at all. `.argoci/scripts/global_prologue.sh` on this branch never received the exports added to `master` in #13432, so `banzai-core` falls back to its tigera-dev developer defaults and the installer dies with:

```
no public route53 zone found matching name "openshift.crc.aws.eng.tigera.net"
```

`openshift.ci.aws.eng.tigera.net` appears nowhere in the failing logs. `master` and `release-v3.33` carry these exports; `release-v3.31` and `release-v3.32` did not. The same gap makes kops 403 on its state store.

## Why not 5.x here

`master` and `release-v3.33` take a 5.0 cell (#13785, #13784) because it is the only way they reach Kubernetes 1.36. This branch does not need it, and 5.0 is release-candidate only, so GA versions throughout.

## Not touched

`e2e-certification.yaml` keeps its existing pins. Its plugin path is `tests/ocp-cert/manifests/cnv-conformance-{{printf "%.4s" .OPENSHIFT_VERSION}}.yaml`, that directory only carries files up to **4.20**, and its cron is parked (`0 0 31 2 *`). Adding the manifests is a separate change.

Patches still need bumping by hand when a new one ships; making these float is deliberately left for later (tigera/banzai-core#1761, parked).
