### PR TITLE
node/startup: claim IPs via a Kubernetes Lease instead of listing all Nodes

### DIFF
--- a/node/pkg/lifecycle/startup/checkconflictingnodes_test.go
+++ b/node/pkg/lifecycle/startup/checkconflictingnodes_test.go
@@ -1,0 +1,1032 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package startup
+
+import (
+	"context"
+	"fmt"
+	stdnet "net"
+	"strings"
+	"testing"
+
+	log "github.com/sirupsen/logrus"
+	logtest "github.com/sirupsen/logrus/hooks/test"
+	coordinationv1 "k8s.io/api/coordination/v1"
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+	clientgotesting "k8s.io/client-go/testing"
+
+	"github.com/projectcalico/calico/libcalico-go/lib/apis/internalapi"
+	cerrors "github.com/projectcalico/calico/libcalico-go/lib/errors"
+	cnet "github.com/projectcalico/calico/libcalico-go/lib/net"
+	"github.com/projectcalico/calico/libcalico-go/lib/options"
+	"github.com/projectcalico/calico/libcalico-go/lib/watch"
+	"github.com/projectcalico/calico/node/pkg/lifecycle/startup/ipclaim"
+)
+
+// coordinationLeaseResource is the GroupResource fake API-error constructors
+// need to build a realistic simulated apiserver error for a Lease.
+func coordinationLeaseResource() schema.GroupResource {
+	return coordinationv1.SchemeGroupVersion.WithResource("leases").GroupResource()
+}
+
+// resetTestLeaseState clears the process-lifetime state checkConflictingNodes
+// keeps (the memoized IP-claim clientset and the one-time backfill flag) so
+// each subtest below observes a fresh process, not the tail end of whatever
+// the previous subtest left behind.
+func resetTestLeaseState(t *testing.T) {
+	t.Helper()
+	leaseBackfilled.Store(false)
+	t.Cleanup(func() { leaseBackfilled.Store(false) })
+}
+
+// mustParseNodeIP parses a Node's BGP CIDR address string (e.g. "10.0.1.5/24")
+// the same way checkConflictingNodes does, for building the Lease name a
+// test expects a given address to have claimed.
+func mustParseNodeIP(t *testing.T, cidr string) stdnet.IP {
+	t.Helper()
+	ip, _, err := cnet.ParseCIDROrIP(cidr)
+	if err != nil {
+		t.Fatalf("failed to parse %q: %v", cidr, err)
+	}
+	return ip.IP
+}
+
+// TestCheckConflictingNodesLeaseWiring covers the gating/wiring logic in
+// checkConflictingNodes: the datastore-type branch that picks Lease-based
+// claim vs. the legacy list scan, the FORCE_NODE_IP_CHECK_LEGACY_SCAN
+// override, the diagnostic Get used to detect a prior IP, its wiring into
+// ReleaseNodeIPLease, the ordering between the v4 and v6 claim blocks, and
+// the addressChanged gate: the legacy list scan only runs when addressChanged
+// is true, while the Lease claim path runs regardless of addressChanged.
+// None of this had unit coverage before: the Kubernetes clientset used for
+// the Lease claim used to be built inline with winutils.BuildConfigFromFlags
+// and kubernetes.NewForConfig, which made it impossible to inject a fake
+// here. newIPClaimClientset (a package variable) and the narrower
+// client.NodeInterface parameter exist specifically to make this
+// reachable without a live etcd/Kubernetes backend, which the rest of this
+// package's (ginkgo-based) test suite requires.
+func TestCheckConflictingNodesLeaseWiring(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("etcd datastore type falls back to the legacy list scan", func(t *testing.T) {
+		resetTestLeaseState(t)
+		t.Setenv("DATASTORE_TYPE", "etcdv3")
+		buildCalls := 0
+		withFakeIPClaimClientset(t, fake.NewSimpleClientset(), &buildCalls)
+
+		nodes := &fakeNodeInterface{}
+		node := makeNode("10.0.1.5/24", "")
+		node.Name = "node-a"
+
+		v4conflict, v6conflict, err := checkConflictingNodes(ctx, nodes, node, nil, true)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if v4conflict || v6conflict {
+			t.Fatalf("unexpected conflict: v4=%v v6=%v", v4conflict, v6conflict)
+		}
+		if nodes.listCalls != 1 {
+			t.Fatalf("expected the legacy list scan to run exactly once, got %d calls", nodes.listCalls)
+		}
+		if buildCalls != 0 {
+			t.Fatalf("expected no attempt to build a Kubernetes clientset for an etcd-backed deployment, got %d", buildCalls)
+		}
+	})
+
+	t.Run("FORCE_NODE_IP_CHECK_LEGACY_SCAN forces the legacy scan even under the Kubernetes datastore type", func(t *testing.T) {
+		resetTestLeaseState(t)
+		t.Setenv("DATASTORE_TYPE", "kubernetes")
+		t.Setenv(ipclaim.ForceLegacyScanEnvVar, "true")
+		buildCalls := 0
+		withFakeIPClaimClientset(t, fake.NewSimpleClientset(), &buildCalls)
+
+		nodes := &fakeNodeInterface{}
+		node := makeNode("10.0.1.5/24", "")
+		node.Name = "node-a"
+
+		_, _, err := checkConflictingNodes(ctx, nodes, node, nil, true)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if nodes.listCalls != 1 {
+			t.Fatalf("expected the legacy list scan to run exactly once, got %d calls", nodes.listCalls)
+		}
+		if buildCalls != 0 {
+			t.Fatalf("expected the forced legacy scan to skip building a Kubernetes clientset, got %d calls", buildCalls)
+		}
+	})
+
+	t.Run("apiconfig.LoadClientConfig error falls back to the legacy list scan when the address changed", func(t *testing.T) {
+		resetTestLeaseState(t)
+		// CALICO_K8S_CLIENT_QPS is a float32 env var read by
+		// envconfig.Process inside apiconfig.LoadClientConfigFromEnvironment;
+		// an unparsable value makes LoadClientConfig itself fail, exercising
+		// the cerr != nil branch without needing to fake apiconfig directly.
+		t.Setenv("DATASTORE_TYPE", "kubernetes")
+		t.Setenv("CALICO_K8S_CLIENT_QPS", "not-a-number")
+		buildCalls := 0
+		withFakeIPClaimClientset(t, fake.NewSimpleClientset(), &buildCalls)
+
+		nodes := &fakeNodeInterface{}
+		node := makeNode("10.0.1.5/24", "")
+		node.Name = "node-a"
+
+		v4conflict, v6conflict, err := checkConflictingNodes(ctx, nodes, node, nil, true)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if v4conflict || v6conflict {
+			t.Fatalf("unexpected conflict: v4=%v v6=%v", v4conflict, v6conflict)
+		}
+		if nodes.listCalls != 1 {
+			t.Fatalf("expected the legacy list scan to run exactly once, got %d calls", nodes.listCalls)
+		}
+		if buildCalls != 0 {
+			t.Fatalf("expected no attempt to build a Kubernetes clientset when the datastore type can't be determined, got %d", buildCalls)
+		}
+	})
+
+	t.Run("apiconfig.LoadClientConfig error skips the legacy list scan when the address hasn't changed", func(t *testing.T) {
+		resetTestLeaseState(t)
+		t.Setenv("DATASTORE_TYPE", "kubernetes")
+		t.Setenv("CALICO_K8S_CLIENT_QPS", "not-a-number")
+		buildCalls := 0
+		withFakeIPClaimClientset(t, fake.NewSimpleClientset(), &buildCalls)
+
+		nodes := &fakeNodeInterface{}
+		node := makeNode("10.0.1.5/24", "")
+		node.Name = "node-a"
+
+		v4conflict, v6conflict, err := checkConflictingNodes(ctx, nodes, node, nil, false)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if v4conflict || v6conflict {
+			t.Fatalf("unexpected conflict: v4=%v v6=%v", v4conflict, v6conflict)
+		}
+		if nodes.listCalls != 0 {
+			t.Fatalf("expected the legacy list scan to be skipped on an unchanged address, got %d calls", nodes.listCalls)
+		}
+		if buildCalls != 0 {
+			t.Fatalf("expected no attempt to build a Kubernetes clientset, got %d", buildCalls)
+		}
+	})
+
+	t.Run("newIPClaimClientset's own error is surfaced as a hard error", func(t *testing.T) {
+		resetTestLeaseState(t)
+		t.Setenv("DATASTORE_TYPE", "kubernetes")
+		wantErr := fmt.Errorf("simulated credential failure")
+		withFakeIPClaimClientsetErr(t, wantErr)
+
+		nodes := &fakeNodeInterface{}
+		node := makeNode("10.0.1.5/24", "")
+		node.Name = "node-a"
+
+		_, _, err := checkConflictingNodes(ctx, nodes, node, nil, true)
+		if err == nil {
+			t.Fatalf("expected the clientset build failure to surface as an error")
+		}
+	})
+
+	// TestCheckConflictingNodesLeaseWiring/a-failed-clientset-build-is-retried
+	// covers the CRITICAL fix: getIPClaimClientset used to memoize via
+	// sync.Once, which runs its function exactly once per process regardless
+	// of whether it errors -- so a single transient failure (e.g. credentials
+	// not yet available at boot) would be cached forever, and every later
+	// call, including from the periodic monitor-addresses goroutine that
+	// Fatals the process on any returned error, would get the same cached
+	// error with no chance to ever succeed. This proves a failed build is
+	// retried on the next call (build count increases), and that once a
+	// build succeeds it is memoized and not rebuilt again.
+	t.Run("a failed clientset build is retried, not cached, while a successful build is memoized", func(t *testing.T) {
+		resetTestLeaseState(t)
+		t.Setenv("DATASTORE_TYPE", "kubernetes")
+		origFn := newIPClaimClientset
+		resetIPClaimClientsetMemo()
+		t.Cleanup(func() {
+			newIPClaimClientset = origFn
+			resetIPClaimClientsetMemo()
+		})
+
+		buildCalls := 0
+		wantErr := fmt.Errorf("simulated transient credential failure")
+		newIPClaimClientset = func() (kubernetes.Interface, error) {
+			buildCalls++
+			return nil, wantErr
+		}
+
+		nodes := &fakeNodeInterface{}
+		node := makeNode("10.0.1.5/24", "")
+		node.Name = "node-a"
+
+		// First call: the build fails and surfaces as a hard error.
+		if _, _, err := checkConflictingNodes(ctx, nodes, node, nil, true); err == nil {
+			t.Fatalf("expected the clientset build failure to surface as an error")
+		}
+		if buildCalls != 1 {
+			t.Fatalf("expected exactly one build attempt, got %d", buildCalls)
+		}
+
+		// Second call: a sync.Once-based memoization would have cached the
+		// error from the first call and never invoked newIPClaimClientset
+		// again, keeping buildCalls at 1. The fix must retry instead.
+		if _, _, err := checkConflictingNodes(ctx, nodes, node, nil, true); err == nil {
+			t.Fatalf("expected the clientset build to still be failing")
+		}
+		if buildCalls != 2 {
+			t.Fatalf("expected the failed build to be retried on the next call (build count to increase), got %d", buildCalls)
+		}
+
+		// Now let the build succeed.
+		cs := fake.NewSimpleClientset()
+		newIPClaimClientset = func() (kubernetes.Interface, error) {
+			buildCalls++
+			return cs, nil
+		}
+		if _, _, err := checkConflictingNodes(ctx, nodes, node, nil, true); err != nil {
+			t.Fatalf("unexpected error on the successful build: %v", err)
+		}
+		if buildCalls != 3 {
+			t.Fatalf("expected exactly one more build attempt for the successful build, got %d", buildCalls)
+		}
+
+		// A further call must not rebuild: the successful clientset is
+		// memoized for the rest of the process.
+		if _, _, err := checkConflictingNodes(ctx, nodes, node, nil, true); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if buildCalls != 3 {
+			t.Fatalf("expected the successful build to be memoized (no further build attempts), got %d", buildCalls)
+		}
+	})
+
+	t.Run("Kubernetes datastore type invokes the Lease claim path", func(t *testing.T) {
+		resetTestLeaseState(t)
+		t.Setenv("DATASTORE_TYPE", "kubernetes")
+		buildCalls := 0
+		cs := fake.NewSimpleClientset()
+		withFakeIPClaimClientset(t, cs, &buildCalls)
+
+		nodes := &fakeNodeInterface{}
+		node := makeNode("10.0.1.5/24", "")
+		node.Name = "node-a"
+
+		v4conflict, v6conflict, err := checkConflictingNodes(ctx, nodes, node, nil, true)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if v4conflict || v6conflict {
+			t.Fatalf("unexpected conflict: v4=%v v6=%v", v4conflict, v6conflict)
+		}
+		if nodes.listCalls != 0 {
+			t.Fatalf("expected the legacy list scan not to run, got %d calls", nodes.listCalls)
+		}
+		if buildCalls != 1 {
+			t.Fatalf("expected exactly one Kubernetes clientset build for the Lease claim, got %d", buildCalls)
+		}
+		lease, err := cs.CoordinationV1().Leases(ipclaim.LeaseNamespace).Get(ctx, ipclaim.LeaseNameForIP(mustParseNodeIP(t, node.Spec.BGP.IPv4Address)), metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("expected the IPv4 Lease to have been claimed: %v", err)
+		}
+		if lease.Spec.HolderIdentity == nil || *lease.Spec.HolderIdentity != "node-a" {
+			t.Fatalf("lease holder = %v, want node-a", lease.Spec.HolderIdentity)
+		}
+	})
+
+	t.Run("invokes the Lease claim path with a real Node and sets the OwnerReference", func(t *testing.T) {
+		resetTestLeaseState(t)
+		t.Setenv("DATASTORE_TYPE", "kubernetes")
+		cs := fake.NewSimpleClientset()
+		withFakeIPClaimClientset(t, cs, new(int))
+
+		k8sNode := &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-a", UID: types.UID("node-a-uid")}}
+		nodes := &fakeNodeInterface{}
+		node := makeNode("10.0.1.5/24", "")
+		node.Name = "node-a"
+
+		if _, _, err := checkConflictingNodes(ctx, nodes, node, k8sNode, true); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		lease, err := cs.CoordinationV1().Leases(ipclaim.LeaseNamespace).Get(ctx, ipclaim.LeaseNameForIP(mustParseNodeIP(t, node.Spec.BGP.IPv4Address)), metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("expected the IPv4 Lease to have been claimed: %v", err)
+		}
+		if len(lease.OwnerReferences) != 1 || lease.OwnerReferences[0].UID != types.UID("node-a-uid") || lease.OwnerReferences[0].Name != "node-a" {
+			t.Fatalf("unexpected owner references: %+v", lease.OwnerReferences)
+		}
+	})
+
+	t.Run("releases the stale lease for the previous IP once the new one is claimed", func(t *testing.T) {
+		resetTestLeaseState(t)
+		t.Setenv("DATASTORE_TYPE", "kubernetes")
+		cs := fake.NewSimpleClientset()
+		withFakeIPClaimClientset(t, cs, new(int))
+
+		oldNode := makeNode("10.0.1.9/24", "")
+		if _, _, err := ipclaim.ClaimNodeIPLease(ctx, cs, nil, "node-a", mustParseNodeIP(t, oldNode.Spec.BGP.IPv4Address)); err != nil {
+			t.Fatalf("failed to seed the previous IP's lease: %v", err)
+		}
+
+		nodes := &fakeNodeInterface{getNode: oldNode}
+		node := makeNode("10.0.1.5/24", "")
+		node.Name = "node-a"
+
+		if _, _, err := checkConflictingNodes(ctx, nodes, node, nil, true); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if nodes.getCalls != 1 {
+			t.Fatalf("expected the diagnostic prior-IP Get to run exactly once, got %d calls", nodes.getCalls)
+		}
+
+		if _, err := cs.CoordinationV1().Leases(ipclaim.LeaseNamespace).Get(ctx, ipclaim.LeaseNameForIP(mustParseNodeIP(t, node.Spec.BGP.IPv4Address)), metav1.GetOptions{}); err != nil {
+			t.Fatalf("expected the new IP's lease to exist: %v", err)
+		}
+		if _, err := cs.CoordinationV1().Leases(ipclaim.LeaseNamespace).Get(ctx, ipclaim.LeaseNameForIP(mustParseNodeIP(t, oldNode.Spec.BGP.IPv4Address)), metav1.GetOptions{}); err == nil {
+			t.Fatalf("expected the previous IP's lease to have been released")
+		}
+	})
+
+	// TestCheckConflictingNodesLeaseWiring/releases-the-stale-lease-for-the-previous-address-even-when-the-new-address-conflicts
+	// closes the gap the two subtests above leave open: they only exercise a
+	// release when the new address's own claim succeeds. releaseIPv4 is
+	// computed purely from whether THIS node's own prior-vs-current address
+	// changed, and must not be gated on whether the new address happens to
+	// conflict with a different node's live claim -- if it were, a node
+	// whose address changes into a genuine conflict would never release its
+	// old Lease, which on an autodetected address then gets compounded by
+	// the caller clearing this node's own stored address on a persistent
+	// conflict, permanently losing the ability to compute which address to
+	// release on any later run. Reverting to gating the release on
+	// !v4conflict would fail this test.
+	t.Run("releases the stale lease for the previous address even when the new address conflicts", func(t *testing.T) {
+		resetTestLeaseState(t)
+		t.Setenv("DATASTORE_TYPE", "kubernetes")
+		cs := fake.NewSimpleClientset()
+		withFakeIPClaimClientset(t, cs, new(int))
+
+		oldNode := makeNode("10.0.1.9/24", "")
+		if _, _, err := ipclaim.ClaimNodeIPLease(ctx, cs, nil, "node-a", mustParseNodeIP(t, oldNode.Spec.BGP.IPv4Address)); err != nil {
+			t.Fatalf("failed to seed the previous IP's lease: %v", err)
+		}
+
+		nodes := &fakeNodeInterface{getNode: oldNode}
+		node := makeNode("10.0.1.5/24", "")
+		node.Name = "node-a"
+
+		// A different node already holds our newly detected v4 address, so
+		// the claim for it conflicts.
+		if _, _, err := ipclaim.ClaimNodeIPLease(ctx, cs, nil, "node-other", mustParseNodeIP(t, node.Spec.BGP.IPv4Address)); err != nil {
+			t.Fatalf("failed to seed the conflicting v4 lease: %v", err)
+		}
+
+		v4conflict, _, err := checkConflictingNodes(ctx, nodes, node, nil, true)
+		if err == nil {
+			t.Fatalf("expected a v4 conflict error")
+		}
+		if !v4conflict {
+			t.Fatalf("expected v4conflict to be true")
+		}
+
+		if _, err := cs.CoordinationV1().Leases(ipclaim.LeaseNamespace).Get(ctx, ipclaim.LeaseNameForIP(mustParseNodeIP(t, oldNode.Spec.BGP.IPv4Address)), metav1.GetOptions{}); err == nil {
+			t.Fatalf("expected the previous IP's lease to have been released despite the new address conflicting")
+		}
+		// The conflicting node's claim on the new address must be untouched.
+		lease, err := cs.CoordinationV1().Leases(ipclaim.LeaseNamespace).Get(ctx, ipclaim.LeaseNameForIP(mustParseNodeIP(t, node.Spec.BGP.IPv4Address)), metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("expected the conflicting node's lease on the new address to still exist: %v", err)
+		}
+		if lease.Spec.HolderIdentity == nil || *lease.Spec.HolderIdentity != "node-other" {
+			t.Fatalf("new address lease holder = %v, want node-other", lease.Spec.HolderIdentity)
+		}
+	})
+
+	// TestCheckConflictingNodesLeaseWiring/releases-the-stale-lease-when-the-address-disappears
+	// covers a gap left by the address-change case above: it only exercised
+	// the prior address changing to a DIFFERENT non-nil address. This proves
+	// the prior Lease is also released when the current address goes from
+	// set to nil (e.g. the interface that provided it disappeared) while the
+	// Node object itself survives -- reverting the release condition back to
+	// requiring a non-nil current address, or moving the release calls back
+	// inside the "we have a current address" claim branch, would leak the
+	// stale Lease forever in this scenario and would not be caught without
+	// this test.
+	t.Run("releases the stale lease when the current address disappears entirely", func(t *testing.T) {
+		resetTestLeaseState(t)
+		t.Setenv("DATASTORE_TYPE", "kubernetes")
+		cs := fake.NewSimpleClientset()
+		withFakeIPClaimClientset(t, cs, new(int))
+
+		oldNode := makeNode("10.0.1.9/24", "")
+		if _, _, err := ipclaim.ClaimNodeIPLease(ctx, cs, nil, "node-a", mustParseNodeIP(t, oldNode.Spec.BGP.IPv4Address)); err != nil {
+			t.Fatalf("failed to seed the previous IP's lease: %v", err)
+		}
+
+		nodes := &fakeNodeInterface{getNode: oldNode}
+		// The current node record has no IPv4 address at all -- simulating
+		// the interface that provided it having disappeared. makeNode can't
+		// express this (net.ParseCIDR("") would panic inside it), so the
+		// Node is built directly with an empty BGP spec.
+		node := &internalapi.Node{Spec: internalapi.NodeSpec{BGP: &internalapi.NodeBGPSpec{}}}
+		node.Name = "node-a"
+
+		if _, _, err := checkConflictingNodes(ctx, nodes, node, nil, true); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if _, err := cs.CoordinationV1().Leases(ipclaim.LeaseNamespace).Get(ctx, ipclaim.LeaseNameForIP(mustParseNodeIP(t, oldNode.Spec.BGP.IPv4Address)), metav1.GetOptions{}); err == nil {
+			t.Fatalf("expected the previous IP's lease to have been released even though there is no current address to claim")
+		}
+	})
+
+	// TestCheckConflictingNodesLeaseWiring/releases-the-stale-lease-even-when-falling-back-to-the-legacy-scan-forced
+	// and its LoadClientConfig-error sibling below close the gap the release
+	// subtests above leave open: they only exercise the release call sites
+	// inside the main Lease-claim path. checkConflictingNodes' three
+	// legacy-scan fallback branches (ForceLegacyScan, a LoadClientConfig
+	// error, and a non-Kubernetes datastore type) used to return via
+	// checkConflictingNodesByList without ever calling
+	// releaseStaleIPClaimLeases, permanently orphaning a stale Lease: once
+	// checkConflictingNodesByList finds no conflict, the caller persists the
+	// new address, so the next run's diagnostic prior-address comparison can
+	// never again compute the old address to release. This proves the
+	// release now happens on the ForceLegacyScan fallback path even though it
+	// never reaches the main claim logic below.
+	t.Run("releases the stale lease even when falling back to the legacy scan (forced)", func(t *testing.T) {
+		resetTestLeaseState(t)
+		t.Setenv("DATASTORE_TYPE", "kubernetes")
+		t.Setenv(ipclaim.ForceLegacyScanEnvVar, "true")
+		cs := fake.NewSimpleClientset()
+		withFakeIPClaimClientset(t, cs, new(int))
+
+		oldNode := makeNode("10.0.1.9/24", "")
+		if _, _, err := ipclaim.ClaimNodeIPLease(ctx, cs, nil, "node-a", mustParseNodeIP(t, oldNode.Spec.BGP.IPv4Address)); err != nil {
+			t.Fatalf("failed to seed the previous IP's lease: %v", err)
+		}
+
+		nodes := &fakeNodeInterface{getNode: oldNode}
+		node := makeNode("10.0.1.5/24", "")
+		node.Name = "node-a"
+
+		v4conflict, v6conflict, err := checkConflictingNodes(ctx, nodes, node, nil, true)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if v4conflict || v6conflict {
+			t.Fatalf("unexpected conflict: v4=%v v6=%v", v4conflict, v6conflict)
+		}
+		if nodes.listCalls != 1 {
+			t.Fatalf("expected the legacy list scan to run exactly once, got %d calls", nodes.listCalls)
+		}
+		if _, err := cs.CoordinationV1().Leases(ipclaim.LeaseNamespace).Get(ctx, ipclaim.LeaseNameForIP(mustParseNodeIP(t, oldNode.Spec.BGP.IPv4Address)), metav1.GetOptions{}); err == nil {
+			t.Fatalf("expected the previous IP's lease to have been released despite falling back to the legacy scan")
+		}
+	})
+
+	t.Run("releases the stale lease even when falling back to the legacy scan (LoadClientConfig error)", func(t *testing.T) {
+		resetTestLeaseState(t)
+		// See the "apiconfig.LoadClientConfig error falls back to the legacy
+		// list scan when the address changed" subtest above: an unparsable
+		// CALICO_K8S_CLIENT_QPS makes LoadClientConfig itself fail.
+		t.Setenv("DATASTORE_TYPE", "kubernetes")
+		t.Setenv("CALICO_K8S_CLIENT_QPS", "not-a-number")
+		cs := fake.NewSimpleClientset()
+		withFakeIPClaimClientset(t, cs, new(int))
+
+		oldNode := makeNode("10.0.1.9/24", "")
+		if _, _, err := ipclaim.ClaimNodeIPLease(ctx, cs, nil, "node-a", mustParseNodeIP(t, oldNode.Spec.BGP.IPv4Address)); err != nil {
+			t.Fatalf("failed to seed the previous IP's lease: %v", err)
+		}
+
+		nodes := &fakeNodeInterface{getNode: oldNode}
+		node := makeNode("10.0.1.5/24", "")
+		node.Name = "node-a"
+
+		v4conflict, v6conflict, err := checkConflictingNodes(ctx, nodes, node, nil, true)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if v4conflict || v6conflict {
+			t.Fatalf("unexpected conflict: v4=%v v6=%v", v4conflict, v6conflict)
+		}
+		if nodes.listCalls != 1 {
+			t.Fatalf("expected the legacy list scan to run exactly once, got %d calls", nodes.listCalls)
+		}
+		if _, err := cs.CoordinationV1().Leases(ipclaim.LeaseNamespace).Get(ctx, ipclaim.LeaseNameForIP(mustParseNodeIP(t, oldNode.Spec.BGP.IPv4Address)), metav1.GetOptions{}); err == nil {
+			t.Fatalf("expected the previous IP's lease to have been released despite falling back to the legacy scan")
+		}
+	})
+
+	// TestCheckConflictingNodesLeaseWiring/diagnostic-Get-error-with-addressChanged-is-fatal
+	// covers a gap: the diagnostic Get error branch (anything other than
+	// ErrorResourceDoesNotExist, e.g. a Forbidden/RBAC-denied response) is
+	// only reachable when nodes.Get returns a non-NotFound error, which no
+	// other subtest here exercises -- every other subtest either has no
+	// prior node record (the implicit ErrorResourceDoesNotExist case) or a
+	// successful Get. When addressChanged is true, this Get is the only
+	// source of truth for the prior address, so this proves the function now
+	// returns the Get error rather than pressing on: pressing on would let
+	// the caller claim and persist the new address with no way to ever
+	// identify and release the old address's Lease again. It also proves the
+	// claim itself is never attempted in this case, since the caller (which
+	// gates persisting the new address on v4conflict/v6conflict, both false
+	// here) must not see a Lease it needs to account for.
+	t.Run("diagnostic Get error with addressChanged is fatal and skips the claim", func(t *testing.T) {
+		resetTestLeaseState(t)
+		t.Setenv("DATASTORE_TYPE", "kubernetes")
+		cs := fake.NewSimpleClientset()
+		withFakeIPClaimClientset(t, cs, new(int))
+
+		// Hook the package-level logrus logger (what startup.go's `log`
+		// alias writes through) so we can assert the diagnostic Get error
+		// actually gets logged, not just that it doesn't blow up the call.
+		hook := logtest.NewGlobal()
+		defer hook.Reset()
+
+		getErr := fmt.Errorf("simulated Forbidden error")
+		nodes := &fakeNodeInterface{getErr: getErr}
+		node := makeNode("10.0.1.5/24", "")
+		node.Name = "node-a"
+
+		v4conflict, v6conflict, err := checkConflictingNodes(ctx, nodes, node, nil, true)
+		if err == nil {
+			t.Fatalf("expected the diagnostic Get error to be surfaced as a hard error when addressChanged is true")
+		}
+		if err != getErr {
+			t.Fatalf("returned error = %v, want the injected Get error %v", err, getErr)
+		}
+		if v4conflict || v6conflict {
+			t.Fatalf("unexpected conflict reported: v4=%v v6=%v", v4conflict, v6conflict)
+		}
+		if nodes.getCalls != 1 {
+			t.Fatalf("expected the diagnostic prior-IP Get to run exactly once, got %d calls", nodes.getCalls)
+		}
+		// The claim must never have been attempted: bailing out before it
+		// is what keeps the caller from persisting the new address this run.
+		if _, err := cs.CoordinationV1().Leases(ipclaim.LeaseNamespace).Get(ctx, ipclaim.LeaseNameForIP(mustParseNodeIP(t, node.Spec.BGP.IPv4Address)), metav1.GetOptions{}); err == nil {
+			t.Fatalf("expected no Lease to have been claimed for the current address when the diagnostic Get failed")
+		}
+
+		// The diagnostic Get error must still be logged (now at Error
+		// level, since it's fatal to this call), with the injected error
+		// attached and the node name in the message.
+		var found *log.Entry
+		for _, e := range hook.AllEntries() {
+			if e.Level == log.ErrorLevel && strings.Contains(e.Message, node.Name) {
+				found = e
+				break
+			}
+		}
+		if found == nil {
+			t.Fatalf("expected an Error-level log entry mentioning node %q for the diagnostic Get error, got entries: %+v", node.Name, hook.AllEntries())
+		}
+		loggedErr, ok := found.Data["error"]
+		if !ok {
+			t.Fatalf("expected the logged entry to carry the diagnostic Get error via WithError, got fields: %+v", found.Data)
+		}
+		if loggedErr != getErr {
+			t.Fatalf("logged error = %v, want the injected error %v", loggedErr, getErr)
+		}
+	})
+
+	// Mirrors the subtest above but with addressChanged false: since nothing
+	// new would be persisted this run either way, a diagnostic Get error
+	// stays a logged warning, not a hard error, and the Lease claim still
+	// proceeds normally -- the pre-fix behavior, preserved for this case.
+	t.Run("diagnostic Get error without addressChanged is logged, not fatal, and the claim still proceeds", func(t *testing.T) {
+		resetTestLeaseState(t)
+		t.Setenv("DATASTORE_TYPE", "kubernetes")
+		cs := fake.NewSimpleClientset()
+		withFakeIPClaimClientset(t, cs, new(int))
+
+		hook := logtest.NewGlobal()
+		defer hook.Reset()
+
+		getErr := fmt.Errorf("simulated Forbidden error")
+		nodes := &fakeNodeInterface{getErr: getErr}
+		node := makeNode("10.0.1.5/24", "")
+		node.Name = "node-a"
+
+		if _, _, err := checkConflictingNodes(ctx, nodes, node, nil, false); err != nil {
+			t.Fatalf("expected the diagnostic Get error to be logged, not surfaced as a hard error: %v", err)
+		}
+		if nodes.getCalls != 1 {
+			t.Fatalf("expected the diagnostic prior-IP Get to run exactly once, got %d calls", nodes.getCalls)
+		}
+		// The claim itself must still have proceeded normally despite the
+		// diagnostic Get failure -- addressChanged=false only gates the
+		// legacy-scan and post-backfill branches, not this first claim.
+		lease, err := cs.CoordinationV1().Leases(ipclaim.LeaseNamespace).Get(ctx, ipclaim.LeaseNameForIP(mustParseNodeIP(t, node.Spec.BGP.IPv4Address)), metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("expected the IPv4 Lease to have been claimed despite the diagnostic Get error: %v", err)
+		}
+		if lease.Spec.HolderIdentity == nil || *lease.Spec.HolderIdentity != "node-a" {
+			t.Fatalf("lease holder = %v, want node-a", lease.Spec.HolderIdentity)
+		}
+
+		var found *log.Entry
+		for _, e := range hook.AllEntries() {
+			if e.Level == log.WarnLevel && strings.Contains(e.Message, node.Name) {
+				found = e
+				break
+			}
+		}
+		if found == nil {
+			t.Fatalf("expected a Warn-level log entry mentioning node %q for the diagnostic Get error, got entries: %+v", node.Name, hook.AllEntries())
+		}
+		loggedErr, ok := found.Data["error"]
+		if !ok {
+			t.Fatalf("expected the logged entry to carry the diagnostic Get error via WithError, got fields: %+v", found.Data)
+		}
+		if loggedErr != getErr {
+			t.Fatalf("logged error = %v, want the injected error %v", loggedErr, getErr)
+		}
+	})
+
+	// Proves the retry/self-healing property the fix depends on: a diagnostic
+	// Get failure with addressChanged=true must not be a permanent dead end.
+	// After it causes an error return (simulating this run bailing out before
+	// persisting anything), a subsequent call -- simulating a retry on the
+	// next startup, with the same on-disk prior address still available --
+	// must still correctly compute and release the true prior address's
+	// Lease once the Get succeeds.
+	t.Run("a later retry with a successful Get still releases the true prior address's lease", func(t *testing.T) {
+		resetTestLeaseState(t)
+		t.Setenv("DATASTORE_TYPE", "kubernetes")
+		cs := fake.NewSimpleClientset()
+		withFakeIPClaimClientset(t, cs, new(int))
+
+		oldNode := makeNode("10.0.1.9/24", "")
+		oldNode.Name = "node-a"
+		if _, _, err := ipclaim.ClaimNodeIPLease(ctx, cs, nil, "node-a", mustParseNodeIP(t, oldNode.Spec.BGP.IPv4Address)); err != nil {
+			t.Fatalf("failed to seed the previous IP's lease: %v", err)
+		}
+
+		nodes := &fakeNodeInterface{getErr: fmt.Errorf("simulated Forbidden error")}
+		node := makeNode("10.0.1.5/24", "")
+		node.Name = "node-a"
+
+		// First attempt: the diagnostic Get fails, so the whole call must
+		// bail out with an error and never claim or persist the new
+		// address.
+		if _, _, err := checkConflictingNodes(ctx, nodes, node, nil, true); err == nil {
+			t.Fatalf("expected the first attempt to fail since the diagnostic Get errored")
+		}
+		if _, err := cs.CoordinationV1().Leases(ipclaim.LeaseNamespace).Get(ctx, ipclaim.LeaseNameForIP(mustParseNodeIP(t, node.Spec.BGP.IPv4Address)), metav1.GetOptions{}); err == nil {
+			t.Fatalf("expected no Lease to have been claimed for the new address on the failed first attempt")
+		}
+		// The old address's lease must still exist -- the first attempt
+		// bailed out before ever computing what to release.
+		if _, err := cs.CoordinationV1().Leases(ipclaim.LeaseNamespace).Get(ctx, ipclaim.LeaseNameForIP(mustParseNodeIP(t, oldNode.Spec.BGP.IPv4Address)), metav1.GetOptions{}); err != nil {
+			t.Fatalf("expected the old address's lease to still exist after the failed first attempt: %v", err)
+		}
+
+		// Second attempt (the retry): the diagnostic Get now succeeds and
+		// finds the true prior address, since the failed first attempt
+		// never persisted the new address over it.
+		nodes.getErr = nil
+		nodes.getNode = oldNode
+
+		v4conflict, v6conflict, err := checkConflictingNodes(ctx, nodes, node, nil, true)
+		if err != nil {
+			t.Fatalf("unexpected error on retry: %v", err)
+		}
+		if v4conflict || v6conflict {
+			t.Fatalf("unexpected conflict on retry: v4=%v v6=%v", v4conflict, v6conflict)
+		}
+		newLease, err := cs.CoordinationV1().Leases(ipclaim.LeaseNamespace).Get(ctx, ipclaim.LeaseNameForIP(mustParseNodeIP(t, node.Spec.BGP.IPv4Address)), metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("expected the new address's lease to have been claimed on retry: %v", err)
+		}
+		if newLease.Spec.HolderIdentity == nil || *newLease.Spec.HolderIdentity != "node-a" {
+			t.Fatalf("new lease holder = %v, want node-a", newLease.Spec.HolderIdentity)
+		}
+		if _, err := cs.CoordinationV1().Leases(ipclaim.LeaseNamespace).Get(ctx, ipclaim.LeaseNameForIP(mustParseNodeIP(t, oldNode.Spec.BGP.IPv4Address)), metav1.GetOptions{}); err == nil {
+			t.Fatalf("expected the true prior address's lease to have been released on retry")
+		}
+	})
+
+	t.Run("both v4 and v6 are attempted even when the v4 claim conflicts", func(t *testing.T) {
+		resetTestLeaseState(t)
+		t.Setenv("DATASTORE_TYPE", "kubernetes")
+		cs := fake.NewSimpleClientset()
+		withFakeIPClaimClientset(t, cs, new(int))
+
+		node := makeNode("10.0.1.5/24", "fe80::1/64")
+		node.Name = "node-a"
+
+		// A different node already holds our detected v4 address.
+		if _, _, err := ipclaim.ClaimNodeIPLease(ctx, cs, nil, "node-other", mustParseNodeIP(t, node.Spec.BGP.IPv4Address)); err != nil {
+			t.Fatalf("failed to seed the conflicting v4 lease: %v", err)
+		}
+
+		nodes := &fakeNodeInterface{}
+		v4conflict, v6conflict, err := checkConflictingNodes(ctx, nodes, node, nil, true)
+		if err == nil {
+			t.Fatalf("expected a v4 conflict error")
+		}
+		if !v4conflict {
+			t.Fatalf("expected v4conflict to be true")
+		}
+		if v6conflict {
+			t.Fatalf("expected no v6 conflict")
+		}
+		// The v6 claim must still have been attempted despite the v4
+		// conflict -- checkConflictingNodes doesn't return early on a
+		// conflict (only on a hard error), so both addresses are always
+		// processed in order.
+		lease, err := cs.CoordinationV1().Leases(ipclaim.LeaseNamespace).Get(ctx, ipclaim.LeaseNameForIP(mustParseNodeIP(t, node.Spec.BGP.IPv6Address)), metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("expected the v6 Lease to have been claimed despite the v4 conflict: %v", err)
+		}
+		if lease.Spec.HolderIdentity == nil || *lease.Spec.HolderIdentity != "node-a" {
+			t.Fatalf("v6 lease holder = %v, want node-a", lease.Spec.HolderIdentity)
+		}
+	})
+
+	t.Run("the legacy list scan is skipped when the address hasn't changed (etcd datastore)", func(t *testing.T) {
+		resetTestLeaseState(t)
+		t.Setenv("DATASTORE_TYPE", "etcdv3")
+		buildCalls := 0
+		withFakeIPClaimClientset(t, fake.NewSimpleClientset(), &buildCalls)
+
+		nodes := &fakeNodeInterface{}
+		node := makeNode("10.0.1.5/24", "")
+		node.Name = "node-a"
+
+		v4conflict, v6conflict, err := checkConflictingNodes(ctx, nodes, node, nil, false)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if v4conflict || v6conflict {
+			t.Fatalf("unexpected conflict: v4=%v v6=%v", v4conflict, v6conflict)
+		}
+		if nodes.listCalls != 0 {
+			t.Fatalf("expected the legacy list scan to be skipped on an unchanged address, got %d calls", nodes.listCalls)
+		}
+	})
+
+	t.Run("the legacy list scan is skipped when the address hasn't changed (forced legacy scan)", func(t *testing.T) {
+		resetTestLeaseState(t)
+		t.Setenv("DATASTORE_TYPE", "kubernetes")
+		t.Setenv(ipclaim.ForceLegacyScanEnvVar, "true")
+		buildCalls := 0
+		withFakeIPClaimClientset(t, fake.NewSimpleClientset(), &buildCalls)
+
+		nodes := &fakeNodeInterface{}
+		node := makeNode("10.0.1.5/24", "")
+		node.Name = "node-a"
+
+		v4conflict, v6conflict, err := checkConflictingNodes(ctx, nodes, node, nil, false)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if v4conflict || v6conflict {
+			t.Fatalf("unexpected conflict: v4=%v v6=%v", v4conflict, v6conflict)
+		}
+		if nodes.listCalls != 0 {
+			t.Fatalf("expected the legacy list scan to be skipped on an unchanged address, got %d calls", nodes.listCalls)
+		}
+		if buildCalls != 0 {
+			t.Fatalf("expected no attempt to build a Kubernetes clientset when the scan is skipped, got %d", buildCalls)
+		}
+	})
+
+	t.Run("the Lease claim path still runs on an unchanged address before it has ever backfilled successfully", func(t *testing.T) {
+		resetTestLeaseState(t)
+		t.Setenv("DATASTORE_TYPE", "kubernetes")
+		buildCalls := 0
+		cs := fake.NewSimpleClientset()
+		withFakeIPClaimClientset(t, cs, &buildCalls)
+
+		nodes := &fakeNodeInterface{}
+		node := makeNode("10.0.1.5/24", "")
+		node.Name = "node-a"
+
+		v4conflict, v6conflict, err := checkConflictingNodes(ctx, nodes, node, nil, false)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if v4conflict || v6conflict {
+			t.Fatalf("unexpected conflict: v4=%v v6=%v", v4conflict, v6conflict)
+		}
+		if nodes.listCalls != 0 {
+			t.Fatalf("expected the legacy list scan not to run, got %d calls", nodes.listCalls)
+		}
+		if buildCalls != 1 {
+			t.Fatalf("expected the Lease claim path to still build a Kubernetes clientset on an unchanged address before it has ever backfilled, got %d", buildCalls)
+		}
+		lease, err := cs.CoordinationV1().Leases(ipclaim.LeaseNamespace).Get(ctx, ipclaim.LeaseNameForIP(mustParseNodeIP(t, node.Spec.BGP.IPv4Address)), metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("expected the IPv4 Lease to have been claimed despite the unchanged address: %v", err)
+		}
+		if lease.Spec.HolderIdentity == nil || *lease.Spec.HolderIdentity != "node-a" {
+			t.Fatalf("lease holder = %v, want node-a", lease.Spec.HolderIdentity)
+		}
+	})
+
+	// TestCheckConflictingNodesLeaseWiring/lease-claim-backfill-gate covers
+	// the CRITICAL fix: once the Lease claim has succeeded once in this
+	// process, a later call with an unchanged address must not repeat it.
+	// Before this fix, checkConflictingNodes ran the Lease claim
+	// unconditionally on every call, including from the periodic
+	// monitor-addresses goroutine (default every 60s) which treats any
+	// returned error as fatal to the whole calico-node process -- so any
+	// transient failure on a later tick would have crash-looped the node
+	// forever, long after the fleet had already converged. This proves the
+	// gate closes after one success, and that a first failed attempt does
+	// not (falsely) close it.
+	t.Run("the Lease claim path runs unconditionally only until it first succeeds, then gates on addressChanged", func(t *testing.T) {
+		resetTestLeaseState(t)
+		t.Setenv("DATASTORE_TYPE", "kubernetes")
+		buildCalls := 0
+		cs := fake.NewSimpleClientset()
+		withFakeIPClaimClientset(t, cs, &buildCalls)
+
+		nodes := &fakeNodeInterface{}
+		node := makeNode("10.0.1.5/24", "")
+		node.Name = "node-a"
+
+		// A failed attempt (Create keeps failing) must not close the gate:
+		// the next call with an unchanged address should still retry.
+		cs.PrependReactor("create", "leases", func(action clientgotesting.Action) (bool, runtime.Object, error) {
+			return true, nil, apierrors.NewServerTimeout(coordinationLeaseResource(), "create", 1)
+		})
+		// ipclaim's own claimRetryAttempts/claimRetryBackoff retry a
+		// transient Create failure a few times (~1s total with the package
+		// defaults) before giving up; that's exercised here rather than
+		// shortened, since those knobs are unexported in the ipclaim
+		// package and this test only needs the attempt to fail once, not to
+		// be fast.
+		if _, _, err := checkConflictingNodes(ctx, nodes, node, nil, false); err == nil {
+			t.Fatalf("expected the seeded transient failure to surface as an error")
+		}
+		if buildCalls != 1 {
+			t.Fatalf("expected the failed attempt to still have built a clientset, got %d", buildCalls)
+		}
+		if leaseBackfilled.Load() {
+			t.Fatalf("a failed attempt must not mark the backfill as done")
+		}
+
+		// Clear the injected failure; the claim now succeeds, closing the
+		// gate.
+		cs = fake.NewSimpleClientset()
+		withFakeIPClaimClientset(t, cs, &buildCalls)
+		buildCalls = 0
+		if _, _, err := checkConflictingNodes(ctx, nodes, node, nil, false); err != nil {
+			t.Fatalf("unexpected error on the successful attempt: %v", err)
+		}
+		if !leaseBackfilled.Load() {
+			t.Fatalf("expected a successful claim to mark the backfill as done")
+		}
+
+		// A further call with an unchanged address must now be skipped
+		// entirely -- no clientset build, no Lease call.
+		buildCalls = 0
+		if _, _, err := checkConflictingNodes(ctx, nodes, node, nil, false); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if buildCalls != 0 {
+			t.Fatalf("expected the Lease claim path to be skipped once backfilled and the address hasn't changed, got %d clientset builds", buildCalls)
+		}
+
+		// An actual address change still runs the claim even after backfill.
+		// getIPClaimClientset memoizes the clientset for the process (see
+		// finding #6), so a real address change doesn't rebuild it -- verify
+		// the claim itself ran instead, by checking a new Lease appears for
+		// the changed address.
+		changedNode := makeNode("10.0.1.9/24", "")
+		changedNode.Name = "node-a"
+		if _, _, err := checkConflictingNodes(ctx, nodes, changedNode, nil, true); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if _, err := cs.CoordinationV1().Leases(ipclaim.LeaseNamespace).Get(ctx, ipclaim.LeaseNameForIP(mustParseNodeIP(t, changedNode.Spec.BGP.IPv4Address)), metav1.GetOptions{}); err != nil {
+			t.Fatalf("expected the changed address to have been claimed even after the backfill gate closed: %v", err)
+		}
+	})
+}
+
+// withFakeIPClaimClientset substitutes newIPClaimClientset -- the seam
+// checkConflictingNodes uses to build the Kubernetes clientset for the Lease
+// claim -- with one that returns cs and counts how many times it was called,
+// restoring the original afterward.
+// withFakeIPClaimClientset also resets the getIPClaimClientset memoization
+// (see the ipClaimClientsetMu/ipClaimClientset package vars) both before and
+// after substituting newIPClaimClientset, so a value cached by a previous
+// subtest -- or by earlier steps within the same subtest -- never survives
+// to be returned instead of calling the substitute this test just installed.
+func withFakeIPClaimClientset(t *testing.T, cs kubernetes.Interface, calls *int) {
+	t.Helper()
+	origFn := newIPClaimClientset
+	resetIPClaimClientsetMemo()
+	newIPClaimClientset = func() (kubernetes.Interface, error) {
+		*calls++
+		return cs, nil
+	}
+	t.Cleanup(func() {
+		newIPClaimClientset = origFn
+		resetIPClaimClientsetMemo()
+	})
+}
+
+// withFakeIPClaimClientsetErr substitutes newIPClaimClientset with one that
+// always fails with wantErr, for exercising newIPClaimClientset's own error
+// path through getIPClaimClientset/checkConflictingNodes.
+func withFakeIPClaimClientsetErr(t *testing.T, wantErr error) {
+	t.Helper()
+	origFn := newIPClaimClientset
+	resetIPClaimClientsetMemo()
+	newIPClaimClientset = func() (kubernetes.Interface, error) {
+		return nil, wantErr
+	}
+	t.Cleanup(func() {
+		newIPClaimClientset = origFn
+		resetIPClaimClientsetMemo()
+	})
+}
+
+// resetIPClaimClientsetMemo clears getIPClaimClientset's memoized state --
+// the cached clientset is reset to nil under its mutex, rather than saved and
+// restored, since no test relies on the memoized state surviving across
+// subtests; each subtest that touches it starts and ends with a clean slate.
+func resetIPClaimClientsetMemo() {
+	ipClaimClientsetMu.Lock()
+	defer ipClaimClientsetMu.Unlock()
+	ipClaimClientset = nil
+}
+
+// fakeNodeInterface is a minimal stand-in for client.NodeInterface. It's
+// enough to exercise checkConflictingNodes/checkConflictingNodesByList,
+// which only ever call Get (the diagnostic prior-IP lookup) and List (the
+// legacy scan) on it; Create/Update/Delete/Watch panic if a test path
+// reaches them, since none of the cases here are expected to.
+type fakeNodeInterface struct {
+	getNode  *internalapi.Node
+	getErr   error
+	getCalls int
+
+	listNodes []internalapi.Node
+	listErr   error
+	listCalls int
+}
+
+func (f *fakeNodeInterface) Create(context.Context, *internalapi.Node, options.SetOptions) (*internalapi.Node, error) {
+	panic("fakeNodeInterface: Create not expected in this test")
+}
+
+func (f *fakeNodeInterface) Update(context.Context, *internalapi.Node, options.SetOptions) (*internalapi.Node, error) {
+	panic("fakeNodeInterface: Update not expected in this test")
+}
+
+func (f *fakeNodeInterface) Delete(context.Context, string, options.DeleteOptions) (*internalapi.Node, error) {
+	panic("fakeNodeInterface: Delete not expected in this test")
+}
+
+func (f *fakeNodeInterface) Get(_ context.Context, name string, _ options.GetOptions) (*internalapi.Node, error) {
+	f.getCalls++
+	if f.getErr != nil {
+		return nil, f.getErr
+	}
+	if f.getNode == nil {
+		// A brand-new node with no prior record: the real Calico datastore
+		// client returns cerrors.ErrorResourceDoesNotExist for this, and
+		// checkConflictingNodes' addressChanged-fatal diagnostic-Get-error
+		// path specifically depends on that type to distinguish "no prior
+		// record yet" (expected, not fatal) from a genuine failure to read
+		// one (fatal when addressChanged). A generic error here would make
+		// every "brand-new node" subtest in this file trip that fatal path.
+		return nil, cerrors.ErrorResourceDoesNotExist{Identifier: name}
+	}
+	return f.getNode, nil
+}
+
+func (f *fakeNodeInterface) List(context.Context, options.ListOptions) (*internalapi.NodeList, error) {
+	f.listCalls++
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	return &internalapi.NodeList{Items: f.listNodes}, nil
+}
+
+func (f *fakeNodeInterface) Watch(context.Context, options.ListOptions) (watch.Interface, error) {
+	panic("fakeNodeInterface: Watch not expected in this test")
+}

--- a/node/pkg/lifecycle/startup/ipclaim/ipclaim.go
+++ b/node/pkg/lifecycle/startup/ipclaim/ipclaim.go
@@ -1,0 +1,346 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package ipclaim claims a node's detected IP addresses via Kubernetes
+// Leases, replacing a full-cluster Node List-and-scan conflict check with an
+// O(1) atomic claim per address.
+package ipclaim
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"net"
+	"os"
+	"strings"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	coordinationv1 "k8s.io/api/coordination/v1"
+	v1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+)
+
+// LeaseNamespace is the namespace the IP claim Lease client reads, creates,
+// and deletes calico-ip-* Leases in. It is deliberately not kube-system:
+// Kubernetes RBAC resourceNames only supports exact literal name lists, and
+// the calico-ip-<ip> Lease names are only known at runtime, so a Role can't
+// scope this down by name. Sharing kube-system with control-plane
+// leader-election Leases (kube-scheduler, kube-controller-manager) would
+// mean a bug or compromised calico-node pod -- hostNetwork and privileged,
+// running on every node -- could delete or overwrite one of those and force
+// an unrelated leader-election flap. calico-system is the namespace
+// calico-node's own ServiceAccount and DaemonSet already live in exclusively,
+// so scoping the Lease RBAC Role there instead bounds the blast radius to
+// calico-node's own resources.
+const LeaseNamespace = "calico-system"
+
+// claimRetryAttempts and claimRetryBackoff bound how many times, and how
+// long between tries, ClaimNodeIPLease retries a Create that failed for a
+// reason other than AlreadyExists (a real conflict, which is never retried)
+// before giving up and returning the error to the caller. A mass scale-up or
+// fleet reboot -- the exact scenario this package exists to survive -- is
+// also when apiserver latency is most likely to be degraded; without a
+// retry, a transient timeout on Create is indistinguishable from a real
+// conflict, and both terminate node startup. Package-level variables, not
+// constants, so tests can shrink claimRetryBackoff instead of sleeping for
+// real.
+var (
+	claimRetryAttempts = 3
+	claimRetryBackoff  = 500 * time.Millisecond
+)
+
+// retryBackoffWithJitter returns claimRetryBackoff plus up to half of
+// claimRetryBackoff again, chosen at random. A mass scale-up or fleet
+// reboot -- the scenario this package exists to survive -- is also the
+// scenario where many nodes' Create calls are most likely to fail together
+// (shared apiserver overload), and a fixed backoff makes them all retry in
+// lock-step, reproducing the very burst they're backing off from. Partial
+// jitter (rather than full 0..claimRetryBackoff jitter) keeps a floor under
+// the sleep so a test that shrinks claimRetryBackoff via withFastRetries can
+// still assume a bounded, short-but-nonzero sleep.
+func retryBackoffWithJitter() time.Duration {
+	if claimRetryBackoff <= 0 {
+		return 0
+	}
+	return claimRetryBackoff + time.Duration(rand.Int63n(int64(claimRetryBackoff)/2+1))
+}
+
+// LeaseNameForIP encodes an IP address as a valid Kubernetes object name,
+// e.g. "10.0.1.5" -> "calico-ip-10-0-1-5", "fe80::1" -> "calico-ip-fe80--1".
+//
+// An IPv6 address whose RFC 5952 canonical form ends in the "::"
+// zero-compression marker (e.g. the unspecified address "::", or
+// "2001:db8:1::") would otherwise produce a name ending in "-", which fails
+// Kubernetes' DNS1123-subdomain name validation (names must start and end
+// with an alphanumeric character) and makes the Lease Create call fail
+// deterministically. Guard only the trailing edge: the "calico-ip-" prefix
+// already guarantees the name starts with an alnum character. "z" is
+// appended because it never occurs naturally in a lowercased IP's string
+// form (which is limited to hex digits, decimal digits, "." and ":"), so it
+// can't collide with a genuine address character, and it's only appended
+// when the string already ends in "-", so it can't collide between two
+// different addresses either -- everything before the trailing hyphen run
+// is already the unique, distinguishing part of the name.
+func LeaseNameForIP(ip net.IP) string {
+	s := strings.ToLower(ip.String())
+	s = strings.ReplaceAll(s, ":", "-")
+	s = strings.ReplaceAll(s, ".", "-")
+	if strings.HasSuffix(s, "-") {
+		s += "z"
+	}
+	return "calico-ip-" + s
+}
+
+// ClaimNodeIPLease atomically claims ip for holderNodeName using a
+// coordination.k8s.io/v1 Lease named after the IP (see LeaseNameForIP).
+// Lease creation is atomic at the API server (an etcd CreateRevision==0
+// guard), so two nodes racing to claim the same IP never both succeed: the
+// loser gets AlreadyExists, reported here as a conflict.
+//
+// The Lease carries an OwnerReference to k8sNode so it is garbage-collected
+// automatically when the Node object is deleted: the caller does not delete
+// its own Lease on shutdown, so a crashed node never leaves the IP wedged --
+// the Node's lifecycle, not the caller's process lifecycle, is the source of
+// truth for whether a claim is still valid. If k8sNode is nil the claim is
+// still made, but without an OwnerReference, so it will not be cleaned up
+// automatically.
+//
+// When the Lease already exists and is already held by holderNodeName, this
+// also repairs a stale owner reference: if the Node object was deleted and
+// re-registered under the same name (a `kubectl delete node`, a
+// cluster-operator/autoscaler action, or a Machine-lifecycle recreate all do
+// this -- the name is stable but the UID isn't), the surviving Lease still
+// owner-references the old, now-nonexistent UID, and Kubernetes' garbage
+// collector will eventually delete it as an orphan out from under a node
+// that is still alive and still holds the address. Re-pointing the
+// OwnerReferences at the current k8sNode.UID closes that window.
+//
+// A Create error that isn't AlreadyExists is retried up to claimRetryAttempts
+// times with a jittered claimRetryBackoff pause in between (see
+// retryBackoffWithJitter): during a mass scale-up or fleet reboot, apiserver
+// latency is exactly what's degraded, so a transient timeout is not a
+// reliable signal of a real conflict and shouldn't be treated as fatal on
+// the first failure. AlreadyExists itself is never retried -- it is already
+// a conclusive answer, not a transient condition -- but the follow-up Get it
+// triggers can still race: if the Lease that caused AlreadyExists is deleted
+// (e.g. its owning Node was deleted and Kubernetes GC reaped it) between our
+// Create and this Get, the Get comes back NotFound even though the IP is
+// free again, and that specific case is retried like any other transient
+// failure instead of being treated as a hard error.
+//
+// If the Lease is already held by us and its OwnerReferences turn out to be
+// stale (see below), a failure to repair that owner reference is logged as a
+// warning, not returned as an error: the claim itself already succeeded --
+// we already hold HolderIdentity -- so a benign race on the repair Update
+// (e.g. a concurrent racer for the same node name during a rolling restart)
+// must not fail node startup over what is, at worst, a deferred cleanup that
+// can be retried on a later run.
+//
+// Returns conflict=true (with the current holder's node name) if the Lease is
+// already held by a different node.
+func ClaimNodeIPLease(ctx context.Context, clientset kubernetes.Interface, k8sNode *v1.Node, holderNodeName string, ip net.IP) (conflict bool, holder string, err error) {
+	name := LeaseNameForIP(ip)
+	leaseClient := clientset.CoordinationV1().Leases(LeaseNamespace)
+
+	lease := &coordinationv1.Lease{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: LeaseNamespace,
+		},
+		Spec: coordinationv1.LeaseSpec{
+			HolderIdentity: &holderNodeName,
+		},
+	}
+	if k8sNode != nil {
+		lease.OwnerReferences = []metav1.OwnerReference{{
+			APIVersion: "v1",
+			Kind:       "Node",
+			Name:       k8sNode.Name,
+			UID:        k8sNode.UID,
+		}}
+	} else {
+		log.Warn("No Kubernetes Node object available; IP claim lease will not be owner-referenced for automatic cleanup")
+	}
+
+	var lastErr error
+	for attempt := 1; attempt <= claimRetryAttempts; attempt++ {
+		_, createErr := leaseClient.Create(ctx, lease, metav1.CreateOptions{})
+		switch {
+		case createErr == nil:
+			return false, holderNodeName, nil
+		case kerrors.IsAlreadyExists(createErr):
+			existing, getErr := leaseClient.Get(ctx, name, metav1.GetOptions{})
+			switch {
+			case getErr == nil:
+				if existing.Spec.HolderIdentity != nil && *existing.Spec.HolderIdentity == holderNodeName {
+					// Already held from a prior run (e.g. a restart with no IP
+					// change) -- not a conflict. But the same holder name isn't
+					// proof that the Lease's OwnerReference still points at a
+					// live Node: if k8sNode was deleted and re-created under the
+					// same name, existing's OwnerReferences still carries the
+					// old UID, and Kubernetes GC will reap the Lease as an
+					// orphan out from under us. Repair it here rather than
+					// leaving that window open.
+					if k8sNode != nil && !hasOwnerUID(existing.OwnerReferences, k8sNode.UID) {
+						existing.OwnerReferences = []metav1.OwnerReference{{
+							APIVersion: "v1",
+							Kind:       "Node",
+							Name:       k8sNode.Name,
+							UID:        k8sNode.UID,
+						}}
+						if _, updateErr := leaseClient.Update(ctx, existing, metav1.UpdateOptions{}); updateErr != nil {
+							// The claim already succeeded (we hold
+							// HolderIdentity); a repair failure -- including a
+							// benign Conflict from a concurrent racer -- is
+							// not worth failing node startup over. Retried on
+							// a later run.
+							log.WithError(updateErr).WithFields(log.Fields{"lease": name, "node": k8sNode.Name}).Warn("IP claim lease has a stale owner reference that could not be repaired this run; the claim itself is unaffected")
+						} else {
+							log.WithFields(log.Fields{"lease": name, "node": k8sNode.Name}).Info("Repaired stale owner reference on IP claim lease after Node recreation")
+						}
+					}
+					return false, holderNodeName, nil
+				}
+				otherHolder := "unknown"
+				if existing.Spec.HolderIdentity != nil {
+					otherHolder = *existing.Spec.HolderIdentity
+				}
+				return true, otherHolder, nil
+			case kerrors.IsNotFound(getErr):
+				// The Lease that caused AlreadyExists is gone by the time we
+				// read it back -- e.g. its owning Node was deleted and
+				// Kubernetes GC reaped it in the window between our Create
+				// and this Get. The IP is free again, so retry the Create
+				// instead of treating this as a hard error.
+				lastErr = fmt.Errorf("IP claim lease %s vanished after AlreadyExists: %w", name, getErr)
+				if attempt == claimRetryAttempts {
+					break
+				}
+				log.WithError(getErr).Warnf("IP claim lease %s existed on Create but vanished before Get (attempt %d/%d); retrying", name, attempt, claimRetryAttempts)
+				select {
+				case <-ctx.Done():
+					return false, "", fmt.Errorf("failed to create IP claim lease %s: %w", name, ctx.Err())
+				case <-time.After(retryBackoffWithJitter()):
+				}
+			default:
+				return false, "", fmt.Errorf("IP %s already claimed and lease %s could not be read: %w", ip, name, getErr)
+			}
+		default:
+			lastErr = createErr
+			if attempt == claimRetryAttempts {
+				break
+			}
+			log.WithError(createErr).Warnf("Failed to create IP claim lease %s (attempt %d/%d); retrying", name, attempt, claimRetryAttempts)
+			select {
+			case <-ctx.Done():
+				return false, "", fmt.Errorf("failed to create IP claim lease %s: %w", name, ctx.Err())
+			case <-time.After(retryBackoffWithJitter()):
+			}
+		}
+	}
+	return false, "", fmt.Errorf("failed to create IP claim lease %s after %d attempts: %w", name, claimRetryAttempts, lastErr)
+}
+
+// hasOwnerUID reports whether refs already contains an owner reference with
+// the given UID.
+func hasOwnerUID(refs []metav1.OwnerReference, uid types.UID) bool {
+	for _, ref := range refs {
+		if ref.UID == uid {
+			return true
+		}
+	}
+	return false
+}
+
+// ReleaseNodeIPLease deletes the Lease claiming ip, but only if it is still
+// held by holderNodeName.
+//
+// This matters because the Lease's OwnerReference only cleans it up when the
+// Node object itself is deleted -- but a node can change its detected IP
+// while its Node object stays alive (e.g. a brief restart that gets a new
+// DHCP-assigned address but keeps the same node identity; the pre-Lease
+// conflict check already logged a warning for exactly this case rather than
+// treating it as an error). When that happens the old IP's Lease is never
+// automatically cleaned up, so callers must release it explicitly once
+// they've confirmed which address is no longer held.
+//
+// The caller's belief that it still owns this Lease can be stale: it comes
+// from a Get made before the release, and in the meantime the old Node could
+// have been deleted (freeing the Lease via its OwnerReference), claimed by a
+// different node, and then claimed again by a third -- all while this node
+// is acting on outdated information. Deleting by name alone would remove
+// whichever Lease happens to have that name when the delete runs, including
+// a different node's live claim, defeating the entire point of an atomic
+// claim: two nodes would end up sharing one IP, exactly the outage this
+// package exists to prevent. So this reads the Lease first and refuses to
+// delete it unless HolderIdentity still names holderNodeName, then deletes
+// with a UID+ResourceVersion precondition tying the delete to exactly the
+// object just read -- if anything replaced the Lease in between, the
+// precondition fails and the delete is skipped rather than removing whatever
+// is there now.
+//
+// A NotFound Get, or a precondition failure (Conflict) or NotFound on
+// Delete, is not an error: either way, there is nothing of ours left to
+// release. Any other error is returned to the caller to log, but is not
+// meant to block claiming the new IP -- leaving a stale Lease around a
+// little longer is far less harmful than failing node startup over an
+// unrelated cleanup hiccup.
+func ReleaseNodeIPLease(ctx context.Context, clientset kubernetes.Interface, holderNodeName string, ip net.IP) error {
+	name := LeaseNameForIP(ip)
+	leaseClient := clientset.CoordinationV1().Leases(LeaseNamespace)
+
+	existing, err := leaseClient.Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		if kerrors.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to read IP claim lease %s before release: %w", name, err)
+	}
+	if existing.Spec.HolderIdentity == nil || *existing.Spec.HolderIdentity != holderNodeName {
+		// Not ours (any more): someone else's live claim now holds this
+		// name. Deleting it would be exactly the bug this check exists to
+		// avoid, so leave it alone.
+		return nil
+	}
+
+	err = leaseClient.Delete(ctx, name, metav1.DeleteOptions{
+		Preconditions: &metav1.Preconditions{
+			UID:             &existing.UID,
+			ResourceVersion: &existing.ResourceVersion,
+		},
+	})
+	if err != nil && !kerrors.IsNotFound(err) && !kerrors.IsConflict(err) {
+		return fmt.Errorf("failed to release stale IP claim lease %s: %w", name, err)
+	}
+	return nil
+}
+
+// ForceLegacyScanEnvVar is a rollout safety valve: when set to "true", it
+// forces callers to use the legacy full-list conflict scan instead of the
+// Lease-based claim in this package, even when a Kubernetes API is otherwise
+// available. This lets an operator revert to the pre-Lease behavior without a
+// full patch rollback or image rebuild if the Lease-based claim misbehaves in
+// production. It is independent of Calico's own DISABLE_NODE_IP_CHECK, which
+// skips the conflict check entirely; this instead forces a specific
+// implementation of the check to run.
+const ForceLegacyScanEnvVar = "FORCE_NODE_IP_CHECK_LEGACY_SCAN"
+
+// ForceLegacyScan reports whether ForceLegacyScanEnvVar is set to "true".
+func ForceLegacyScan() bool {
+	return os.Getenv(ForceLegacyScanEnvVar) == "true"
+}

--- a/node/pkg/lifecycle/startup/ipclaim/ipclaim_test.go
+++ b/node/pkg/lifecycle/startup/ipclaim/ipclaim_test.go
@@ -1,0 +1,529 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ipclaim
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+	"time"
+
+	coordinationv1 "k8s.io/api/coordination/v1"
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/validation"
+	"k8s.io/client-go/kubernetes/fake"
+	clientgotesting "k8s.io/client-go/testing"
+)
+
+// coordinationLeaseResource is the GroupResource fake API-error constructors
+// need to build a realistic simulated apiserver error for a Lease.
+func coordinationLeaseResource() schema.GroupResource {
+	return coordinationv1.SchemeGroupVersion.WithResource("leases").GroupResource()
+}
+
+// withFastRetries shrinks claimRetryBackoff to something a test can afford to
+// actually sleep through, and restores both retry knobs afterward.
+func withFastRetries(t *testing.T, attempts int) {
+	t.Helper()
+	origAttempts, origBackoff := claimRetryAttempts, claimRetryBackoff
+	claimRetryAttempts = attempts
+	claimRetryBackoff = time.Millisecond
+	t.Cleanup(func() {
+		claimRetryAttempts, claimRetryBackoff = origAttempts, origBackoff
+	})
+}
+
+func TestLeaseNameForIP(t *testing.T) {
+	cases := []struct {
+		name string
+		ip   string
+		want string
+	}{
+		{name: "IPv4", ip: "10.0.1.5", want: "calico-ip-10-0-1-5"},
+		{name: "IPv6", ip: "fe80::1", want: "calico-ip-fe80--1"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := LeaseNameForIP(net.ParseIP(tc.ip))
+			if got != tc.want {
+				t.Errorf("LeaseNameForIP(%s) = %q, want %q", tc.ip, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestLeaseNameForIPTrailingZeroCompression covers IPv6 addresses whose RFC
+// 5952 canonical string ends in the "::" zero-compression marker. Left
+// unguarded, the naive ":" -> "-" substitution produces a name ending in
+// "-", which Kubernetes' DNS1123-subdomain validation rejects, so the Lease
+// Create call would fail deterministically rather than racing cleanly. Each
+// case is checked against the real k8s name validator, not just eyeballed,
+// so this actually proves the fix works rather than just checking cosmetic
+// properties of the returned string.
+func TestLeaseNameForIPTrailingZeroCompression(t *testing.T) {
+	cases := []struct {
+		name string
+		ip   string
+	}{
+		{name: "unspecified address", ip: "::"},
+		{name: "address with trailing zero-compression", ip: "2001:db8:1::"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			parsed := net.ParseIP(tc.ip)
+			if parsed == nil {
+				t.Fatalf("net.ParseIP(%q) returned nil", tc.ip)
+			}
+			got := LeaseNameForIP(parsed)
+			if got == "" {
+				t.Fatalf("LeaseNameForIP(%s) returned an empty name", tc.ip)
+			}
+			last := got[len(got)-1]
+			if !(last >= 'a' && last <= 'z' || last >= '0' && last <= '9') {
+				t.Fatalf("LeaseNameForIP(%s) = %q, does not end in an alphanumeric character", tc.ip, got)
+			}
+			if errs := validation.IsDNS1123Subdomain(got); len(errs) != 0 {
+				t.Fatalf("LeaseNameForIP(%s) = %q is not a valid DNS1123 subdomain: %v", tc.ip, got, errs)
+			}
+		})
+	}
+}
+
+func TestClaimNodeIPLease(t *testing.T) {
+	ctx := context.Background()
+	ip := net.ParseIP("10.0.1.5")
+	nodeA := &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-a", UID: types.UID("node-a-uid")}}
+	nodeB := &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-b", UID: types.UID("node-b-uid")}}
+
+	t.Run("succeeds and owner-references the Node when no one else holds the IP", func(t *testing.T) {
+		clientset := fake.NewSimpleClientset()
+
+		conflict, holder, err := ClaimNodeIPLease(ctx, clientset, nodeA, "node-a", ip)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if conflict {
+			t.Fatalf("expected no conflict, got conflict with holder %q", holder)
+		}
+		if holder != "node-a" {
+			t.Fatalf("holder = %q, want node-a", holder)
+		}
+
+		lease, err := clientset.CoordinationV1().Leases(LeaseNamespace).Get(ctx, "calico-ip-10-0-1-5", metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("lease not found: %v", err)
+		}
+		if lease.Spec.HolderIdentity == nil || *lease.Spec.HolderIdentity != "node-a" {
+			t.Fatalf("lease holder identity = %v, want node-a", lease.Spec.HolderIdentity)
+		}
+		if len(lease.OwnerReferences) != 1 || lease.OwnerReferences[0].UID != types.UID("node-a-uid") {
+			t.Fatalf("unexpected owner references: %+v", lease.OwnerReferences)
+		}
+	})
+
+	t.Run("is idempotent when the caller already holds the lease", func(t *testing.T) {
+		clientset := fake.NewSimpleClientset()
+
+		if _, _, err := ClaimNodeIPLease(ctx, clientset, nodeA, "node-a", ip); err != nil {
+			t.Fatalf("first claim failed: %v", err)
+		}
+		conflict, holder, err := ClaimNodeIPLease(ctx, clientset, nodeA, "node-a", ip)
+		if err != nil {
+			t.Fatalf("second claim (re-claim by same holder) failed: %v", err)
+		}
+		if conflict {
+			t.Fatalf("expected no conflict on re-claim by the same holder, got conflict with holder %q", holder)
+		}
+	})
+
+	t.Run("reports a conflict when a different node already holds the IP", func(t *testing.T) {
+		clientset := fake.NewSimpleClientset()
+
+		if _, _, err := ClaimNodeIPLease(ctx, clientset, nodeA, "node-a", ip); err != nil {
+			t.Fatalf("first claim failed: %v", err)
+		}
+		conflict, holder, err := ClaimNodeIPLease(ctx, clientset, nodeB, "node-b", ip)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !conflict {
+			t.Fatalf("expected a conflict, got none")
+		}
+		if holder != "node-a" {
+			t.Fatalf("holder = %q, want node-a (the original claimant)", holder)
+		}
+	})
+
+	t.Run("repairs a stale owner reference when the lease is still held by us but the Node was recreated with a new UID", func(t *testing.T) {
+		// Simulates a Node delete+re-register under the same name: the
+		// Lease's HolderIdentity still names us, so this isn't a conflict,
+		// but its OwnerReferences UID is now stale and would eventually be
+		// reaped by Kubernetes GC as an orphan out from under a node that's
+		// still alive and still holds the address.
+		clientset := fake.NewSimpleClientset()
+		nodeARecreated := &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-a", UID: types.UID("node-a-uid-2")}}
+
+		if _, _, err := ClaimNodeIPLease(ctx, clientset, nodeA, "node-a", ip); err != nil {
+			t.Fatalf("first claim failed: %v", err)
+		}
+
+		conflict, holder, err := ClaimNodeIPLease(ctx, clientset, nodeARecreated, "node-a", ip)
+		if err != nil {
+			t.Fatalf("re-claim after Node recreation failed: %v", err)
+		}
+		if conflict {
+			t.Fatalf("expected no conflict, got conflict with holder %q", holder)
+		}
+
+		lease, err := clientset.CoordinationV1().Leases(LeaseNamespace).Get(ctx, "calico-ip-10-0-1-5", metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("lease not found: %v", err)
+		}
+		if len(lease.OwnerReferences) != 1 || lease.OwnerReferences[0].UID != types.UID("node-a-uid-2") {
+			t.Fatalf("expected the owner reference to be repaired to the new UID, got: %+v", lease.OwnerReferences)
+		}
+	})
+
+	t.Run("a stale owner reference repair failure is logged, not returned, since the claim itself already succeeded", func(t *testing.T) {
+		// Simulates a benign race on the repair Update -- e.g. a concurrent
+		// racer touching the same Lease during a rolling restart -- which
+		// must not fail the claim: we already hold HolderIdentity by the
+		// time the repair is attempted.
+		clientset := fake.NewSimpleClientset()
+		nodeARecreated := &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-a", UID: types.UID("node-a-uid-2")}}
+
+		if _, _, err := ClaimNodeIPLease(ctx, clientset, nodeA, "node-a", ip); err != nil {
+			t.Fatalf("first claim failed: %v", err)
+		}
+		clientset.PrependReactor("update", "leases", func(action clientgotesting.Action) (bool, runtime.Object, error) {
+			return true, nil, apierrors.NewConflict(coordinationLeaseResource(), "calico-ip-10-0-1-5", errors.New("simulated concurrent repair"))
+		})
+
+		conflict, holder, err := ClaimNodeIPLease(ctx, clientset, nodeARecreated, "node-a", ip)
+		if err != nil {
+			t.Fatalf("expected the repair failure to be non-fatal, got: %v", err)
+		}
+		if conflict {
+			t.Fatalf("expected no conflict, got conflict with holder %q", holder)
+		}
+		if holder != "node-a" {
+			t.Fatalf("holder = %q, want node-a", holder)
+		}
+	})
+
+	t.Run("retries the Create when the AlreadyExists lease vanishes before the follow-up Get", func(t *testing.T) {
+		// Simulates the blocking Lease's owning Node being deleted (and the
+		// Lease GC'd) in the window between our failed Create and the
+		// follow-up Get: the IP is free again, so the Create should be
+		// retried rather than treated as a hard error.
+		withFastRetries(t, 3)
+		clientset := fake.NewSimpleClientset()
+		var createCalls int
+		clientset.PrependReactor("create", "leases", func(action clientgotesting.Action) (bool, runtime.Object, error) {
+			createCalls++
+			if createCalls == 1 {
+				return true, nil, apierrors.NewAlreadyExists(coordinationLeaseResource(), "calico-ip-10-0-1-5")
+			}
+			return false, nil, nil // let the fake tracker actually create it.
+		})
+		var getCalls int
+		clientset.PrependReactor("get", "leases", func(action clientgotesting.Action) (bool, runtime.Object, error) {
+			getCalls++
+			if getCalls == 1 {
+				return true, nil, apierrors.NewNotFound(coordinationLeaseResource(), "calico-ip-10-0-1-5")
+			}
+			return false, nil, nil
+		})
+
+		conflict, holder, err := ClaimNodeIPLease(ctx, clientset, nodeA, "node-a", ip)
+		if err != nil {
+			t.Fatalf("expected the claim to eventually succeed, got: %v", err)
+		}
+		if conflict {
+			t.Fatalf("expected no conflict, got conflict with holder %q", holder)
+		}
+		if createCalls != 2 {
+			t.Fatalf("expected exactly 2 Create attempts (one AlreadyExists, one retry that succeeds), got %d", createCalls)
+		}
+	})
+
+	t.Run("still claims the lease, without an owner reference, when no Kubernetes Node is available", func(t *testing.T) {
+		clientset := fake.NewSimpleClientset()
+
+		conflict, holder, err := ClaimNodeIPLease(ctx, clientset, nil, "node-a", ip)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if conflict {
+			t.Fatalf("expected no conflict, got conflict with holder %q", holder)
+		}
+
+		lease, err := clientset.CoordinationV1().Leases(LeaseNamespace).Get(ctx, "calico-ip-10-0-1-5", metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("lease not found: %v", err)
+		}
+		if len(lease.OwnerReferences) != 0 {
+			t.Fatalf("expected no owner references, got %+v", lease.OwnerReferences)
+		}
+	})
+
+	t.Run("retries a transient Create failure and succeeds once the apiserver recovers", func(t *testing.T) {
+		withFastRetries(t, 3)
+		clientset := fake.NewSimpleClientset()
+		var calls int
+		clientset.PrependReactor("create", "leases", func(action clientgotesting.Action) (bool, runtime.Object, error) {
+			calls++
+			if calls < 3 {
+				return true, nil, apierrors.NewServerTimeout(coordinationLeaseResource(), "create", 1)
+			}
+			return false, nil, nil // let the fake tracker's default reactor actually create it.
+		})
+
+		conflict, holder, err := ClaimNodeIPLease(ctx, clientset, nodeA, "node-a", ip)
+		if err != nil {
+			t.Fatalf("expected the claim to eventually succeed, got: %v", err)
+		}
+		if conflict {
+			t.Fatalf("expected no conflict, got conflict with holder %q", holder)
+		}
+		if calls != 3 {
+			t.Fatalf("expected 3 Create attempts, got %d", calls)
+		}
+	})
+
+	t.Run("gives up and returns the error after exhausting retries on a persistent transient failure", func(t *testing.T) {
+		withFastRetries(t, 3)
+		clientset := fake.NewSimpleClientset()
+		var calls int
+		clientset.PrependReactor("create", "leases", func(action clientgotesting.Action) (bool, runtime.Object, error) {
+			calls++
+			return true, nil, apierrors.NewServerTimeout(coordinationLeaseResource(), "create", 1)
+		})
+
+		_, _, err := ClaimNodeIPLease(ctx, clientset, nodeA, "node-a", ip)
+		if err == nil {
+			t.Fatalf("expected an error after exhausting retries, got nil")
+		}
+		if calls != 3 {
+			t.Fatalf("expected exactly 3 Create attempts (claimRetryAttempts), got %d", calls)
+		}
+	})
+
+	t.Run("never retries AlreadyExists -- it is a conclusive answer, not a transient failure", func(t *testing.T) {
+		withFastRetries(t, 3)
+		clientset := fake.NewSimpleClientset()
+		if _, _, err := ClaimNodeIPLease(ctx, clientset, nodeA, "node-a", ip); err != nil {
+			t.Fatalf("first claim failed: %v", err)
+		}
+
+		var calls int
+		clientset.PrependReactor("create", "leases", func(action clientgotesting.Action) (bool, runtime.Object, error) {
+			calls++
+			return false, nil, nil // fall through to the fake tracker, which returns AlreadyExists.
+		})
+
+		conflict, holder, err := ClaimNodeIPLease(ctx, clientset, nodeB, "node-b", ip)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !conflict {
+			t.Fatalf("expected a conflict, got holder %q", holder)
+		}
+		if calls != 1 {
+			t.Fatalf("expected exactly 1 Create attempt for a conclusive AlreadyExists, got %d", calls)
+		}
+	})
+}
+
+func TestReleaseNodeIPLease(t *testing.T) {
+	ctx := context.Background()
+	ip := net.ParseIP("10.0.1.5")
+	nodeA := &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-a", UID: types.UID("node-a-uid")}}
+
+	t.Run("deletes an existing lease still held by the caller", func(t *testing.T) {
+		clientset := fake.NewSimpleClientset()
+		if _, _, err := ClaimNodeIPLease(ctx, clientset, nodeA, "node-a", ip); err != nil {
+			t.Fatalf("claim failed: %v", err)
+		}
+
+		if err := ReleaseNodeIPLease(ctx, clientset, "node-a", ip); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		_, err := clientset.CoordinationV1().Leases(LeaseNamespace).Get(ctx, "calico-ip-10-0-1-5", metav1.GetOptions{})
+		if err == nil {
+			t.Fatalf("expected lease to be deleted, but it still exists")
+		}
+	})
+
+	t.Run("is a no-op, not an error, when there is nothing to release", func(t *testing.T) {
+		clientset := fake.NewSimpleClientset()
+
+		if err := ReleaseNodeIPLease(ctx, clientset, "node-a", ip); err != nil {
+			t.Fatalf("unexpected error releasing a lease that was never claimed: %v", err)
+		}
+	})
+
+	t.Run("does not delete another node's live claim on the same IP (stale release)", func(t *testing.T) {
+		// Reproduces the scenario this ownership check exists to prevent:
+		// node-a's own stored record of "the IP I used to hold" is stale --
+		// node-a's original Lease was already reclaimed (e.g. its Node
+		// object was replaced, GC'd the old Lease, and a different node,
+		// node-b, has genuinely and cleanly claimed the same IP since). If
+		// node-a releases by name alone, it deletes node-b's live claim and
+		// the address is now unprotected for a third node to grab -- two
+		// nodes sharing one IP, the exact outage the Lease claim exists to
+		// prevent.
+		clientset := fake.NewSimpleClientset()
+		nodeB := &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-b", UID: types.UID("node-b-uid")}}
+		if _, _, err := ClaimNodeIPLease(ctx, clientset, nodeB, "node-b", ip); err != nil {
+			t.Fatalf("node-b's claim failed: %v", err)
+		}
+
+		// node-a, acting on stale information, tries to release the IP it
+		// used to think it held.
+		if err := ReleaseNodeIPLease(ctx, clientset, "node-a", ip); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		lease, err := clientset.CoordinationV1().Leases(LeaseNamespace).Get(ctx, LeaseNameForIP(ip), metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("expected node-b's live claim to survive the stale release, but the lease is gone: %v", err)
+		}
+		if lease.Spec.HolderIdentity == nil || *lease.Spec.HolderIdentity != "node-b" {
+			t.Fatalf("lease holder identity = %v, want node-b (unchanged)", lease.Spec.HolderIdentity)
+		}
+	})
+
+	t.Run("skips the delete when a precondition-failing race loses to a concurrent replacement", func(t *testing.T) {
+		// Simulates the Get-then-Delete race directly: between our Get and
+		// our Delete, someone else's Delete+Create replaced the object, so
+		// the apiserver would reject our Delete's UID/ResourceVersion
+		// precondition with a Conflict. That must be treated the same as
+		// "nothing of ours to release", not as an error.
+		clientset := fake.NewSimpleClientset()
+		if _, _, err := ClaimNodeIPLease(ctx, clientset, nodeA, "node-a", ip); err != nil {
+			t.Fatalf("claim failed: %v", err)
+		}
+		clientset.PrependReactor("delete", "leases", func(action clientgotesting.Action) (bool, runtime.Object, error) {
+			return true, nil, apierrors.NewConflict(coordinationLeaseResource(), "calico-ip-10-0-1-5", errors.New("simulated precondition failure"))
+		})
+
+		if err := ReleaseNodeIPLease(ctx, clientset, "node-a", ip); err != nil {
+			t.Fatalf("expected a precondition/Conflict failure to be treated as success, got: %v", err)
+		}
+	})
+
+	t.Run("propagates a real error instead of swallowing it like NotFound or Conflict", func(t *testing.T) {
+		clientset := fake.NewSimpleClientset()
+		if _, _, err := ClaimNodeIPLease(ctx, clientset, nodeA, "node-a", ip); err != nil {
+			t.Fatalf("claim failed: %v", err)
+		}
+		clientset.PrependReactor("delete", "leases", func(action clientgotesting.Action) (bool, runtime.Object, error) {
+			return true, nil, apierrors.NewInternalError(errors.New("simulated apiserver failure"))
+		})
+
+		err := ReleaseNodeIPLease(ctx, clientset, "node-a", ip)
+		if err == nil {
+			t.Fatalf("expected the simulated failure to be returned, got nil")
+		}
+	})
+
+	t.Run("supports the node-changed-IP scenario: claim a new address, release the old one", func(t *testing.T) {
+		clientset := fake.NewSimpleClientset()
+		oldIP := net.ParseIP("10.0.1.5")
+		newIP := net.ParseIP("10.0.1.9")
+
+		if _, _, err := ClaimNodeIPLease(ctx, clientset, nodeA, "node-a", oldIP); err != nil {
+			t.Fatalf("claim of old IP failed: %v", err)
+		}
+		if _, _, err := ClaimNodeIPLease(ctx, clientset, nodeA, "node-a", newIP); err != nil {
+			t.Fatalf("claim of new IP failed: %v", err)
+		}
+		if err := ReleaseNodeIPLease(ctx, clientset, "node-a", oldIP); err != nil {
+			t.Fatalf("release of old IP failed: %v", err)
+		}
+
+		if _, err := clientset.CoordinationV1().Leases(LeaseNamespace).Get(ctx, LeaseNameForIP(oldIP), metav1.GetOptions{}); err == nil {
+			t.Fatalf("expected the old IP's lease to be gone")
+		}
+		if _, err := clientset.CoordinationV1().Leases(LeaseNamespace).Get(ctx, LeaseNameForIP(newIP), metav1.GetOptions{}); err != nil {
+			t.Fatalf("expected the new IP's lease to still exist: %v", err)
+		}
+	})
+}
+
+func TestForceLegacyScan(t *testing.T) {
+	cases := []struct {
+		name string
+		val  string
+		set  bool
+		want bool
+	}{
+		{name: "unset", set: false, want: false},
+		{name: "true", val: "true", set: true, want: true},
+		{name: "false", val: "false", set: true, want: false},
+		{name: "empty", val: "", set: true, want: false},
+		{name: "wrong case not honored", val: "TRUE", set: true, want: false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if c.set {
+				t.Setenv(ForceLegacyScanEnvVar, c.val)
+			}
+			if got := ForceLegacyScan(); got != c.want {
+				t.Errorf("ForceLegacyScan() = %v, want %v", got, c.want)
+			}
+		})
+	}
+}
+
+// TestRetryBackoffWithJitter proves retryBackoffWithJitter actually applies
+// jitter -- reverting it to a fixed claimRetryBackoff sleep wouldn't fail any
+// other test in this file, since the retry paths it's used from only assert
+// on outcomes, not on the sleep duration.
+func TestRetryBackoffWithJitter(t *testing.T) {
+	origBackoff := claimRetryBackoff
+	claimRetryBackoff = 100 * time.Millisecond
+	t.Cleanup(func() { claimRetryBackoff = origBackoff })
+
+	const samples = 20
+	got := make([]time.Duration, samples)
+	seenDistinct := false
+	for i := 0; i < samples; i++ {
+		d := retryBackoffWithJitter()
+		if d < claimRetryBackoff {
+			t.Fatalf("retryBackoffWithJitter() = %v, want >= claimRetryBackoff (%v)", d, claimRetryBackoff)
+		}
+		// Doc comment: "up to half again" -- so the upper bound is
+		// claimRetryBackoff + claimRetryBackoff/2.
+		if max := claimRetryBackoff + claimRetryBackoff/2; d > max {
+			t.Fatalf("retryBackoffWithJitter() = %v, want <= %v (claimRetryBackoff plus up to half again)", d, max)
+		}
+		got[i] = d
+		if i > 0 && d != got[0] {
+			seenDistinct = true
+		}
+	}
+	if !seenDistinct {
+		t.Fatalf("expected at least two different values across %d calls, got the same value (%v) every time -- jitter does not appear to be applied", samples, got[0])
+	}
+}

--- a/node/pkg/lifecycle/startup/startup.go
+++ b/node/pkg/lifecycle/startup/startup.go
@@ -24,6 +24,8 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	api "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
@@ -48,6 +50,7 @@ import (
 	"github.com/projectcalico/calico/node/pkg/health"
 	"github.com/projectcalico/calico/node/pkg/lifecycle/startup/autodetection"
 	"github.com/projectcalico/calico/node/pkg/lifecycle/startup/autodetection/ipv4"
+	"github.com/projectcalico/calico/node/pkg/lifecycle/startup/ipclaim"
 	"github.com/projectcalico/calico/node/pkg/lifecycle/utils"
 	"github.com/projectcalico/calico/pkg/buildinfo"
 )
@@ -60,6 +63,16 @@ const (
 	DEFAULT_IPV6_POOL_NAME       = "default-ipv6-ippool"
 
 	DEFAULT_MONITOR_IP_POLL_INTERVAL = 60 * time.Second
+
+	// ipClaimLeaseTimeout is the Kubernetes API request timeout used only for
+	// the IP-claim Lease client built in checkConflictingNodes -- deliberately
+	// its own value rather than the 2s timeout used elsewhere in this file for
+	// cheap ConfigMap/Node gets. A mass scale-up or fleet reboot, the exact
+	// scenario the Lease-based claim exists to survive, is also when apiserver
+	// latency is most likely to be degraded; a too-tight timeout there misreads
+	// ordinary slowness as a real IP conflict and crash-loops nodes that should
+	// just retry (see also ipclaim.ClaimNodeIPLease's own bounded retry).
+	ipClaimLeaseTimeout = 10 * time.Second
 
 	// KubeadmConfigConfigMap is defined in k8s.io/kubernetes, which we can't import due to versioning issues.
 	KubeadmConfigConfigMap = "kubeadm-config"
@@ -408,10 +421,34 @@ func configureAndCheckIPAddressSubnetsErr(ctx context.Context, cli client.Interf
 		return checkConflicts, nil
 	}
 
-	// If we report an IP change (v4 or v6) we should verify there are no
-	// conflicts between Nodes.
-	if checkConflicts && os.Getenv("DISABLE_NODE_IP_CHECK") != "true" {
-		v4conflict, v6conflict, err := checkConflictingNodes(ctx, cli, node)
+	// checkConflictingNodes' Lease-based claim path (see its own doc comment)
+	// runs unconditionally on every call only until it has succeeded once in
+	// this process -- tracked by leaseBackfilled -- so that a node whose
+	// detected address is unchanged from a prior run still backfills a Lease
+	// for it at least once after this image rolls out, letting the whole
+	// fleet converge to full Lease coverage within one DaemonSet roll instead
+	// of never. This function is called both at node startup and, via
+	// MonitorIPAddressSubnetsWithContext, from a periodic goroutine (default
+	// every 60s) that runs for the lifetime of the process and treats any
+	// error it gets back as fatal to the whole calico-node process, not just
+	// this check -- so once the one-time backfill has succeeded, repeating
+	// the Lease claim on every tick forever (and turning any transient
+	// apiserver hiccup into a process-killing error) is not something we
+	// want; checkConflictingNodes reverts to gating on addressChanged after
+	// that first success, the same as before this behavior was introduced.
+	//
+	// checkConflicts is passed through as checkConflictingNodes'
+	// addressChanged argument both for that post-backfill gating and because
+	// checkConflictingNodes isn't only the Lease path -- it falls back to
+	// checkConflictingNodesByList, the original full Node List scan, when the
+	// legacy-scan override is set or the datastore isn't Kubernetes. That
+	// scan is exactly the O(n) per-node / O(n^2) fleet-wide apiserver load
+	// this patch exists to eliminate, and unlike the Lease claim it is not a
+	// cheap no-op to repeat on an unchanged address, so the fallback scan
+	// only ever runs on an address change. DISABLE_NODE_IP_CHECK remains the
+	// intentional opt-out for skipping this check entirely.
+	if os.Getenv("DISABLE_NODE_IP_CHECK") != "true" {
+		v4conflict, v6conflict, err := checkConflictingNodes(ctx, cli.Nodes(), node, k8sNode, checkConflicts)
 		if err != nil {
 			// If we've auto-detected a new IP address for an existing node that now conflicts, clear the old IP address(es)
 			// from the node in the datastore. This frees the address in case it needs to be used for another node.
@@ -1140,19 +1177,174 @@ func createIPPool(ctx context.Context, client client.Interface, cidr *cnet.IPNet
 	}
 }
 
+// newIPClaimClientset builds the Kubernetes clientset checkConflictingNodes
+// uses to claim/release the IP-claim Lease. A package variable rather than a
+// direct call, so tests can substitute a fake clientset instead of requiring
+// real in-cluster/kubeconfig credentials -- the same seam pattern
+// claimRetryAttempts/claimRetryBackoff use in the ipclaim package.
+var newIPClaimClientset = func() (kubernetes.Interface, error) {
+	kubeConfig, err := winutils.BuildConfigFromFlags("", os.Getenv("KUBECONFIG"))
+	if err != nil {
+		return nil, fmt.Errorf("no in-cluster/kubeconfig credentials available: %w", err)
+	}
+	kubeConfig.Timeout = ipClaimLeaseTimeout
+	clientset, err := kubernetes.NewForConfig(kubeConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build Kubernetes clientset: %w", err)
+	}
+	return clientset, nil
+}
+
+// ipClaimClientsetMu guards ipClaimClientset, memoizing the clientset
+// newIPClaimClientset builds so parsing kubeconfig/in-cluster credentials and
+// TLS certificates happens once per process instead of on every
+// checkConflictingNodes call -- this compounds with the Lease-claim path now
+// running on every startup (see configureAndCheckIPAddressSubnetsErr), so
+// without memoization a stable, unchanging address would still rebuild a
+// whole clientset on every backfill attempt.
+//
+// A mutex-guarded "built successfully yet" check, not sync.Once: sync.Once.Do
+// runs its function exactly once per process regardless of whether it errors,
+// which would permanently cache a transient build failure (e.g. credentials
+// not yet available at boot) and hand every later call -- including from the
+// periodic monitor-addresses goroutine, which Fatals the process on any
+// returned error -- the same cached error forever, with no chance to ever
+// succeed and close the leaseBackfilled gate. Only a successful build is
+// memoized; a failed build is retried on the next call.
+//
+// Package-level, not local to getIPClaimClientset, so a test can reset it
+// between subtests: each subtest substitutes newIPClaimClientset with its own
+// fake and expects its own call count, which a cached value surviving from a
+// prior subtest would break.
+var (
+	ipClaimClientsetMu sync.Mutex
+	ipClaimClientset   kubernetes.Interface
+)
+
+// getIPClaimClientset returns the memoized Kubernetes clientset for the IP
+// claim Lease, building it via newIPClaimClientset on first use and on every
+// subsequent call until a build succeeds. Once a build succeeds, the result
+// is cached for the rest of the process and newIPClaimClientset is never
+// called again.
+func getIPClaimClientset() (kubernetes.Interface, error) {
+	ipClaimClientsetMu.Lock()
+	defer ipClaimClientsetMu.Unlock()
+	if ipClaimClientset != nil {
+		return ipClaimClientset, nil
+	}
+	clientset, err := newIPClaimClientset()
+	if err != nil {
+		return nil, err
+	}
+	ipClaimClientset = clientset
+	return ipClaimClientset, nil
+}
+
+// leaseBackfilled tracks whether checkConflictingNodes' Lease-based claim
+// path has completed a claim successfully at least once in this process. It
+// is set only on success (not merely attempted), so a real failure keeps
+// retrying on every subsequent call until it eventually succeeds once. See
+// configureAndCheckIPAddressSubnetsErr for why this one-time-success gate
+// exists: it lets a stable node backfill its Lease once per process without
+// re-running the claim on every periodic-monitor tick forever afterward.
+var leaseBackfilled atomic.Bool
+
+// releaseStaleIPClaimLeases attempts to release the IP-claim Leases for a
+// node's previous IPv4/IPv6 addresses -- releaseIPv4/releaseIPv6 as computed
+// by checkConflictingNodes' diagnostic prior-address comparison. It is the
+// single shared implementation of that release attempt, called from every
+// return path in checkConflictingNodes that has a stale address to release:
+// the main Lease-claim path and all three of its legacy-scan fallback
+// branches (ForceLegacyScan, a LoadClientConfig error, and a non-Kubernetes
+// datastore type).
+//
+// This is best-effort and never fails the caller. Building the clientset can
+// fail here too -- most notably from the fallback branches, which are
+// explicitly choosing not to depend on Kubernetes-Lease functionality being
+// available (a LoadClientConfig error or a non-Kubernetes Calico datastore
+// says nothing about whether the underlying Kubernetes cluster's own API is
+// reachable, so it's still worth trying, but a failure to reach it must not
+// block the legacy-scan conflict check those branches exist to run). A
+// clientset build failure is logged as a warning and treated as a no-op,
+// exactly like an individual ReleaseNodeIPLease failure below.
+// ReleaseNodeIPLease itself is safe to call unconditionally: it re-reads the
+// Lease and only deletes it if this node is still its HolderIdentity,
+// deleting with a UID+ResourceVersion precondition tied to that exact read,
+// so it can never take down a different node's live claim.
+func releaseStaleIPClaimLeases(ctx context.Context, nodeName string, releaseIPv4, releaseIPv6 net.IP) {
+	if releaseIPv4 == nil && releaseIPv6 == nil {
+		return
+	}
+	clientset, err := getIPClaimClientset()
+	if err != nil {
+		log.WithError(err).Warnf("Failed to build Kubernetes clientset to release stale IP claim lease(s) for %q; they will not be retried this run", nodeName)
+		return
+	}
+	if releaseIPv4 != nil {
+		if rerr := ipclaim.ReleaseNodeIPLease(ctx, clientset, nodeName, releaseIPv4); rerr != nil {
+			log.WithError(rerr).Warnf("Failed to release the stale IP claim lease for our previous IPv4 address %s; it will not be retried this run", releaseIPv4)
+		}
+	}
+	if releaseIPv6 != nil {
+		if rerr := ipclaim.ReleaseNodeIPLease(ctx, clientset, nodeName, releaseIPv6); rerr != nil {
+			log.WithError(rerr).Warnf("Failed to release the stale IP claim lease for our previous IPv6 address %s; it will not be retried this run", releaseIPv6)
+		}
+	}
+}
+
 // checkConflictingNodes checks whether any other nodes have been configured
 // with the same IP addresses.
-func checkConflictingNodes(ctx context.Context, client client.Interface, node *internalapi.Node) (v4conflict, v6conflict bool, retErr error) {
-	// Get the full set of nodes.
-	var nodes []internalapi.Node
-	if nodeList, err := client.Nodes().List(ctx, options.ListOptions{}); err != nil {
-		log.WithError(err).Errorf("Unable to query node configuration")
-		retErr = err
-		return
-	} else {
-		nodes = nodeList.Items
-	}
-
+// checkConflictingNodes claims our detected IP addresses and reports a
+// conflict if another node already holds them.
+//
+// This claims via a Kubernetes Lease named after the IP rather than listing
+// every Calico Node and scanning client-side. Lease creation is atomic at the
+// API server (an etcd CreateRevision==0 guard), so two nodes racing to claim
+// the same IP never both succeed -- the loser gets AlreadyExists, which is
+// treated as a real conflict. The previous implementation ran a full Node
+// List on every node whose detected IP changed; under a mass scale-up or
+// reboot that is O(n) apiserver load times n nodes doing it concurrently,
+// i.e. O(n^2), and was a confirmed contributor to Calico control-plane
+// overload at scale.
+//
+// The Lease path needs a Kubernetes API to claim against, so it only applies
+// when running under the Kubernetes datastore driver -- the actual resolved
+// Calico datastore type (apiconfig.LoadClientConfig), not merely "were
+// in-cluster/kubeconfig credentials loadable". A calico-node DaemonSet
+// running with DATASTORE_TYPE=etcdv3 still has a normal in-cluster
+// ServiceAccount mounted, so that alone would build a kubeconfig
+// successfully and can't tell KDD and etcd apart. On an etcd-backed
+// deployment there is no Kubernetes-datastore API to claim a Lease against,
+// and checkConflictingNodesByList (the original scan) is used instead.
+//
+// nodes takes the narrow client.NodeInterface rather than the full
+// client.Interface -- this is the only part of the Calico client this
+// function (and checkConflictingNodesByList) ever uses, and it's what makes
+// the gating/wiring logic here unit-testable with a hand-written fake: the
+// full client.Interface pulls in dozens of unrelated resource-client
+// methods that a fake would otherwise have to implement for no reason.
+//
+// addressChanged is the caller's checkConflicts value -- whether
+// configureIPsAndSubnets detected our address changed since the last
+// startup. The Lease-based claim above runs regardless of addressChanged
+// only until it has succeeded once in this process -- see leaseBackfilled --
+// after which it, too, only runs when addressChanged is true, the same as
+// checkConflictingNodesByList always has. Before that first success it's a
+// cheap, idempotent no-op when we already hold the Lease, and needs to run
+// on every call so an already-stable node backfills its Lease; after that
+// first success, repeating it on every call forever (including from the
+// periodic monitor goroutine, which treats any error as fatal to the whole
+// process) is unnecessary load and unnecessary fragility for no benefit. The
+// checkConflictingNodesByList fallback branches are different regardless --
+// that's the original O(n) full Node List scan, not a cheap no-op, so each
+// of those branches only ever runs it when addressChanged is true, same as
+// the pre-Lease behavior. When addressChanged is false and a fallback branch
+// would otherwise have run the scan, it's skipped and (false, false, nil) is
+// returned instead. When addressChanged is true and a fallback branch does
+// run the scan, it first calls releaseStaleIPClaimLeases so a stale Lease
+// from a previous address is still attempted, exactly as the main Lease-claim
+// path does below -- see releaseStaleIPClaimLeases and its callers.
+func checkConflictingNodes(ctx context.Context, nodes client.NodeInterface, node *internalapi.Node, k8sNode *v1.Node, addressChanged bool) (v4conflict, v6conflict bool, retErr error) {
 	ourIPv4, _, err := cnet.ParseCIDROrIP(node.Spec.BGP.IPv4Address)
 	if err != nil && node.Spec.BGP.IPv4Address != "" {
 		log.WithError(err).Errorf("Error parsing IPv4 CIDR '%s' for node '%s'", node.Spec.BGP.IPv4Address, node.Name)
@@ -1166,11 +1358,200 @@ func checkConflictingNodes(ctx context.Context, client client.Interface, node *i
 		return
 	}
 
-	for _, theirNode := range nodes {
-		if theirNode.Spec.BGP == nil {
-			// Skip nodes that don't have BGP configured.  We know
-			// that this node does have BGP since we only perform
-			// this check after configuring BGP.
+	// Diagnostic only, and cheap: a single targeted Get on our own prior
+	// record (not the full-cluster List the conflict check itself used to
+	// do) to warn if our IP changed since last time, which could indicate
+	// two nodes sharing a name. Not an error condition on its own when
+	// addressChanged is false, since nothing new is being committed this run
+	// in that case. A NotFound here is expected for a brand-new node with no
+	// prior record and isn't worth a warning; any other error is logged so a
+	// Forbidden/RBAC-denied or otherwise unexpected failure doesn't disappear
+	// silently.
+	//
+	// When addressChanged is true, though, this Get is the only source of
+	// truth for what the prior address was: it's what releaseIPv4/releaseIPv6
+	// below are computed from. If it fails here with anything other than
+	// ErrorResourceDoesNotExist and we pressed on anyway, the caller would go
+	// on to claim and persist the new address this run with nothing marking
+	// that the prior-address diagnostic never actually ran -- and once the
+	// node record is overwritten with the new address, that prior address is
+	// gone for good and its Lease can never be identified and released again.
+	// So in that case this is treated as fatal: return the error, let the
+	// caller propagate it without persisting anything, and let the whole
+	// check retry (next startup, or after the process is restarted) once the
+	// Get can succeed and the true prior address is still derivable.
+	//
+	// This also gives us the previous address(es), if any, so that once
+	// we've handled the new address below we can release the stale Lease for
+	// the old one -- see ipclaim.ReleaseNodeIPLease. The Node object itself
+	// hasn't been deleted here (it's the same node, just a new or now-absent
+	// address), so the old Lease's OwnerReference-based GC never fires on its
+	// own. A prior address is released not only when it changed to a
+	// different address, but also when it disappeared entirely (e.g. the
+	// interface that provided it went away): either way the old Lease is no
+	// longer backed by a live address on this node and would otherwise leak
+	// until the Node object itself is deleted.
+	//
+	// Whether that release happens below is independent of whether the new
+	// address's own claim conflicts with another node: releaseIPv4/releaseIPv6
+	// are computed purely from this node's own prior-vs-current address, and
+	// gating the release on the new address's claim result would leave the
+	// old Lease orphaned whenever the new address genuinely conflicts. That
+	// matters because a persistent conflict on an autodetected address makes
+	// the caller clear this node's own stored BGP address and the process
+	// then restarts; on the next run there is no prior address left to diff
+	// against, so the release could never be computed again and the old
+	// Lease would never be freed. ReleaseNodeIPLease is safe to call
+	// unconditionally here: it re-reads the Lease and only deletes it if this
+	// node is still its HolderIdentity, deleting with a UID+ResourceVersion
+	// precondition tied to that exact read, so it can never take down a
+	// different node's live claim.
+	//
+	// This release attempt is genuinely unconditional across every return
+	// path below that has a stale address to release, not merely the main
+	// Lease-claim path: each of the three legacy-scan fallback branches
+	// (ForceLegacyScan, a LoadClientConfig error, and a non-Kubernetes
+	// datastore type) also calls releaseStaleIPClaimLeases before falling
+	// back to checkConflictingNodesByList, since those branches choosing not
+	// to use the Lease-based claim for the new address says nothing about
+	// whether a stale Lease from a previous address still needs cleaning up.
+	// See releaseStaleIPClaimLeases.
+	var releaseIPv4, releaseIPv6 net.IP
+	prior, gerr := nodes.Get(ctx, node.Name, options.GetOptions{})
+	if gerr != nil {
+		if _, ok := gerr.(cerrors.ErrorResourceDoesNotExist); !ok {
+			if addressChanged {
+				log.WithError(gerr).Errorf("Failed to read our own prior node record %q for the IP-change diagnostic; refusing to claim and persist the new address this run so the prior address isn't lost", node.Name)
+				retErr = gerr
+				return
+			}
+			log.WithError(gerr).Warnf("Failed to read our own prior node record %q for the IP-change diagnostic; skipping stale IP claim lease release detection this run", node.Name)
+		}
+	} else if prior.Spec.BGP != nil {
+		if priorIPv4, _, perr := cnet.ParseCIDROrIP(prior.Spec.BGP.IPv4Address); perr == nil &&
+			priorIPv4.IP != nil && (ourIPv4.IP == nil || !priorIPv4.Equal(ourIPv4.IP)) {
+			if ourIPv4.IP != nil {
+				fields := log.Fields{"node": node.Name, "original": priorIPv4.String(), "updated": ourIPv4.String()}
+				log.WithFields(fields).Warnf("IPv4 address has changed. This could happen if there are multiple nodes with the same name.")
+			} else {
+				log.WithFields(log.Fields{"node": node.Name, "original": priorIPv4.String()}).Warnf("IPv4 address is no longer detected; releasing its IP claim lease.")
+			}
+			releaseIPv4 = priorIPv4.IP
+		}
+		if priorIPv6, _, perr := cnet.ParseCIDROrIP(prior.Spec.BGP.IPv6Address); perr == nil &&
+			priorIPv6.IP != nil && (ourIPv6.IP == nil || !priorIPv6.Equal(ourIPv6.IP)) {
+			if ourIPv6.IP != nil {
+				fields := log.Fields{"node": node.Name, "original": priorIPv6.String(), "updated": ourIPv6.String()}
+				log.WithFields(fields).Warnf("IPv6 address has changed. This could happen if there are multiple nodes with the same name.")
+			} else {
+				log.WithFields(log.Fields{"node": node.Name, "original": priorIPv6.String()}).Warnf("IPv6 address is no longer detected; releasing its IP claim lease.")
+			}
+			releaseIPv6 = priorIPv6.IP
+		}
+	}
+
+	// See ipclaim.ForceLegacyScanEnvVar: a rollout safety valve so operators
+	// can revert to the pre-Lease behavior without a full patch rollback or
+	// image rebuild if the Lease-based claim misbehaves in production.
+	// Independent of DISABLE_NODE_IP_CHECK, which skips the conflict check
+	// entirely; this instead forces a specific implementation of the check to
+	// still run.
+	if ipclaim.ForceLegacyScan() {
+		if !addressChanged {
+			return false, false, nil
+		}
+		log.Infof("%s is set; using the legacy full-list IP conflict scan instead of the Lease-based claim", ipclaim.ForceLegacyScanEnvVar)
+		releaseStaleIPClaimLeases(ctx, node.Name, releaseIPv4, releaseIPv6)
+		return checkConflictingNodesByList(ctx, nodes, node, ourIPv4, ourIPv6)
+	}
+
+	cfg, cerr := apiconfig.LoadClientConfig("")
+	if cerr != nil {
+		if !addressChanged {
+			return false, false, nil
+		}
+		log.WithError(cerr).Error("Failed to determine the Calico datastore type; using the legacy full-list IP conflict scan")
+		releaseStaleIPClaimLeases(ctx, node.Name, releaseIPv4, releaseIPv6)
+		return checkConflictingNodesByList(ctx, nodes, node, ourIPv4, ourIPv6)
+	}
+	if cfg.Spec.DatastoreType != apiconfig.Kubernetes {
+		if !addressChanged {
+			return false, false, nil
+		}
+		releaseStaleIPClaimLeases(ctx, node.Name, releaseIPv4, releaseIPv6)
+		return checkConflictingNodesByList(ctx, nodes, node, ourIPv4, ourIPv6)
+	}
+
+	// The one-time backfill gate: once the Lease-based claim has succeeded
+	// once in this process, treat it the same as the legacy-scan fallback
+	// branches above and only run it again when the address actually
+	// changed. See leaseBackfilled and this function's addressChanged
+	// doc paragraph.
+	if !addressChanged && leaseBackfilled.Load() {
+		return false, false, nil
+	}
+
+	clientset, err := getIPClaimClientset()
+	if err != nil {
+		log.WithError(err).Error("Failed to build Kubernetes clientset for IP claim lease")
+		retErr = err
+		return
+	}
+
+	if ourIPv4.IP != nil {
+		conflict, holder, err := ipclaim.ClaimNodeIPLease(ctx, clientset, k8sNode, node.Name, ourIPv4.IP)
+		if err != nil {
+			retErr = err
+			return
+		}
+		if conflict {
+			log.Warnf("Calico node '%s' is already using the IPv4 address %s.", holder, ourIPv4.String())
+			v4conflict = true
+			retErr = fmt.Errorf("IPv4 address conflict")
+		}
+	}
+
+	if ourIPv6.IP != nil {
+		conflict, holder, err := ipclaim.ClaimNodeIPLease(ctx, clientset, k8sNode, node.Name, ourIPv6.IP)
+		if err != nil {
+			retErr = err
+			return
+		}
+		if conflict {
+			log.Warnf("Calico node '%s' is already using the IPv6 address %s.", holder, ourIPv6.String())
+			v6conflict = true
+			retErr = fmt.Errorf("IPv6 address conflict")
+		}
+	}
+
+	releaseStaleIPClaimLeases(ctx, node.Name, releaseIPv4, releaseIPv6)
+
+	if retErr == nil {
+		leaseBackfilled.Store(true)
+	}
+	return
+}
+
+// checkConflictingNodesByList is the pre-Lease conflict-detection strategy:
+// list every Calico Node and scan client-side for an IP match. Kept as the
+// fallback for etcd-backed deployments, where there is no Kubernetes API to
+// claim a Lease against; see checkConflictingNodes.
+func checkConflictingNodesByList(ctx context.Context, nodes client.NodeInterface, node *internalapi.Node, ourIPv4, ourIPv6 *cnet.IP) (v4conflict, v6conflict bool, retErr error) {
+	var allNodes []internalapi.Node
+	if nodeList, err := nodes.List(ctx, options.ListOptions{}); err != nil {
+		log.WithError(err).Errorf("Unable to query node configuration")
+		retErr = err
+		return
+	} else {
+		allNodes = nodeList.Items
+	}
+
+	for _, theirNode := range allNodes {
+		if theirNode.Spec.BGP == nil || theirNode.Name == node.Name {
+			// Skip nodes that don't have BGP configured (we know this node
+			// does, since we only perform this check after configuring BGP),
+			// and skip ourselves -- checkConflictingNodes already handled the
+			// "did our own IP change" diagnostic via a targeted Get.
 			continue
 		}
 
@@ -1186,22 +1567,6 @@ func checkConflictingNodes(ctx context.Context, client client.Interface, node *i
 			log.WithError(err).Errorf("Error parsing IPv6 CIDR '%s' for node '%s'", theirNode.Spec.BGP.IPv6Address, theirNode.Name)
 			retErr = err
 			return
-		}
-
-		// If this is our node (based on the name), check if the IP
-		// addresses have changed.  If so warn the user as it could be
-		// an indication of multiple nodes using the same name.  This
-		// is not an error condition as the IPs could actually change.
-		if theirNode.Name == node.Name {
-			if theirIPv4.IP != nil && ourIPv4.IP != nil && !theirIPv4.Equal(ourIPv4.IP) {
-				fields := log.Fields{"node": theirNode.Name, "original": theirIPv4.String(), "updated": ourIPv4.String()}
-				log.WithFields(fields).Warnf("IPv4 address has changed. This could happen if there are multiple nodes with the same name.")
-			}
-			if theirIPv6.IP != nil && ourIPv6.IP != nil && !theirIPv6.Equal(ourIPv6.IP) {
-				fields := log.Fields{"node": theirNode.Name, "original": theirIPv6.String(), "updated": ourIPv6.String()}
-				log.WithFields(fields).Warnf("IPv6 address has changed. This could happen if there are multiple nodes with the same name.")
-			}
-			continue
 		}
 
 		// Check that other nodes aren't using the same IP addresses.


### PR DESCRIPTION
## Summary

`checkConflictingNodes` lists every Calico Node and scans client-side for a matching BGP address whenever a node's detected IP (or interfaces) change. Under a mass scale-up or fleet reboot that is O(n) apiserver load per node doing it concurrently — O(n²) overall.

This replaces that List with an atomic `coordination.k8s.io` Lease Create keyed by IP (`calico-ip-<addr>` in `calico-system`). Two nodes racing for the same address cannot both succeed; the loser gets `AlreadyExists` and is treated as a conflict. The Lease is owner-referenced to the Kubernetes Node so GC cleans it up on Node deletion. An explicit, holder-checked release covers IP changes (and disappearing addresses) while the Node object stays alive.

The claim runs once per process even when the address is unchanged, so rolling this image onto an already-stable fleet still backfills Leases. After that first success it returns to the existing "only on address change" gate, including for the etcd / `FORCE_NODE_IP_CHECK_LEGACY_SCAN=true` full-list fallback.

Related historical discussion: #871 / #915 (those reduced *when* the List runs; this changes *how* the check works).

## Known issue (please look)

`ParseCIDROrIP("")` returns a nil `*cnet.IP`. The prior-address comparison and claim guards then dereference `ourIPv4.IP` / `ourIPv6.IP` without a nil check. A dual-stack node that loses only IPv4 (or only IPv6) will panic. The new subtest "releases the stale lease when the current address disappears entirely" hits the same path. Happy to follow up with `ourIPv4 == nil || ourIPv4.IP == nil` before this leaves draft.

## Operator / RBAC

The Lease client needs `create`/`get`/`update`/`delete` on `leases` in `calico-system` (not `kube-system`, so the Role cannot touch control-plane leader-election Leases). Manifest/operator grants are not in this PR.

Rollout safety valve: `FORCE_NODE_IP_CHECK_LEGACY_SCAN=true` restores the original List scan without an image rebuild.

## Test plan

- [ ] `go test ./node/pkg/lifecycle/startup/ipclaim/...`
- [ ] `go test ./node/pkg/lifecycle/startup/ -run '^TestCheckConflictingNodesLeaseWiring$'` (Linux; package has GOOS-constrained autodetection)
- [ ] Dual-stack: IPv4 address disappears, IPv6 remains — must not panic, must release the IPv4 Lease
- [ ] Two nodes racing the same IP — one conflict, one success
- [ ] Rolling restart of a stable fleet — every node creates (or idempotently re-holds) a Lease

**Release note:**
```release-note
calico-node now claims node BGP addresses with a Kubernetes Lease instead of listing every Node, avoiding O(n²) apiserver load when many nodes start or change IP at once.
```