### PR TITLE
[v3.32] BPF: keep conntrack RST state on the tracking entry for NAT'd flows

### DIFF
--- a/felix/bpf-gpl/conntrack.h
+++ b/felix/bpf-gpl/conntrack.h
@@ -727,7 +727,11 @@ static CALI_BPF_INLINE struct calico_ct_result calico_ct_lookup(struct cali_tc_c
 
 	struct calico_ct_leg *src_to_dst, *dst_to_src;
 
-	struct calico_ct_value *tracking_v;
+	/* The RST timestamp is connection-level state and lives on the tracking
+	 * entry: the reverse entry for a NAT_FWD hit, the looked-up entry otherwise.
+	 */
+	struct calico_ct_value *tracking_v = v;
+
 	switch (v->type) {
 	case CALI_CT_TYPE_NAT_FWD:
 		// This is a forward NAT entry; since we do the bookkeeping on the
@@ -997,15 +1001,15 @@ static CALI_BPF_INLINE struct calico_ct_result calico_ct_lookup(struct cali_tc_c
 		if (tcp_header->rst) {
 			CALI_CT_DEBUG("RST seen, marking CT entry.");
 			src_to_dst->rst_seen = 1;
-			v->rst_seen = now;
-		} else if (v->rst_seen) {
-			if (now - v->rst_seen > 2 * 60 * 1000000000ull || now - v->rst_seen > (1ull << 63)) {
+			tracking_v->rst_seen = now;
+		} else if (tracking_v->rst_seen) {
+			if (now - tracking_v->rst_seen > 2 * 60 * 1000000000ull || now - tracking_v->rst_seen > (1ull << 63)) {
 				/* It's been a looong time (2m) since we saw the RST, we still see
 				 * traffic, we must have seen traffic between now and rst_seen,
 				 * otherwise the entry would have been GCed, the connection is
 				 * likely established and the RST was spurious.
 				 */
-				v->rst_seen = 0;
+				tracking_v->rst_seen = 0;
 			}
 		}
 		ct_tcp_entry_update(ctx, tcp_header, src_to_dst, dst_to_src);

--- a/felix/bpf/ut/conntrack_nat_rst_test.go
+++ b/felix/bpf/ut/conntrack_nat_rst_test.go
@@ -1,0 +1,228 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ut_test
+
+import (
+	"encoding/binary"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/gopacket/gopacket/layers"
+	. "github.com/onsi/gomega"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/projectcalico/calico/felix/bpf"
+	"github.com/projectcalico/calico/felix/bpf/conntrack"
+	"github.com/projectcalico/calico/felix/bpf/conntrack/timeouts"
+	ctv4 "github.com/projectcalico/calico/felix/bpf/conntrack/v4"
+	"github.com/projectcalico/calico/felix/bpf/maps"
+	"github.com/projectcalico/calico/felix/bpf/routes"
+)
+
+// natRSTFixture stages the CT entry pair of a NAT'd flow: a connection opened
+// by a local workload (srcIP) to a service (svcIP:svcPort) backed by a remote
+// workload (dstIP:backendPort). All connection state lives on the reverse
+// "tracking" entry; the forward entry is a stub holding the reverse key.
+type natRSTFixture struct {
+	fwdKey, revKey ctv4.Key
+	ctMap          maps.Map
+}
+
+const (
+	// natRSTIfIndex must match the BPF UT's default skb ifindex so the
+	// workload RPF check (route iface vs skb iface) passes.
+	natRSTIfIndex            = 1
+	natRSTSrcPort     uint16 = 12377
+	natRSTSvcPort     uint16 = 8080
+	natRSTBackendPort uint16 = 8055
+)
+
+var natRSTSvcIP = net.IPv4(10, 101, 0, 10)
+
+func (f natRSTFixture) fwdEntry() ctv4.ValueInterface {
+	b, err := f.ctMap.Get(f.fwdKey.AsBytes())
+	Expect(err).NotTo(HaveOccurred())
+	return ctv4.ValueFromBytes(b)
+}
+
+func (f natRSTFixture) revEntry() ctv4.ValueInterface {
+	b, err := f.ctMap.Get(f.revKey.AsBytes())
+	Expect(err).NotTo(HaveOccurred())
+	return ctv4.ValueFromBytes(b)
+}
+
+// setupNATRSTFixture installs the routes and the CT entry pair. revRSTSeen seeds
+// the tracking entry's rst_seen timestamp (0 for a connection that has seen no
+// RST).
+func setupNATRSTFixture(t *testing.T, revRSTSeen uint64) natRSTFixture {
+	rtKey := routes.NewKey(srcV4CIDR).AsBytes()
+	rtVal := routes.NewValueWithIfIndex(routes.FlagsLocalWorkload|routes.FlagInIPAMPool, natRSTIfIndex).AsBytes()
+	Expect(rtMap.Update(rtKey, rtVal)).NotTo(HaveOccurred())
+	rtKey = routes.NewKey(dstV4CIDR).AsBytes()
+	rtVal = routes.NewValueWithIfIndex(routes.FlagsRemoteWorkload|routes.FlagInIPAMPool, natRSTIfIndex).AsBytes()
+	Expect(rtMap.Update(rtKey, rtVal)).NotTo(HaveOccurred())
+	t.Cleanup(func() { resetRTMap(rtMap) })
+
+	ctMap := conntrack.Map()
+	Expect(ctMap.EnsureExists()).NotTo(HaveOccurred())
+	resetCTMap(ctMap)
+	t.Cleanup(func() { resetCTMap(ctMap) })
+
+	f := natRSTFixture{
+		fwdKey: ctv4.NewKey(6, srcIP, natRSTSrcPort, natRSTSvcIP, natRSTSvcPort),
+		revKey: ctv4.NewKey(6, srcIP, natRSTSrcPort, dstIP, natRSTBackendPort),
+		ctMap:  ctMap,
+	}
+
+	// The pod is the opener and carries the pod ifindex on its leg. Approved
+	// must be set on both legs: from_wep is CALI_F_TO_HOST, so
+	// calico_ct_lookup checks src_to_dst->approved and would otherwise return
+	// CALI_CT_INVALID for these non-SYN packets and drop them before they
+	// demonstrate anything.
+	legA := ctv4.Leg{SynSeen: true, AckSeen: true, Approved: true, Opener: true, Ifindex: natRSTIfIndex}
+	legB := ctv4.Leg{SynSeen: true, AckSeen: true, Approved: true}
+
+	revVal := ctv4.NewValueNATReverse(time.Duration(0), 0, legA, legB,
+		nil /* tunnelIP */, natRSTSvcIP /* origIP */, natRSTSvcPort)
+	if revRSTSeen != 0 {
+		vb := revVal.AsBytes()
+		binary.LittleEndian.PutUint64(vb[ctv4.VoRSTSeen:ctv4.VoRSTSeen+8], revRSTSeen)
+		Expect(ctMap.Update(f.revKey.AsBytes(), vb[:])).NotTo(HaveOccurred())
+	} else {
+		Expect(ctMap.Update(f.revKey.AsBytes(), revVal.AsBytes()[:])).NotTo(HaveOccurred())
+	}
+
+	fwdVal := ctv4.NewValueNATForward(time.Duration(0), 0, f.revKey)
+	Expect(ctMap.Update(f.fwdKey.AsBytes(), fwdVal.AsBytes()[:])).NotTo(HaveOccurred())
+
+	return f
+}
+
+// natRSTPacket builds a packet on the pre-DNAT tuple, i.e. one that hits the
+// forward entry, with the given TCP flags.
+func natRSTPacket(rst bool) []byte {
+	ip := *ipv4Default
+	ip.DstIP = natRSTSvcIP
+	_, _, _, _, pkt, err := testPacketV4(nil, &ip, &layers.TCP{
+		RST:        rst,
+		ACK:        true,
+		SrcPort:    layers.TCPPort(natRSTSrcPort),
+		DstPort:    layers.TCPPort(natRSTSvcPort),
+		DataOffset: 5,
+	}, nil)
+	Expect(err).NotTo(HaveOccurred())
+	return pkt
+}
+
+// waitForKTime blocks until the clock the BPF programs read has passed d.
+//
+// bpf_ktime_get_ns() counts from boot, so any test that needs the dataplane to
+// see a given age has to wait for the host to have been up that long — no
+// choice of seeded timestamp avoids it. The wait is bounded by d and only ever
+// happens on a freshly booted host. bpf.KTimeNanos() reads the same
+// CLOCK_MONOTONIC base, which conntrack_scanner_test.go already relies on when
+// it seeds last_seen for the BPF side to compare against.
+func waitForKTime(d time.Duration) {
+	for {
+		remaining := d - time.Duration(bpf.KTimeNanos())
+		if remaining <= 0 {
+			return
+		}
+		// Logged, not t.Logf'd: a passing test's t.Log output is suppressed,
+		// and an unexplained multi-minute pause is worse than the wait.
+		log.Infof("Waiting %s for the BPF clock to reach %s; host booted recently.", remaining, d)
+		time.Sleep(remaining)
+	}
+}
+
+// TestCTNatRSTHandling exercises TCP RST handling for a NAT'd flow in the
+// client->service direction. That direction matches the forward entry, so the
+// reverse direction is no substitute: it hits the tracking entry directly and
+// behaves correctly regardless.
+func TestCTNatRSTHandling(t *testing.T) {
+	RegisterTestingT(t)
+
+	bpfIfaceName = "NATrst"
+	defer func() { bpfIfaceName = "" }()
+
+	// runPkt replays pkt through from_wep. The retval check keeps a dropped
+	// packet from making the assertions pass, or fail, for the wrong reason.
+	runPkt := func(t *testing.T, f natRSTFixture, pkt []byte) {
+		skbMark = 0
+		runBpfTest(t, "calico_from_workload_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+			res, err := bpfrun(pkt)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(res.Retval).NotTo(Equal(resTC_ACT_SHOT))
+		})
+	}
+
+	t.Run("an RST is recorded for the flow", func(t *testing.T) {
+		RegisterTestingT(t)
+		f := setupNATRSTFixture(t, 0)
+
+		runPkt(t, f, natRSTPacket(true /* rst */))
+
+		Expect(f.revEntry().RSTSeen()).NotTo(BeZero(),
+			"the flow has no record of the RST; it is kept on the tracking entry, "+
+				"which is where every reader looks")
+		Expect(f.fwdEntry().RSTSeen()).To(BeZero(),
+			"the forward entry is a stub — state written there is never read")
+	})
+
+	t.Run("a flow closed by an RST expires without waiting out the established timeout",
+		func(t *testing.T) {
+			RegisterTestingT(t)
+			f := setupNATRSTFixture(t, 0)
+
+			runPkt(t, f, natRSTPacket(true /* rst */))
+
+			rev := f.revEntry()
+			to := timeouts.DefaultTimeouts()
+
+			// Three minutes after the RST, with no traffic since.
+			reason, expired := conntrack.EntryExpired(to,
+				rev.LastSeen()+int64(3*time.Minute), 6 /* TCP */, rev)
+			Expect(expired).To(BeTrue(),
+				"flow survived to the established timeout (%s); reason=%q",
+				to.TCPEstablished, reason)
+
+			// One minute in it is still inside the spurious-RST window: the
+			// RST may yet turn out to have been bogus, so the flow has to stay.
+			reason, expired = conntrack.EntryExpired(to,
+				rev.LastSeen()+int64(time.Minute), 6, rev)
+			Expect(expired).To(BeFalse(),
+				"flow expired inside the 2-minute spurious-RST window; reason=%q", reason)
+		})
+
+	t.Run("a spurious RST is retracted once traffic continues", func(t *testing.T) {
+		RegisterTestingT(t)
+
+		// rst_seen = 1ns is the earliest timestamp there is, so the
+		// dataplane calls the RST spurious as soon as its clock passes the
+		// two-minute window.
+		waitForKTime(2*time.Minute + time.Second)
+
+		f := setupNATRSTFixture(t, 1)
+		Expect(f.revEntry().RSTSeen()).NotTo(BeZero())
+
+		runPkt(t, f, natRSTPacket(false /* data, not rst */))
+
+		Expect(f.revEntry().RSTSeen()).To(BeZero(),
+			"traffic past the two-minute mark should have retracted the RST; the "+
+				"verdict reads the tracking entry's timestamp, so a flow whose RST "+
+				"was recorded elsewhere never reaches it")
+	})
+}


### PR DESCRIPTION
**Cherry-pick history**
- Pick onto **release-v3.32**: projectcalico/calico#13526

## Problem

A NAT'd flow has two conntrack entries: a forward stub keyed on the pre-DNAT tuple, holding only the reverse key, and a reverse tracking entry holding all the connection state. On a `NAT_FWD` hit — every client→service packet — `calico_ct_lookup()`'s `v` is the stub. It already redirects `src_to_dst`/`dst_to_src` into the tracking entry's legs, but wrote the RST timestamp to the stub (`v->rst_seen = now`), where nothing reads it.

The entry-level timestamp is what expires an RST-closed flow at `rst_seen + 2m`, because `ct_tcp_entry_update()` clears both legs' `rst_seen` on the RST packet's own pass. With it on the stub, the tracking entry has none and falls through to `TCPEstablished`: **a service connection reset by the client holds its conntrack entry for an hour instead of two minutes**. Reset by the backend it behaves correctly, since that direction hits the tracking entry directly. The 2-minute spurious-RST branch reads the same stub zero, so continued traffic never clears the flag it was written to guard.

## Change

Initialise the existing `tracking_v` pointer to `v` at declaration — it was already set to the reverse entry for `NAT_FWD` and left unset otherwise — and use it for the `rst_seen` write, read and clear.

## Result

RST state lands on the tracking entry for NAT'd flows, so a client-side RST expires the entry after two minutes in both directions, and the spurious-RST recovery works on service traffic.

## Backport notes

- `felix/design/bpf-conntrack-flowstate.md` dropped: the design doc does not exist on `release-v3.32`.
- Two `conntrack.h` conflict hunks, both pure connlimit additions from the original PR (`qos_connlimit_decrement_for_ct(tracking_v)` on close, and the `INGRESS_CONN_LIMIT_CONFIGURED` flag propagation on the SYN path). Neither mechanism exists on `release-v3.32` — no `qos_connlimit_decrement_for_ct`, no `INGRESS_CONN_LIMIT_CONFIGURED`, no `CALI_CT_FLAG_CONNLIMIT_*` in this file — so both were dropped.
- The remaining hunks — the `tracking_v = v` initialisation and the three `rst_seen` sites — applied against identical context; the resolved code is the same fix, the same conditions and the same state transitions as master, minus the connlimit callers that have no counterpart here. The declaration comment was trimmed to drop its reference to connlimit flags.
- `felix/bpf/ut/conntrack_nat_rst_test.go` is byte-identical to the original.

## Verification

`make build-bpf` in the felix build container: clean, exit 0, 189 objects, no clang warnings under `-Wall -Werror`. `go vet ./bpf/ut/...` cannot run on this host (the package needs cgo, which needs `pcap.h`); the one type error it reports under `CGO_ENABLED=0` is `bpf_prog_test.go:925 m.MaxEntries undefined`, which reproduces identically with the new test file removed, so it is pre-existing and unrelated.

<details>
<summary><b>Cherry-Pick PR details</b></summary>

- **Original PR ID**: 13526
- **Original Commit SHA**: 2619d6a289
- **Source Repo**: `projectcalico/calico`
- **Target Repo**: `projectcalico/calico`
- **Target Branch**: `release-v3.32`
</details>

**Release note:**
```release-note
Fixed BPF conntrack entries for NAT'd (service) connections surviving up to an hour after a client-side TCP RST instead of expiring after two minutes.
```
