### PR TITLE
[release-v3.32] ALP fixes roundup: staged-policy scope and cheapest-first rule matching

### DIFF
--- a/app-policy/checker/adapter_checkrequest.go
+++ b/app-policy/checker/adapter_checkrequest.go
@@ -19,7 +19,6 @@ import (
 	"strings"
 
 	authz "github.com/envoyproxy/go-control-plane/envoy/service/auth/v3"
-	log "github.com/sirupsen/logrus"
 )
 
 // CheckRequestToFlowAdapter adapts CheckRequest to the l4 and l7 flow interfaces for use in the
@@ -69,7 +68,7 @@ func (a *CheckRequestToFlowAdapter) GetProtocol() int {
 	if p, ok := protocolMap[strings.ToLower(protocol)]; ok {
 		return p
 	}
-	log.Warnf("unsupported protocol: %s, defaulting to TCP", protocol)
+	rlogBadProtocolName.Warnf("unsupported protocol: %s, defaulting to TCP", protocol)
 	return 6
 }
 

--- a/app-policy/checker/alp_check_provider.go
+++ b/app-policy/checker/alp_check_provider.go
@@ -45,6 +45,6 @@ func (a *ALPCheckProvider) EnabledForRequest(ps *policystore.PolicyStore, _ *aut
 // for the local workload endpoint and returns the authorization decision.
 func (a *ALPCheckProvider) Check(ps *policystore.PolicyStore, req *authz.CheckRequest) (*authz.CheckResponse, error) {
 	flow := NewCheckRequestToFlowAdapter(req)
-	st := checkStore(ps, ps.Endpoint, rules.RuleDirIngress, flow)
+	st := checkStore(EnforcedOnly, ps, ps.Endpoint, rules.RuleDirIngress, flow)
 	return &authz.CheckResponse{Status: &st}, nil
 }

--- a/app-policy/checker/bench_egress_test.go
+++ b/app-policy/checker/bench_egress_test.go
@@ -1,0 +1,308 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package checker
+
+// Benchmark for Evaluate() against a single-tier egress allow-list, the second rule-set shape
+// measured in production (the first is in bench_test.go). All data is synthetic; the scale
+// parameters and distributions below are anonymized measurements from a policy dump.
+//
+//	go test ./app-policy/checker/ -run '^$' -bench BenchmarkEvaluateEgressAllowList \
+//	    -benchmem -benchtime 100x -cpu 1
+//
+// Shape: one tier, ~301 policies with no selector (so all of them apply to every endpoint),
+// ~18,600 egress rules, almost all Pass. The tier is a destination allow-list: match a rule
+// and leave the tier, match nothing and the tier default denies. Every rule's source block is
+// empty; each matches a destination address plus a handful of destination ports.
+//
+// The three cases below must be read separately, because criterion ordering helps them by
+// different amounts. A flow whose port is shared by few rules is rejected on the port
+// comparison almost everywhere and never pays for the address criteria; a flow on a popular
+// port pays the address criteria on every rule that shares it; and a denied flow walks the
+// whole tier no matter what, so ordering can only reduce its per-rule cost, never its scan
+// depth. Averaging the three hides that.
+
+import (
+	"fmt"
+	"math/rand"
+	"net"
+	"testing"
+
+	v3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/projectcalico/calico/app-policy/policystore"
+	"github.com/projectcalico/calico/felix/proto"
+	"github.com/projectcalico/calico/felix/rules"
+	"github.com/projectcalico/calico/felix/types"
+)
+
+const (
+	egressNumPolicies    = 301
+	egressRulesPerPolicy = 62 // 18,662 rules.
+
+	// Fraction of rules whose destination is a selector, which reaches Dikastes as an IP set
+	// reference; the rest carry a CIDR. Measured: 4,644 of 18,675.
+	egressIPSetRuleFraction = 0.25
+
+	// Where in the walk the rule that matches sits, as a fraction of the whole tier. Real
+	// flows match at every depth; this picks one representative depth so the two matching
+	// cases are comparable with each other.
+	egressTargetDepth = 0.65
+
+	// The flow. The denied case keeps this destination, which no rule's CIDR contains; the
+	// matching cases replace it with an address inside the target rule's CIDR.
+	egressSourceIP   = "192.0.2.10"
+	egressDeniedIP   = "198.51.100.20"
+	egressSourcePort = 45000
+)
+
+// egressPortWeights reproduces the measured head of the port distribution: the fraction of
+// rules whose destination ports include each of these. 443 appears in 3,395 of 18,675 rules,
+// 11001 in 2,289, 27054 in 2,281 and 80 in 1,505. Rules not drawing a head port get ports from
+// a long tail of otherwise-unique values, so a tail port is shared by only a rule or two.
+var egressPortWeights = []struct {
+	port     int32
+	fraction float64
+}{
+	{443, 0.182},
+	{11001, 0.123},
+	{27054, 0.122},
+	{80, 0.081},
+}
+
+// egressPortsPerRule is the measured spread of destination ports per rule: median 2, mean ~5.
+var egressPortsPerRule = []struct {
+	count    int
+	fraction float64
+}{
+	{1, 0.25},
+	{2, 0.45},
+	{3, 0.15},
+	{8, 0.10},
+	{20, 0.05},
+}
+
+func BenchmarkEvaluateEgressAllowList(b *testing.B) {
+	// A flow on a port few rules share: rejected on the port comparison nearly everywhere.
+	b.Run("TailPort", func(b *testing.B) {
+		benchEvaluateEgressAllowList(b, egressTailPortFlow)
+	})
+	// A flow on the most popular port: ~18% of rules share it and go on to the address check.
+	b.Run("PopularPort", func(b *testing.B) {
+		benchEvaluateEgressAllowList(b, egressPopularPortFlow)
+	})
+	// No rule matches, so the walk covers the whole tier and ends in the tier default deny.
+	// Ordering cannot reduce the scan depth here, only the cost of each rejected rule.
+	b.Run("Denied", func(b *testing.B) {
+		benchEvaluateEgressAllowList(b, egressDeniedFlow)
+	})
+}
+
+// egressCase is what one benchmark case measures: the flow, how many rules the walk is
+// expected to visit, and whether a rule is expected to match it.
+type egressCase struct {
+	flow        *MockFlow
+	rulesWalked int
+	matches     bool
+}
+
+// egressCaseFunc builds one case from the fixture's target rule.
+type egressCaseFunc func(target egressTarget) egressCase
+
+func egressTailPortFlow(target egressTarget) egressCase {
+	return egressCase{
+		flow:        egressFlow(target.addrInCIDR, target.tailPort),
+		rulesWalked: target.rulesWalked,
+		matches:     true,
+	}
+}
+
+func egressPopularPortFlow(target egressTarget) egressCase {
+	return egressCase{
+		flow:        egressFlow(target.addrInCIDR, egressPortWeights[0].port),
+		rulesWalked: target.rulesWalked,
+		matches:     true,
+	}
+}
+
+func egressDeniedFlow(_ egressTarget) egressCase {
+	return egressCase{
+		flow:        egressFlow(egressDeniedIP, egressPortWeights[0].port),
+		rulesWalked: egressNumPolicies * egressRulesPerPolicy,
+	}
+}
+
+func egressFlow(destIP string, destPort int32) *MockFlow {
+	return &MockFlow{
+		SourceIP:   net.ParseIP(egressSourceIP),
+		DestIP:     net.ParseIP(destIP),
+		SourcePort: egressSourcePort,
+		DestPort:   int(destPort),
+		Protocol:   6, // TCP
+	}
+}
+
+func benchEvaluateEgressAllowList(b *testing.B, caseFor egressCaseFunc) {
+	_, restoreLogging := withBenchLogging(log.WarnLevel)
+	defer restoreLogging()
+
+	store, ep, target := buildEgressAllowListStore()
+	c := caseFor(target)
+
+	// Pre-flight outside the timed loop: prove the walk is the one the case intends, so that
+	// a fixture change cannot silently turn a full walk into an early exit.
+	trace, err := Evaluate(EnforcedOnly, rules.RuleDirEgress, store, ep, c.flow)
+	if err != nil {
+		b.Fatalf("evaluation failed: %v", err)
+	}
+	if c.matches {
+		if len(trace) != 1 || trace[0].Action != rules.RuleActionAllow || trace[0].Index != target.ruleIndex {
+			b.Fatalf("expected an allow from the target rule at index %d, got %v", target.ruleIndex, trace)
+		}
+	} else if len(trace) != 1 || trace[0].Action != rules.RuleActionDeny || trace[0].Index != tierDefaultActionIndex {
+		b.Fatalf("expected a full walk ending in the tier default deny, got %v", trace)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		benchTraceSink, _ = Evaluate(EnforcedOnly, rules.RuleDirEgress, store, ep, c.flow)
+	}
+	b.StopTimer()
+	b.ReportMetric(float64(c.rulesWalked), "rules/op")
+	b.ReportMetric(float64(b.Elapsed().Nanoseconds())/float64(b.N)/float64(c.rulesWalked), "ns/rule")
+}
+
+// egressTarget describes the one rule in the fixture that a matching flow is built to hit.
+type egressTarget struct {
+	ruleIndex   int    // Index of the rule within its policy, for the trace assertion.
+	addrInCIDR  string // An address inside the rule's destination CIDR.
+	tailPort    int32  // A port on the rule that few other rules share.
+	rulesWalked int    // Rules visited before and including it.
+}
+
+// buildEgressAllowListStore builds the policy store and the endpoint whose single tier applies
+// every policy, and returns the target rule a matching flow is aimed at.
+//
+// Destination CIDRs are handed out sequentially rather than at random so that no rule except
+// the target can contain the matching flow's address: a second rule matching earlier would
+// shorten the walk and make the case measure something other than what it claims to.
+func buildEgressAllowListStore() (*policystore.PolicyStore, *proto.WorkloadEndpoint, egressTarget) {
+	rng := rand.New(rand.NewSource(20200))
+	store := policystore.NewPolicyStore()
+	setIDs := makeEgressIPSets(store)
+
+	numRules := egressNumPolicies * egressRulesPerPolicy
+	targetRule := int(float64(numRules) * egressTargetDepth)
+
+	tier := &proto.TierInfo{Name: "perimeter", DefaultAction: "Deny"}
+	var target egressTarget
+	nextCIDR := 0
+	ruleIdx := 0
+	for i := 0; i < egressNumPolicies; i++ {
+		policyID := &proto.PolicyID{Name: fmt.Sprintf("egress-%03d", i), Kind: v3.KindGlobalNetworkPolicy}
+		policy := &proto.Policy{Tier: tier.Name}
+		for j := 0; j < egressRulesPerPolicy; j++ {
+			// All rules are Pass bar the target: a rule's action is only consulted once it
+			// matches, so the action mix does not affect the walk.
+			rule := &proto.Rule{Action: "pass", DstPorts: makeEgressRulePorts(rng)}
+			if rng.Float64() < egressIPSetRuleFraction {
+				rule.DstIpSetIds = []string{setIDs[rng.Intn(len(setIDs))]}
+			} else {
+				rule.DstNet = []string{fmt.Sprintf("10.%d.%d.0/24", nextCIDR>>8&0xff, nextCIDR&0xff)}
+				nextCIDR++
+			}
+			if ruleIdx == targetRule {
+				// Make the target reachable on address and on a port of its own, and give it
+				// a distinct action so the trace assertion is unambiguous.
+				rule.Action = "allow"
+				rule.DstNet = []string{fmt.Sprintf("10.%d.%d.0/24", nextCIDR>>8&0xff, nextCIDR&0xff)}
+				rule.DstIpSetIds = nil
+				// Carry both ports the matching cases use, so they differ only in how many
+				// rules along the way survive the port comparison.
+				rule.DstPorts = append(rule.DstPorts,
+					&proto.PortRange{First: egressTailPort, Last: egressTailPort},
+					&proto.PortRange{First: egressPortWeights[0].port, Last: egressPortWeights[0].port},
+				)
+				target = egressTarget{
+					ruleIndex:   j,
+					addrInCIDR:  fmt.Sprintf("10.%d.%d.7", nextCIDR>>8&0xff, nextCIDR&0xff),
+					tailPort:    egressTailPort,
+					rulesWalked: ruleIdx + 1,
+				}
+				nextCIDR++
+			}
+			policy.OutboundRules = append(policy.OutboundRules, rule)
+			ruleIdx++
+		}
+		store.PolicyByID[types.ProtoToPolicyID(policyID)] = policy
+		tier.EgressPolicies = append(tier.EgressPolicies, policyID)
+	}
+
+	ep := &proto.WorkloadEndpoint{Tiers: []*proto.TierInfo{tier}}
+	return store, ep, target
+}
+
+// egressTailPort is outside the range makeEgressRulePorts draws from, so only the target rule
+// carries it — the extreme of the measured tail, where 90% of ports are on 5 rules or fewer.
+const egressTailPort = 60999
+
+// makeEgressRulePorts picks a rule's destination ports: the measured head with its measured
+// frequency, topped up from a wide tail.
+func makeEgressRulePorts(rng *rand.Rand) []*proto.PortRange {
+	var ports []int32
+	for _, w := range egressPortWeights {
+		if rng.Float64() < w.fraction {
+			ports = append(ports, w.port)
+		}
+	}
+	for _, n := range egressPortsPerRule {
+		if rng.Float64() < n.fraction {
+			for len(ports) < n.count {
+				ports = append(ports, int32(1024+rng.Intn(55000)))
+			}
+			break
+		}
+	}
+	if len(ports) == 0 {
+		ports = append(ports, int32(1024+rng.Intn(55000)))
+	}
+
+	ranges := make([]*proto.PortRange, 0, len(ports))
+	for _, p := range ports {
+		ranges = append(ranges, &proto.PortRange{First: p, Last: p})
+	}
+	return ranges
+}
+
+// makeEgressIPSets populates the store with the NET sets the selector-matching rules reference:
+// 3,862 sets at a median of 3 members, none containing the flow's addresses. Members are /32s
+// from 10.128.0.0/9, kept clear of the rule CIDRs handed out from 10.0.0.0/9.
+func makeEgressIPSets(store *policystore.PolicyStore) []string {
+	const numSets = 3862
+	ids := make([]string, 0, numSets)
+	member := 0
+	for i := 0; i < numSets; i++ {
+		id := fmt.Sprintf("s:egress-%04d", i)
+		s := policystore.NewIPSet(proto.IPSetUpdate_NET)
+		for j := 0; j < 3; j++ {
+			s.AddString(fmt.Sprintf("10.%d.%d.%d/32", 128+(member>>16&0x7f), member>>8&0xff, member&0xff))
+			member++
+		}
+		store.IPSetByID[id] = s
+		ids = append(ids, id)
+	}
+	return ids
+}

--- a/app-policy/checker/bench_test.go
+++ b/app-policy/checker/bench_test.go
@@ -146,7 +146,7 @@ func benchEvaluateBaselinePolicyScale(b *testing.B, p baselinePolicyScaleParams,
 
 	// Pre-flight outside the timed loop: prove the walk is the intended one and that
 	// the warning count matches the analytic count, so that warnings/op is exact.
-	trace := Evaluate(rules.RuleDirIngress, store, ep, flow)
+	trace, _ := Evaluate(EnforcedOnly, rules.RuleDirIngress, store, ep, flow)
 	if matchEarly {
 		if len(trace) != 1 || trace[0].Action != rules.RuleActionAllow || trace[0].Index != 0 {
 			b.Fatalf("expected an immediate allow from the match-early policy, got %v", trace)
@@ -165,7 +165,7 @@ func benchEvaluateBaselinePolicyScale(b *testing.B, p baselinePolicyScaleParams,
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		benchTraceSink = Evaluate(rules.RuleDirIngress, store, ep, flow)
+		benchTraceSink, _ = Evaluate(EnforcedOnly, rules.RuleDirIngress, store, ep, flow)
 	}
 	b.StopTimer()
 	b.ReportMetric(float64(counter.count.Load())/float64(b.N), "warnings/op")

--- a/app-policy/checker/bench_test.go
+++ b/app-policy/checker/bench_test.go
@@ -38,8 +38,10 @@ import (
 	"io"
 	"math/rand"
 	"net"
+	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	v3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
 	log "github.com/sirupsen/logrus"
@@ -49,6 +51,7 @@ import (
 	"github.com/projectcalico/calico/felix/proto"
 	"github.com/projectcalico/calico/felix/rules"
 	"github.com/projectcalico/calico/felix/types"
+	"github.com/projectcalico/calico/libcalico-go/lib/logutils"
 )
 
 // baselinePolicyScaleParams describes a policy store dominated by "baseline" policies:
@@ -87,6 +90,19 @@ var ipSetSizeHistogram = []struct{ numSets, minSize, maxSize int }{
 	{1, 54566, 54566},
 }
 
+// The benchmark flow. TEST-NET addresses; generated IP set members and rule CIDRs all
+// come from 10.0.0.0/8, so no rule ever matches on address and the walk covers the
+// whole policy set.
+const (
+	benchSourceIP   = "192.0.2.10"
+	benchDestIP     = "198.51.100.20"
+	benchSourcePort = 45000
+	benchDestPort   = 8080
+
+	// benchSentinelIPSetID is a set containing the flow's addresses; see makeScaleRule.
+	benchSentinelIPSetID = "s:bench-sentinel"
+)
+
 // benchTraceSink prevents the compiler from eliminating the Evaluate call.
 var benchTraceSink []*calc.RuleID
 
@@ -115,32 +131,18 @@ func BenchmarkEvaluateBaselinePolicyScale(b *testing.B) {
 
 func benchEvaluateBaselinePolicyScale(b *testing.B, p baselinePolicyScaleParams, level log.Level, matchEarly bool) {
 	logger := log.StandardLogger()
-	oldLevel, oldOut := logger.GetLevel(), logger.Out
-	counter := &ipsetMissCounter{}
-	hooks := make(log.LevelHooks)
-	hooks.Add(counter)
-	oldHooks := logger.ReplaceHooks(hooks)
-	defer func() {
-		logger.SetLevel(oldLevel)
-		logger.SetOutput(oldOut)
-		logger.ReplaceHooks(oldHooks)
-	}()
-	log.SetLevel(level)
-	// Discard output so we don't benchmark the terminal; the formatting cost stays, but
-	// a real deployment pays the log write too.
-	log.SetOutput(io.Discard)
+	counter, restoreLogging := withBenchLogging(level)
+	defer restoreLogging()
 
 	store, ep, expectedWarns := buildBaselinePolicyStore(p)
 	if matchEarly {
 		addMatchEarlyPolicy(store, ep)
 	}
 	flow := &MockFlow{
-		// TEST-NET addresses; generated IP set members all come from 10.0.0.0/8, so no
-		// rule ever matches and the walk covers the whole policy set.
-		SourceIP:   net.ParseIP("192.0.2.10"),
-		DestIP:     net.ParseIP("198.51.100.20"),
-		SourcePort: 45000,
-		DestPort:   8080,
+		SourceIP:   net.ParseIP(benchSourceIP),
+		DestIP:     net.ParseIP(benchDestIP),
+		SourcePort: benchSourcePort,
+		DestPort:   benchDestPort,
 		Protocol:   6, // TCP
 	}
 
@@ -243,6 +245,11 @@ func buildBaselinePolicyStore(p baselinePolicyScaleParams) (*policystore.PolicyS
 // measured deployment: selector and networkset derived sets) following the measured
 // size histogram. Members are unique /32s from 10.0.0.0/8.
 func makeScaleIPSets(rng *rand.Rand, store *policystore.PolicyStore) []string {
+	sentinel := policystore.NewIPSet(proto.IPSetUpdate_NET)
+	sentinel.AddString(benchSourceIP + "/32")
+	sentinel.AddString(benchDestIP + "/32")
+	store.IPSetByID[benchSentinelIPSetID] = sentinel
+
 	var ids []string
 	member := 0
 	for _, bucket := range ipSetSizeHistogram {
@@ -261,31 +268,29 @@ func makeScaleIPSets(rng *rand.Rand, store *policystore.PolicyStore) []string {
 	return ids
 }
 
-// makeScaleRule builds a rule that never matches the benchmark flow but still pays the
-// full match cost. Rules that reference an IP set are shaped so the set lookup always
-// executes:
-//   - src refs guard with a non-matching source port, which match() evaluates after the
-//     src IP set lookup; the guard is needed because a missing src set is skipped rather
-//     than treated as a non-match.
-//   - dst refs guard with a non-matching destination port for the same reason, and
-//     leave the source criteria empty so evaluation reaches the destination.
+// makeScaleRule builds a rule that never matches the benchmark flow. It returns the
+// referenced IP set ID, or "" for a rule with no reference.
 //
-// It returns the referenced IP set ID, or "" for a rule with no reference.
+// A rule that references an IP set must reach the set lookup whatever order match()
+// evaluates criteria in, and must still miss when the referenced set is absent from
+// the store (an absent set is skipped rather than treated as a non-match). Both hold
+// by pairing the reference with a negated reference to benchSentinelIPSetID, which
+// contains the flow's addresses: if the referenced set is present the lookup misses
+// and evaluation stops there; if it is absent the sentinel makes the rule miss.
 func makeScaleRule(rng *rand.Rand, setIDs []string, action string, refFraction float64) (*proto.Rule, string) {
 	rule := &proto.Rule{Action: action}
 	if rng.Float64() < refFraction {
 		id := setIDs[rng.Intn(len(setIDs))]
 		if rng.Intn(2) == 0 {
 			rule.SrcIpSetIds = []string{id}
-			rule.SrcPorts = []*proto.PortRange{{First: 65001, Last: 65001}}
+			rule.NotSrcIpSetIds = []string{benchSentinelIPSetID}
 		} else {
 			rule.DstIpSetIds = []string{id}
-			rule.DstPorts = []*proto.PortRange{{First: 65001, Last: 65001}}
+			rule.NotDstIpSetIds = []string{benchSentinelIPSetID}
 		}
 		return rule, id
 	}
-	// No IP set reference: guard with a non-matching destination port so the match walks
-	// the whole chain (including the per-rule dst-IP-port formatting) before failing.
+	// No IP set reference: guard with a non-matching destination port.
 	rule.DstPorts = []*proto.PortRange{{First: 65001, Last: 65001}}
 	return rule, ""
 }
@@ -309,8 +314,58 @@ type ipsetMissCounter struct {
 func (c *ipsetMissCounter) Levels() []log.Level { return []log.Level{log.WarnLevel} }
 
 func (c *ipsetMissCounter) Fire(e *log.Entry) error {
-	if e.Message == "IPSet not found" {
+	// The message carries the set ID, so match on the prefix.
+	if strings.HasPrefix(e.Message, "IPSet not found") {
 		c.count.Add(1)
 	}
 	return nil
+}
+
+// withBenchLogging sets the log level, discards output so the terminal is not part of the
+// measurement, installs the "IPSet not found" counter, and unthrottles the evaluation path's
+// rate-limited loggers. It returns the counter and a function restoring everything.
+func withBenchLogging(level log.Level) (*ipsetMissCounter, func()) {
+	logger := log.StandardLogger()
+	oldLevel, oldOut := logger.GetLevel(), logger.Out
+	counter := &ipsetMissCounter{}
+	hooks := make(log.LevelHooks)
+	hooks.Add(counter)
+	oldHooks := logger.ReplaceHooks(hooks)
+	restoreLoggers := withUnthrottledEvalPathLogs()
+
+	logger.SetLevel(level)
+	// The formatting cost stays in the measurement; a real deployment pays the write too.
+	logger.SetOutput(io.Discard)
+
+	return counter, func() {
+		logger.SetLevel(oldLevel)
+		logger.SetOutput(oldOut)
+		logger.ReplaceHooks(oldHooks)
+		restoreLoggers()
+	}
+}
+
+// withUnthrottledEvalPathLogs replaces the evaluation path's rate-limited loggers with ones
+// that never suppress, and returns a function restoring them. The warnings/op metric counts
+// every occurrence, which is the point of it — production gets the throttled loggers, and the
+// emitted line's "logsSkipped" field carries the count this benchmark reports directly.
+func withUnthrottledEvalPathLogs() func() {
+	saved := []**logutils.RateLimitedLogger{
+		&rlogIPSetMissing, &rlogBadPrincipal, &rlogBadProtocol, &rlogBadProtocolName,
+		&rlogBadCIDR, &rlogBadSelector, &rlogBadRulePath,
+	}
+	originals := make([]*logutils.RateLimitedLogger, len(saved))
+	for i, l := range saved {
+		originals[i] = *l
+		// A negative interval puts the next-log deadline in the past on every call. The
+		// burst keeps the limiter off the WithFields path it takes to report a skip count,
+		// which would otherwise allocate on every line the benchmark measures.
+		*l = logutils.NewRateLimitedLogger(
+			logutils.OptInterval(-time.Nanosecond), logutils.OptBurst(1))
+	}
+	return func() {
+		for i, l := range saved {
+			*l = originals[i]
+		}
+	}
 }

--- a/app-policy/checker/check.go
+++ b/app-policy/checker/check.go
@@ -15,6 +15,7 @@
 package checker
 
 import (
+	"fmt"
 	"strings"
 
 	v3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
@@ -29,6 +30,7 @@ import (
 	"github.com/projectcalico/calico/felix/proto"
 	"github.com/projectcalico/calico/felix/rules"
 	ftypes "github.com/projectcalico/calico/felix/types"
+	"github.com/projectcalico/calico/libcalico-go/lib/backend/model"
 	"github.com/projectcalico/calico/libcalico-go/lib/logutils"
 )
 
@@ -42,6 +44,23 @@ var (
 
 	rlog1 = logutils.NewRateLimitedLogger()
 	rlog2 = logutils.NewRateLimitedLogger()
+	// A missing policy is one log line per evaluation, and Felix's collector re-evaluates every
+	// flow in both directions on every sweep, so a policy that stays missing would log per flow
+	// per sweep.
+	rlogMissingPolicy = logutils.NewRateLimitedLogger()
+)
+
+// PolicyScope selects which of an endpoint's policies take part in an evaluation.
+type PolicyScope int
+
+const (
+	// EnforcedOnly ignores staged policies, giving the verdict that is actually enforced.
+	// A tier whose policies are all staged is skipped entirely, end-of-tier action included,
+	// exactly as if the tier were not attached to the endpoint at all.
+	EnforcedOnly PolicyScope = iota
+	// StagedAsEnforced evaluates staged policies as though they had been promoted to enforced,
+	// giving the "pending" verdict: what would happen if the staged policies went live now.
+	StagedAsEnforced
 )
 
 // Action is an enumeration of actions a policy rule can take if it is matched.
@@ -61,10 +80,21 @@ const (
 	unknownIndex = -2
 )
 
-// Evaluate evaluates the flow against the policy store and returns the trace of rules.
-func Evaluate(dir rules.RuleDir, store *policystore.PolicyStore, ep *proto.WorkloadEndpoint, flow Flow) []*calc.RuleID {
-	_, trace := checkTiers(store, ep, dir, flow)
-	return trace
+// Evaluate evaluates the flow against the policy store and returns the trace of rules. The scope
+// decides whether staged policies take part: pass StagedAsEnforced for the pending trace, or
+// EnforcedOnly for the trace the dataplane enforces.
+//
+// It returns an error if the evaluation could not be completed, in which case the trace is nil and
+// the caller should hold on to whatever trace it already had: an empty trace would say the flow has
+// no policy, which is a stronger claim than "we could not work it out".
+func Evaluate(scope PolicyScope, dir rules.RuleDir, store *policystore.PolicyStore, ep *proto.WorkloadEndpoint, flow Flow) ([]*calc.RuleID, error) {
+	s, trace := checkTiers(scope, store, ep, dir, flow)
+	if s.Code == INTERNAL || s.Code == INVALID_ARGUMENT {
+		// The evaluation stopped part way through, so the trace stops short of a verdict. Drop it
+		// and report why it stopped.
+		return nil, fmt.Errorf("%s: %s", code.Code(s.Code), s.Message)
+	}
+	return trace, nil
 }
 
 // LookupEndpointKeysFromSrcDst looks up the source and destination endpoint keys for the given
@@ -99,16 +129,16 @@ func ipToEndpointKeys(store *policystore.PolicyStore, addr ip.Addr) []proto.Work
 
 // checkStore applies the tiered policy plus any config based corrections and returns OK if the
 // check passes or PERMISSION_DENIED if the check fails.
-func checkStore(store *policystore.PolicyStore, ep *proto.WorkloadEndpoint, dir rules.RuleDir, req Flow) (s status.Status) {
+func checkStore(scope PolicyScope, store *policystore.PolicyStore, ep *proto.WorkloadEndpoint, dir rules.RuleDir, req Flow) (s status.Status) {
 	// Check using the configured policy
-	s, _ = checkTiers(store, ep, dir, req)
+	s, _ = checkTiers(scope, store, ep, dir, req)
 	return
 }
 
 // checkTiers applies the tiered policy in the given store and returns OK if the check passes, or PERMISSION_DENIED if
 // the check fails. Note, if no policy matches, the default is PERMISSION_DENIED. It returns the trace of rules that
 // were evaluated.
-func checkTiers(store *policystore.PolicyStore, ep *proto.WorkloadEndpoint, dir rules.RuleDir, flow Flow) (s status.Status, trace []*calc.RuleID) {
+func checkTiers(scope PolicyScope, store *policystore.PolicyStore, ep *proto.WorkloadEndpoint, dir rules.RuleDir, flow Flow) (s status.Status, trace []*calc.RuleID) {
 	s = status.Status{Code: PERMISSION_DENIED}
 	if ep == nil {
 		return
@@ -127,12 +157,35 @@ func checkTiers(store *policystore.PolicyStore, ep *proto.WorkloadEndpoint, dir 
 		var (
 			ruleIndex               int
 			tierDefaultActionRuleID *calc.RuleID
+			// Policies of this tier that are in scope for this evaluation. A tier with none of
+			// them contributes nothing at all, end-of-tier action included.
+			policiesInScope int
 		)
 
 		action := NO_MATCH
 	Policy:
 		for i, pID := range policies {
-			policy := store.PolicyByID[ftypes.ProtoToPolicyID(pID)]
+			if scope == EnforcedOnly && model.KindIsStaged(pID.Kind) {
+				log.Debugf("Staged policy, not enforced, skipping (ordinal=%d, Id=%+v)", i, pID)
+				continue Policy
+			}
+			policiesInScope++
+
+			policyID := ftypes.ProtoToPolicyID(pID)
+			policy := store.PolicyByID[policyID]
+			if policy == nil {
+				// The endpoint's tier names this policy but the store does not have it, so we cannot
+				// know its verdict. We should never get here: a policy is sent before the endpoints
+				// that reference it. Fail closed rather than apply the rest of the tier to a request
+				// this policy may govern.
+				rlogMissingPolicy.Errorf("Policy named in tier is missing from the store, failing evaluation (ordinal=%d, policy=%s, tier=%s)",
+					i, policyID.ID(), tier.GetName())
+				s.Code = INTERNAL
+				s.Message = fmt.Sprintf("policy %s of tier %s is missing from the policy store",
+					policyID.ID(), tier.GetName())
+				return
+			}
+
 			action, ruleIndex = checkPolicy(policy, dir, request)
 			log.Debugf("Policy checked (ordinal=%d, Id=%+v, action=%v)", i, pID, action)
 			switch action {
@@ -157,11 +210,12 @@ func checkTiers(store *policystore.PolicyStore, ep *proto.WorkloadEndpoint, dir 
 			case LOG:
 				log.Debug("policy should never return LOG action")
 				s.Code = INVALID_ARGUMENT
+				s.Message = fmt.Sprintf("policy %s returned a LOG action", policyID.ID())
 				return
 			}
 		}
 		// Done evaluating policies in the tier. If no policy rules have matched, apply tier's default action.
-		if action == NO_MATCH {
+		if policiesInScope > 0 && action == NO_MATCH {
 			log.Debugf("No policy matched. Tier default action %v applies.", tier.DefaultAction)
 			trace = append(trace, tierDefaultActionRuleID)
 			// If the default action is anything beside Pass, then apply tier default deny action.
@@ -288,7 +342,7 @@ func handlePanic(s *status.Status) {
 	if r := recover(); r != nil {
 		if v, ok := r.(*InvalidDataFromDataPlane); ok {
 			log.Debug("InvalidFromDataPlane: ", v.string)
-			*s = status.Status{Code: INVALID_ARGUMENT}
+			*s = status.Status{Code: INVALID_ARGUMENT, Message: v.string}
 		} else {
 			panic(r)
 		}

--- a/app-policy/checker/check.go
+++ b/app-policy/checker/check.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2025 Tigera, Inc. All rights reserved.
+// Copyright (c) 2018-2026 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ package checker
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	v3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
 	log "github.com/sirupsen/logrus"
@@ -42,8 +43,8 @@ var (
 	INTERNAL          = int32(code.Code_INTERNAL)
 	UNKNOWN           = int32(code.Code_UNKNOWN)
 
-	rlog1 = logutils.NewRateLimitedLogger()
-	rlog2 = logutils.NewRateLimitedLogger()
+	rlogBadDstAddr = logutils.NewRateLimitedLogger()
+	rlogBadSrcAddr = logutils.NewRateLimitedLogger()
 	// A missing policy is one log line per evaluation, and Felix's collector re-evaluates every
 	// flow in both directions on every sweep, so a policy that stays missing would log per flow
 	// per sweep.
@@ -62,6 +63,40 @@ const (
 	// giving the "pending" verdict: what would happen if the staged policies went live now.
 	StagedAsEnforced
 )
+
+// Every log site on the per-request evaluation path needs its own rate limiter.
+//
+// A rule set that applies tens of thousands of rules to one endpoint turns any per-rule log
+// into a storm: the conditions below are all "shouldn't happen, but does" — a dangling IP set
+// reference while the store catches up, a malformed CIDR or selector that got past validation,
+// a flow that is not IP at all — and each one repeats for every rule in the set, on every
+// request. Rate limiting is per logger instance, so sharing one across sites would let the
+// noisiest message starve the rest; sites that report the same condition do share one.
+//
+// These sites must not use the WithField/WithError builders: those allocate a fields map, a
+// logrus.Entry and a wrapper *before* the rate limiter gets to drop the message, which is the
+// per-rule allocation this path has been optimised to avoid. Pass the value to Warnf instead.
+var (
+	rlogIPSetMissing = newEvalPathLogger()
+	rlogBadPrincipal = newEvalPathLogger()
+	rlogBadProtocol  = newEvalPathLogger()
+	// The adapter warns when Envoy names a protocol it cannot map. requestCache memoizes
+	// the resolved protocol, so this fires once per request rather than once per rule.
+	rlogBadProtocolName = newEvalPathLogger()
+	rlogBadCIDR         = newEvalPathLogger()
+	rlogBadSelector     = newEvalPathLogger()
+	rlogBadRulePath     = newEvalPathLogger()
+)
+
+// newEvalPathLogger returns a logger that admits a short burst and then one line per interval,
+// so a storm leaves a few concrete examples plus a "logsSkipped" count rather than filling the
+// log. Tests that need every line replace these vars; see withUnthrottledEvalPathLogs.
+func newEvalPathLogger() *logutils.RateLimitedLogger {
+	return logutils.NewRateLimitedLogger(
+		logutils.OptInterval(30*time.Second),
+		logutils.OptBurst(10),
+	)
+}
 
 // Action is an enumeration of actions a policy rule can take if it is matched.
 type Action int
@@ -106,14 +141,14 @@ func LookupEndpointKeysFromSrcDst(store *policystore.PolicyStore, src, dst strin
 
 	// Map the destination
 	if destinationIp, err := ip.ParseCIDROrIP(dst); err != nil {
-		rlog1.WithError(err).Errorf("cannot process destination addr %s", dst)
+		rlogBadDstAddr.Errorf("cannot process destination addr %s: %v", dst, err)
 	} else {
 		log.Debugf("lookup endpoint for destination %s", destinationIp.String())
 		destination = ipToEndpointKeys(store, destinationIp.Addr())
 	}
 	// Map the source
 	if sourceIp, err := ip.ParseCIDROrIP(src); err != nil {
-		rlog2.WithError(err).Errorf("cannot process source addr %s", src)
+		rlogBadSrcAddr.Errorf("cannot process source addr %s: %v", src, err)
 	} else {
 		log.Debugf("lookup endpoint for source %s", sourceIp.String())
 		source = ipToEndpointKeys(store, sourceIp.Addr())

--- a/app-policy/checker/check_test.go
+++ b/app-policy/checker/check_test.go
@@ -25,6 +25,7 @@ import (
 	v3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
 
 	"github.com/projectcalico/calico/app-policy/policystore"
+	"github.com/projectcalico/calico/felix/calc"
 	"github.com/projectcalico/calico/felix/ip"
 	"github.com/projectcalico/calico/felix/proto"
 	"github.com/projectcalico/calico/felix/rules"
@@ -37,7 +38,7 @@ func TestEvaluateNoEndpoint(t *testing.T) {
 	store := policystore.NewPolicyStore()
 
 	flow := &MockFlow{}
-	trace := Evaluate(rules.RuleDirIngress, store, nil, flow)
+	trace, _ := Evaluate(EnforcedOnly, rules.RuleDirIngress, store, nil, flow)
 	Expect(trace).To(BeNil())
 }
 
@@ -48,7 +49,7 @@ func TestEvaluateEndpointNoTiersNoProfiles(t *testing.T) {
 
 	ep := &proto.WorkloadEndpoint{}
 	flow := &MockFlow{}
-	trace := Evaluate(rules.RuleDirIngress, store, ep, flow)
+	trace, _ := Evaluate(EnforcedOnly, rules.RuleDirIngress, store, ep, flow)
 	Expect(trace).To(HaveLen(1))
 	Expect(trace[0].Action).To(Equal(rules.RuleActionDeny))
 	Expect(trace[0].Direction).To(Equal(rules.RuleDirIngress))
@@ -84,7 +85,7 @@ func TestEvaluateEndpointWithMatchingPolicy(t *testing.T) {
 		Protocol: 6,
 		DestPort: 80,
 	}
-	trace := Evaluate(rules.RuleDirIngress, store, ep, flow)
+	trace, _ := Evaluate(EnforcedOnly, rules.RuleDirIngress, store, ep, flow)
 	Expect(trace).To(HaveLen(1))
 	Expect(trace[0].Action).To(Equal(rules.RuleActionAllow))
 	Expect(trace[0].Direction).To(Equal(rules.RuleDirIngress))
@@ -150,7 +151,7 @@ func TestEvaluateEndpointWithNonMatchingPolicyTierDefaultAction(t *testing.T) {
 			store.PolicyByID[types.PolicyID{Name: "policy2", Kind: v3.KindGlobalNetworkPolicy}] = &proto.Policy{Tier: "default"}
 
 			flow := &MockFlow{Protocol: 6, DestPort: 443}
-			trace := Evaluate(rules.RuleDirIngress, store, ep, flow)
+			trace, _ := Evaluate(EnforcedOnly, rules.RuleDirIngress, store, ep, flow)
 
 			Expect(trace).To(HaveLen(tt.expLen))
 			for i, act := range tt.expActs {
@@ -180,7 +181,7 @@ func TestEvaluateEndpointWithMatchingProfile(t *testing.T) {
 		Protocol: 6,
 		DestPort: 80,
 	}
-	trace := Evaluate(rules.RuleDirIngress, store, ep, flow)
+	trace, _ := Evaluate(EnforcedOnly, rules.RuleDirIngress, store, ep, flow)
 	Expect(trace).To(HaveLen(1))
 	Expect(trace[0].Action).To(Equal(rules.RuleActionAllow))
 	Expect(trace[0].Direction).To(Equal(rules.RuleDirIngress))
@@ -237,7 +238,7 @@ func TestEvaluateEndpointWithNonMatchingProfile(t *testing.T) {
 		SourceIP:   ip_10_0_0_1,
 		DestIP:     ip_192_168_1_1,
 	}
-	trace := Evaluate(rules.RuleDirEgress, store, ep, flow1)
+	trace, _ := Evaluate(EnforcedOnly, rules.RuleDirEgress, store, ep, flow1)
 	Expect(trace).To(HaveLen(1))
 	Expect(trace[0].Action).To(Equal(rules.RuleActionDeny))
 	Expect(trace[0].Direction).To(Equal(rules.RuleDirEgress))
@@ -254,7 +255,7 @@ func TestEvaluateEndpointWithNonMatchingProfile(t *testing.T) {
 		SourceIP:   ip_10_0_0_1,
 		DestIP:     ip_192_168_1_1,
 	}
-	trace = Evaluate(rules.RuleDirEgress, store, ep, flow2)
+	trace, _ = Evaluate(EnforcedOnly, rules.RuleDirEgress, store, ep, flow2)
 	Expect(trace).To(HaveLen(1))
 	Expect(trace[0].Action).To(Equal(rules.RuleActionAllow))
 	Expect(trace[0].Direction).To(Equal(rules.RuleDirEgress))
@@ -271,7 +272,7 @@ func TestEvaluateEndpointWithNonMatchingProfile(t *testing.T) {
 		SourceIP:   ip_192_168_1_2,
 		DestIP:     ip_10_0_0_2,
 	}
-	trace = Evaluate(rules.RuleDirEgress, store, ep, flow3)
+	trace, _ = Evaluate(EnforcedOnly, rules.RuleDirEgress, store, ep, flow3)
 	Expect(trace).To(HaveLen(1))
 	Expect(trace[0].Action).To(Equal(rules.RuleActionDeny))
 	Expect(trace[0].Direction).To(Equal(rules.RuleDirEgress))
@@ -424,7 +425,7 @@ func TestCheckNoIngressPolicyRulesInTier(t *testing.T) {
 		},
 	}}
 	flow := NewCheckRequestToFlowAdapter(req)
-	status, _ := checkTiers(store, store.Endpoint, rules.RuleDirIngress, flow)
+	status, _ := checkTiers(EnforcedOnly, store, store.Endpoint, rules.RuleDirIngress, flow)
 	expectedStatus := rpc.Status{Code: OK}
 	Expect(status.Code).To(Equal(expectedStatus.Code))
 	Expect(status.Message).To(Equal(expectedStatus.Message))
@@ -448,7 +449,7 @@ func TestCheckStoreNoEndpoint(t *testing.T) {
 		},
 	}}
 	flow := NewCheckRequestToFlowAdapter(req)
-	status := checkStore(store, nil, rules.RuleDirIngress, flow)
+	status := checkStore(EnforcedOnly, store, nil, rules.RuleDirIngress, flow)
 	Expect(status.Code).To(Equal(PERMISSION_DENIED))
 }
 
@@ -472,7 +473,7 @@ func TestCheckStoreNoTiers(t *testing.T) {
 		},
 	}}
 	flow := NewCheckRequestToFlowAdapter(req)
-	status := checkStore(store, store.Endpoint, rules.RuleDirIngress, flow)
+	status := checkStore(EnforcedOnly, store, store.Endpoint, rules.RuleDirIngress, flow)
 	Expect(status.Code).To(Equal(PERMISSION_DENIED))
 }
 
@@ -522,13 +523,13 @@ func TestCheckStorePolicyMatch(t *testing.T) {
 	}}
 	flow := NewCheckRequestToFlowAdapter(req)
 
-	status := checkStore(store, store.Endpoint, rules.RuleDirIngress, flow)
+	status := checkStore(EnforcedOnly, store, store.Endpoint, rules.RuleDirIngress, flow)
 	Expect(status.Code).To(Equal(OK))
 
 	http := req.GetAttributes().GetRequest().GetHttp()
 	http.Method = "HEAD"
 
-	status = checkStore(store, store.Endpoint, rules.RuleDirIngress, flow)
+	status = checkStore(EnforcedOnly, store, store.Endpoint, rules.RuleDirIngress, flow)
 	Expect(status.Code).To(Equal(PERMISSION_DENIED))
 }
 
@@ -571,13 +572,13 @@ func TestCheckStoreProfileOnly(t *testing.T) {
 	}}
 	flow := NewCheckRequestToFlowAdapter(req)
 
-	status := checkStore(store, store.Endpoint, rules.RuleDirIngress, flow)
+	status := checkStore(EnforcedOnly, store, store.Endpoint, rules.RuleDirIngress, flow)
 	Expect(status.Code).To(Equal(OK))
 
 	http := req.GetAttributes().GetRequest().GetHttp()
 	http.Method = "HEAD"
 
-	status = checkStore(store, store.Endpoint, rules.RuleDirIngress, flow)
+	status = checkStore(EnforcedOnly, store, store.Endpoint, rules.RuleDirIngress, flow)
 	Expect(status.Code).To(Equal(PERMISSION_DENIED))
 }
 
@@ -627,7 +628,7 @@ func TestCheckStorePolicyDefaultDeny(t *testing.T) {
 	}}
 	flow := NewCheckRequestToFlowAdapter(req)
 
-	status := checkStore(store, store.Endpoint, rules.RuleDirIngress, flow)
+	status := checkStore(EnforcedOnly, store, store.Endpoint, rules.RuleDirIngress, flow)
 	Expect(status.Code).To(Equal(PERMISSION_DENIED))
 }
 
@@ -688,7 +689,7 @@ func TestCheckStorePass(t *testing.T) {
 	}}
 	flow := NewCheckRequestToFlowAdapter(req)
 
-	status := checkStore(store, store.Endpoint, rules.RuleDirIngress, flow)
+	status := checkStore(EnforcedOnly, store, store.Endpoint, rules.RuleDirIngress, flow)
 	Expect(status.Code).To(Equal(OK))
 }
 
@@ -715,8 +716,10 @@ func TestCheckStoreInitFails(t *testing.T) {
 	}}
 	flow := NewCheckRequestToFlowAdapter(req)
 
-	status := checkStore(store, store.Endpoint, rules.RuleDirIngress, flow)
-	Expect(status.Code).To(Equal(PERMISSION_DENIED))
+	// The tier names policies the store does not have, so their verdict is unknowable and
+	// evaluation fails closed rather than guessing.
+	status := checkStore(EnforcedOnly, store, store.Endpoint, rules.RuleDirIngress, flow)
+	Expect(status.Code).To(Equal(INTERNAL))
 }
 
 // Ensure checkStore returns INVALID_ARGUMENT on invalid input
@@ -757,7 +760,7 @@ func TestCheckStoreWithInvalidData(t *testing.T) {
 		},
 	}}
 	flow := NewCheckRequestToFlowAdapter(req)
-	status := checkStore(store, store.Endpoint, rules.RuleDirIngress, flow)
+	status := checkStore(EnforcedOnly, store, store.Endpoint, rules.RuleDirIngress, flow)
 	Expect(status.Code).To(Equal(INVALID_ARGUMENT))
 }
 
@@ -842,20 +845,20 @@ func TestCheckStorePolicyMultiTierMatch(t *testing.T) {
 	}}
 	flow := NewCheckRequestToFlowAdapter(req)
 
-	status := checkStore(store, store.Endpoint, rules.RuleDirIngress, flow)
+	status := checkStore(EnforcedOnly, store, store.Endpoint, rules.RuleDirIngress, flow)
 	Expect(status.Code).To(Equal(OK))
 
 	// Change to a bad path, and check that we get PERMISSION_DENIED
 	http := req.GetAttributes().GetRequest().GetHttp()
 	http.Path = "/bad"
 
-	status = checkStore(store, store.Endpoint, rules.RuleDirIngress, flow)
+	status = checkStore(EnforcedOnly, store, store.Endpoint, rules.RuleDirIngress, flow)
 	Expect(status.Code).To(Equal(PERMISSION_DENIED))
 
 	// Change to a path that hits tier2 default Pass action, and then is allowed in tier3
 	http.Path = "/bar"
 
-	status = checkStore(store, store.Endpoint, rules.RuleDirIngress, flow)
+	status = checkStore(EnforcedOnly, store, store.Endpoint, rules.RuleDirIngress, flow)
 	Expect(status.Code).To(Equal(OK))
 }
 
@@ -921,13 +924,13 @@ func TestCheckStorePolicyMultiTierDiffTierMatch(t *testing.T) {
 		},
 	}}
 	flow := NewCheckRequestToFlowAdapter(req)
-	status := checkStore(store, store.Endpoint, rules.RuleDirIngress, flow)
+	status := checkStore(EnforcedOnly, store, store.Endpoint, rules.RuleDirIngress, flow)
 	Expect(status.Code).To(Equal(PERMISSION_DENIED))
 
 	http := req.GetAttributes().GetRequest().GetHttp()
 	http.Method = "GET"
 
-	status = checkStore(store, store.Endpoint, rules.RuleDirIngress, flow)
+	status = checkStore(EnforcedOnly, store, store.Endpoint, rules.RuleDirIngress, flow)
 	Expect(status.Code).To(Equal(OK))
 }
 
@@ -1060,4 +1063,201 @@ func (m *MockFlow) GetSourceLabels() map[string]string {
 
 func (m *MockFlow) GetDestLabels() map[string]string {
 	return m.DestLabels
+}
+
+// Staged policies are stored like any other, so which verdict comes out depends entirely on the
+// PolicyScope the caller asks for. Under EnforcedOnly the answer must be the same as if the staged
+// policies were not attached to the endpoint at all: they match nothing, and a tier holding only
+// staged policies does not even get to apply its end-of-tier action. Under StagedAsEnforced they
+// behave like ordinary policies, end-of-tier action included.
+func TestCheckTiersPolicyScope(t *testing.T) {
+	RegisterTestingT(t)
+
+	stagedDeny := &proto.PolicyID{Name: "staged-deny", Kind: v3.KindStagedGlobalNetworkPolicy}
+	stagedNoMatch := &proto.PolicyID{Name: "staged-no-match", Kind: v3.KindStagedGlobalNetworkPolicy}
+	enforcedAllow := &proto.PolicyID{Name: "allow", Kind: v3.KindGlobalNetworkPolicy}
+	enforcedNoMatch := &proto.PolicyID{Name: "no-match", Kind: v3.KindGlobalNetworkPolicy}
+	notInStore := &proto.PolicyID{Name: "not-in-store", Kind: v3.KindGlobalNetworkPolicy}
+
+	for _, tc := range []struct {
+		name        string
+		tiers       []*proto.TierInfo
+		wantEnforce int32
+		wantPending int32
+	}{
+		{
+			name:        "tier of only staged policies is skipped when enforcing",
+			tiers:       tierInfos(policyIDs(stagedDeny)),
+			wantEnforce: OK, // Falls through the tier, so the endpoint's allowing profile decides.
+			wantPending: PERMISSION_DENIED,
+		},
+		{
+			name:  "end-of-tier action of a staged-only tier applies only when pending",
+			tiers: tierInfos(policyIDs(stagedNoMatch)),
+			// Nothing matches either way, but when enforcing there is no tier to apply a default.
+			wantEnforce: OK,
+			wantPending: PERMISSION_DENIED,
+		},
+		{
+			name:        "end-of-tier action survives a staged policy last in a mixed tier",
+			tiers:       tierInfos(policyIDs(enforcedNoMatch, stagedNoMatch)),
+			wantEnforce: PERMISSION_DENIED,
+			wantPending: PERMISSION_DENIED,
+		},
+		{
+			name:        "end-of-tier action survives a staged policy first in a mixed tier",
+			tiers:       tierInfos(policyIDs(stagedNoMatch, enforcedNoMatch)),
+			wantEnforce: PERMISSION_DENIED,
+			wantPending: PERMISSION_DENIED,
+		},
+		{
+			name:        "staged policy ahead of an enforced one only decides the pending verdict",
+			tiers:       tierInfos(policyIDs(stagedDeny, enforcedAllow)),
+			wantEnforce: OK,
+			wantPending: PERMISSION_DENIED,
+		},
+		{
+			name:        "a staged policy does not shadow a later tier when enforcing",
+			tiers:       tierInfos(policyIDs(stagedDeny), policyIDs(enforcedAllow)),
+			wantEnforce: OK,
+			wantPending: PERMISSION_DENIED,
+		},
+		{
+			name: "a policy missing from the store fails the evaluation",
+			// Its verdict is unknowable, so fail closed rather than hand the request on to the rest
+			// of the tier.
+			tiers:       tierInfos(policyIDs(notInStore, enforcedAllow)),
+			wantEnforce: INTERNAL,
+			wantPending: INTERNAL,
+		},
+		{
+			name: "a policy missing from the store behind a match is never reached",
+			// Evaluation stops at the first match, in the store as in the dataplane, so a missing
+			// policy does not invalidate a verdict reached before it.
+			tiers:       tierInfos(policyIDs(enforcedAllow, notInStore)),
+			wantEnforce: OK,
+			wantPending: OK,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, scope := range []struct {
+				PolicyScope
+				want int32
+			}{{EnforcedOnly, tc.wantEnforce}, {StagedAsEnforced, tc.wantPending}} {
+				store := policystore.NewPolicyStore()
+				store.Endpoint = &proto.WorkloadEndpoint{Tiers: tc.tiers, ProfileIds: []string{"profile1"}}
+				// An allowing profile, so that an end-of-tier deny which failed to apply shows up as
+				// OK instead of being masked by the overall default deny.
+				store.ProfileByID[types.ProtoToProfileID(&proto.ProfileID{Name: "profile1"})] = &proto.Profile{
+					InboundRules: []*proto.Rule{{Action: "allow"}},
+				}
+				for _, id := range []*proto.PolicyID{stagedNoMatch, enforcedNoMatch} {
+					store.PolicyByID[types.ProtoToPolicyID(id)] = &proto.Policy{Tier: "tier1"}
+				}
+				for _, id := range []*proto.PolicyID{stagedDeny} {
+					store.PolicyByID[types.ProtoToPolicyID(id)] = &proto.Policy{
+						Tier:         "tier1",
+						InboundRules: []*proto.Rule{{Action: "deny"}},
+					}
+				}
+				store.PolicyByID[types.ProtoToPolicyID(enforcedAllow)] = &proto.Policy{
+					InboundRules: []*proto.Rule{{Action: "allow"}},
+				}
+
+				st := checkStore(scope.PolicyScope, store, store.Endpoint, rules.RuleDirIngress,
+					&MockFlow{Protocol: 6, DestPort: 80})
+				Expect(st.Code).To(Equal(scope.want), "scope %v", scope.PolicyScope)
+			}
+		})
+	}
+}
+
+// policyIDs and tierInfos build one tier per argument list, named tier1, tier2, ... , each denying
+// at the end so that skipping a tier is visible.
+func policyIDs(ids ...*proto.PolicyID) []*proto.PolicyID { return ids }
+
+func tierInfos(tiers ...[]*proto.PolicyID) []*proto.TierInfo {
+	var tierInfos []*proto.TierInfo
+	for i, policies := range tiers {
+		tierInfos = append(tierInfos, &proto.TierInfo{
+			Name:            fmt.Sprintf("tier%d", i+1),
+			IngressPolicies: policies,
+			DefaultAction:   "Deny",
+		})
+	}
+	return tierInfos
+}
+
+// The status message says which policy was missing, so an operator seeing a denied request in the
+// Dikastes log does not have to guess.
+func TestCheckStoreReportsWhichPolicyIsMissing(t *testing.T) {
+	RegisterTestingT(t)
+
+	missing := &proto.PolicyID{Name: "policy1", Namespace: "ns1", Kind: v3.KindNetworkPolicy}
+
+	store := policystore.NewPolicyStore()
+	store.Endpoint = &proto.WorkloadEndpoint{Tiers: tierInfos(policyIDs(missing))}
+
+	st := checkStore(EnforcedOnly, store, store.Endpoint, rules.RuleDirIngress,
+		&MockFlow{Protocol: 6, DestPort: 80})
+	Expect(st.Code).To(Equal(INTERNAL))
+	Expect(st.Message).To(Equal("policy np/ns1/policy1 of tier tier1 is missing from the policy store"))
+}
+
+// A trace that stops short of a verdict is worse than no trace: a flow log would show the flow
+// running off the end of policy. Callers are told the evaluation failed, so they can keep whatever
+// trace they had rather than record the flow as having no policy at all.
+func TestEvaluateReportsFailureInsteadOfPartialTrace(t *testing.T) {
+	RegisterTestingT(t)
+
+	notInStore := &proto.PolicyID{Name: "not-in-store", Kind: v3.KindGlobalNetworkPolicy}
+	passes := &proto.PolicyID{Name: "passes", Kind: v3.KindGlobalNetworkPolicy}
+
+	store := policystore.NewPolicyStore()
+	store.PolicyByID[types.ProtoToPolicyID(passes)] = &proto.Policy{
+		InboundRules: []*proto.Rule{{Action: "pass"}},
+	}
+	// tier1 passes, then tier2 holds a policy we have not been told the rules for.
+	ep := &proto.WorkloadEndpoint{Tiers: tierInfos(policyIDs(passes), policyIDs(notInStore))}
+
+	for _, scope := range []PolicyScope{EnforcedOnly, StagedAsEnforced} {
+		trace, err := Evaluate(scope, rules.RuleDirIngress, store, ep, &MockFlow{Protocol: 6, DestPort: 80})
+		Expect(err).To(MatchError(ContainSubstring("not-in-store")), "scope %v", scope)
+		Expect(trace).To(BeNil(), "scope %v", scope)
+	}
+}
+
+// The pending trace records the staged policy that decided it, so that flow logs can show which
+// staged policy would have taken effect.
+func TestEvaluateRecordsStagedPolicyInPendingTraceOnly(t *testing.T) {
+	RegisterTestingT(t)
+
+	stagedDeny := &proto.PolicyID{Name: "staged-deny", Kind: v3.KindStagedGlobalNetworkPolicy}
+	enforcedAllow := &proto.PolicyID{Name: "allow", Kind: v3.KindGlobalNetworkPolicy}
+
+	store := policystore.NewPolicyStore()
+	store.PolicyByID[types.ProtoToPolicyID(stagedDeny)] = &proto.Policy{
+		Tier:         "tier1",
+		InboundRules: []*proto.Rule{{Action: "deny"}},
+	}
+	store.PolicyByID[types.ProtoToPolicyID(enforcedAllow)] = &proto.Policy{
+		Tier:         "tier2",
+		InboundRules: []*proto.Rule{{Action: "allow"}},
+	}
+	ep := &proto.WorkloadEndpoint{Tiers: tierInfos(policyIDs(stagedDeny), policyIDs(enforcedAllow))}
+	flow := &MockFlow{Protocol: 6, DestPort: 80}
+
+	pending, err := Evaluate(StagedAsEnforced, rules.RuleDirIngress, store, ep, flow)
+	Expect(err).ToNot(HaveOccurred())
+	Expect(pending).To(Equal([]*calc.RuleID{
+		calc.NewRuleID(v3.KindStagedGlobalNetworkPolicy, "tier1", "staged-deny", "",
+			0, rules.RuleDirIngress, rules.RuleActionDeny),
+	}))
+
+	enforced, err := Evaluate(EnforcedOnly, rules.RuleDirIngress, store, ep, flow)
+	Expect(err).ToNot(HaveOccurred())
+	Expect(enforced).To(Equal([]*calc.RuleID{
+		calc.NewRuleID(v3.KindGlobalNetworkPolicy, "tier2", "allow", "",
+			0, rules.RuleDirIngress, rules.RuleActionAllow),
+	}))
 }

--- a/app-policy/checker/check_test.go
+++ b/app-policy/checker/check_test.go
@@ -1261,3 +1261,88 @@ func TestEvaluateRecordsStagedPolicyInPendingTraceOnly(t *testing.T) {
 			0, rules.RuleDirIngress, rules.RuleActionAllow),
 	}))
 }
+
+// A rule whose HTTP criteria would reject a malformed request path no longer decides the
+// request when the rule does not apply to it in the first place. Ordering the criteria
+// cheapest-first drops such a rule on its protocol, before matchRequest can panic on the
+// path, so the walk carries on to a rule that does apply.
+func TestMalformedHTTPPathOnlyFailsRulesThatReachIt(t *testing.T) {
+	RegisterTestingT(t)
+
+	udpWithPaths := &proto.PolicyID{Name: "udp-with-paths", Kind: v3.KindGlobalNetworkPolicy}
+	allowsTCP := &proto.PolicyID{Name: "allows-tcp", Kind: v3.KindGlobalNetworkPolicy}
+
+	httpRule := func(protocol string) *proto.Rule {
+		return &proto.Rule{
+			Action:   "allow",
+			Protocol: &proto.Protocol{NumberOrName: &proto.Protocol_Name{Name: protocol}},
+			HttpMatch: &proto.HTTPMatch{
+				Paths: []*proto.HTTPMatch_PathMatch{
+					{PathMatch: &proto.HTTPMatch_PathMatch_Exact{Exact: "/foo"}},
+				},
+			},
+		}
+	}
+
+	store := policystore.NewPolicyStore()
+	store.PolicyByID[types.ProtoToPolicyID(allowsTCP)] = &proto.Policy{
+		InboundRules: []*proto.Rule{{Action: "allow"}},
+	}
+	ep := &proto.WorkloadEndpoint{Tiers: tierInfos(policyIDs(udpWithPaths, allowsTCP))}
+
+	// A TCP request whose path is missing its leading "/". Envoy should not send one, so the
+	// evaluator treats it as bad data from the data plane rather than as a non-match.
+	badPath := "no-leading-slash"
+	flow := &MockFlow{Protocol: 6, DestPort: 80, HttpPath: &badPath}
+
+	// The UDP rule cannot apply to a TCP request, so its HTTP criteria are never reached and
+	// the next policy allows.
+	store.PolicyByID[types.ProtoToPolicyID(udpWithPaths)] = &proto.Policy{
+		InboundRules: []*proto.Rule{httpRule("UDP")},
+	}
+	Expect(checkStore(EnforcedOnly, store, ep, rules.RuleDirIngress, flow).Code).To(Equal(OK))
+
+	// The same rule on TCP does reach them, and the malformed path still fails the request.
+	store.PolicyByID[types.ProtoToPolicyID(udpWithPaths)] = &proto.Policy{
+		InboundRules: []*proto.Rule{httpRule("TCP")},
+	}
+	st := checkStore(EnforcedOnly, store, ep, rules.RuleDirIngress, flow)
+	Expect(st.Code).To(Equal(INVALID_ARGUMENT))
+	Expect(st.Message).To(ContainSubstring(badPath))
+}
+
+// countingFlow counts how often the evaluator asks the data plane for the flow's protocol.
+type countingFlow struct {
+	Flow
+	protocolCalls int
+}
+
+func (c *countingFlow) GetProtocol() int {
+	c.protocolCalls++
+	return c.Flow.GetProtocol()
+}
+
+// The protocol is the first criterion every rule is tested against, so the evaluator must not
+// ask the data plane for it per rule: the Envoy adapter derives it from an enum name via a
+// lowercased map lookup, which allocates.
+func TestProtocolResolvedOncePerRequest(t *testing.T) {
+	RegisterTestingT(t)
+
+	// Rules that no request matches, so that every one of them tests the protocol.
+	var noMatch []*proto.Rule
+	for range 50 {
+		noMatch = append(noMatch, &proto.Rule{
+			Action:   "allow",
+			Protocol: &proto.Protocol{NumberOrName: &proto.Protocol_Number{Number: 132}},
+		})
+	}
+
+	policy := &proto.PolicyID{Name: "policy1", Kind: v3.KindGlobalNetworkPolicy}
+	store := policystore.NewPolicyStore()
+	store.PolicyByID[types.ProtoToPolicyID(policy)] = &proto.Policy{InboundRules: noMatch}
+	ep := &proto.WorkloadEndpoint{Tiers: tierInfos(policyIDs(policy))}
+
+	flow := &countingFlow{Flow: &MockFlow{Protocol: 6, DestPort: 80}}
+	Expect(checkStore(EnforcedOnly, store, ep, rules.RuleDirIngress, flow).Code).To(Equal(PERMISSION_DENIED))
+	Expect(flow.protocolCalls).To(Equal(1))
+}

--- a/app-policy/checker/match.go
+++ b/app-policy/checker/match.go
@@ -21,6 +21,7 @@ import (
 	"path"
 	"regexp"
 	"slices"
+	"strconv"
 	"strings"
 
 	log "github.com/sirupsen/logrus"
@@ -30,7 +31,7 @@ import (
 	"github.com/projectcalico/calico/libcalico-go/lib/selector"
 )
 
-var protocolMapL4 = map[int32]string{
+var protocolMapL4 = map[int]string{
 	1:  "icmp",
 	6:  "tcp",
 	17: "udp",
@@ -92,15 +93,33 @@ func match(policyNamespace string, rule *proto.Rule, req *requestCache) bool {
 			"HttpPath":   req.GetHttpPath(),
 		}).Debug("Checking rule on request")
 	}
-	return matchSource(policyNamespace, rule, req) &&
-		matchDestination(policyNamespace, rule, req) &&
-		matchRequest(rule, req) &&
-		matchL4Protocol(rule, int32(req.GetProtocol()))
+	// A rule's criteria are ANDed, so they may be evaluated in any order. Evaluate them
+	// cheapest-first, because most rules in a large policy set are rejected by exactly
+	// one criterion and the walk stops at it:
+	//
+	//   - protocol and ports are integer comparisons against the flow;
+	//   - the address criteria parse a CIDR per entry, or hash and walk an IP set;
+	//   - the identity criteria parse and evaluate a label selector.
+	//
+	// The HTTP criteria go last because matchRequest normalises the request path,
+	// and because it panics on a malformed one: leaving it last confines that to
+	// requests that a rule otherwise matches.
+	return matchL4Protocol(rule, req.GetProtocol()) &&
+		matchSrcPort(rule, req) &&
+		matchDstPort(rule, req) &&
+		matchSrcNet(rule, req) &&
+		matchDstNet(rule, req) &&
+		matchSrcIPSets(rule, req) &&
+		matchDstIPSets(rule, req) &&
+		matchDstIPPortSetIds(rule, req) &&
+		matchSrcIdentity(policyNamespace, rule, req) &&
+		matchDstIdentity(policyNamespace, rule, req) &&
+		matchRequest(rule, req)
 }
 
-// matchSource checks if the source part of the Rule matches the request. It returns true if the
-// Rule matches, false otherwise.
-func matchSource(policyNamespace string, r *proto.Rule, req *requestCache) bool {
+// matchSrcIdentity checks the source service account and namespace criteria of the Rule
+// against the request's identity. It returns true if the Rule matches, false otherwise.
+func matchSrcIdentity(policyNamespace string, r *proto.Rule, req *requestCache) bool {
 	nsMatch := computeNamespaceMatch(
 		policyNamespace,
 		r.GetOriginalSrcNamespaceSelector(),
@@ -109,15 +128,13 @@ func matchSource(policyNamespace string, r *proto.Rule, req *requestCache) bool 
 		r.GetSrcServiceAccountMatch())
 
 	return matchServiceAccounts(r.GetSrcServiceAccountMatch(), req.getSrcPeer()) &&
-		matchNamespace(nsMatch, req.getSrcNamespace()) &&
-		matchSrcIPSets(r, req) &&
-		matchSrcPort(r, req) &&
-		matchSrcNet(r, req)
+		matchNamespace(nsMatch, req.getSrcNamespace())
 }
 
-// matchDestination checks if the destination part of the Rule matches the request. It returns true if the
-// Rule matches, false otherwise.
-func matchDestination(policyNamespace string, r *proto.Rule, req *requestCache) bool {
+// matchDstIdentity checks the destination service account and namespace criteria of the
+// Rule against the request's identity. It returns true if the Rule matches, false
+// otherwise.
+func matchDstIdentity(policyNamespace string, r *proto.Rule, req *requestCache) bool {
 	nsMatch := computeNamespaceMatch(
 		policyNamespace,
 		r.GetOriginalDstNamespaceSelector(),
@@ -126,11 +143,7 @@ func matchDestination(policyNamespace string, r *proto.Rule, req *requestCache) 
 		r.GetDstServiceAccountMatch())
 
 	return matchServiceAccounts(r.GetDstServiceAccountMatch(), req.getDstPeer()) &&
-		matchNamespace(nsMatch, req.getDstNamespace()) &&
-		matchDstIPSets(r, req) &&
-		matchDstIPPortSetIds(r, req) &&
-		matchDstPort(r, req) &&
-		matchDstNet(r, req)
+		matchNamespace(nsMatch, req.getDstNamespace())
 }
 
 // computeNamespaceMatch computes the namespace match based on the policyNamespace, namespace
@@ -219,7 +232,7 @@ func matchLabels(selectorStr string, labels map[string]string) bool {
 	}
 	sel, err := selector.Parse(selectorStr)
 	if err != nil {
-		log.Warnf("Could not parse label selector %v, %v", selectorStr, err)
+		rlogBadSelector.Warnf("Could not parse label selector %v, %v", selectorStr, err)
 		return false
 	}
 	log.Debugf("Parsed selector.")
@@ -339,7 +352,7 @@ func matchHTTPPaths(paths []*proto.HTTPMatch_PathMatch, reqPath *string) bool {
 		case *proto.HTTPMatch_PathMatch_Exact:
 			rulePath, ok := normalizeHTTPPath(m.Exact)
 			if !ok {
-				log.WithField("rulePath", m.Exact).Warn("HTTP Path exact rule could not be normalized; skipping.")
+				rlogBadRulePath.Warnf("HTTP Path exact rule could not be normalized; skipping: %s", m.Exact)
 				continue
 			}
 			if normalizedReq == rulePath {
@@ -349,7 +362,7 @@ func matchHTTPPaths(paths []*proto.HTTPMatch_PathMatch, reqPath *string) bool {
 		case *proto.HTTPMatch_PathMatch_Prefix:
 			rulePrefix, ok := normalizeHTTPPath(m.Prefix)
 			if !ok {
-				log.WithField("rulePath", m.Prefix).Warn("HTTP Path prefix rule could not be normalized; skipping.")
+				rlogBadRulePath.Warnf("HTTP Path prefix rule could not be normalized; skipping: %s", m.Prefix)
 				continue
 			}
 			if segmentPrefixMatch(normalizedReq, rulePrefix) {
@@ -579,8 +592,11 @@ func matchPort(dir string, ranges []*proto.PortRange, namedPortSets []string, ip
 			return true
 		}
 	}
+	if len(namedPortSets) == 0 {
+		return false
+	}
+	portStr := strconv.Itoa(port)
 	for _, id := range namedPortSets {
-		portStr := fmt.Sprintf("%d", port)
 		if s := ipsSetFunc(id); s != nil && s.Contains(portStr) {
 			return true
 		}
@@ -608,8 +624,11 @@ func matchNotPort(dir string, ranges []*proto.PortRange, namedPortSets []string,
 			return false
 		}
 	}
+	if len(namedPortSets) == 0 {
+		return true
+	}
+	portStr := strconv.Itoa(port)
 	for _, id := range namedPortSets {
-		portStr := fmt.Sprintf("%d", port)
 		if s := ipsSetFunc(id); s != nil && s.Contains(portStr) {
 			return false
 		}
@@ -648,7 +667,7 @@ func matchNet(dir string, nets []string, ip net.IP) bool {
 		if err != nil {
 			// Don't match CIDRs if they are malformed. This case should generally be weeded out by
 			// validation earlier in processing before it gets to Dikastes.
-			log.WithField("cidr", n).Warn("unable to parse CIDR")
+			rlogBadCIDR.Warnf("unable to parse CIDR %s", n)
 			return false
 		}
 		if ipn.Contains(ip) {
@@ -677,7 +696,7 @@ func matchNotNet(dir string, nets []string, ip net.IP) bool {
 		if err != nil {
 			// Don't match CIDRs if they are malformed. This case should generally be weeded out by
 			// validation earlier in processing before it gets to Dikastes.
-			log.WithField("cidr", n).Warn("unable to parse CIDR")
+			rlogBadCIDR.Warnf("unable to parse CIDR %s", n)
 			return false
 		}
 		if ipn.Contains(ip) {
@@ -687,7 +706,7 @@ func matchNotNet(dir string, nets []string, ip net.IP) bool {
 	return true
 }
 
-var stringToProto = map[string]int32{
+var stringToProto = map[string]int{
 	"icmp":    1,
 	"icmpv6":  58,
 	"tcp":     6,
@@ -696,14 +715,16 @@ var stringToProto = map[string]int32{
 	"sctp":    132,
 }
 
+// validL4Protocol reports whether the flow's protocol is one the data plane could
+// have observed. Protocol is an 8-bit field, and 0 is unassigned.
+func validL4Protocol(protocol int) bool {
+	return protocol >= 1 && protocol <= 255
+}
+
 // matchL4Protocol checks if the L4 protocol matches the rule. It returns true if the protocol
-// matches, false otherwise.
-func matchL4Protocol(rule *proto.Rule, protocol int32) bool {
-	// Protocol is a 8-bit field.
-	if protocol > 255 || protocol < 1 {
-		log.WithFields(log.Fields{
-			"protocol": protocol,
-		}).Warn("Unsupported L4 protocol")
+// matches, false otherwise. requestCache.GetProtocol warns about an out-of-range protocol.
+func matchL4Protocol(rule *proto.Rule, protocol int) bool {
+	if !validL4Protocol(protocol) {
 		return false
 	}
 	if log.IsLevelEnabled(log.DebugLevel) {
@@ -714,13 +735,13 @@ func matchL4Protocol(rule *proto.Rule, protocol int32) bool {
 		}).Debug("Matching L4 protocol")
 	}
 
-	checkStringInRuleProtocol := func(p *proto.Protocol, pNumber int32, defaultResult bool) bool {
+	checkStringInRuleProtocol := func(p *proto.Protocol, pNumber int, defaultResult bool) bool {
 		if p == nil {
 			return defaultResult
 		}
 
 		// Check if given protocol matches what is specified in rule.
-		var protoNumber int32
+		var protoNumber int
 		if name := p.GetName(); name != "" {
 			var ok bool
 			protoNumber, ok = stringToProto[strings.ToLower(name)]
@@ -728,7 +749,8 @@ func matchL4Protocol(rule *proto.Rule, protocol int32) bool {
 				return false
 			}
 		} else {
-			protoNumber = p.GetNumber()
+			// Widening the rule's protobuf int32, so no value is lost.
+			protoNumber = int(p.GetNumber())
 		}
 		return protoNumber == pNumber
 	}

--- a/app-policy/checker/match_test.go
+++ b/app-policy/checker/match_test.go
@@ -15,6 +15,8 @@
 package checker
 
 import (
+	"fmt"
+	"math"
 	"strings"
 	"testing"
 
@@ -1223,6 +1225,130 @@ func TestMatchDstIPPortSetIds(t *testing.T) {
 
 			req := &requestCache{Flow: fl, store: store}
 			Expect(matchDstIPPortSetIds(tc.rule, req)).To(Equal(tc.expected), "Test case: %s", tc.title)
+		})
+	}
+}
+
+// Port matching covers both forms a rule can take: explicit ranges, and named port
+// sets resolved through the store.
+func TestMatchPort(t *testing.T) {
+	RegisterTestingT(t)
+
+	const namedPortSetID = "namedPortSet"
+
+	testCases := []struct {
+		title    string
+		rule     *proto.Rule
+		port     int
+		expected bool
+	}{
+		{"no port criteria", &proto.Rule{}, 8080, true},
+		{
+			"in range",
+			&proto.Rule{DstPorts: []*proto.PortRange{{First: 80, Last: 90}}},
+			85, true,
+		},
+		{
+			"below range",
+			&proto.Rule{DstPorts: []*proto.PortRange{{First: 80, Last: 90}}},
+			79, false,
+		},
+		{
+			"above range",
+			&proto.Rule{DstPorts: []*proto.PortRange{{First: 80, Last: 90}}},
+			91, false,
+		},
+		{
+			"in second of two ranges",
+			&proto.Rule{DstPorts: []*proto.PortRange{{First: 80, Last: 80}, {First: 443, Last: 443}}},
+			443, true,
+		},
+		{
+			"in negated range",
+			&proto.Rule{NotDstPorts: []*proto.PortRange{{First: 80, Last: 90}}},
+			85, false,
+		},
+		{
+			"outside negated range",
+			&proto.Rule{NotDstPorts: []*proto.PortRange{{First: 80, Last: 90}}},
+			91, true,
+		},
+		{
+			"in named port set",
+			&proto.Rule{DstNamedPortIpSetIds: []string{namedPortSetID}},
+			8080, true,
+		},
+		{
+			"not in named port set",
+			&proto.Rule{DstNamedPortIpSetIds: []string{namedPortSetID}},
+			8081, false,
+		},
+		{
+			"in negated named port set",
+			&proto.Rule{NotDstNamedPortIpSetIds: []string{namedPortSetID}},
+			8080, false,
+		},
+		{
+			"not in negated named port set",
+			&proto.Rule{NotDstNamedPortIpSetIds: []string{namedPortSetID}},
+			8081, true,
+		},
+		{
+			"range misses but named port set matches",
+			&proto.Rule{
+				DstPorts:             []*proto.PortRange{{First: 80, Last: 80}},
+				DstNamedPortIpSetIds: []string{namedPortSetID},
+			},
+			8080, true,
+		},
+		{
+			"unknown named port set is skipped",
+			&proto.Rule{DstNamedPortIpSetIds: []string{"nonexistent"}},
+			8080, false,
+		},
+	}
+
+	store := policystore.NewPolicyStore()
+	namedPortSet := policystore.NewIPSet(proto.IPSetUpdate_IP)
+	namedPortSet.AddString("8080")
+	store.IPSetByID[namedPortSetID] = namedPortSet
+
+	for _, tc := range testCases {
+		t.Run(tc.title, func(t *testing.T) {
+			fl := &mocks.Flow{}
+			fl.On("GetDestPort").Return(tc.port)
+			req := &requestCache{Flow: fl, store: store}
+			Expect(matchDstPort(tc.rule, req)).To(Equal(tc.expected), "Test case: %s", tc.title)
+
+			// The source criteria are the same code with the other set of fields, so
+			// mirror the case onto them.
+			srcRule := &proto.Rule{
+				SrcPorts:                tc.rule.DstPorts,
+				NotSrcPorts:             tc.rule.NotDstPorts,
+				SrcNamedPortIpSetIds:    tc.rule.DstNamedPortIpSetIds,
+				NotSrcNamedPortIpSetIds: tc.rule.NotDstNamedPortIpSetIds,
+			}
+			srcFl := &mocks.Flow{}
+			srcFl.On("GetSourcePort").Return(tc.port)
+			srcReq := &requestCache{Flow: srcFl, store: store}
+			Expect(matchSrcPort(srcRule, srcReq)).To(Equal(tc.expected), "Test case (source): %s", tc.title)
+		})
+	}
+}
+
+// Protocol is an 8-bit field, so a flow reporting a value outside 1-255 — a Unix pipe, say —
+// can match no rule, not even one with no protocol criterion of its own. match() tests this
+// first, so the warning it logs is rate limited: otherwise one such flow logs once per rule.
+func TestMatchUnsupportedL4Protocol(t *testing.T) {
+	RegisterTestingT(t)
+
+	for _, protocol := range []int{0, -1, 256, 1 << 20, math.MaxInt} {
+		t.Run(fmt.Sprintf("protocol %d", protocol), func(t *testing.T) {
+			fl := &mocks.Flow{}
+			fl.On("GetProtocol").Return(protocol)
+			req := &requestCache{Flow: fl, store: policystore.NewPolicyStore()}
+
+			Expect(match("testns", &proto.Rule{}, req)).To(BeFalse())
 		})
 	}
 }

--- a/app-policy/checker/requestcache.go
+++ b/app-policy/checker/requestcache.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2025 Tigera, Inc. All rights reserved.
+// Copyright (c) 2018-2026 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -50,6 +50,34 @@ type requestCache struct {
 	srcIPStr       string
 	dstIPStr       string
 	dstIPProtoPort string
+
+	// Memoized identity, indexed by flowSide. Resolving it parses a SPIFFE ID and copies
+	// two label maps, and the match functions ask for it once per rule.
+	identities [numFlowSides]identity
+
+	// Memoized L4 protocol. The Envoy adapter derives it from an enum name via a
+	// lowercase and a map lookup, and match() asks for it once per rule. Protocol 0
+	// is a value the data plane can send, so resolution needs its own flag.
+	protocol         int
+	protocolResolved bool
+}
+
+// flowSide identifies which end of the flow an identity belongs to.
+type flowSide int
+
+const (
+	sourceSide flowSide = iota
+	destSide
+	numFlowSides
+)
+
+// identity is the resolved peer and namespace for one side of the flow. A nil peer means
+// the side carries no principal, or one that could not be parsed; both cases match any
+// rule, because Dikastes falls back on IP addresses for plain-text requests.
+type identity struct {
+	peer      *peer
+	namespace *namespace
+	resolved  bool
 }
 
 type peer struct {
@@ -72,39 +100,45 @@ func NewRequestCache(store *policystore.PolicyStore, request Flow) *requestCache
 
 // getSrcPeer returns the source peer.
 func (r *requestCache) getSrcPeer() *peer {
-	if principal := r.GetSourcePrincipal(); principal != nil {
-		return r.initPeer(*principal, r.GetSourceLabels())
-	}
-
-	return nil
+	return r.getIdentity(sourceSide).peer
 }
 
 // getDstPeer returns the destination peer.
 func (r *requestCache) getDstPeer() *peer {
-	if principal := r.GetDestPrincipal(); principal != nil {
-		return r.initPeer(*principal, r.GetDestLabels())
-	}
-
-	return nil
+	return r.getIdentity(destSide).peer
 }
 
-// getSourceNamespace returns the namespace of the source peer.
+// getSrcNamespace returns the namespace of the source peer.
 func (r *requestCache) getSrcNamespace() *namespace {
-	if peer := r.getSrcPeer(); peer != nil {
-		return r.initNamespace(peer.Namespace)
-	}
-
-	return nil
+	return r.getIdentity(sourceSide).namespace
 }
 
 // getDstNamespace returns the namespace of the destination peer.
 func (r *requestCache) getDstNamespace() *namespace {
-	if peer := r.getDstPeer(); peer != nil {
-		return r.initNamespace(peer.Namespace)
+	return r.getIdentity(destSide).namespace
+}
 
+// getIdentity returns the peer and namespace for one side of the flow, resolving them from
+// the request and the store on first use and memoizing the result for the rest of the
+// request.
+func (r *requestCache) getIdentity(side flowSide) identity {
+	id := &r.identities[side]
+	if id.resolved {
+		return *id
 	}
+	id.resolved = true
 
-	return nil
+	principal, labels := r.GetSourcePrincipal(), r.GetSourceLabels()
+	if side == destSide {
+		principal, labels = r.GetDestPrincipal(), r.GetDestLabels()
+	}
+	if principal == nil {
+		return *id
+	}
+	if id.peer = r.initPeer(*principal, labels); id.peer != nil {
+		id.namespace = r.initNamespace(id.peer.Namespace)
+	}
+	return *id
 }
 
 // getSrcIPStr returns the source IP in string form, memoized across the request.
@@ -123,11 +157,27 @@ func (r *requestCache) getDstIPStr() string {
 	return r.dstIPStr
 }
 
+// GetProtocol shadows the embedded Flow's method to memoize the protocol across the
+// request. Callers need not know: it returns what the Flow would have returned.
+func (r *requestCache) GetProtocol() int {
+	if !r.protocolResolved {
+		r.protocol = r.Flow.GetProtocol()
+		r.protocolResolved = true
+		if !validL4Protocol(r.protocol) {
+			// Warn here rather than in matchL4Protocol: an out-of-range protocol
+			// rejects every rule, so the check runs once per rule and even a
+			// suppressed rate-limited log takes the logger's lock.
+			rlogBadProtocol.Warnf("Unsupported L4 protocol: %d", r.protocol)
+		}
+	}
+	return r.protocol
+}
+
 // getDstIPProtoPortStr returns the destination "<IP>,<protocol>:<port>" key used for
 // IP+port set matching, memoized across the request.
 func (r *requestCache) getDstIPProtoPortStr() string {
 	if r.dstIPProtoPort == "" {
-		protocolStr := protocolMapL4[int32(r.GetProtocol())]
+		protocolStr := protocolMapL4[r.GetProtocol()]
 		r.dstIPProtoPort = fmt.Sprintf("%s,%s:%d", r.getDstIPStr(), protocolStr, r.GetDestPort())
 	}
 	return r.dstIPProtoPort
@@ -137,7 +187,7 @@ func (r *requestCache) getDstIPProtoPortStr() string {
 func (r *requestCache) getIPSet(id string) policystore.IPSet {
 	s, ok := r.store.IPSetByID[id]
 	if !ok {
-		log.WithField("ipset", id).Warn("IPSet not found")
+		rlogIPSetMissing.Warnf("IPSet not found: %s", id)
 		return nil
 	}
 	return s
@@ -160,7 +210,7 @@ func (r *requestCache) initNamespace(name string) *namespace {
 func (r *requestCache) initPeer(principal string, labels map[string]string) *peer {
 	peer, err := parseSpiffeID(principal)
 	if err != nil {
-		log.WithError(err).Error("failed to parse source principal")
+		rlogBadPrincipal.Errorf("failed to parse principal: %v", err)
 		return nil
 	}
 	peer.Labels = make(map[string]string)

--- a/app-policy/checker/requestcache_test.go
+++ b/app-policy/checker/requestcache_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2025 Tigera, Inc. All rights reserved.
+// Copyright (c) 2018-2026 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,14 +15,18 @@
 package checker
 
 import (
+	"io"
 	"testing"
+	"time"
 
 	authz "github.com/envoyproxy/go-control-plane/envoy/service/auth/v3"
 	. "github.com/onsi/gomega"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/projectcalico/calico/app-policy/policystore"
 	"github.com/projectcalico/calico/felix/proto"
 	"github.com/projectcalico/calico/felix/types"
+	"github.com/projectcalico/calico/libcalico-go/lib/logutils"
 )
 
 // Successful parse should return name and namespace.
@@ -215,4 +219,110 @@ func TestNamespaceLabels(t *testing.T) {
 	Expect(uut.getSrcNamespace().Labels).To(Equal(map[string]string{"k5": "v5", "k6": "v6"}))
 	Expect(uut.getDstNamespace().Name).To(Equal("sub"))
 	Expect(uut.getDstNamespace().Labels).To(Equal(map[string]string{"k7": "v7", "k8": "v8"}))
+}
+
+// Identity is resolved once per request, not once per rule: the match functions ask for the
+// peer and namespace of both sides for every rule, and resolving parses the SPIFFE ID and
+// copies two label maps.
+func TestIdentityResolvedOncePerRequest(t *testing.T) {
+	RegisterTestingT(t)
+
+	req := &authz.CheckRequest{Attributes: &authz.AttributeContext{
+		Source: &authz.AttributeContext_Peer{
+			Principal: "spiffe://cluster.local/ns/sandwich/sa/bacon",
+		},
+		Destination: &authz.AttributeContext_Peer{
+			Principal: "spiffe://cluster.local/ns/salad/sa/lettuce",
+		},
+	}}
+	uut := NewRequestCache(policystore.NewPolicyStore(), NewCheckRequestToFlowAdapter(req))
+
+	Expect(uut.getSrcPeer().Name).To(Equal("bacon"))
+	Expect(uut.getDstPeer().Name).To(Equal("lettuce"))
+	Expect(uut.getSrcNamespace().Name).To(Equal("sandwich"))
+	Expect(uut.getDstNamespace().Name).To(Equal("salad"))
+
+	// Repeated lookups return the memoized values rather than resolving again.
+	Expect(uut.getSrcPeer()).To(BeIdenticalTo(uut.getSrcPeer()))
+	Expect(uut.getDstPeer()).To(BeIdenticalTo(uut.getDstPeer()))
+	Expect(uut.getSrcNamespace()).To(BeIdenticalTo(uut.getSrcNamespace()))
+	Expect(uut.getDstNamespace()).To(BeIdenticalTo(uut.getDstNamespace()))
+	Expect(uut.getSrcPeer()).NotTo(BeIdenticalTo(uut.getDstPeer()))
+}
+
+// A principal that is not a SPIFFE ID leaves the side unidentified. Dikastes falls back on IP
+// addresses in that case, so rules without identity criteria still match.
+func TestUnparseablePrincipalIsMemoized(t *testing.T) {
+	RegisterTestingT(t)
+
+	req := &authz.CheckRequest{Attributes: &authz.AttributeContext{
+		Source: &authz.AttributeContext_Peer{
+			Principal: "http://foo.bar.com/ns/sandwich/sa/bacon",
+		},
+		Destination: &authz.AttributeContext_Peer{
+			Principal: "",
+		},
+	}}
+	uut := NewRequestCache(policystore.NewPolicyStore(), NewCheckRequestToFlowAdapter(req))
+
+	Expect(uut.getSrcPeer()).To(BeNil())
+	Expect(uut.getSrcNamespace()).To(BeNil())
+	// A nil peer must not be mistaken for "not resolved yet", or every rule retries the parse
+	// and re-logs the failure.
+	Expect(uut.identities[sourceSide].resolved).To(BeTrue())
+	Expect(matchServiceAccounts(nil, uut.getSrcPeer())).To(BeTrue())
+}
+
+// Repeated failures on the evaluation path are rate limited: one line, then a count of what
+// was suppressed. Without this a single dangling IP set reference logs once per rule, for
+// every request.
+func TestEvalPathWarningsAreRateLimited(t *testing.T) {
+	RegisterTestingT(t)
+
+	logger := log.StandardLogger()
+	oldLevel, oldOut := logger.GetLevel(), logger.Out
+	counter := &entryCounter{}
+	hooks := make(log.LevelHooks)
+	hooks.Add(counter)
+	oldHooks := logger.ReplaceHooks(hooks)
+	savedLogger := rlogIPSetMissing
+	defer func() {
+		logger.SetLevel(oldLevel)
+		logger.SetOutput(oldOut)
+		logger.ReplaceHooks(oldHooks)
+		rlogIPSetMissing = savedLogger
+	}()
+	logger.SetLevel(log.WarnLevel)
+	logger.SetOutput(io.Discard)
+	// A long interval with no burst allowance: the first message is written, the rest are
+	// counted.
+	rlogIPSetMissing = logutils.NewRateLimitedLogger(logutils.OptInterval(time.Hour))
+
+	uut := NewRequestCache(policystore.NewPolicyStore(), NewCheckRequestToFlowAdapter(
+		&authz.CheckRequest{Attributes: &authz.AttributeContext{}}))
+	for range 100 {
+		Expect(uut.getIPSet("missing-set")).To(BeNil())
+	}
+
+	Expect(counter.entries).To(HaveLen(1), "expected one emitted warning for 100 misses")
+	Expect(counter.entries[0].Message).To(ContainSubstring("missing-set"))
+	Expect(counter.entries[0].Data).NotTo(HaveKey("logsSkipped"))
+
+	// The suppressed count surfaces on the next line that is allowed through, so the storm is
+	// still visible in the log.
+	rlogIPSetMissing.Force().Warnf("IPSet not found: %s", "missing-set")
+	Expect(counter.entries).To(HaveLen(2))
+	Expect(counter.entries[1].Data).To(HaveKeyWithValue("logsSkipped", 99))
+}
+
+// entryCounter collects the log entries written during a test.
+type entryCounter struct {
+	entries []*log.Entry
+}
+
+func (c *entryCounter) Levels() []log.Level { return log.AllLevels }
+
+func (c *entryCounter) Fire(e *log.Entry) error {
+	c.entries = append(c.entries, e)
+	return nil
 }

--- a/app-policy/policystore/ipset.go
+++ b/app-policy/policystore/ipset.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2025 Tigera, Inc. All rights reserved.
+// Copyright (c) 2018-2026 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,10 +18,20 @@ import (
 	"net"
 	"strconv"
 	"strings"
+	"time"
 
 	log "github.com/sirupsen/logrus"
 
 	syncapi "github.com/projectcalico/calico/felix/proto"
+	"github.com/projectcalico/calico/libcalico-go/lib/logutils"
+)
+
+// rlogBadAddr rate limits the unparseable-address warning: membership is tested once per set
+// per rule, so a single non-IP request would otherwise log once for every set reference in the
+// endpoint's whole policy set.
+var rlogBadAddr = logutils.NewRateLimitedLogger(
+	logutils.OptInterval(30*time.Second),
+	logutils.OptBurst(10),
 )
 
 // IPSet is a data structure that contains IP addresses, or IP address/port pairs. It allows fast
@@ -162,9 +172,10 @@ func (m ipNetSet) RemoveString(network string) {
 func (m ipNetSet) Contains(addr string) bool {
 	ip := net.ParseIP(addr)
 	if ip == nil {
-		// Envoy should not send us malformed IP addresses, but its possible we could get requests from non-IP
-		// connections, like Pipes.
-		log.WithField("addr", ip).Warn("could not parse IP")
+		// Envoy should not send us malformed IP addresses, but it's possible we could get requests from non-IP
+		// connections, like Pipes. Such a request is tested against every NET set every rule references, so
+		// the log is rate limited.
+		rlogBadAddr.Warnf("could not parse IP: %s", addr)
 		return false
 	}
 	ip4 := ip.To4()

--- a/app-policy/policystore/process.go
+++ b/app-policy/policystore/process.go
@@ -19,11 +19,13 @@ import (
 
 	"github.com/projectcalico/calico/felix/proto"
 	"github.com/projectcalico/calico/felix/types"
-	"github.com/projectcalico/calico/libcalico-go/lib/backend/model"
 )
 
 // ProcessUpdate -  Update the PolicyStore with the information passed over the Sync API.
-func (store *PolicyStore) ProcessUpdate(subscriptionType string, update *proto.ToDataplane, storeStaged bool) {
+//
+// Staged policies are stored like any other. Whether they count towards a verdict is up to the
+// evaluation, which takes a checker.PolicyScope; see checker.Evaluate.
+func (store *PolicyStore) ProcessUpdate(subscriptionType string, update *proto.ToDataplane) {
 	// TODO: maybe coalesce-ing updater fits here
 	switch payload := update.Payload.(type) {
 	case *proto.ToDataplane_InSync:
@@ -39,24 +41,8 @@ func (store *PolicyStore) ProcessUpdate(subscriptionType string, update *proto.T
 	case *proto.ToDataplane_ActiveProfileRemove:
 		store.processActiveProfileRemove(payload.ActiveProfileRemove)
 	case *proto.ToDataplane_ActivePolicyUpdate:
-		if !storeStaged && model.KindIsStaged(payload.ActivePolicyUpdate.Id.Name) {
-			log.WithFields(log.Fields{
-				"id": payload.ActivePolicyUpdate.Id,
-			}).Debug("Skipping StagedPolicy ActivePolicyUpdate")
-
-			return
-		}
-
 		store.processActivePolicyUpdate(payload.ActivePolicyUpdate)
 	case *proto.ToDataplane_ActivePolicyRemove:
-		if !storeStaged && model.KindIsStaged(payload.ActivePolicyRemove.Id.Name) {
-			log.WithFields(log.Fields{
-				"id": payload.ActivePolicyRemove.Id,
-			}).Debug("Skipping StagedPolicy ActivePolicyRemove")
-
-			return
-		}
-
 		store.processActivePolicyRemove(payload.ActivePolicyRemove)
 	case *proto.ToDataplane_WorkloadEndpointUpdate:
 		store.processWorkloadEndpointUpdate(subscriptionType, payload.WorkloadEndpointUpdate)

--- a/app-policy/policystore/process_test.go
+++ b/app-policy/policystore/process_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	. "github.com/onsi/gomega"
+	v3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
 
 	"github.com/projectcalico/calico/felix/proto"
 	"github.com/projectcalico/calico/felix/types"
@@ -143,7 +144,7 @@ func TestIPSetUpdateDispatch(t *testing.T) {
 			},
 		}},
 	}
-	Expect(func() { store.ProcessUpdate("", update, false) }).ToNot(Panic())
+	Expect(func() { store.ProcessUpdate("", update) }).ToNot(Panic())
 }
 
 // IPSetDeltaUpdate with existing ID.
@@ -186,7 +187,7 @@ func TestIPSetDeltaUpdateDispatch(t *testing.T) {
 			RemovedMembers: []string{addr3Ip},
 		},
 	}}
-	Expect(func() { store.ProcessUpdate("", update, false) }).ToNot(Panic())
+	Expect(func() { store.ProcessUpdate("", update) }).ToNot(Panic())
 }
 
 // IPSetRemove with an existing ID.
@@ -221,7 +222,7 @@ func TestIPSetRemoveDispatch(t *testing.T) {
 	update := &proto.ToDataplane{Payload: &proto.ToDataplane_IpsetRemove{
 		IpsetRemove: &proto.IPSetRemove{Id: id},
 	}}
-	Expect(func() { store.ProcessUpdate("", update, false) }).ToNot(Panic())
+	Expect(func() { store.ProcessUpdate("", update) }).ToNot(Panic())
 }
 
 // ActiveProfileUpdate with a new id
@@ -264,7 +265,7 @@ func TestActiveProfileUpdateDispatch(t *testing.T) {
 			Profile: profile1,
 		},
 	}}
-	Expect(func() { store.ProcessUpdate("", update, false) }).ToNot(Panic())
+	Expect(func() { store.ProcessUpdate("", update) }).ToNot(Panic())
 }
 
 // ActiveProfileRemove with an unknown id is handled without panic.
@@ -298,7 +299,7 @@ func TestActiveProfileRemoveDispatch(t *testing.T) {
 	update := &proto.ToDataplane{Payload: &proto.ToDataplane_ActiveProfileRemove{
 		ActiveProfileRemove: &proto.ActiveProfileRemove{Id: &id},
 	}}
-	Expect(func() { store.ProcessUpdate("", update, false) }).ToNot(Panic())
+	Expect(func() { store.ProcessUpdate("", update) }).ToNot(Panic())
 }
 
 // ActivePolicyUpdate for a new id
@@ -341,7 +342,7 @@ func TestActivePolicyUpdateDispatch(t *testing.T) {
 			Policy: policy1,
 		},
 	}}
-	Expect(func() { store.ProcessUpdate("", update, false) }).ToNot(Panic())
+	Expect(func() { store.ProcessUpdate("", update) }).ToNot(Panic())
 }
 
 // ActivePolicyRemove with unknown id is handled
@@ -377,7 +378,7 @@ func TestActivePolicyRemoveDispatch(t *testing.T) {
 	update := &proto.ToDataplane{Payload: &proto.ToDataplane_ActivePolicyRemove{
 		ActivePolicyRemove: &proto.ActivePolicyRemove{Id: &id},
 	}}
-	Expect(func() { store.ProcessUpdate("", update, false) }).ToNot(Panic())
+	Expect(func() { store.ProcessUpdate("", update) }).ToNot(Panic())
 }
 
 // WorkloadEndpointUpdate sets the endpoint
@@ -396,7 +397,7 @@ func TestWorkloadEndpointUpdateDispatch(t *testing.T) {
 	update := &proto.ToDataplane{Payload: &proto.ToDataplane_WorkloadEndpointUpdate{
 		WorkloadEndpointUpdate: &proto.WorkloadEndpointUpdate{Endpoint: endpoint1},
 	}}
-	Expect(func() { store.ProcessUpdate("", update, false) }).ToNot(Panic())
+	Expect(func() { store.ProcessUpdate("", update) }).ToNot(Panic())
 }
 
 // WorkloadEndpointRemove removes the endpoint
@@ -417,14 +418,14 @@ func TestWorkloadEndpointRemoveDispatch(t *testing.T) {
 	update := &proto.ToDataplane{Payload: &proto.ToDataplane_WorkloadEndpointRemove{
 		WorkloadEndpointRemove: &proto.WorkloadEndpointRemove{},
 	}}
-	Expect(func() { store.ProcessUpdate("", update, false) }).ToNot(Panic())
+	Expect(func() { store.ProcessUpdate("", update) }).ToNot(Panic())
 }
 
 func TestServiceAccountUpdateDispatch(t *testing.T) {
 	RegisterTestingT(t)
 	store := NewPolicyStore()
 	update := &proto.ToDataplane{Payload: &proto.ToDataplane_ServiceAccountUpdate{ServiceAccountUpdate: serviceAccount1}}
-	Expect(func() { store.ProcessUpdate("", update, false) }).ToNot(Panic())
+	Expect(func() { store.ProcessUpdate("", update) }).ToNot(Panic())
 	Expect(store.ServiceAccountByID).To(Equal(map[types.ServiceAccountID]*proto.ServiceAccountUpdate{
 		types.ProtoToServiceAccountID(serviceAccount1.GetId()): serviceAccount1,
 	}))
@@ -438,7 +439,7 @@ func TestServiceAccountRemoveDispatch(t *testing.T) {
 	remove := &proto.ToDataplane{Payload: &proto.ToDataplane_ServiceAccountRemove{
 		ServiceAccountRemove: &proto.ServiceAccountRemove{Id: serviceAccount1.Id},
 	}}
-	Expect(func() { store.ProcessUpdate("", remove, false) }).ToNot(Panic())
+	Expect(func() { store.ProcessUpdate("", remove) }).ToNot(Panic())
 	Expect(store.ServiceAccountByID).To(Equal(map[types.ServiceAccountID]*proto.ServiceAccountUpdate{}))
 }
 
@@ -446,7 +447,7 @@ func TestNamespaceUpdateDispatch(t *testing.T) {
 	RegisterTestingT(t)
 	store := NewPolicyStore()
 	update := &proto.ToDataplane{Payload: &proto.ToDataplane_NamespaceUpdate{NamespaceUpdate: namespace1}}
-	Expect(func() { store.ProcessUpdate("", update, false) }).ToNot(Panic())
+	Expect(func() { store.ProcessUpdate("", update) }).ToNot(Panic())
 	Expect(store.NamespaceByID).To(Equal(map[types.NamespaceID]*proto.NamespaceUpdate{
 		types.ProtoToNamespaceID(namespace1.GetId()): namespace1,
 	}))
@@ -460,7 +461,7 @@ func TestNamespaceRemoveDispatch(t *testing.T) {
 	remove := &proto.ToDataplane{Payload: &proto.ToDataplane_NamespaceRemove{
 		NamespaceRemove: &proto.NamespaceRemove{Id: namespace1.Id},
 	}}
-	Expect(func() { store.ProcessUpdate("", remove, false) }).ToNot(Panic())
+	Expect(func() { store.ProcessUpdate("", remove) }).ToNot(Panic())
 	Expect(store.NamespaceByID).To(Equal(map[types.NamespaceID]*proto.NamespaceUpdate{}))
 }
 
@@ -469,5 +470,27 @@ func TestInSyncDispatch(t *testing.T) {
 	RegisterTestingT(t)
 	store := NewPolicyStore()
 	update := &proto.ToDataplane{Payload: &proto.ToDataplane_InSync{}}
-	Expect(func() { store.ProcessUpdate("", update, false) }).ToNot(Panic())
+	Expect(func() { store.ProcessUpdate("", update) }).ToNot(Panic())
+}
+
+// Staged policies are stored like enforced ones; it is the evaluation that decides whether they
+// count (see checker.PolicyScope).
+func TestActivePolicyUpdateStoresStagedPolicies(t *testing.T) {
+	RegisterTestingT(t)
+
+	for _, kind := range []string{v3.KindStagedGlobalNetworkPolicy, v3.KindStagedNetworkPolicy, v3.KindGlobalNetworkPolicy} {
+		t.Run(kind, func(t *testing.T) {
+			id := &proto.PolicyID{Name: "test_id", Kind: kind}
+			store := NewPolicyStore()
+			store.ProcessUpdate("", &proto.ToDataplane{Payload: &proto.ToDataplane_ActivePolicyUpdate{
+				ActivePolicyUpdate: &proto.ActivePolicyUpdate{Id: id, Policy: policy1},
+			}})
+			Expect(store.PolicyByID).To(HaveKey(types.ProtoToPolicyID(id)))
+
+			store.ProcessUpdate("", &proto.ToDataplane{Payload: &proto.ToDataplane_ActivePolicyRemove{
+				ActivePolicyRemove: &proto.ActivePolicyRemove{Id: id},
+			}})
+			Expect(store.PolicyByID).ToNot(HaveKey(types.ProtoToPolicyID(id)))
+		})
+	}
 }

--- a/app-policy/syncher/syncserver.go
+++ b/app-policy/syncher/syncserver.go
@@ -147,7 +147,7 @@ func (s *SyncClient) syncStore(cxt context.Context, inSync chan<- struct{}, done
 			s.storeManager.OnInSync()
 		default:
 			s.storeManager.DoWithLock(func(ps *policystore.PolicyStore) {
-				ps.ProcessUpdate(s.subscriptionType, update, false)
+				ps.ProcessUpdate(s.subscriptionType, update)
 			})
 		}
 	}

--- a/felix/collector/collector.go
+++ b/felix/collector/collector.go
@@ -286,7 +286,7 @@ func (c *collector) loopProcessingDataplaneInfoUpdates(dpInfoC <-chan *proto.ToD
 		c.policyStoreManager.DoWithLock(func(ps *policystore.PolicyStore) {
 			log.Debugf("Dataplane payload: %+v and sequenceNumber: %d, ", dpInfo.Payload, dpInfo.SequenceNumber)
 			// Get the data and update the endpoints.
-			ps.ProcessUpdate(perHostPolicySubscription, dpInfo, true)
+			ps.ProcessUpdate(perHostPolicySubscription, dpInfo)
 		})
 		if _, ok := dpInfo.Payload.(*proto.ToDataplane_InSync); ok {
 			// Sync the policy store. This will swap the pending store to the active store. Setting the
@@ -906,7 +906,14 @@ func (c *collector) evaluatePendingRuleTraceForLocalEp(data *Data) {
 func (c *collector) evaluatePendingRuleTrace(direction rules.RuleDir, store *policystore.PolicyStore, ep calc.EndpointData, flow TupleAsFlow, ruleIDs *[]*calc.RuleID) {
 	// Get the proto.WorkloadEndpoint, needed for the evaluation, from the policy store.
 	if protoEp := c.lookupProtoWorkloadEndpoint(store, ep.Key()); protoEp != nil {
-		trace := checker.Evaluate(direction, store, protoEp, &flow)
+		trace, err := checker.Evaluate(checker.StagedAsEnforced, direction, store, protoEp, &flow)
+		if err != nil {
+			// Keep the trace we worked out last time: reporting no pending policy at all would be a
+			// stronger claim than we are in a position to make. The checker logs the reason, rate
+			// limited, so this one stays at trace level.
+			log.WithError(err).Tracef("Pending %s evaluation failed, tuple: %v", direction, flow)
+			return
+		}
 		if !equal(*ruleIDs, trace) {
 			*ruleIDs = append([]*calc.RuleID(nil), trace...)
 			log.Tracef("Updated pending %s, tuple: %v, rule trace: %v", direction, flow, ruleIDs)

--- a/felix/collector/pending_rule_trace_test.go
+++ b/felix/collector/pending_rule_trace_test.go
@@ -1,0 +1,144 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+import (
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+	v3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
+
+	"github.com/projectcalico/calico/app-policy/policystore"
+	"github.com/projectcalico/calico/felix/calc"
+	clttypes "github.com/projectcalico/calico/felix/collector/types"
+	"github.com/projectcalico/calico/felix/collector/types/tuple"
+	"github.com/projectcalico/calico/felix/proto"
+	"github.com/projectcalico/calico/felix/rules"
+	"github.com/projectcalico/calico/felix/types"
+	"github.com/projectcalico/calico/libcalico-go/lib/backend/model"
+)
+
+// An evaluation that cannot be completed says so, rather than returning an empty trace. Overwriting
+// the flow's pending trace with that would report the flow as having no pending policy at all,
+// which is a stronger claim than "we could not work it out" — so the last trace stands.
+func TestPendingRuleTraceKeptWhenEvaluationFails(t *testing.T) {
+	RegisterTestingT(t)
+
+	c, flowTuple1, _ := setupPolicyEvalCollector(t)
+	evaluated := []*calc.RuleID{calc.NewRuleID(
+		v3.KindGlobalNetworkPolicy, "default", "policy1", "", 0, rules.RuleDirIngress, rules.RuleActionAllow)}
+
+	// Control: with the endpoint's policy in the store, the trace is worked out and recorded.
+	var ruleIDs []*calc.RuleID
+	c.policyStoreManager.DoWithLock(func(ps *policystore.PolicyStore) {
+		c.evaluatePendingRuleTrace(rules.RuleDirIngress, ps, localEd1, TupleAsFlow(flowTuple1), &ruleIDs)
+	})
+	Expect(ruleIDs).To(Equal(evaluated))
+
+	c.policyStoreManager.DoWithLock(func(ps *policystore.PolicyStore) {
+		// The endpoint's tier still names policy1, but its rules are no longer in the store, so the
+		// evaluation fails part way through.
+		delete(ps.PolicyByID, types.PolicyID{Name: "policy1", Kind: v3.KindGlobalNetworkPolicy})
+		c.evaluatePendingRuleTrace(rules.RuleDirIngress, ps, localEd1, TupleAsFlow(flowTuple1), &ruleIDs)
+	})
+	Expect(ruleIDs).To(Equal(evaluated), "the trace from the last successful evaluation should stand")
+}
+
+// The two helpers below live in collector_test.go on master, where #13316 added them. They are
+// carried here so that this test does not depend on backporting that change as well.
+
+// workloadEndpointID converts a model workload endpoint key to its protobuf endpoint ID.
+func workloadEndpointID(key model.WorkloadEndpointKey) types.WorkloadEndpointID {
+	return types.WorkloadEndpointID{
+		OrchestratorId: key.OrchestratorID,
+		WorkloadId:     key.WorkloadID,
+		EndpointId:     key.EndpointID,
+	}
+}
+
+// setupPolicyEvalCollector builds a collector holding two flows against a populated policy store:
+// flow1 is local-to-local (policy1 allow), flow2 is local-to-remote (policy2 deny). It returns the
+// collector and the two flow tuples.
+func setupPolicyEvalCollector(t *testing.T) (*collector, tuple.Tuple, tuple.Tuple) {
+	t.Helper()
+
+	epMap := map[[16]byte]calc.EndpointData{
+		localIp1:  localEd1,
+		localIp2:  localEd2,
+		remoteIp1: remoteEd1,
+	}
+	lm := newMockLookupsCache(epMap, nil, nil, nil)
+	policyStoreManager := policystore.NewPolicyStoreManager()
+
+	c := newCollector(lm, &Config{
+		AgeTimeout:            10 * time.Second,
+		InitialReportingDelay: 5 * time.Second,
+		ExportingInterval:     time.Second,
+		FlowLogsFlushInterval: 100 * time.Second,
+		PolicyStoreManager:    policyStoreManager,
+	}).(*collector)
+
+	flowTuple1 := tuple.New(localIp1, localIp2, proto_tcp, 1000, 1000)
+	flowTuple2 := tuple.New(localIp2, remoteIp1, proto_tcp, 1000, 1000)
+
+	localWlEp1Proto := calc.ModelWorkloadEndpointToProto(localWlEp1, nil, nil, []*proto.TierInfo{{
+		Name:            "default",
+		IngressPolicies: []*proto.PolicyID{{Name: "policy1", Kind: v3.KindGlobalNetworkPolicy}},
+		EgressPolicies:  []*proto.PolicyID{{Name: "policy1", Kind: v3.KindGlobalNetworkPolicy}},
+	}})
+	localWlEp2Proto := calc.ModelWorkloadEndpointToProto(localWlEp2, nil, nil, []*proto.TierInfo{{
+		Name:            "default",
+		IngressPolicies: []*proto.PolicyID{{Name: "policy2", Kind: v3.KindGlobalNetworkPolicy}},
+		EgressPolicies:  []*proto.PolicyID{{Name: "policy2", Kind: v3.KindGlobalNetworkPolicy}},
+	}})
+	remoteWlEp1Proto := calc.ModelWorkloadEndpointToProto(remoteWlEp1, nil, nil, []*proto.TierInfo{})
+
+	policyStoreManager.DoWithLock(func(ps *policystore.PolicyStore) {
+		ps.Endpoints[workloadEndpointID(localWlEPKey1)] = localWlEp1Proto
+		ps.Endpoints[workloadEndpointID(localWlEPKey2)] = localWlEp2Proto
+		ps.Endpoints[workloadEndpointID(remoteWlEpKey1)] = remoteWlEp1Proto
+		ps.PolicyByID[types.PolicyID{Name: "policy1", Kind: v3.KindGlobalNetworkPolicy}] = &proto.Policy{
+			Tier:          "default",
+			InboundRules:  []*proto.Rule{{Action: "allow"}},
+			OutboundRules: []*proto.Rule{{Action: "allow"}},
+		}
+		ps.PolicyByID[types.PolicyID{Name: "policy2", Kind: v3.KindGlobalNetworkPolicy}] = &proto.Policy{
+			Tier:          "default",
+			InboundRules:  []*proto.Rule{{Action: "deny"}},
+			OutboundRules: []*proto.Rule{{Action: "deny"}},
+		}
+	})
+	policyStoreManager.OnInSync()
+
+	// Simulate packet processing to create flow data in epStats.
+	c.applyPacketInfo(clttypes.PacketInfo{
+		Tuple:     *flowTuple1,
+		Direction: rules.RuleDirIngress,
+		RuleHits:  []clttypes.RuleHit{{RuleID: calc.NewRuleID(v3.KindGlobalNetworkPolicy, "default", "policy1", "", 0, rules.RuleDirIngress, rules.RuleActionAllow), Hits: 1, Bytes: 100}},
+	})
+	c.applyPacketInfo(clttypes.PacketInfo{
+		Tuple:     *flowTuple1,
+		Direction: rules.RuleDirEgress,
+		RuleHits:  []clttypes.RuleHit{{RuleID: calc.NewRuleID(v3.KindGlobalNetworkPolicy, "default", "policy1", "", 0, rules.RuleDirEgress, rules.RuleActionAllow), Hits: 1, Bytes: 100}},
+	})
+	c.applyPacketInfo(clttypes.PacketInfo{
+		Tuple:     *flowTuple2,
+		Direction: rules.RuleDirEgress,
+		RuleHits:  []clttypes.RuleHit{{RuleID: calc.NewRuleID(v3.KindGlobalNetworkPolicy, "default", "policy2", "", 0, rules.RuleDirEgress, rules.RuleActionDeny), Hits: 1, Bytes: 100}},
+	})
+
+	return c, *flowTuple1, *flowTuple2
+}


### PR DESCRIPTION
Backports the outstanding ALP (Dikastes) changes to `release-v3.32`, in dependency order:

| Commit | Original |
|---|---|
| Make the staged-policy scope of ALP policy evaluation explicit | #13416 |
| Evaluate policy rule criteria cheapest-first in Dikastes | #13408 |

#13408 builds on #13416, so picking them in this order keeps each commit close to its master original. An earlier revision of this PR carried #13408 alone with hand-written adaptations for the missing `PolicyScope`; picking #13416 first removed the need for all of them.

### Survey

`release-v3.32` was checked for other ALP fixes that had been missed. These are the only two. Everything else in the `app-policy/` delta against master is infrastructure rather than a fix, and is deliberately not picked:

- the single-binary consolidation (#12225 — `cmd/` → `pkg/`, Dockerfile, Makefile);
- the logrus utility consolidation (#13034 — `libcalico-go/lib/logutils` → `lib/logrusr`);
- dependency bumps and regenerated files.

Two things that looked missing from `git log` but are already present, having been backported under different SHAs: the HTTP path normalisation hardening (matrix params, backslash folding, null bytes, double-encoded separators) and #13265's per-rule allocation cuts.

### Deviations from the originals

Only one, and it is mechanical: this branch predates #13034, so the rate-limited logger is `libcalico-go/lib/logutils` rather than `lib/logrusr`. The API is identical, so it is a package-qualifier swap in `check.go`, `bench_test.go`, `requestcache_test.go` and `policystore/ipset.go`.

One addition: #13416's new `felix/collector/pending_rule_trace_test.go` uses `setupPolicyEvalCollector` and `workloadEndpointID`, which master gained from #13316 (a collector sweep change that is not an ALP fix and is not being backported). Both helpers are carried into the new test file itself, with a comment recording where they live on master, so the test keeps its coverage without pulling #13316 in.

### Testing

`make -C app-policy ut` passes (280 tests) and `make -C app-policy static-checks` reports 0 issues. `make -C felix static-checks` also reports 0 issues, and `go test ./felix/collector/` passes, including the ported `TestPendingRuleTraceKeptWhenEvaluationFails`.

#13408's two new tests were re-checked on this branch and still fail against the pre-change ordering, so they pin the behaviour here as they do on master. The benchmarks compile and run with the same allocation counts as master: 20 / 6,825 / 10,361 for the three egress cases, 51 for the baseline fixture.

**Release Note:**
```release-note
Felix/Dikastes performance: evaluate policy rule criteria cheapest-first in the user-mode policy engine, 1.6-3.7x faster evaluation for large policy sets. Rate limit the policy engine's per-rule warnings, which could previously emit tens of thousands of log lines per request. Make the staged-policy scope of ALP policy evaluation explicit, and keep the last known pending rule trace when an evaluation cannot be completed.
```
