### PR TITLE
[v3.31] fix FV container startup race with apiserver.crt bind mount

### DIFF
--- a/felix/fv/infrastructure/infra_k8s.go
+++ b/felix/fv/infrastructure/infra_k8s.go
@@ -623,7 +623,6 @@ func (kds *K8sDatastoreInfra) GetDockerArgs() []string {
 		"-e", "K8S_API_ENDPOINT=" + kds.Endpoint,
 		"-e", "KUBERNETES_MASTER=" + kds.Endpoint,
 		"-e", "K8S_INSECURE_SKIP_TLS_VERIFY=true",
-		"-v", kds.CertFileName + ":/tmp/apiserver.crt",
 	}
 }
 
@@ -634,7 +633,6 @@ func (kds *K8sDatastoreInfra) GetBadEndpointDockerArgs() []string {
 		"-e", "TYPHA_DATASTORETYPE=kubernetes",
 		"-e", "K8S_API_ENDPOINT=" + kds.BadEndpoint,
 		"-e", "K8S_INSECURE_SKIP_TLS_VERIFY=true",
-		"-v", kds.CertFileName + ":/tmp/apiserver.crt",
 	}
 }
 


### PR DESCRIPTION
**Cherry-pick history**
- Pick onto **release-v3.31**: projectcalico/calico#11891

## Problem

The FV felix container's `docker run` carries both `-v /tmp:/tmp` and a second mount of the API server cert onto `/tmp/apiserver.crt`. Because the first mount shares the host's `/tmp`, runc creates the `/tmp/apiserver.crt` mountpoint on the *host* filesystem; with several ginkgo nodes starting containers at once, the next container finds that path already there and dies in `BeforeEach` with `create mountpoint for /tmp/apiserver.crt mount: ... file exists: unknown`. On `release-v3.31` this hits roughly 9% of Felix FV batches and has already failed three backport PRs (#13791, #13794, #13796) on unrelated CI red.

## Change

Drop the redundant `-v <certfile>:/tmp/apiserver.crt` argument from `GetDockerArgs()` and `GetBadEndpointDockerArgs()`. The cert is already reachable inside the container at its host path via `-v /tmp:/tmp`, and every one of these containers runs with `K8S_INSECURE_SKIP_TLS_VERIFY=true`, so nothing reads `/tmp/apiserver.crt`.

## Result

Concurrent FV containers no longer collide on a shared-`/tmp` mountpoint, removing that startup failure mode.

## Backport notes

Master had already moved these `docker run` arguments to `--mount type=bind,...` syntax, so the cherry-pick conflicted on both hunks. `release-v3.31` has the same two helpers (`GetDockerArgs`, `GetBadEndpointDockerArgs`) but builds the argument with the older `-v <src>:<dst>` form. The same removal was applied to both sites; no other change, and master's surrounding refactors were not ported.

## Verification

`CGO_ENABLED=0 go vet ./felix/fv/infrastructure/...`, `CGO_ENABLED=0 go vet -tags fvtests ./felix/fv/` and `CGO_ENABLED=0 go build -tags fvtests ./felix/fv/...` all pass; `gofmt -l` on the changed file is clean. `git grep apiserver.crt` over the branch confirms no remaining reader of that path in `felix/`: the cert is written host-side as `/tmp/<apiserver-container>.crt` and no env var or test points at `/tmp/apiserver.crt`. Resulting commit is a 2-line deletion in one file. The FVs themselves were not run (they need docker and a cluster).

<details>
<summary><b>Cherry-Pick PR details</b></summary>

- **Original PR ID**: 11891
- **Original Commit SHA**: 0e990b3fe8
- **Source Repo**: `projectcalico/calico`
- **Target Repo**: `projectcalico/calico`
- **Target Branch**: `release-v3.31`
</details>

**Release note:**
```release-note
NONE
```
