### PR TITLE
[v3.32] Key BPF route wireguard tunnelled flag off the manager's own IP family

### DIFF
--- a/felix/dataplane/linux/bpf_route_mgr.go
+++ b/felix/dataplane/linux/bpf_route_mgr.go
@@ -143,6 +143,13 @@ func newBPFRouteManager(config *Config, maps *bpfmap.IPMaps, ipFamily proto.IPVe
 		dirtyCIDRs.Add(cidr)
 	}
 
+	// Wireguard is configured per address family; a route only belongs to the
+	// family this manager serves, so consult that family's setting alone.
+	wgEnabled := config.Wireguard.Enabled
+	if ipFamily == proto.IPVersion_IPV6 {
+		wgEnabled = config.Wireguard.EnabledV6
+	}
+
 	m := &bpfRouteManager{
 		myNodename:        config.Hostname,
 		cidrToRoute:       map[ip.CIDR]*proto.RouteUpdate{},
@@ -165,7 +172,7 @@ func newBPFRouteManager(config *Config, maps *bpfmap.IPMaps, ipFamily proto.IPVe
 
 		opReporter: opReporter,
 
-		wgEnabled:         config.Wireguard.Enabled || config.Wireguard.EnabledV6,
+		wgEnabled:         wgEnabled,
 		ipFamily:          ipFamily,
 		svcLoopPrevention: config.ServiceLoopPrevention,
 	}

--- a/felix/dataplane/linux/bpf_route_mgr_test.go
+++ b/felix/dataplane/linux/bpf_route_mgr_test.go
@@ -1,0 +1,89 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package intdataplane
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/projectcalico/calico/felix/bpf/bpfmap"
+	"github.com/projectcalico/calico/felix/bpf/routes"
+	"github.com/projectcalico/calico/felix/ip"
+	"github.com/projectcalico/calico/felix/logutils"
+	"github.com/projectcalico/calico/felix/proto"
+	"github.com/projectcalico/calico/felix/wireguard"
+)
+
+var _ = Describe("BPF route manager", func() {
+	// remoteWorkloadFlags programs a remote-workload route in a no-encap pool and
+	// returns the flags the manager computed for it.
+	remoteWorkloadFlags := func(ipFamily proto.IPVersion, wgV4, wgV6 bool) routes.Flags {
+		config := &Config{
+			Hostname: "node-local",
+			Wireguard: wireguard.Config{
+				Enabled:   wgV4,
+				EnabledV6: wgV6,
+			},
+		}
+		m := newBPFRouteManager(config, &bpfmap.IPMaps{}, ipFamily, logutils.NewSummarizer("test"))
+
+		dst := "10.0.1.0/26"
+		nodeIP := "172.16.0.2"
+		if ipFamily == proto.IPVersion_IPV6 {
+			dst = "fdcc:10:1::/122"
+			nodeIP = "fdcc:172:16::2"
+		}
+
+		m.onRouteUpdate(&proto.RouteUpdate{
+			Types:       proto.RouteType_REMOTE_WORKLOAD,
+			IpPoolType:  proto.IPPoolType_NO_ENCAP,
+			Dst:         dst,
+			DstNodeName: "node-remote",
+			DstNodeIp:   nodeIP,
+		})
+
+		route := m.calculateRoute(ip.MustParseCIDROrIP(dst))
+		Expect(route).NotTo(BeNil())
+		return route.Flags()
+	}
+
+	// Wireguard is enabled per address family, so the tunnelled flag must follow
+	// the family the route belongs to, not either family's setting.
+	It("should only flag remote workloads tunnelled for the family wireguard is enabled for", func() {
+		By("enabling wireguard for IPv4 only")
+		Expect(remoteWorkloadFlags(proto.IPVersion_IPV4, true, false) & routes.FlagTunneled).
+			To(Equal(routes.FlagTunneled))
+		Expect(remoteWorkloadFlags(proto.IPVersion_IPV6, true, false) & routes.FlagTunneled).
+			To(BeZero())
+
+		By("enabling wireguard for IPv6 only")
+		Expect(remoteWorkloadFlags(proto.IPVersion_IPV4, false, true) & routes.FlagTunneled).
+			To(BeZero())
+		Expect(remoteWorkloadFlags(proto.IPVersion_IPV6, false, true) & routes.FlagTunneled).
+			To(Equal(routes.FlagTunneled))
+
+		By("disabling wireguard for both families")
+		Expect(remoteWorkloadFlags(proto.IPVersion_IPV4, false, false) & routes.FlagTunneled).
+			To(BeZero())
+		Expect(remoteWorkloadFlags(proto.IPVersion_IPV6, false, false) & routes.FlagTunneled).
+			To(BeZero())
+
+		By("enabling wireguard for both families")
+		Expect(remoteWorkloadFlags(proto.IPVersion_IPV4, true, true) & routes.FlagTunneled).
+			To(Equal(routes.FlagTunneled))
+		Expect(remoteWorkloadFlags(proto.IPVersion_IPV6, true, true) & routes.FlagTunneled).
+			To(Equal(routes.FlagTunneled))
+	})
+})


### PR DESCRIPTION
**Cherry-pick history**
- Pick onto **release-v3.32**: projectcalico/calico#13729

## Problem

`newBPFRouteManager` is constructed once per address family, but it derived `wgEnabled` from `config.Wireguard.Enabled || config.Wireguard.EnabledV6`. On a dual-stack cluster with wireguard enabled for one family only, every remote-workload route of the *other* family was permanently flagged `routes.FlagTunneled`. The BPF dataplane reads that flag as "this destination needs an encapsulating egress" (`cali_rt_needs_tunnel_egress`), so on a native/no-encap pool with a cross-subnet destination it claims an encap egress for a destination the kernel routes natively over a plain NIC, and the disagreement never converges.

## Change

Consult the manager's own `ipFamily` — `Wireguard.Enabled` for v4, `Wireguard.EnabledV6` for v6.

## Result

The tunnelled flag follows the family the route belongs to, so a family without wireguard no longer gets bogus encap-egress routes.

## Backport notes

`lib/logrusr` does not exist on `release-v3.32`; `newBPFRouteManager` takes a `logutils.OpRecorder` there. The new test's import and its `NewSummarizer("test")` call were repointed at `felix/logutils`, which holds the identical function. The `bpf_route_mgr.go` change is byte-identical to the original.

## Verification

`go build` and `go vet` on `./felix/dataplane/linux/...` pass, and the new spec ("BPF route manager", all four wireguard on/off combinations across both families) passes: `Ran 1 of 974 Specs`, `SUCCESS! -- 1 Passed | 0 Failed`.

<details>
<summary><b>Cherry-Pick PR details</b></summary>

- **Original PR ID**: 13729
- **Original Commit SHA**: f0ccb63596
- **Source Repo**: `projectcalico/calico`
- **Target Repo**: `projectcalico/calico`
- **Target Branch**: `release-v3.32`
</details>

**Release note:**
```release-note
Fixed the eBPF dataplane flagging remote workload routes as tunnelled for an address family that does not have WireGuard enabled, on dual-stack clusters with WireGuard enabled for one family only.
```
