### PR TITLE
Select nftables e2e specs by config, not inline ginkgo flags

### DIFF
--- a/.argoci/cron/e2e-nftables.yaml
+++ b/.argoci/cron/e2e-nftables.yaml
@@ -11,7 +11,6 @@ globalPrologue: |
   export ENABLE_AUTOHEP="${ENABLE_AUTOHEP:-true}"
   export FUNCTIONAL_AREA="${FUNCTIONAL_AREA:-nftables.yml}"
   export INSTALLER="${INSTALLER:-operator}"
-  export K8S_E2E_FLAGS="${K8S_E2E_FLAGS:---ginkgo.focus=(\[sig-calico\]|\[Conformance\]) --ginkgo.skip=(\[Slow\]|\[Disruptive\]|sig-node|sig-apps|sig-storage|sig-scheduling|sig-calico-enterprise|\[DataPath\]|WireGuard)}"
   export K8S_VERSION="${K8S_VERSION:-stable-3}"
   export KUBE_PROXY_MODE="${KUBE_PROXY_MODE:-nftables}"
   export PRIVATE_REGISTRY="${PRIVATE_REGISTRY:-quay.io/}"
@@ -28,6 +27,8 @@ steps:
       - docker
       - http-cache-proxy
     env:
+      - name: E2E_TEST_CONFIG
+        value: e2e/config/nftables/arm64-wg.yaml
       - name: ENABLE_WIREGUARD
         value: "true"
       - name: GOOGLE_MACHINE_TYPE
@@ -60,6 +61,8 @@ steps:
       - docker
       - http-cache-proxy
     env:
+      - name: E2E_TEST_CONFIG
+        value: e2e/config/nftables/pipeline.yaml
       - name: ENCAPSULATION_TYPE
         value: VXLAN
       - name: PROVISIONER
@@ -78,6 +81,8 @@ steps:
     env:
       - name: CLUSTER_ROUTING_MODE
         value: Felix
+      - name: E2E_TEST_CONFIG
+        value: e2e/config/nftables/native-v3-crds-gcp.yaml
       # gcp-kubeadm uses the fixed semaphore-autotest VPC + reserved IPs, which
       # exist only in us-central1; pin region/zone (the load-spread randomisation
       # in the prologue can't apply to region-fixed jobs). See arm64-wg.
@@ -98,6 +103,8 @@ steps:
       - docker
       - http-cache-proxy
     env:
+      - name: E2E_TEST_CONFIG
+        value: e2e/config/nftables/native-v3-crds-aws.yaml
       - name: K8S_VERSION
         value: stable-3
       - name: PROVISIONER
@@ -111,6 +118,8 @@ steps:
       - docker
       - http-cache-proxy
     env:
+      - name: E2E_TEST_CONFIG
+        value: e2e/config/nftables/eks-aws-cni.yaml
       - name: K8S_VERSION
         value: stable-1
       - name: PROVISIONER
@@ -127,14 +136,14 @@ steps:
       - docker
       - http-cache-proxy
     env:
+      - name: E2E_TEST_CONFIG
+        value: e2e/config/nftables/eks-calico-cni.yaml
       - name: INSTALLER
         value: helmerator
       - name: IPAM_TEST_POOL_SUBNET
         value: 10.0.0.0/29
       - name: IPV4_POD_CIDR
         value: 172.16.0.0/16
-      - name: K8S_E2E_FLAGS
-        value: --ginkgo.focus=(\[sig-calico\]|\[Conformance\]) --ginkgo.skip=(\[Slow\]|\[Disruptive\]|sig-node|sig-apps|sig-storage|sig-scheduling|sig-calico-enterprise|\[DataPath\]|WireGuard|both.pod.and.service.Proxy\b|proxy.through.a.service.and.a.pod|replica.with.a.public.image|DNS.for.ExternalName.services|DNS.for.pods.for.Hostname|DNS.for.pods.for.Subdomain|DNS.for.services|DNS.for.the.cluster|DNS.qualified.names.for.services)
       - name: K8S_VERSION
         value: stable-1
       - name: PROVISIONER
@@ -152,6 +161,8 @@ steps:
       - docker
       - http-cache-proxy
     env:
+      - name: E2E_TEST_CONFIG
+        value: e2e/config/nftables/pipeline.yaml
       - name: ENABLE_DUAL_STACK
         value: "true"
       - name: ENCAPSULATION_TYPE
@@ -176,6 +187,8 @@ steps:
       - docker
       - http-cache-proxy
     env:
+      - name: E2E_TEST_CONFIG
+        value: e2e/config/nftables/pipeline.yaml
       - name: ENABLE_DUAL_STACK
         value: "true"
       - name: ENCAPSULATION_TYPE_V6

--- a/e2e/config/nftables/arm64-wg.yaml
+++ b/e2e/config/nftables/arm64-wg.yaml
@@ -1,0 +1,10 @@
+# Copyright (c) 2026 Tigera, Inc. All rights reserved.
+#
+# arm64-wg.yaml - gcp-kubeadm on arm64 with WireGuard enabled.
+
+extends: pipeline.yaml
+
+exclude:
+  labels:
+    - label: RequiresBGPMesh
+      reason: "Felix owns the cluster routes here (VXLAN CrossSubnet), so BGP full mesh is not the sole routing mechanism"

--- a/e2e/config/nftables/eks-aws-cni.yaml
+++ b/e2e/config/nftables/eks-aws-cni.yaml
@@ -1,0 +1,16 @@
+# Copyright (c) 2026 Tigera, Inc. All rights reserved.
+#
+# eks-aws-cni.yaml - aws-eks with the Amazon VPC CNI, so neither Calico
+# networking nor Calico IPAM is in play.
+
+extends: pipeline.yaml
+
+exclude:
+  labels:
+    # RequiresBGP is deliberately left in: the route-reflector specs under that
+    # label pass on this lane, so excluding it would drop real coverage.
+    - label: RequiresBGPMesh
+      reason: "AmazonVPC handles routing; there is no BGP mesh"
+
+    - label: Feature:IPAM
+      reason: "AmazonVPC supplies the addresses, so the cluster does not use Calico IPAM"

--- a/e2e/config/nftables/eks-calico-cni.yaml
+++ b/e2e/config/nftables/eks-calico-cni.yaml
@@ -1,0 +1,25 @@
+# Copyright (c) 2026 Tigera, Inc. All rights reserved.
+#
+# eks-calico-cni.yaml - aws-eks with Calico CNI, installed by helmerator.
+
+extends: pipeline.yaml
+
+exclude:
+  labels:
+    # RequiresBGP is deliberately left in: the route-reflector specs under that
+    # label pass on this lane, so excluding it would drop real coverage.
+    - label: RequiresBGPMesh
+      reason: "EKS routes through the VPC; there is no BGP mesh"
+
+  namePatterns:
+    - group: "EKS control plane cannot reach the Calico pod network"
+      patterns:
+        - "both.pod.and.service.Proxy\\b"
+        - "proxy.through.a.service.and.a.pod"
+        - "replica.with.a.public.image"
+        - "DNS.for.ExternalName.services"
+        - "DNS.for.pods.for.Hostname"
+        - "DNS.for.pods.for.Subdomain"
+        - "DNS.for.services"
+        - "DNS.for.the.cluster"
+        - "DNS.qualified.names.for.services"

--- a/e2e/config/nftables/native-v3-crds-aws.yaml
+++ b/e2e/config/nftables/native-v3-crds-aws.yaml
@@ -1,0 +1,11 @@
+# Copyright (c) 2026 Tigera, Inc. All rights reserved.
+#
+# native-v3-crds-aws.yaml - aws-kubeadm, v3 CRD mode (no aggregated API
+# server). BGP mesh is intact here, unlike the GCP variant.
+
+extends: pipeline.yaml
+
+exclude:
+  labels:
+    - label: RequiresCalicoAPIServer
+      reason: "USE_API_SERVER=false, so tier RBAC is only enforced on write and the read-path specs cannot pass"

--- a/e2e/config/nftables/native-v3-crds-gcp.yaml
+++ b/e2e/config/nftables/native-v3-crds-gcp.yaml
@@ -1,0 +1,14 @@
+# Copyright (c) 2026 Tigera, Inc. All rights reserved.
+#
+# native-v3-crds-gcp.yaml - gcp-kubeadm, v3 CRD mode (no aggregated API
+# server), Felix-owned cluster routes.
+
+extends: pipeline.yaml
+
+exclude:
+  labels:
+    - label: RequiresCalicoAPIServer
+      reason: "USE_API_SERVER=false, so tier RBAC is only enforced on write and the read-path specs cannot pass"
+
+    - label: RequiresBGPMesh
+      reason: "CLUSTER_ROUTING_MODE=Felix, so BGP full mesh is not the sole routing mechanism"

--- a/e2e/config/nftables/pipeline.yaml
+++ b/e2e/config/nftables/pipeline.yaml
@@ -1,0 +1,27 @@
+# Copyright (c) 2026 Tigera, Inc. All rights reserved.
+#
+# pipeline.yaml - selection shared by every nftables lane.
+#
+# base.yaml already scopes the suite to sig-calico plus networking
+# conformance and drops the labels no lane can satisfy (ExternalNode,
+# Feature:KubeVirt). This file adds what is true of the nftables lanes as a
+# group; each lane file then adds only what its own cluster shape rules out.
+
+extends: ../base.yaml
+
+exclude:
+  labels:
+    - label: sig-calico-enterprise
+      reason: "Enterprise-only specs; this is the open-source pipeline"
+
+  namePatterns:
+    - pattern: "DataPath"
+      reason: "directory-based test name, not a Ginkgo label"
+
+    # Not the whole Feature:Istio label: the OpenShift platform-config spec in
+    # that label passes here, only the ambient-mode ones need Istio installed.
+    - pattern: "Istio Ambient Mode"
+      reason: "no Istio on these lanes; these specs wait for TigeraStatus 'istio' to go Available and so fail instead of skipping"
+
+    - pattern: "WireGuard"
+      reason: "WireGuard specs are not part of the nftables selection"


### PR DESCRIPTION
The nftables lanes on this branch still set `K8S_E2E_FLAGS`. `.argoci/scripts/phases/run_tests.sh` treats that as the legacy selection channel and skips the `e2e/config` tree entirely, so `base.yaml` never applies — even though it already drops the labels no lane can satisfy.

The consequence is that specs run whose prerequisites are absent, and the e2e suite's guard clauses fail them loudly rather than skipping. On the 2026-09-07 cron run (`e2e-nftables-release-v3-33-1788822600`) that accounted for **94 of the 151 failures**:

| Guard | Failures |
| --- | --- |
| `No external node is configured` | 28 |
| KubeVirt CRDs absent / `MockVirt is not deployed` | 48 |
| `requires the aggregated Calico API server` | 4 |
| `requires BGP full mesh as the sole routing mechanism` | 6 |
| Istio ambient (`TigeraStatus 'istio' should be Available`) | 6 |
| `cluster does not use Calico IPAM` | 2 |

Master fixed this in #13452/#13547/#13556/#13558, but all four landed after `release-v3.33` was cut and together touch 190 files — not a cherry-pick. This does the same thing using only what this branch already has: `e2e/pkg/testconfig` supports `extends`/`exclude`, `run_tests.sh` already honours `E2E_TEST_CONFIG`, and the `kubevirt-e2e-tests` step already uses it (and is notably the one step in that run with **no** guard failures).

## Approach

A shared `e2e/config/nftables/pipeline.yaml` extends `../base.yaml` and adds what is true of the nftables lanes as a group. Per-lane files add only what that lane's cluster shape rules out. `talos` and both `kind` lanes point at `pipeline.yaml` directly — their steps died before testing (Talos can't run k8s 1.37; the kind step failed on `stern:create`), so there is no evidence of what else they need; that can be added when a run shows it.

Exclusions are label-level **only where no spec carrying that label passes**, checked against the run's JUnit:

- `RequiresBGP` is deliberately **not** excluded on the EKS lanes even though the guard explicitly asks for it, because the three route-reflector specs under that label pass there. Excluding it would have cost real coverage. Those three IPIP/BGP-password failures are left visible.
- `Feature:Istio` is carved out by name pattern (`Istio Ambient Mode`) rather than by label, because the OpenShift platform-config spec under that label passes.

The dropped `sig-node|sig-apps|sig-storage|sig-scheduling` skip patterns are covered by `base.yaml`'s narrower include scope (`sig-calico` OR `Conformance && sig-network`); those specs were already being skipped.

## Testing done

`go test ./e2e/pkg/testconfig/...` passes and `make yaml-lint` is clean. Each config was loaded through `testconfig.Load` + `ToFlags` to confirm the compiled `--ginkgo.label-filter` and `--ginkgo.skip` are as intended.

The real check was replaying the run's JUnit for all four lanes that reached testing against the new selection, counting only specs that actually ran (ginkgo records skipped specs as `<testcase><skipped/>`, which must not be read as passes):

| Lane | Failures excluded | Failures remaining | Passing specs retained | Passing specs dropped |
| --- | --- | --- | --- | --- |
| arm64-wg | 22 | 26 | 153 | **0** |
| eks-aws-cni | 24 | 31 | 145 | **0** |
| eks-calico-cni | 22 | 22 | 150 | **0** |
| native-v3-crds-gcp | 26 | 18 | 157 | **0** |
| **total** | **94** | **97** | — | **0** |

So this removes the 94 prerequisite failures, keeps the 97 genuine ones visible, and drops no passing spec on any lane.

## Follow-ups, not in this PR

- The e2e suite asks lanes to exclude `RequiresBGP` while some specs carrying that label pass without BGP. That looks like a spec-tagging inconsistency worth a look by whoever owns those tests.
- `Makefile` exports `RAPIDCLIENT_TAG ?= kind-e2e` globally, and `images.RapidClientImage()` reads any non-empty value as "side-loaded", so callers set `ImagePullPolicy: Never`. Only the kind targets and gcp-kubeadm's `load_images.sh` actually side-load, so on EKS/arm64/talos the packet-size server pods sit in `ErrImageNeverPull`. That is 27 more failures in this run and it affects master too (higher rate there) — separate fix.
- master has `e2e/pkg/testconfig/repoconfigs_test.go`, which validates every config in the repo. Worth backporting on its own.

**Release note:**
```release-note
NONE
```
