### PR TITLE
Move the nftables flow-offload rule into its own chain

### DIFF
--- a/felix/design/dataplane.md
+++ b/felix/design/dataplane.md
@@ -458,9 +458,10 @@ the flowtable entry.
 
 Two invariants follow:
 
-- **The offload rule sits ahead of the dispatch jumps.** It matches
-  `RELATED,ESTABLISHED` only, so `NEW` and `INVALID` packets still
-  traverse policy. Per-endpoint chains accept established traffic
+- **The offload rule sits ahead of the dispatch jumps.** FORWARD
+  jumps to `cali-flow-offload` on `RELATED,ESTABLISHED` only, so `NEW`
+  and `INVALID` packets still traverse policy and pay for neither the
+  jump nor the chain. Per-endpoint chains accept established traffic
   before any NFLOG rule, so policy attribution in flow logs is
   unaffected; connection byte counts come from `nf_conntrack_acct`
   rather than from Felix.
@@ -470,8 +471,8 @@ Two invariants follow:
   the `no-flow-offload` IP set, holding the IPs of endpoints with DSCP
   marking (rendered into mangle POSTROUTING) or a connection or packet
   rate limit (rendered into the endpoint's filter chain), and the
-  offload rule matches neither source nor destination in that set.
-  Bandwidth QoS is
+  offload rule in `cali-flow-offload` matches neither source nor
+  destination in that set. Bandwidth QoS is
   enforced by tc on the veth, which the fast path still traverses, so
   it does not disqualify an endpoint.
 
@@ -547,7 +548,8 @@ nothing about the next.
 - A PR that renders a new rule into filter FORWARD or mangle
   POSTROUTING for a subset of endpoints has to decide whether those
   endpoints can still be offloaded. If the rule has to run, add them to
-  the `no-flow-offload` set and cover it in `fv/flowtable_test.go`.
+  the `no-flow-offload` set, or return from `cali-flow-offload` for the
+  traffic it matches, and cover it in `fv/flowtable_test.go`.
 - A PR adding `*tables` rule semantics must first decide the
   iptables/nftables story explicitly (both? nft-only? — see above),
   and should carry FV coverage in the relevant mode(s)

--- a/felix/rules/rule_defs.go
+++ b/felix/rules/rule_defs.go
@@ -55,6 +55,10 @@ const (
 
 	ChainConnStateLog = ChainNamePrefix + "log-conn"
 
+	// ChainFlowOffload holds the nftables flow-offload rule and the exclusions
+	// that keep ineligible endpoints off the fast path.
+	ChainFlowOffload = ChainNamePrefix + "flow-offload"
+
 	ChainNATPrerouting  = ChainNamePrefix + "PREROUTING"
 	ChainNATPostrouting = ChainNamePrefix + "POSTROUTING"
 	ChainNATOutput      = ChainNamePrefix + "OUTPUT"
@@ -252,6 +256,9 @@ var (
 
 type RuleRenderer interface {
 	StaticFilterTableChains(ipVersion uint8) []*generictables.Chain
+	// FlowOffloadChain renders the flow-offload chain. Only meaningful under
+	// nftables flowtable offload; the caller checks that.
+	FlowOffloadChain(ipVersion uint8) *generictables.Chain
 	StaticNATTableChains(ipVersion uint8) []*generictables.Chain
 	StaticNATPostroutingChains(ipVersion uint8) []*generictables.Chain
 	StaticRawTableChains(ipVersion uint8) []*generictables.Chain

--- a/felix/rules/static.go
+++ b/felix/rules/static.go
@@ -34,6 +34,9 @@ func (r *DefaultRuleRenderer) StaticFilterTableChains(ipVersion uint8) (chains [
 	if r.LogConnectionTransitions {
 		chains = append(chains, r.connStateLogChain(ipVersion))
 	}
+	if r.nft && r.NFTablesFlowTableOffload {
+		chains = append(chains, r.FlowOffloadChain(ipVersion))
+	}
 	return
 }
 
@@ -613,24 +616,13 @@ func (r *DefaultRuleRenderer) StaticFilterForwardChains(ipVersion uint8) []*gene
 	rules := []generictables.Rule{}
 
 	if r.nft && r.NFTablesFlowTableOffload {
-		// Offload established flows here, ahead of the dispatch jumps below. Two things pin the
-		// spot: the per-workload dispatch chains terminally accept established traffic (so a rule
-		// after them never runs), and the kernel only allows flow offload in chains reached from
-		// the forward hook, which rules out those shared per-workload chains.
-		//
-		// An offloaded flow skips the FORWARD and POSTROUTING hooks for its whole life, so
-		// endpoints that need rules in those hooks are excluded by IP.
-		noOffloadSetName := r.ipSetConfig(ipVersion).NameForMainIPSet(IPSetIDNoFlowOffload)
-		rules = append(rules,
-			generictables.Rule{
-				Match: r.NewMatch().
-					ConntrackState("RELATED,ESTABLISHED").
-					NotSourceIPSet(noOffloadSetName).
-					NotDestIPSet(noOffloadSetName),
-				Action:  r.FlowOffload(),
-				Comment: []string{"Offload established Calico flows."},
-			},
-		)
+		// Offload established flows here, ahead of the dispatch jumps below: the per-workload
+		// dispatch chains terminally accept established traffic, and the kernel only allows flow
+		// offload in chains reached from the forward hook.
+		rules = append(rules, generictables.Rule{
+			Match:  r.NewMatch().ConntrackState("RELATED,ESTABLISHED"),
+			Action: r.Jump(ChainFlowOffload),
+		})
 	}
 
 	// Rules for filter forward chains dispatches the packet to our dispatch chains if it is going
@@ -692,6 +684,23 @@ func (r *DefaultRuleRenderer) StaticFilterForwardChains(ipVersion uint8) []*gene
 		Name:  ChainFilterForward,
 		Rules: rules,
 	}}
+}
+
+// FlowOffloadChain renders the chain filter FORWARD jumps to under flowtable
+// offload. An offloaded flow skips FORWARD and POSTROUTING for its whole life,
+// so endpoints needing rules there are excluded by IP.
+func (r *DefaultRuleRenderer) FlowOffloadChain(ipVersion uint8) *generictables.Chain {
+	noOffloadSetName := r.ipSetConfig(ipVersion).NameForMainIPSet(IPSetIDNoFlowOffload)
+	return &generictables.Chain{
+		Name: ChainFlowOffload,
+		Rules: []generictables.Rule{{
+			Match: r.NewMatch().
+				NotSourceIPSet(noOffloadSetName).
+				NotDestIPSet(noOffloadSetName),
+			Action:  r.FlowOffload(),
+			Comment: []string{"Offload established Calico flows."},
+		}},
+	}
 }
 
 // StaticFilterForwardAppendRules returns rules which should be statically appended to the end of the filter

--- a/felix/rules/static_test.go
+++ b/felix/rules/static_test.go
@@ -2078,7 +2078,7 @@ var _ = Describe("Static", func() {
 })
 
 var _ = Describe("Flowtable offload", func() {
-	config := Config{
+	flowtableConfig := Config{
 		IPSetConfigV4:       ipsets.NewIPVersionConfig(ipsets.IPFamilyV4, "cali", nil, nil),
 		IPSetConfigV6:       ipsets.NewIPVersionConfig(ipsets.IPFamilyV6, "cali", nil, nil),
 		MarkAccept:          0x8,
@@ -2096,50 +2096,63 @@ var _ = Describe("Flowtable offload", func() {
 
 		NFTablesFlowTableOffload: true,
 	}
-	renderer := NewRenderer(config, true).(*DefaultRuleRenderer)
+	renderer := NewRenderer(flowtableConfig, true).(*DefaultRuleRenderer)
 
 	noOffloadSetName := ipSetName(IPSetIDNoFlowOffload, 4)
 	offloadRule := generictables.Rule{
 		Match: nftrender.Match().
-			ConntrackState("RELATED,ESTABLISHED").
 			NotSourceIPSet(noOffloadSetName).
 			NotDestIPSet(noOffloadSetName),
 		Action:  nftrender.FlowOffloadAction{},
 		Comment: []string{"Offload established Calico flows."},
 	}
 
-	It("should offload established flows at the top of the forward chain, ahead of the workload dispatch jump", func() {
+	It("should jump to the flow-offload chain at the top of the forward chain, ahead of the workload dispatch jump", func() {
 		chains := renderer.StaticFilterForwardChains(4)
 		chain := findChain(chains, ChainFilterForward)
 		Expect(chain).NotTo(BeNil())
-		Expect(chain.Rules).To(ContainElement(offloadRule))
 
-		offloadIdx := indexOfRuleWithAction(chain.Rules, offloadRule.Action)
+		offloadIdx := indexOfJumpTo(chain.Rules, ChainFlowOffload)
+		Expect(offloadIdx).To(BeNumerically(">=", 0), "expected a jump to the flow-offload chain")
 		dispatchIdx := indexOfJumpTo(chain.Rules, ChainFromWorkloadDispatch)
 		Expect(dispatchIdx).To(BeNumerically(">=", 0), "expected a jump to the workload dispatch chain")
-		Expect(offloadIdx).To(BeNumerically("<", dispatchIdx), "offload rule must precede the workload dispatch jump")
+		Expect(offloadIdx).To(BeNumerically("<", dispatchIdx), "offload jump must precede the workload dispatch jump")
+		Expect(chain.Rules[offloadIdx].Match).To(Equal(nftrender.Match().ConntrackState("RELATED,ESTABLISHED")),
+			"NEW and INVALID packets must not pay for the jump")
+	})
+
+	It("should offload established flows from the flow-offload chain", func() {
+		chain := renderer.FlowOffloadChain(4)
+		Expect(chain).NotTo(BeNil())
+		Expect(chain.Name).To(Equal(ChainFlowOffload))
+		Expect(chain.Rules).To(ConsistOf(offloadRule))
+	})
+
+	It("should render the flow-offload chain as part of the static filter chains", func() {
+		Expect(findChain(renderer.StaticFilterTableChains(4), ChainFlowOffload)).NotTo(BeNil())
 	})
 
 	It("should not offload flows when flow table offload is disabled", func() {
-		disabledConfig := config
+		disabledConfig := flowtableConfig
 		disabledConfig.NFTablesFlowTableOffload = false
 		disabledRenderer := NewRenderer(disabledConfig, true).(*DefaultRuleRenderer)
 
 		chains := disabledRenderer.StaticFilterForwardChains(4)
 		chain := findChain(chains, ChainFilterForward)
 		Expect(chain).NotTo(BeNil())
-		Expect(chain.Rules).NotTo(ContainElement(offloadRule))
+		Expect(indexOfJumpTo(chain.Rules, ChainFlowOffload)).To(Equal(-1))
+		Expect(findChain(disabledRenderer.StaticFilterTableChains(4), ChainFlowOffload)).To(BeNil())
+	})
+
+	It("should not offload flows in iptables mode", func() {
+		iptablesRenderer := NewRenderer(flowtableConfig, false).(*DefaultRuleRenderer)
+
+		chain := findChain(iptablesRenderer.StaticFilterForwardChains(4), ChainFilterForward)
+		Expect(chain).NotTo(BeNil())
+		Expect(indexOfJumpTo(chain.Rules, ChainFlowOffload)).To(Equal(-1))
+		Expect(findChain(iptablesRenderer.StaticFilterTableChains(4), ChainFlowOffload)).To(BeNil())
 	})
 })
-
-func indexOfRuleWithAction(rules []generictables.Rule, action generictables.Action) int {
-	for i, r := range rules {
-		if r.Action == action {
-			return i
-		}
-	}
-	return -1
-}
 
 func indexOfJumpTo(rules []generictables.Rule, chainName string) int {
 	for i, r := range rules {


### PR DESCRIPTION
Under nftables flowtable offload, the flow-offload rule sits inline in the forward chain. This moves it into its own chain that the forward chain jumps to on established traffic, so a later change can opt specific traffic out with a return rather than by adding endpoints to the exclusion IP set. No behavior change beyond the extra jump, and the existing rendering tests cover the chain contents and the rule ordering.

**Release note:**
```release-note
None
```

**AI assistance:** Claude Code wrote the change and the test updates.
