### PR TITLE
[v3.33] argoci: move the OpenShift cells off 4.18/4.19

### DIFF
--- a/.argoci/cron/e2e-iptables.yaml
+++ b/.argoci/cron/e2e-iptables.yaml
@@ -30,18 +30,18 @@ steps:
       - name: PROVISIONER
         value: aws-openshift
     matrix:
-      - name: 4-18-29
+      - name: 4-20-35
         env:
           - name: OPENSHIFT_VERSION
-            value: 4.18.29
-      - name: 4-19-20
+            value: 4.20.35
+      - name: 4-21-30
         env:
           - name: OPENSHIFT_VERSION
-            value: 4.19.20
-      - name: 4-20-6
+            value: 4.21.30
+      - name: 4-22-11
         env:
           - name: OPENSHIFT_VERSION
-            value: 4.20.6
+            value: 4.22.11
     commands: |
       .argoci/scripts/body_standard.sh
   - name: arm64-smoke-tests-aks-arm64

--- a/.argoci/cron/e2e-iptables.yaml
+++ b/.argoci/cron/e2e-iptables.yaml
@@ -30,10 +30,10 @@ steps:
       - name: PROVISIONER
         value: aws-openshift
     matrix:
-      - name: 4-20-35
+      - name: 5-0-0-rc-0
         env:
           - name: OPENSHIFT_VERSION
-            value: 4.20.35
+            value: 5.0.0-rc.0
       - name: 4-21-30
         env:
           - name: OPENSHIFT_VERSION

--- a/.argoci/cron/e2e-patch-verification.yaml
+++ b/.argoci/cron/e2e-patch-verification.yaml
@@ -402,7 +402,7 @@ steps:
       - name: IP_FAMILY
         value: ipv4
       - name: OPENSHIFT_VERSION
-        value: 4.18.17
+        value: 4.22.11
       - name: PROVISIONER
         value: aws-openshift
     commands: |

--- a/.argoci/cron/e2e-upgrade.yaml
+++ b/.argoci/cron/e2e-upgrade.yaml
@@ -131,10 +131,10 @@ steps:
       - name: PROVISIONER
         value: aws-openshift
     matrix:
-      - name: 4-19-20-calicoiptables-operator
+      - name: 4-22-11-calicoiptables-operator
         env:
           - name: OPENSHIFT_VERSION
-            value: 4.19.20
+            value: 4.22.11
           - name: DATAPLANE
             value: CalicoIptables
           - name: INSTALLER


### PR DESCRIPTION
The OpenShift e2e cells were pinned to 4.18/4.19/4.20, i.e. **Kubernetes 1.31/1.32/1.33**, while every other cell on this branch tests 1.34 and up. The two oldest fail almost every run.

OpenShift and Kubernetes pair 1:1, and each release states the pairing in its own `release.txt`:

| OpenShift | Kubernetes |
|---|---|
| 4.20 | 1.33 |
| 4.21 | 1.34 |
| 4.22 | 1.35 |
| 5.0 (RC) | 1.36 |

There is no 4.23 — **5.0 is the release after 4.22**.

## What changes

`e2e-iptables.yaml` — the three OpenShift cells become **5.0.0-rc.0 · 4.22.11 · 4.21.30**:

| was | now |
|---|---|
| 4.18.29 (k8s 1.31) | **4.21.30** (k8s 1.34) |
| 4.19.20 (k8s 1.32) | **4.22.11** (k8s 1.35) |
| 4.20.6 (k8s 1.33) | **5.0.0-rc.0** (k8s 1.36) |

5.x is included because it is the only way this branch reaches Kubernetes 1.36 on OpenShift at all. `clients/ocp/5.0.0-rc.0/` is served, so the installer can fetch it — unlike `-ec.N` builds, which live under `ocp-dev-preview` and 404.

Provision failure rate for OSS `aws-openshift` over 14 days, which is monotonic in the version:

| OpenShift | runs | failed |
|---|---|---|
| 4.18 | 46 | 44 (96%) |
| 4.19 | 32 | 22 (69%) |
| 4.20 | 22 | 16 (73%) |
| 4.21 | 12 | 8 (67%) |
| 4.22 | 4 | **0** |

## Prerequisite satisfied

A pre-release `OPENSHIFT_VERSION` used to close the version gates in `provisioners/aws-openshift/Taskfile.yml:323`/`:331`, silently skipping `openshift-cluster-api-sg` and `openshift-kube-proxy` — `semverCompare` does not match a pre-release against a constraint carrying none:

```
4.22.11    >= 4.16.0   -> true
5.0.0-rc.0 >= 4.16.0   -> false
5.0.0-rc.0 >= 4.16.0-0 -> true
```

tigera/banzai-core#1762 added the `-0` suffix and has reached the runs: the `stable-v0.9` tag that `bz init profile` clones now resolves to `f234d89f`, with both gates present. Nothing further is needed here.

## Not touched

`e2e-certification.yaml` keeps its existing pins. Its plugin path is `tests/ocp-cert/manifests/cnv-conformance-{{printf "%.4s" .OPENSHIFT_VERSION}}.yaml` and that directory only carries files up to **4.20**, so a bump would fail on a missing plugin. Its cron is parked (`0 0 31 2 *`), so nothing runs today. Adding the manifests is a separate change.

`e2e-patch-verification.yaml` and `e2e-upgrade.yaml` have a single OpenShift cell each, both now **4.22.11**.

Matches the change on `master` (#13785).

Patches still need bumping by hand when a new one ships; making these float is deliberately left for later (tigera/banzai-core#1761, parked).



