### PR TITLE
[v3.33] Keep conntrack counters current for offloaded flows

### DIFF
--- a/app-policy/deps.txt
+++ b/app-policy/deps.txt
@@ -124,7 +124,7 @@ kubevirt.io/client-go v1.9.0-beta.0.0.20260820173903-b1272ce720d5
 kubevirt.io/containerized-data-importer-api v1.64.0
 kubevirt.io/controller-lifecycle-operator-sdk/api v0.2.4
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730
-sigs.k8s.io/knftables v0.0.22
+sigs.k8s.io/knftables v0.0.23-0.20260903141422-0087e9ef619d
 sigs.k8s.io/network-policy-api v0.2.0
 sigs.k8s.io/randfill v1.0.0
 sigs.k8s.io/structured-merge-diff/v6 v6.4.2

--- a/cmd/deps.txt
+++ b/cmd/deps.txt
@@ -231,7 +231,7 @@ modernc.org/memory v1.11.0
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.36.0
 sigs.k8s.io/controller-runtime v0.24.1
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730
-sigs.k8s.io/knftables v0.0.22
+sigs.k8s.io/knftables v0.0.23-0.20260903141422-0087e9ef619d
 sigs.k8s.io/kustomize/api v0.21.1
 sigs.k8s.io/kustomize/kyaml v0.21.1
 sigs.k8s.io/network-policy-api v0.2.0

--- a/cni-plugin/deps.txt
+++ b/cni-plugin/deps.txt
@@ -126,7 +126,7 @@ kubevirt.io/client-go v1.9.0-beta.0.0.20260820173903-b1272ce720d5
 kubevirt.io/containerized-data-importer-api v1.64.0
 kubevirt.io/controller-lifecycle-operator-sdk/api v0.2.4
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730
-sigs.k8s.io/knftables v0.0.22
+sigs.k8s.io/knftables v0.0.23-0.20260903141422-0087e9ef619d
 sigs.k8s.io/network-policy-api v0.2.0
 sigs.k8s.io/randfill v1.0.0
 sigs.k8s.io/structured-merge-diff/v6 v6.4.2

--- a/felix/dataplane/linux/int_dataplane.go
+++ b/felix/dataplane/linux/int_dataplane.go
@@ -569,6 +569,7 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 		}
 	}
 
+	var flowtableCounter bool
 	if nftablesEnabled && config.RulesConfig.NFTablesFlowTableOffload {
 		// Best-effort load of the flowtable module before probing: on hosts where it ships as a
 		// module but isn't autoloaded, this lets detection succeed. Kernels that have it built in
@@ -577,10 +578,14 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 		out, err := mp.Exec()
 		log.WithError(err).WithField("output", out).Infof("attempted to modprobe %s", moduleFlowTable)
 
-		if !nftables.DetectFlowOffloadSupported(config.NewNftablesDataplane) {
+		supported, counterSupported := nftables.DetectFlowOffloadSupported(config.NewNftablesDataplane)
+		if !supported {
 			log.Warn("NFTables flowtable offload is enabled but the kernel does not support it (nf_flow_table unavailable); disabling offload.")
 			config.RulesConfig.NFTablesFlowTableOffload = false
+		} else if !counterSupported {
+			log.Warn("Kernel does not support flowtable counters; flow log packet and byte counts will be missing for offloaded flows.")
 		}
+		flowtableCounter = counterSupported
 	}
 
 	ruleRenderer := config.RuleRendererOverride
@@ -664,6 +669,7 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 		OpRecorder:       dp.loopSummarizer,
 		Disabled:         !nftablesEnabled,
 		NewDataplane:     config.NewNftablesDataplane,
+		FlowtableCounter: flowtableCounter,
 	}
 
 	var cleanupTables []generictables.CleanupTable

--- a/felix/deps.txt
+++ b/felix/deps.txt
@@ -178,7 +178,7 @@ kubevirt.io/containerized-data-importer-api v1.64.0
 kubevirt.io/controller-lifecycle-operator-sdk/api v0.2.4
 modernc.org/memory v1.11.0
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730
-sigs.k8s.io/knftables v0.0.22
+sigs.k8s.io/knftables v0.0.23-0.20260903141422-0087e9ef619d
 sigs.k8s.io/network-policy-api v0.2.0
 sigs.k8s.io/randfill v1.0.0
 sigs.k8s.io/structured-merge-diff/v6 v6.4.2

--- a/felix/fv/flowtable_test.go
+++ b/felix/fv/flowtable_test.go
@@ -17,6 +17,7 @@ package fv_test
 import (
 	"fmt"
 	"regexp"
+	"strconv"
 	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -145,6 +146,25 @@ var _ = infrastructure.DatastoreDescribe("nftables flowtable offload", []apiconf
 		}, "30s", "1s").Should(ContainSubstring("[OFFLOAD]"))
 	})
 
+	It("keeps conntrack counters up to date for an offloaded flow", func() {
+		pc := w[0].StartPersistentConnection(w[1].IP, 8055, workload.PersistentConnectionOpts{
+			MonitorConnectivity: true,
+		})
+		defer pc.Stop()
+
+		Eventually(func() int {
+			return offloadedPacketCount(tc.Felixes[0], w[0].IP, w[1].IP)
+		}, "30s", "1s").Should(BeNumerically(">", 0))
+
+		before := offloadedPacketCount(tc.Felixes[0], w[0].IP, w[1].IP)
+
+		// Flow logs take their counts off the conntrack entry, so frozen counters report a
+		// busy flow as idle.
+		Eventually(func() int {
+			return offloadedPacketCount(tc.Felixes[0], w[0].IP, w[1].IP)
+		}, "30s", "1s").Should(BeNumerically(">", before))
+	})
+
 	It("keeps a connection-limited workload off the fast path", func() {
 		// The limit lives in the workload's filter chain, which an offloaded flow skips entirely.
 		w[1].WorkloadEndpoint.Spec.QoSControls = &internalapi.QoSControls{IngressMaxConnections: 10}
@@ -230,3 +250,26 @@ var _ = infrastructure.DatastoreDescribe("nftables flowtable offload", []apiconf
 		}, "30s", "1s").ShouldNot(ContainSubstring(fmt.Sprintf("flowtable %s", dataplanedefs.FlowtableName)))
 	})
 })
+
+var conntrackPacketsRegexp = regexp.MustCompile(`packets=(\d+)`)
+
+// offloadedPacketCount totals both directions' packets on the offloaded conntrack entry between
+// the two IPs, or 0 if there is none.
+func offloadedPacketCount(felix *infrastructure.Felix, ipA, ipB string) int {
+	out, _ := felix.ExecOutput("conntrack", "-L")
+
+	for _, line := range strings.Split(out, "\n") {
+		if !strings.Contains(line, "[OFFLOAD]") || !strings.Contains(line, ipA) || !strings.Contains(line, ipB) {
+			continue
+		}
+
+		total := 0
+		for _, match := range conntrackPacketsRegexp.FindAllStringSubmatch(line, -1) {
+			packets, err := strconv.Atoi(match[1])
+			Expect(err).NotTo(HaveOccurred())
+			total += packets
+		}
+		return total
+	}
+	return 0
+}

--- a/felix/nftables/flowoffload_detect.go
+++ b/felix/nftables/flowoffload_detect.go
@@ -23,15 +23,19 @@ import (
 )
 
 // flowOffloadProbeTable is a throwaway table used only while probing for flowtable offload
-// support. It is created and immediately deleted, so it never coexists with the real "calico" table.
+// support, so a failed cleanup can't disturb the real "calico" table.
 const flowOffloadProbeTable = "calico-flowtable-probe"
 
-// DetectFlowOffloadSupported reports whether the running kernel accepts an nftables flowtable.
-// Kernels without the nf_flow_table module reject flowtable programming with ENOENT, which would
-// otherwise take Felix down when it installs the real flowtable and offload rule. We find out up
-// front by adding a device-less flowtable in a throwaway table: the flowtable object needs the
-// module regardless of its device set, so this hits the same failure a real flowtable would.
-func DetectFlowOffloadSupported(newDataplane NewNftablesDataplaneFn) bool {
+// The two probes use different flowtable names because the kernel turns an add of an existing
+// flowtable into an update, and pre-5.13 update paths accept the counter flag they reject on add.
+const (
+	counterProbeFlowtable = "probe-counter"
+	plainProbeFlowtable   = "probe"
+)
+
+// DetectFlowOffloadSupported reports whether the kernel accepts an nftables flowtable, and whether
+// it also accepts the flowtable counter flag.
+func DetectFlowOffloadSupported(newDataplane NewNftablesDataplaneFn) (supported bool, counter bool) {
 	if newDataplane == nil {
 		newDataplane = knftables.New
 	}
@@ -39,31 +43,46 @@ func DetectFlowOffloadSupported(newDataplane NewNftablesDataplaneFn) bool {
 	nft, err := newDataplane(knftables.IPv4Family, flowOffloadProbeTable)
 	if err != nil {
 		logrus.WithError(err).Warn("Failed to create nftables interface to probe flowtable offload support; assuming unsupported.")
-		return false
+		return false, false
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
+	// Counters arrived in 5.13, long after flowtables. Probing twice separates a kernel with no
+	// flowtables from one with no counters.
+	supported = probeFlowtable(ctx, nft, counterProbeFlowtable, true)
+	counter = supported
+	if !supported {
+		supported = probeFlowtable(ctx, nft, plainProbeFlowtable, false)
+	}
+
+	if supported {
+		// Deleting the probe table takes the flowtable with it. A leftover empty table is harmless.
+		cleanup := nft.NewTransaction()
+		cleanup.Delete(&knftables.Table{})
+		if err := nft.Run(ctx, cleanup); err != nil {
+			logrus.WithError(err).Warn("Failed to clean up nftables flowtable offload probe table.")
+		}
+	}
+
+	return supported, counter
+}
+
+// probeFlowtable adds a device-less flowtable, which kernels without nf_flow_table reject just as
+// they would the real one.
+func probeFlowtable(ctx context.Context, nft knftables.Interface, name string, counter bool) bool {
 	prio := knftables.FilterIngressPriority
 	tx := nft.NewTransaction()
 	tx.Add(&knftables.Table{})
 	tx.Add(&knftables.Flowtable{
-		Name:     "probe",
+		Name:     name,
 		Priority: &prio,
+		Counter:  knftables.PtrTo(counter),
 	})
 	if err := nft.Run(ctx, tx); err != nil {
-		logrus.WithError(err).Debug("Kernel rejected the flowtable probe; nftables flowtable offload is unsupported.")
+		logrus.WithError(err).WithField("counter", counter).Debug("Kernel rejected the flowtable probe.")
 		return false
 	}
-
-	// Deleting the probe table takes the flowtable with it. Best-effort: a leftover empty table is
-	// harmless and gets reused on the next probe.
-	cleanup := nft.NewTransaction()
-	cleanup.Delete(&knftables.Table{})
-	if err := nft.Run(ctx, cleanup); err != nil {
-		logrus.WithError(err).Warn("Failed to clean up nftables flowtable offload probe table.")
-	}
-
 	return true
 }

--- a/felix/nftables/flowoffload_detect_test.go
+++ b/felix/nftables/flowoffload_detect_test.go
@@ -17,6 +17,8 @@ package nftables_test
 import (
 	"context"
 	"fmt"
+	"regexp"
+	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -35,25 +37,97 @@ func (f *flowtableRejectFake) Run(ctx context.Context, tx *knftables.Transaction
 	return fmt.Errorf("/dev/stdin:1:1-50: Error: Could not process rule: No such file or directory")
 }
 
+// counterRejectFake wraps a knftables Fake but rejects transactions carrying the counter flag,
+// standing in for a kernel older than 5.13.
+type counterRejectFake struct {
+	*knftables.Fake
+}
+
+func (f *counterRejectFake) Run(ctx context.Context, tx *knftables.Transaction) error {
+	if strings.Contains(tx.String(), "counter ;") {
+		return fmt.Errorf("/dev/stdin:1:1-50: Error: syntax error, unexpected counter")
+	}
+	return f.Fake.Run(ctx, tx)
+}
+
+var flowtableAddRe = regexp.MustCompile(`(?m)^add flowtable \S+ \S+ (\S+)`)
+
+// oldKernelFake stands in for a pre-5.13 kernel whose flowtable update path ignores the counter
+// flag that its add path rejects. Cleanup always fails, so probe state survives to the next
+// detection.
+type oldKernelFake struct {
+	*knftables.Fake
+
+	flowtables map[string]bool
+}
+
+func (f *oldKernelFake) Run(ctx context.Context, tx *knftables.Transaction) error {
+	cmds := tx.String()
+	if strings.Contains(cmds, "delete table") {
+		return fmt.Errorf("/dev/stdin:1:1-50: Error: Could not process rule: Device or resource busy")
+	}
+
+	match := flowtableAddRe.FindStringSubmatch(cmds)
+	if match == nil {
+		return f.Fake.Run(ctx, tx)
+	}
+
+	name := match[1]
+	if strings.Contains(cmds, "counter ;") && !f.flowtables[name] {
+		return fmt.Errorf("/dev/stdin:1:1-50: Error: syntax error, unexpected counter")
+	}
+	f.flowtables[name] = true
+	return nil
+}
+
 var _ = Describe("DetectFlowOffloadSupported", func() {
-	It("returns true when the kernel accepts a flowtable", func() {
+	It("reports both supported when the kernel accepts a flowtable with counters", func() {
 		newDataplane := func(fam knftables.Family, name string, opts ...knftables.Option) (knftables.Interface, error) {
 			return knftables.NewFake(fam, name), nil
 		}
-		Expect(DetectFlowOffloadSupported(newDataplane)).To(BeTrue())
+		supported, counter := DetectFlowOffloadSupported(newDataplane)
+		Expect(supported).To(BeTrue())
+		Expect(counter).To(BeTrue())
 	})
 
-	It("returns false when the kernel rejects the flowtable", func() {
+	It("reports offload without counters when the kernel rejects the counter flag", func() {
+		newDataplane := func(fam knftables.Family, name string, opts ...knftables.Option) (knftables.Interface, error) {
+			return &counterRejectFake{Fake: knftables.NewFake(fam, name)}, nil
+		}
+		supported, counter := DetectFlowOffloadSupported(newDataplane)
+		Expect(supported).To(BeTrue())
+		Expect(counter).To(BeFalse())
+	})
+
+	It("reports unsupported when the kernel rejects the flowtable", func() {
 		newDataplane := func(fam knftables.Family, name string, opts ...knftables.Option) (knftables.Interface, error) {
 			return &flowtableRejectFake{Fake: knftables.NewFake(fam, name)}, nil
 		}
-		Expect(DetectFlowOffloadSupported(newDataplane)).To(BeFalse())
+		supported, counter := DetectFlowOffloadSupported(newDataplane)
+		Expect(supported).To(BeFalse())
+		Expect(counter).To(BeFalse())
 	})
 
-	It("returns false when the nftables interface can't be created", func() {
+	It("does not read counter support off a probe flowtable left over from a previous detection", func() {
+		fake := &oldKernelFake{Fake: knftables.NewFake(knftables.IPv4Family, "probe"), flowtables: map[string]bool{}}
+		newDataplane := func(fam knftables.Family, name string, opts ...knftables.Option) (knftables.Interface, error) {
+			return fake, nil
+		}
+		supported, counter := DetectFlowOffloadSupported(newDataplane)
+		Expect(supported).To(BeTrue())
+		Expect(counter).To(BeFalse())
+
+		supported, counter = DetectFlowOffloadSupported(newDataplane)
+		Expect(supported).To(BeTrue())
+		Expect(counter).To(BeFalse())
+	})
+
+	It("reports unsupported when the nftables interface can't be created", func() {
 		newDataplane := func(fam knftables.Family, name string, opts ...knftables.Option) (knftables.Interface, error) {
 			return nil, fmt.Errorf("nft binary not found")
 		}
-		Expect(DetectFlowOffloadSupported(newDataplane)).To(BeFalse())
+		supported, counter := DetectFlowOffloadSupported(newDataplane)
+		Expect(supported).To(BeFalse())
+		Expect(counter).To(BeFalse())
 	})
 })

--- a/felix/nftables/table.go
+++ b/felix/nftables/table.go
@@ -301,6 +301,9 @@ type NftablesTable struct {
 	// pruning dropped a device. Bounded by MaxFlowtablePruneRetries.
 	flowtablePruneRetries int
 
+	// flowtableCounter programs the flowtable's counter flag, from TableOptions.
+	flowtableCounter bool
+
 	// chainToDataplaneHashes contains the rule hashes that we think are in the dataplane.
 	// it is updated when we write to the dataplane but it can also be read back and compared
 	// to what we calculate from chainToContents.
@@ -375,6 +378,10 @@ type TableOptions struct {
 	// ListInterfacesOverride for tests, if non-nil, replaces the net.Interfaces()-based
 	// lister used to prune the flowtable device list against kernel truth.
 	ListInterfacesOverride func() ([]string, error)
+
+	// FlowtableCounter keeps conntrack accounting up to date for offloaded flows. Only set it
+	// when the kernel supports the flag.
+	FlowtableCounter bool
 
 	// Thunk to call periodically when doing a long-running operation.
 	OnStillAlive func()
@@ -544,6 +551,8 @@ func newTable(
 		timeNow:   now,
 
 		listInterfaces: listInterfaces,
+
+		flowtableCounter: options.FlowtableCounter,
 
 		gaugeNumChains:                  gaugeNumChains.WithLabelValues(gaugeLabel),
 		gaugeNumRules:                   gaugeNumRules.WithLabelValues(gaugeLabel),
@@ -1336,6 +1345,7 @@ func (t *NftablesTable) applyUpdates() error {
 			Name:     dataplanedefs.FlowtableName,
 			Priority: &prio,
 			Devices:  devices,
+			Counter:  knftables.PtrTo(t.flowtableCounter),
 		})
 		t.gaugeNumFlowtableDevices.Set(float64(len(devices)))
 		t.gaugeNumFlowtableMissingDevices.Set(float64(len(t.flowtableDevices) - len(devices)))

--- a/felix/nftables/table_test.go
+++ b/felix/nftables/table_test.go
@@ -1359,6 +1359,41 @@ var _ = Describe("Table with flowtable offload enabled", func() {
 		Expect(f.List(context.TODO(), "flowtable")).To(ConsistOf(dataplanedefs.FlowtableName))
 	})
 
+	It("should leave the counter flag off when the kernel doesn't support it", func() {
+		table.SetOverlayDevices([]string{"vxlan.calico"})
+		Expect(table.Apply()).To(BeNumerically("<", 100*time.Millisecond))
+
+		Expect(f.Fake().Dump()).NotTo(ContainSubstring("counter ;"))
+	})
+
+	It("should set the counter flag when the kernel supports it", func() {
+		newDataplane := func(fam knftables.Family, name string, options ...knftables.Option) (knftables.Interface, error) {
+			f = NewFake(fam, name)
+			return f, nil
+		}
+		table = nftables.NewTable(
+			"calico",
+			4,
+			rulesdefs.RuleHashPrefix,
+			environment.NewFeatureDetector(nil),
+			nftables.TableOptions{
+				NewDataplane:     newDataplane,
+				LookPathOverride: testutils.LookPathNoLegacy,
+				OpRecorder:       logrusr.NewSummarizer("test loop"),
+				FlowtableCounter: true,
+				ListInterfacesOverride: func() ([]string, error) {
+					return []string{"vxlan.calico"}, nil
+				},
+			},
+			true,
+		)
+
+		table.SetOverlayDevices([]string{"vxlan.calico"})
+		Expect(table.Apply()).To(BeNumerically("<", 100*time.Millisecond))
+
+		Expect(f.Fake().Dump()).To(ContainSubstring("counter ;"))
+	})
+
 	It("should attach the configured overlay and workload devices to the flowtable", func() {
 		table.SetOverlayDevices([]string{"vxlan.calico"})
 		table.SetWorkloadInterfaces([]string{"cali1234"})

--- a/go.mod
+++ b/go.mod
@@ -129,7 +129,7 @@ require (
 	sigs.k8s.io/gateway-api v1.5.1
 	sigs.k8s.io/gateway-api/conformance v1.5.1
 	sigs.k8s.io/kind v0.32.0
-	sigs.k8s.io/knftables v0.0.22
+	sigs.k8s.io/knftables v0.0.23-0.20260903141422-0087e9ef619d
 	sigs.k8s.io/network-policy-api v0.2.0
 	sigs.k8s.io/randfill v1.0.0
 	sigs.k8s.io/yaml v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -1380,8 +1380,8 @@ sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 h1:IpInykpT6ceI+QxKBbEflcR5E
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730/go.mod h1:mdzfpAEoE6DHQEN0uh9ZbOCuHbLK5wOm7dK4ctXE9Tg=
 sigs.k8s.io/kind v0.32.0 h1:p9hscbj98u/qyrjVpjId86LI70nQmbSsipV7wCG10Xk=
 sigs.k8s.io/kind v0.32.0/go.mod h1:FSqriGaoTPruiXWfRnUXNykF8r2t+fHtK0P0m1AbGF8=
-sigs.k8s.io/knftables v0.0.22 h1:RMbBSxQb4t730I6m492NDzWTOaActPpF9OCACQmF9bE=
-sigs.k8s.io/knftables v0.0.22/go.mod h1:tig4GDnk1aG8sNsKW/iqid/PGgVLxJLEZkuUlO5C44Y=
+sigs.k8s.io/knftables v0.0.23-0.20260903141422-0087e9ef619d h1:NahRmK2pVp7PEWNMyLW3pu5+7uDADo4GDH9cT7F46Mw=
+sigs.k8s.io/knftables v0.0.23-0.20260903141422-0087e9ef619d/go.mod h1:tig4GDnk1aG8sNsKW/iqid/PGgVLxJLEZkuUlO5C44Y=
 sigs.k8s.io/kustomize/api v0.21.1 h1:lzqbzvz2CSvsjIUZUBNFKtIMsEw7hVLJp0JeSIVmuJs=
 sigs.k8s.io/kustomize/api v0.21.1/go.mod h1:f3wkKByTrgpgltLgySCntrYoq5d3q7aaxveSagwTlwI=
 sigs.k8s.io/kustomize/kyaml v0.21.1 h1:IVlbmhC076nf6foyL6Taw4BkrLuEsXUXNpsE+ScX7fI=

--- a/hack/cmd/deps/deps.go
+++ b/hack/cmd/deps/deps.go
@@ -768,11 +768,19 @@ func printModules(pkg string) {
 	// For ease, do the full cross product. Only takes ~100ms.
 	var mods []string
 	for _, mod := range modules {
+		// Imports still use the original module path, so match on that, but report the
+		// replacement, since that's the code we actually build against.
+		importPath := mod.Path
 		if mod.Replace != nil {
+			if mod.Replace.Version == "" {
+				// Replaced by a local directory; its files are already inputs in their own right.
+				continue
+			}
 			mod = *mod.Replace
 		}
+
 		for _, pkg := range packageDeps {
-			if strings.HasPrefix(pkg, mod.Path) {
+			if strings.HasPrefix(pkg, importPath) {
 				if mod.Version != "" {
 					mods = append(mods, mod.Path+" "+mod.Version)
 				} else {

--- a/kube-controllers/deps.txt
+++ b/kube-controllers/deps.txt
@@ -158,7 +158,7 @@ kubevirt.io/containerized-data-importer-api v1.64.0
 kubevirt.io/controller-lifecycle-operator-sdk/api v0.2.4
 sigs.k8s.io/controller-runtime v0.24.1
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730
-sigs.k8s.io/knftables v0.0.22
+sigs.k8s.io/knftables v0.0.23-0.20260903141422-0087e9ef619d
 sigs.k8s.io/kustomize/api v0.21.1
 sigs.k8s.io/kustomize/kyaml v0.21.1
 sigs.k8s.io/network-policy-api v0.2.0

--- a/node/deps.txt
+++ b/node/deps.txt
@@ -179,7 +179,7 @@ kubevirt.io/containerized-data-importer-api v1.64.0
 kubevirt.io/controller-lifecycle-operator-sdk/api v0.2.4
 modernc.org/memory v1.11.0
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730
-sigs.k8s.io/knftables v0.0.22
+sigs.k8s.io/knftables v0.0.23-0.20260903141422-0087e9ef619d
 sigs.k8s.io/network-policy-api v0.2.0
 sigs.k8s.io/randfill v1.0.0
 sigs.k8s.io/structured-merge-diff/v6 v6.4.2


### PR DESCRIPTION
Cherry-pick of #13496, which fixes flow log packet and byte counts freezing once a connection is offloaded to the software flowtable. Setting the flowtable's counter flag keeps the kernel updating them, and Felix probes for the flag at startup since it needs kernel 5.13 or later. The pick carries the knftables bump from the original PR.

Related: [CORE-13614](https://tigera.atlassian.net/browse/CORE-13614)

```release-note
Fixes flow log packet and byte counts freezing for connections offloaded to the nftables software flowtable.
```


[CORE-13614]: https://tigera.atlassian.net/browse/CORE-13614?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ