### PR TITLE
refactor(release): publish images through one shared step

### DIFF
--- a/release/cmd/flags.go
+++ b/release/cmd/flags.go
@@ -478,6 +478,12 @@ var (
 
 // Hashrelease specific flags.
 var (
+	hashreleaseFlag = &cli.BoolFlag{
+		Name:     "hashrelease",
+		Category: stepControlCategory,
+		Usage:    "Indicates that the release is a hashrelease",
+		Sources:  cli.EnvVars("HASHRELEASE"),
+	}
 
 	// Hashrelease server configuration flags.
 	hashreleaseServerFlags = []cli.Flag{hashreleaseServerBucketFlag}

--- a/release/cmd/images.go
+++ b/release/cmd/images.go
@@ -50,7 +50,7 @@ func imagesCommand(cfg *Config) *cli.Command {
 }
 
 var (
-	imagesBuildFlags  = []cli.Flag{registryFlag, archFlag, imageReleaseDirsFlag}
+	imagesBuildFlags  = []cli.Flag{registryFlag, archFlag, imageReleaseDirsFlag, hashreleaseFlag}
 	imagesBuildAction = func(cfg *Config) func(ctx context.Context, c *cli.Command) error {
 		return func(ctx context.Context, c *cli.Command) error {
 			configureLogging("images-build.log")
@@ -81,13 +81,13 @@ func imagesBuildCommand(cfg *Config) *cli.Command {
 
 var (
 	imagesPublishFlags = append([]cli.Flag{
-		registryFlag, archFlag, localFlag, imageReleaseDirsFlag,
+		registryFlag, archFlag, localFlag, imageReleaseDirsFlag, hashreleaseFlag,
 		fromRegistryFlag, fromTagFlag, skipDevImageRetagFlag, forceFlag,
 	}, imageScanFlags...)
 	imagesPublishAction = func(cfg *Config) func(ctx context.Context, c *cli.Command) error {
 		return func(_ context.Context, c *cli.Command) error {
 			configureLogging("images-publish.log")
-			ver, _, err := version.VersionsFromManifests(cfg.RepoRootDir)
+			ver, err := releaseVersion(cfg, c)
 			if err != nil {
 				return err
 			}
@@ -97,7 +97,7 @@ var (
 			if len(scanDirs) == 0 {
 				scanDirs = utils.ImageDiscoveryDirs()
 			}
-			scan, err := scanRequest(c, cfg, scanDirs, ver.Stream(), utils.CalicoProductCode)
+			scan, err := scanRequest(c, cfg, scanDirs, ver.PrimaryStream(), utils.CalicoProductCode)
 			if err != nil {
 				return err
 			}

--- a/release/cmd/shared.go
+++ b/release/cmd/shared.go
@@ -26,9 +26,11 @@ import (
 	"github.com/snowzach/rotatefilehook"
 	cli "github.com/urfave/cli/v3"
 
+	"github.com/projectcalico/calico/release/internal/command"
 	"github.com/projectcalico/calico/release/internal/outputs"
 	"github.com/projectcalico/calico/release/internal/slack"
 	"github.com/projectcalico/calico/release/internal/utils"
+	"github.com/projectcalico/calico/release/internal/version"
 )
 
 var (
@@ -127,4 +129,21 @@ func slackConfig(c *cli.Command) *slack.Config {
 		Token:   c.String(slackTokenFlag.Name),
 		Channel: c.String(slackChannelFlag.Name),
 	}
+}
+
+// releaseVersion is the version being released
+var releaseVersion = func(cfg *Config, c *cli.Command) (*version.Version, error) {
+	if c.Bool(hashreleaseFlag.Name) {
+		v, err := command.GitVersion(cfg.RepoRootDir, true)
+		if err != nil {
+			return nil, fmt.Errorf("git version: %w", err)
+		}
+		ver := version.Version(v)
+		return &ver, nil
+	}
+	ver, _, err := version.VersionsFromManifests(cfg.RepoRootDir)
+	if err != nil {
+		return nil, fmt.Errorf("version from manifest: %w", err)
+	}
+	return &ver, nil
 }

--- a/release/internal/images/actions.go
+++ b/release/internal/images/actions.go
@@ -90,7 +90,10 @@ func saveUnit(s settings, u unit, reg, tarDir string) error {
 }
 
 func publishEnv(s settings) []string {
-	env := append(s.env(), utils.EnvTrue(utils.EnvRelease))
+	env := append(s.env(),
+		utils.EnvTrue(utils.EnvRelease),
+		utils.Env(utils.EnvReleaseTag, s.Version),
+	)
 	if s.confirm {
 		env = append(env, utils.EnvTrue(utils.EnvConfirm))
 	} else {
@@ -104,7 +107,6 @@ func publishEnv(s settings) []string {
 			utils.Env(utils.EnvDevTag, s.retag.tag),
 			utils.Env(utils.EnvDevRegistries, s.retag.registry),
 			utils.Env(utils.EnvReleaseRegistries, strings.Join(s.Registries, " ")),
-			utils.Env(utils.EnvReleaseTag, s.Version),
 		)
 		if s.retag.skipDev {
 			env = append(env, utils.EnvTrue(utils.EnvSkipDevImageRetag))
@@ -140,6 +142,7 @@ func Publish(repoRoot, version string, variants []Variant, confirm bool, resolve
 	}
 	if len(units) == 0 {
 		s.Logger().Info("Every image is already published")
+		sendImagesToISS(s)
 		return nil
 	}
 	s.Logger().WithField("images", len(units)).Info("Publishing container images")
@@ -155,15 +158,20 @@ func Publish(repoRoot, version string, variants []Variant, confirm bool, resolve
 	}
 	s.Logger().Info("Finished publishing container images")
 
+	sendImagesToISS(s)
+	return nil
+}
+
+// A scan failure must not fail the release: the images are already published.
+func sendImagesToISS(s settings) {
 	if s.scan == nil {
-		return nil
+		return
 	}
 	s.Logger().Info("Sending images to ISS")
 	scanner := imagescanner.New(s.scan.Config)
 	if err := scanner.Scan(s.scan.ProductCode, s.scan.Images, s.scan.Stream, s.scan.Release, s.scan.OutputDir); err != nil {
 		s.Logger().WithError(err).Error("Failed to scan images")
 	}
-	return nil
 }
 
 // newSettings is generic so each step accepts only its own option type.

--- a/release/internal/images/images.go
+++ b/release/internal/images/images.go
@@ -264,6 +264,17 @@ func WithLogsDir(dir string) Option {
 	})
 }
 
+// WithStepName overrides the step name, use when default is not sufficient.
+func WithStepName(name string) Option {
+	return setting(func(s *settings) error {
+		if name == "" {
+			return fmt.Errorf("no step name given")
+		}
+		s.Apply([]command.Option{command.WithName(name)})
+		return nil
+	})
+}
+
 // WithPull sets whether an archive may fetch an image that is not already
 // local, which a release that did not build its own images needs.
 func WithPull(pull bool) ArchiveOption {
@@ -526,7 +537,10 @@ func unitState(s settings, u unit, recorded recordedDigests) (done bool, err err
 				image := fmt.Sprintf("%s:%s", repo, tag)
 				got, exists, err := s.resolve(image)
 				if err != nil {
-					return false, fmt.Errorf("resolving %s: %w", image, err)
+					// A failed lookup says nothing about what is published.
+					s.Logger().WithError(err).WithField("image", image).
+						Warn("Could not resolve digest, will publish")
+					return false, nil
 				}
 				if !exists {
 					return false, nil

--- a/release/internal/images/images_test.go
+++ b/release/internal/images/images_test.go
@@ -15,6 +15,7 @@
 package images
 
 import (
+	"errors"
 	"fmt"
 	"path"
 	"slices"
@@ -728,6 +729,32 @@ func TestPublishSkipsAlreadyPublishedUnits(t *testing.T) {
 		if slices.Contains(c.args, "release-publish") {
 			t.Errorf("republished an already-published unit: %v", c.args)
 		}
+	}
+}
+
+// A lookup that fails reaches no verdict, so the unit is published rather than
+// aborting a resume that a flaky registry would otherwise stop.
+func TestPublishOnUnresolvableDigest(t *testing.T) {
+	f := &imageNameRunner{images: "whisker"}
+	resolve := func(string) (string, bool, error) {
+		return "", false, errors.New("unauthorized")
+	}
+	// Recording resolves the digests it just pushed and is a separate concern,
+	// so this drives the resume decision alone.
+	err := Publish(testRepoRoot, testVersion, oneStandardVariant("whisker"), true, resolve,
+		WithRunner(f), WithRegistries("quay.io/calico"),
+		WithResume([]string{"quay.io/calico/whisker@sha256:aaa"}, false))
+	if err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	var published bool
+	for _, c := range f.calls {
+		if slices.Contains(c.args, "release-publish") {
+			published = true
+		}
+	}
+	if !published {
+		t.Errorf("a failed lookup skipped the unit instead of publishing it: %v", f.calls)
 	}
 }
 

--- a/release/pkg/manager/calico/manager.go
+++ b/release/pkg/manager/calico/manager.go
@@ -56,6 +56,8 @@ var (
 	helmIndexFileName = "index.yaml"
 
 	s3ACLPublicRead = []string{"--acl", "public-read"}
+
+	branchTagTarget = "retag-build-images-with-registries push-images-to-registries push-manifests"
 )
 
 func NewManager(opts ...Option) *CalicoManager {
@@ -75,6 +77,7 @@ func NewManager(opts ...Option) *CalicoManager {
 		helmCharts:       true,
 		helmIndex:        true,
 		e2eBinaries:      true,
+		dryRun:           false,
 		gitRef:           true,
 		githubRelease:    true,
 		imageRegistries:  defaultRegistries,
@@ -166,6 +169,7 @@ type CalicoManager struct {
 	// after a run, and the directory can be uploaded as a CI artifact.
 	logsDir string
 
+	dryRun        bool
 	gitRef        bool
 	githubRelease bool
 	awsProfile    string
@@ -230,6 +234,10 @@ type CalicoManager struct {
 	helmCharts     bool
 	helmIndex      bool
 	e2eBinaries    bool
+
+	retagImages  bool
+	fromRegistry string
+	fromTag      string
 }
 
 func releaseImages(images []string, version, registry, operatorImage, operatorVersion, operatorRegistry string) []string {
@@ -1475,13 +1483,13 @@ func (r *CalicoManager) publishContainerImages() error {
 	}
 	refs, err := outputs.NewRefsWriter(r.outputDir, "images-publish", r.calicoVersion)
 	if err != nil {
-		return err
+		return fmt.Errorf("image publish refs writer: %w", err)
 	}
 	// An earlier run of this version records what it published, so a resume
 	// skips the units already done.
 	published, err := outputs.ReadRefs(r.outputDir, "images-publish", r.calicoVersion)
 	if err != nil {
-		return err
+		return fmt.Errorf("read published image refs: %w", err)
 	}
 	opts := []images.PublishOption{
 		images.WithRunner(r.runner),
@@ -1496,18 +1504,17 @@ func (r *CalicoManager) publishContainerImages() error {
 	if len(published) > 0 {
 		opts = append(opts, images.WithResume(published, false))
 	}
+	if r.retagImages {
+		opts = append(opts, images.WithRetag(r.fromRegistry, r.fromTag, !r.gitRef))
+	}
 	if err := images.Publish(
 		r.repoRoot, r.calicoVersion,
 		images.NarrowVariants(images.PublishVariants, r.imageReleaseDirs),
-		true, r.digestResolver(), opts...,
+		!r.dryRun, r.digestResolver(), opts...,
 	); err != nil {
 		return fmt.Errorf("publish images: %w", err)
 	}
-
-	if r.isHashRelease {
-		return r.publishBranchTag()
-	}
-	return nil
+	return r.publishBranchTag()
 }
 
 // digestResolver reports a published tag's digest, defaulting to the registry.
@@ -1525,42 +1532,58 @@ func (r *CalicoManager) scanRequest() *images.ScanRequest {
 	if !r.imageScanning {
 		return nil
 	}
+	ver := version.Version(r.calicoVersion)
 	return &images.ScanRequest{
 		Config:      r.imageScanningConfig,
 		ProductCode: r.productCode,
 		Images:      slices.Collect(maps.Values(r.componentImages())),
-		Stream:      r.hashrelease.Stream,
+		Stream:      ver.PrimaryStream(),
 		Release:     !r.isHashRelease,
 		OutputDir:   r.tmpDir,
 	}
+}
+
+var releaseBranch = func(r *CalicoManager) (string, error) {
+	if r.releaseBranchPrefix == "" {
+		return "", fmt.Errorf("release branch prefix is not set")
+	}
+	ver := version.Version(r.calicoVersion)
+	return fmt.Sprintf("%s-%s", r.releaseBranchPrefix, ver.Stream()), nil
 }
 
 // publishBranchTag moves the branch-named tag (e.g. release-v3.33) onto the
 // images just published, so the branch always has a pullable tag between
 // official releases.
 func (r *CalicoManager) publishBranchTag() error {
-	if r.releaseBranchPrefix == "" {
-		return fmt.Errorf("release branch prefix is not set, cannot derive the branch tag")
+	branch, err := releaseBranch(r)
+	if err != nil {
+		return fmt.Errorf("release branch: %w", err)
 	}
-	ver := version.Version(r.calicoVersion)
-	tag := fmt.Sprintf("%s-%s", r.releaseBranchPrefix, ver.Stream())
-
+	if branch == "" {
+		return nil
+	}
+	registry, err := r.getRegistryFromManifests()
+	if err != nil {
+		return fmt.Errorf("get registry from manifests: %w", err)
+	}
 	// The arch images must carry the branch tag before the manifest can list
 	// them as its children.
 	if err := images.Publish(
-		r.repoRoot, tag,
+		r.repoRoot, branch,
 		images.NarrowVariants([]images.Variant{{
 			Name:        images.StandardVariant,
-			Target:      "retag-build-images-with-registries push-images-to-registries push-manifests",
+			Target:      branchTagTarget,
 			ReleaseDirs: images.VariantDirs(images.PublishVariants),
 		}}, r.imageReleaseDirs),
-		true, r.digestResolver(),
+		!r.dryRun, r.digestResolver(),
 		images.WithRunner(r.runner),
-		images.WithRegistries(r.imageRegistries...),
+		images.WithRegistries(registry),
 		images.WithArches(r.architectures...),
 		images.WithLogsDir(r.logsDir),
+		images.WithStepName("images-publish-branch"),
+		images.WithRetag(r.imageRegistries[0], r.calicoVersion, true),
 	); err != nil {
-		return fmt.Errorf("publish branch %s tag images: %w", tag, err)
+		return fmt.Errorf("publish branch %s tag images: %w", branch, err)
 	}
 	return nil
 }

--- a/release/pkg/manager/calico/manager_test.go
+++ b/release/pkg/manager/calico/manager_test.go
@@ -616,14 +616,17 @@ func imageManager(t *testing.T, f *fakeRunner, logsDir string) *CalicoManager {
 		base := path.Base(dir)
 		f.on(fmt.Sprintf("make -C /repo/%s -s build-images", dir), base+" "+base+"-windows", nil)
 	}
+	// The branch tag is published into the registry the manifests name.
+	f.on(`grep -Po image:\K(.*) calicoctl.yaml`, "quay.io/calico/ctl:v3.30.0", nil)
 	return &CalicoManager{
-		runner:          f,
-		repoRoot:        "/repo",
-		calicoVersion:   "v3.30.0",
-		imageRegistries: []string{"quay.io/tigera"},
-		images:          true,
-		logsDir:         logsDir,
-		outputDir:       t.TempDir(),
+		runner:              f,
+		repoRoot:            "/repo",
+		calicoVersion:       "v3.30.0",
+		imageRegistries:     []string{"quay.io/tigera"},
+		images:              true,
+		logsDir:             logsDir,
+		outputDir:           t.TempDir(),
+		releaseBranchPrefix: "release",
 		resolveDigest: func(string) (string, bool, error) {
 			return "sha256:aaa", true, nil
 		},
@@ -662,6 +665,8 @@ func TestImageStepsWriteLogFiles(t *testing.T) {
 			"/logs/images-build/node.log",
 		}},
 		{"publish", (*CalicoManager).publishContainerImages, []string{
+			// The branch tag is a second publish, so it logs under its own step.
+			"/logs/images-publish-branch/node.log",
 			"/logs/images-publish/node-windows.log",
 			"/logs/images-publish/node.log",
 		}},
@@ -712,12 +717,13 @@ func TestPublishContainerImagesBranchTag(t *testing.T) {
 			wantTag:       "release-v3.33-1",
 		},
 		{
-			name:          "official release does not move the branch tag",
+			name:          "an official release moves it too",
 			version:       "v3.33.0",
 			images:        true,
 			isHashRelease: false,
 			wantPublish:   true,
-			wantBranchTag: false,
+			wantBranchTag: true,
+			wantTag:       "release-v3.33",
 		},
 		{
 			// An unset prefix would silently tag images "-v3.33".
@@ -767,11 +773,11 @@ func TestPublishContainerImagesBranchTag(t *testing.T) {
 			if got := f.ran("make -C /repo/cmd/calico release-publish"); got != tt.wantPublish {
 				t.Errorf("release-publish ran = %v, want %v (calls: %v)", got, tt.wantPublish, f.calls)
 			}
-			if got := f.ran("make -C /repo/cmd/calico retag-build-images-with-registries"); got != tt.wantBranchTag {
+			if got := f.ran("make -C /repo/cmd/calico " + branchTagTarget); got != tt.wantBranchTag {
 				t.Errorf("branch tag publish ran = %v, want %v (calls: %v)", got, tt.wantBranchTag, f.calls)
 			}
 			if tt.wantBranchTag {
-				if got := f.envFor("make -C /repo/cmd/calico retag-build-images-with-registries"); !slices.Contains(got, "IMAGETAG="+tt.wantTag) {
+				if got := f.envFor("make -C /repo/cmd/calico " + branchTagTarget); !slices.Contains(got, "IMAGETAG="+tt.wantTag) {
 					t.Errorf("branch tag env = %v, want IMAGETAG=%s", got, tt.wantTag)
 				}
 			}

--- a/release/pkg/manager/calico/options.go
+++ b/release/pkg/manager/calico/options.go
@@ -15,6 +15,7 @@
 package calico
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/projectcalico/calico/release/internal/branch"
@@ -325,5 +326,24 @@ func WithImageReleaseDirs(dirs []string) Option {
 	return func(r *CalicoManager) error {
 		r.imageReleaseDirs = dirs
 		return nil
+	}
+}
+
+func WithRetagImages(fromRegistry, fromTag string) Option {
+	return func(r *CalicoManager) error {
+		var err error
+		if fromRegistry == "" {
+			err = errors.Join(err, fmt.Errorf("fromRegistry cannot be blank"))
+		}
+		if fromTag == "" {
+			err = errors.Join(err, fmt.Errorf("fromTag cannot be blank"))
+		}
+		if err != nil {
+			return err
+		}
+		r.retagImages = true
+		r.fromRegistry = fromRegistry
+		r.fromTag = fromTag
+		return err
 	}
 }


### PR DESCRIPTION
The branch tag was published by its own copy of the image fan-out, so it missed the digest record, resume and per-component logs the shared step already had, and it wrote its logs over the release publish's own. It now goes through `images.Publish` under its own step name, and moves on every publish rather than only on a hashrelease. A failed digest lookup during a resume now publishes instead of aborting the run, since a lookup that fails says nothing about what is published and the component's own registry check will skip an image that is already there.

Also adds `--hashrelease` to the image commands so a standalone publish can take the git version, and `WithRetagImages` so a release can publish by retagging images that are already pushed.

<!-- For any user-visible change, replace TBD with a one-line description. -->
**Release note:**
```release-note
TBD
```

<!-- Replace TBD: say what AI tools helped write this change, or "None". -->
**AI assistance:** Claude Code — implementation and testing.
