### PR TITLE
Build the rapidclient manifest list on a builder that supports it

### DIFF
--- a/e2e/images/rapidclient/Makefile
+++ b/e2e/images/rapidclient/Makefile
@@ -50,23 +50,19 @@ image: bin/rapidclient-$(ARCH)
 	docker buildx build --load --platform=linux/$(ARCH) --pull \
 		-f Dockerfile -t $(IMAGE):$(TAG_NAME) .
 
-BUILDX_BUILDER ?= rapidclient-builder
+# Build and push one arch, tagged $(TAG_NAME)-<arch>. Single-platform builds so the
+# default docker driver can run them; multi-platform needs the docker-container
+# driver, which the CI agent lacks.
+push-image-%: bin/rapidclient-%
+	docker buildx build --load --platform=linux/$* --pull \
+		-f Dockerfile -t $(IMAGE):$(TAG_NAME)-$* .
+	docker push $(IMAGE):$(TAG_NAME)-$*
 
-# A multi-platform build needs the docker-container driver; the default docker
-# driver refuses it, which is what the CI agent starts with.
-.PHONY: setup-multiarch-builder clean-multiarch-builder
-clean-multiarch-builder:
-	-docker buildx rm $(BUILDX_BUILDER)
-
-setup-multiarch-builder: clean-multiarch-builder
-	docker buildx create --name=$(BUILDX_BUILDER) --driver=docker-container
-	docker buildx inspect --bootstrap $(BUILDX_BUILDER)
-
-# publish builds all architectures into a single manifest list and pushes it.
-publish: var-require-all-TAG_NAME setup-multiarch-builder $(addprefix bin/rapidclient-,$(ARCHES))
-	docker buildx build --builder=$(BUILDX_BUILDER) \
-		--platform=$(shell echo $(ARCHES) | sed 's/ /,/g; s,[^,]*,linux/&,g') \
-		--push --pull -f Dockerfile -t $(IMAGE):$(TAG_NAME) .
+# publish assembles the per-arch tags into one manifest list, the same shape as
+# lib.Makefile's push-manifests.
+publish: var-require-all-TAG_NAME $(addprefix push-image-,$(ARCHES))
+	docker buildx imagetools create -t $(IMAGE):$(TAG_NAME) \
+		$(addprefix $(IMAGE):$(TAG_NAME)-,$(ARCHES))
 	# Guard against silently regressing to a single-arch image (the original bug):
 	# the published tag must be a manifest list covering every arch in ARCHES.
 	@for a in $(ARCHES); do \

--- a/e2e/images/rapidclient/Makefile
+++ b/e2e/images/rapidclient/Makefile
@@ -50,9 +50,22 @@ image: bin/rapidclient-$(ARCH)
 	docker buildx build --load --platform=linux/$(ARCH) --pull \
 		-f Dockerfile -t $(IMAGE):$(TAG_NAME) .
 
+BUILDX_BUILDER ?= rapidclient-builder
+
+# A multi-platform build needs the docker-container driver; the default docker
+# driver refuses it, which is what the CI agent starts with.
+.PHONY: setup-multiarch-builder clean-multiarch-builder
+clean-multiarch-builder:
+	-docker buildx rm $(BUILDX_BUILDER)
+
+setup-multiarch-builder: clean-multiarch-builder
+	docker buildx create --name=$(BUILDX_BUILDER) --driver=docker-container
+	docker buildx inspect --bootstrap $(BUILDX_BUILDER)
+
 # publish builds all architectures into a single manifest list and pushes it.
-publish: var-require-all-TAG_NAME $(addprefix bin/rapidclient-,$(ARCHES))
-	docker buildx build --platform=$(shell echo $(ARCHES) | sed 's/ /,/g; s,[^,]*,linux/&,g') \
+publish: var-require-all-TAG_NAME setup-multiarch-builder $(addprefix bin/rapidclient-,$(ARCHES))
+	docker buildx build --builder=$(BUILDX_BUILDER) \
+		--platform=$(shell echo $(ARCHES) | sed 's/ /,/g; s,[^,]*,linux/&,g') \
 		--push --pull -f Dockerfile -t $(IMAGE):$(TAG_NAME) .
 	# Guard against silently regressing to a single-arch image (the original bug):
 	# the published tag must be a manifest list covering every arch in ARCHES.


### PR DESCRIPTION
The e2e test image publish has never worked in CI. #13780 made the promotion auto-fire, it fired on the merge, and the job failed in 86 seconds:

```
docker buildx build --platform=linux/amd64,linux/arm64 --push --pull -f Dockerfile -t quay.io/tigeradev/rapidclient:master .
ERROR: failed to build: Multi-platform build is not supported for the docker driver.
```

The agent starts with the default buildx driver, which refuses a multi-platform build, so `publish` creates a docker-container builder and passes it explicitly rather than relying on whichever builder is current. Same approach as `setup-windows-builder` in lib.Makefile.

- verified locally: the two-platform build that CI failed on completes on the new builder
- the published tag is still checked for both architectures afterwards
- `quay.io/tigeradev/rapidclient:latest` is still the 20 May build, which predates the server mode the packet-size specs need, so their server pod exits 1 on every platform

Related: [CORE-13575](https://tigera.atlassian.net/browse/CORE-13575)

```release-note
None
```


[CORE-13575]: https://tigera.atlassian.net/browse/CORE-13575?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ