### PR TITLE
Preserve externally-managed caBundle on MutatingWebhookConfiguration reconciles

### DIFF
--- a/operator/pkg/controller/utils/component.go
+++ b/operator/pkg/controller/utils/component.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/go-logr/logr"
 	v3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
+	admissionregv1 "k8s.io/api/admissionregistration/v1"
 	apps "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
@@ -795,6 +796,27 @@ func mergeState(desired client.Object, current runtime.Object) client.Object {
 			dsa.ImagePullSecrets = csa.ImagePullSecrets
 		}
 		return dsa
+	case *admissionregv1.MutatingWebhookConfiguration:
+		// Some MutatingWebhookConfigurations (e.g. the bundled Envoy Gateway
+		// topology injector) are rendered from an upstream chart that never
+		// sets clientConfig.caBundle — a separate, externally-owned job
+		// populates it post-install. Preserve that value across reconciles
+		// instead of wiping it back to empty, which otherwise reopens a
+		// window where TLS verification of the webhook fails.
+		cmwc := current.(*admissionregv1.MutatingWebhookConfiguration)
+		dmwc := desired.(*admissionregv1.MutatingWebhookConfiguration)
+		currentByName := make(map[string][]byte, len(cmwc.Webhooks))
+		for _, wh := range cmwc.Webhooks {
+			currentByName[wh.Name] = wh.ClientConfig.CABundle
+		}
+		for i, wh := range dmwc.Webhooks {
+			if len(wh.ClientConfig.CABundle) == 0 {
+				if cur, ok := currentByName[wh.Name]; ok {
+					dmwc.Webhooks[i].ClientConfig.CABundle = cur
+				}
+			}
+		}
+		return dmwc
 	case *v3.NetworkPolicy:
 		cnp := current.(*v3.NetworkPolicy)
 		dnp := desired.(*v3.NetworkPolicy)

--- a/operator/pkg/controller/utils/component_test.go
+++ b/operator/pkg/controller/utils/component_test.go
@@ -23,6 +23,7 @@ import (
 	. "github.com/onsi/gomega"
 	ocsv1 "github.com/openshift/api/security/v1"
 	v3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
+	admissionregv1 "k8s.io/api/admissionregistration/v1"
 	apps "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -72,6 +73,7 @@ var _ = Describe("Component handler tests", func() {
 		Expect(apps.SchemeBuilder.AddToScheme(scheme)).ShouldNot(HaveOccurred())
 		Expect(batchv1.SchemeBuilder.AddToScheme(scheme)).ShouldNot(HaveOccurred())
 		Expect(rbacv1.SchemeBuilder.AddToScheme(scheme)).ShouldNot(HaveOccurred())
+		Expect(admissionregv1.SchemeBuilder.AddToScheme(scheme)).ShouldNot(HaveOccurred())
 
 		c = ctrlrfake.DefaultFakeClientBuilder(scheme).Build()
 		ctx = context.Background()
@@ -1907,6 +1909,70 @@ var _ = Describe("Component handler tests", func() {
 			Expect(c.Get(ctx, client.ObjectKey{Name: "a", Namespace: "a"}, sa)).NotTo(HaveOccurred())
 			Expect(sa.Secrets).To(HaveLen(1))
 			Expect(sa.ImagePullSecrets).To(HaveLen(1))
+		})
+	})
+	Context("MutatingWebhookConfiguration updates should not clobber an externally-managed caBundle", func() {
+		It("preserves an existing caBundle when the desired object doesn't set one", func() {
+			sideEffectsNone := admissionregv1.SideEffectClassNone
+			mwc := &admissionregv1.MutatingWebhookConfiguration{
+				TypeMeta:   metav1.TypeMeta{},
+				ObjectMeta: metav1.ObjectMeta{Name: "topology-injector"},
+				Webhooks: []admissionregv1.MutatingWebhook{
+					{
+						Name:        "topology.webhook.example.io",
+						SideEffects: &sideEffectsNone,
+						ClientConfig: admissionregv1.WebhookClientConfig{
+							CABundle: []byte("existing-ca-bundle"),
+						},
+						AdmissionReviewVersions: []string{"v1"},
+					},
+				},
+			}
+			Expect(c.Create(ctx, mwc)).NotTo(HaveOccurred())
+
+			// The rendered (desired) object mirrors what the upstream Envoy Gateway chart
+			// produces: no caBundle, since that's populated out-of-band by certgen.
+			desired := mwc.DeepCopy()
+			desired.Webhooks[0].ClientConfig.CABundle = nil
+			fc := &fakeComponent{
+				supportedOSType: rmeta.OSTypeLinux,
+				objs:            []client.Object{desired},
+			}
+
+			Expect(handler.CreateOrUpdateOrDelete(ctx, fc, sm)).NotTo(HaveOccurred())
+			Expect(c.Get(ctx, client.ObjectKey{Name: "topology-injector"}, mwc)).NotTo(HaveOccurred())
+			Expect(mwc.Webhooks[0].ClientConfig.CABundle).To(Equal([]byte("existing-ca-bundle")))
+		})
+		It("does not override a caBundle the desired object explicitly sets", func() {
+			sideEffectsNone := admissionregv1.SideEffectClassNone
+			mwc := &admissionregv1.MutatingWebhookConfiguration{
+				TypeMeta:   metav1.TypeMeta{},
+				ObjectMeta: metav1.ObjectMeta{Name: "topology-injector-owned"},
+				Webhooks: []admissionregv1.MutatingWebhook{
+					{
+						Name:        "owned.webhook.example.io",
+						SideEffects: &sideEffectsNone,
+						ClientConfig: admissionregv1.WebhookClientConfig{
+							CABundle: []byte("stale-ca-bundle"),
+						},
+						AdmissionReviewVersions: []string{"v1"},
+					},
+				},
+			}
+			Expect(c.Create(ctx, mwc)).NotTo(HaveOccurred())
+
+			// Unlike the Envoy Gateway case, this webhook's caBundle is owned and
+			// actively rotated by the operator itself, so the desired object sets it.
+			desired := mwc.DeepCopy()
+			desired.Webhooks[0].ClientConfig.CABundle = []byte("rotated-ca-bundle")
+			fc := &fakeComponent{
+				supportedOSType: rmeta.OSTypeLinux,
+				objs:            []client.Object{desired},
+			}
+
+			Expect(handler.CreateOrUpdateOrDelete(ctx, fc, sm)).NotTo(HaveOccurred())
+			Expect(c.Get(ctx, client.ObjectKey{Name: "topology-injector-owned"}, mwc)).NotTo(HaveOccurred())
+			Expect(mwc.Webhooks[0].ClientConfig.CABundle).To(Equal([]byte("rotated-ca-bundle")))
 		})
 	})
 	Context("volumes and volume mounts", func() {


### PR DESCRIPTION
<!-- Describe your changes, including the type of change (bug fix, feature, etc.),
why it should be merged, testing done, and links to related issues. -->

Bug fix. The operator periodically reconciles the `envoy-gateway-topology-injector`
`MutatingWebhookConfiguration`, which is rendered verbatim from the bundled Envoy
Gateway Helm chart. That upstream chart never sets `webhooks[].clientConfig.caBundle`
on this object — a separate, out-of-band `certgen` Job populates it after install.
Because the operator's generic reconcile path (`mergeState` in
`operator/pkg/controller/utils/component.go`) had no special case for
`MutatingWebhookConfiguration`, every update replaced the whole object with the
chart-rendered desired state, wiping the `caBundle` that `certgen` had set. `certgen`
restores it roughly a second later, but during that window the API server can reject
requests through the webhook with `x509: certificate signed by unknown authority`.

This adds a `mergeState` case for `*admissionregv1.MutatingWebhookConfiguration`,
matching the existing pattern used for `Service` (preserves `ClusterIP`) and
`ServiceAccount` (preserves `Secrets`/`ImagePullSecrets`) in the same switch: when the
desired object's webhook entry has an empty `caBundle`, copy the value already on the
cluster instead of clearing it. A desired webhook that explicitly sets a non-empty
`caBundle` is left untouched, so this doesn't affect webhooks whose CA the operator
itself owns and rotates (e.g. the ones rendered by
`operator/pkg/render/webhooks/render.go` and `operator/pkg/render/apiserver.go`,
which always set a non-empty `CABundle` on the desired object).

Note for reviewers: this new `mergeState` case is unconditional for the whole
`MutatingWebhookConfiguration` type, so it would also apply ahead of the
`extensionObjectRules.MergeState` hook for any enterprise-only webhook of this kind.
I could not check the enterprise extension code from this checkout to confirm nothing
there currently special-cases this type; the new default (preserve only when desired
leaves `caBundle` empty) is conservative and matches what such an extension would
likely already do, but it's worth a maintainer's confirmation.

**Release note:**
```release-note
Fix a race where periodic reconciliation of the bundled Envoy Gateway topology
injector webhook could briefly clear its TLS CA bundle, causing transient
`x509: certificate signed by unknown authority` errors on pod scheduling.
```

<!-- Replace TBD: say what AI tools helped write this change, or "None". -->
**AI assistance:** Implemented, tested, and reviewed with Claude (Anthropic).

By opening this PR you take responsibility for every line in it, and you agree to explain the change yourself during review rather than routing review comments back through an agent. See [AI_POLICY.md](../AI_POLICY.md).

Fixes #13695