### PR TITLE
[v3.33] Run the host-writing CNI init containers as root in the static manifests

### DIFF
--- a/charts/calico/templates/calico-node.yaml
+++ b/charts/calico/templates/calico-node.yaml
@@ -89,6 +89,7 @@ spec:
               name: cni-bin-dir
           securityContext:
             privileged: true
+            runAsUser: 0
 {{- end }}
         # This container installs the CNI binaries
         # and CNI network config file on each node.
@@ -188,6 +189,7 @@ spec:
 {{- end }}
           securityContext:
             privileged: true
+            runAsUser: 0
         # This init container mounts the necessary filesystems needed by the BPF data plane
         # i.e. bpf at /sys/fs/bpf and cgroup2 at /run/calico/cgroup. It also configures the initial
         # networking to allow communication with the API Server. Calico-node initialization is executed

--- a/charts/test/calico_chart_test.go
+++ b/charts/test/calico_chart_test.go
@@ -1,0 +1,92 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package charttest
+
+import (
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/helm"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/yaml"
+)
+
+// The calico image declares USER 10001, so an init container that writes the host CNI
+// directories has to ask for root explicitly. Without it calico-node never leaves
+// Init:CrashLoopBackOff on a manifest install.
+func TestCalicoNodeRunsHostWritingInitContainersAsRoot(t *testing.T) {
+	g := NewWithT(t)
+
+	var daemonSet appsv1.DaemonSet
+	renderCalicoResource(t, "templates/calico-node.yaml", "DaemonSet", "calico-node", &daemonSet)
+
+	for _, name := range []string{"upgrade-ipam", "install-cni"} {
+		container := containerByName(t, daemonSet.Spec.Template.Spec.InitContainers, name)
+		g.Expect(container.SecurityContext.RunAsUser).To(Equal(ptr.To[int64](0)), "%s writes to root-owned host CNI directories", name)
+	}
+}
+
+func renderCalicoResource(t *testing.T, templatePath, kind, name string, into any) {
+	t.Helper()
+	g := NewWithT(t)
+
+	if _, err := exec.LookPath("helm"); err != nil {
+		t.Skip("skipping chart render tests since 'helm' is not installed")
+	}
+
+	chartPath, err := filepath.Abs("../calico")
+	g.Expect(err).ToNot(HaveOccurred())
+
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"datastore": "kubernetes",
+			"network":   "calico",
+			"useV3CRDs": "true",
+		},
+	}
+	output, err := helm.RenderTemplateE(t, options, chartPath, "calico", []string{templatePath})
+	g.Expect(err).ToNot(HaveOccurred())
+
+	for _, doc := range strings.Split(output, "\n---") {
+		var meta metav1.PartialObjectMetadata
+		if err := yaml.Unmarshal([]byte(doc), &meta); err != nil {
+			continue
+		}
+		if meta.Kind != kind || meta.Name != name {
+			continue
+		}
+		g.Expect(yaml.Unmarshal([]byte(doc), into)).To(Succeed())
+		return
+	}
+	t.Fatalf("%s %q was not rendered from %s", kind, name, templatePath)
+}
+
+func containerByName(t *testing.T, containers []corev1.Container, name string) corev1.Container {
+	t.Helper()
+
+	for _, container := range containers {
+		if container.Name == name {
+			return container
+		}
+	}
+	t.Fatalf("container %q not found", name)
+	return corev1.Container{}
+}

--- a/manifests/calico-bpf.yaml
+++ b/manifests/calico-bpf.yaml
@@ -12603,6 +12603,7 @@ spec:
               name: cni-bin-dir
           securityContext:
             privileged: true
+            runAsUser: 0
         # This container installs the CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
@@ -12656,6 +12657,7 @@ spec:
               name: cni-net-dir
           securityContext:
             privileged: true
+            runAsUser: 0
         # This init container mounts the necessary filesystems needed by the BPF data plane
         # i.e. bpf at /sys/fs/bpf and cgroup2 at /run/calico/cgroup. It also configures the initial
         # networking to allow communication with the API Server. Calico-node initialization is executed

--- a/manifests/calico-etcd.yaml
+++ b/manifests/calico-etcd.yaml
@@ -407,6 +407,7 @@ spec:
               name: etcd-certs
           securityContext:
             privileged: true
+            runAsUser: 0
         # This init container mounts the necessary filesystems needed by the BPF data plane
         # i.e. bpf at /sys/fs/bpf and cgroup2 at /run/calico/cgroup. It also configures the initial
         # networking to allow communication with the API Server. Calico-node initialization is executed

--- a/manifests/calico-policy-only.yaml
+++ b/manifests/calico-policy-only.yaml
@@ -12572,6 +12572,7 @@ spec:
               name: cni-net-dir
           securityContext:
             privileged: true
+            runAsUser: 0
         # This init container mounts the necessary filesystems needed by the BPF data plane
         # i.e. bpf at /sys/fs/bpf and cgroup2 at /run/calico/cgroup. It also configures the initial
         # networking to allow communication with the API Server. Calico-node initialization is executed

--- a/manifests/calico-typha.yaml
+++ b/manifests/calico-typha.yaml
@@ -12623,6 +12623,7 @@ spec:
               name: cni-bin-dir
           securityContext:
             privileged: true
+            runAsUser: 0
         # This container installs the CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
@@ -12665,6 +12666,7 @@ spec:
               name: cni-net-dir
           securityContext:
             privileged: true
+            runAsUser: 0
         # This init container mounts the necessary filesystems needed by the BPF data plane
         # i.e. bpf at /sys/fs/bpf and cgroup2 at /run/calico/cgroup. It also configures the initial
         # networking to allow communication with the API Server. Calico-node initialization is executed

--- a/manifests/calico-v3-crds.yaml
+++ b/manifests/calico-v3-crds.yaml
@@ -12992,6 +12992,7 @@ spec:
               name: cni-bin-dir
           securityContext:
             privileged: true
+            runAsUser: 0
         # This container installs the CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
@@ -13034,6 +13035,7 @@ spec:
               name: cni-net-dir
           securityContext:
             privileged: true
+            runAsUser: 0
         # This init container mounts the necessary filesystems needed by the BPF data plane
         # i.e. bpf at /sys/fs/bpf and cgroup2 at /run/calico/cgroup. It also configures the initial
         # networking to allow communication with the API Server. Calico-node initialization is executed

--- a/manifests/calico-vxlan.yaml
+++ b/manifests/calico-vxlan.yaml
@@ -12587,6 +12587,7 @@ spec:
               name: cni-bin-dir
           securityContext:
             privileged: true
+            runAsUser: 0
         # This container installs the CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
@@ -12629,6 +12630,7 @@ spec:
               name: cni-net-dir
           securityContext:
             privileged: true
+            runAsUser: 0
         # This init container mounts the necessary filesystems needed by the BPF data plane
         # i.e. bpf at /sys/fs/bpf and cgroup2 at /run/calico/cgroup. It also configures the initial
         # networking to allow communication with the API Server. Calico-node initialization is executed

--- a/manifests/calico.yaml
+++ b/manifests/calico.yaml
@@ -12587,6 +12587,7 @@ spec:
               name: cni-bin-dir
           securityContext:
             privileged: true
+            runAsUser: 0
         # This container installs the CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
@@ -12629,6 +12630,7 @@ spec:
               name: cni-net-dir
           securityContext:
             privileged: true
+            runAsUser: 0
         # This init container mounts the necessary filesystems needed by the BPF data plane
         # i.e. bpf at /sys/fs/bpf and cgroup2 at /run/calico/cgroup. It also configures the initial
         # networking to allow communication with the API Server. Calico-node initialization is executed

--- a/manifests/canal-etcd.yaml
+++ b/manifests/canal-etcd.yaml
@@ -515,6 +515,7 @@ spec:
               name: etcd-certs
           securityContext:
             privileged: true
+            runAsUser: 0
         # This init container mounts the necessary filesystems needed by the BPF data plane
         # i.e. bpf at /sys/fs/bpf and cgroup2 at /run/calico/cgroup. It also configures the initial
         # networking to allow communication with the API Server. Calico-node initialization is executed

--- a/manifests/canal.yaml
+++ b/manifests/canal.yaml
@@ -12607,6 +12607,7 @@ spec:
               name: cni-net-dir
           securityContext:
             privileged: true
+            runAsUser: 0
         # This init container mounts the necessary filesystems needed by the BPF data plane
         # i.e. bpf at /sys/fs/bpf and cgroup2 at /run/calico/cgroup. It also configures the initial
         # networking to allow communication with the API Server. Calico-node initialization is executed

--- a/manifests/flannel-migration/calico.yaml
+++ b/manifests/flannel-migration/calico.yaml
@@ -12589,6 +12589,7 @@ spec:
               name: cni-bin-dir
           securityContext:
             privileged: true
+            runAsUser: 0
         # This container installs the CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
@@ -12631,6 +12632,7 @@ spec:
               name: cni-net-dir
           securityContext:
             privileged: true
+            runAsUser: 0
         # This init container mounts the necessary filesystems needed by the BPF data plane
         # i.e. bpf at /sys/fs/bpf and cgroup2 at /run/calico/cgroup. It also configures the initial
         # networking to allow communication with the API Server. Calico-node initialization is executed


### PR DESCRIPTION
**Cherry-pick history**
- Pick onto **release-v3.33**: projectcalico/calico#13665

**Partial pick.** Only the `charts/calico/templates/calico-node.yaml` hunk is taken from #13665, byte-identical to master (commit `03492bc2bb`), plus the regenerated manifests and the chart test that guards it. The rest of #13665 is tiered-RBAC e2e coverage that does not belong on a release branch — a full `git cherry-pick -m 1 03492bc2bb` onto `release-v3.33` conflicts in 66 files, all `e2e/testsets` scaffolding.

## Problem

A manifest install from the shipped v3.33 manifests never comes up. `calico-node` sits in `Init:Error` indefinitely and the cluster gets no CNI:

```
install-cni: FATAL found no writeable directory
```

The unified `calico` image declares `USER 10001:10001` (`docker/calico/Dockerfile`), and the chart asks for no `runAsUser`, so `upgrade-ipam` and `install-cni` run as 10001 and cannot write the root-owned `/host/opt/cni/bin` and `/host/etc/cni/net.d` mounts. `install.go` exits FATAL and the init container never recovers.

v3.32 was unaffected because `install-cni` came from the separate `calico/cni` image, which ran as root. The image consolidation moved the UID out from under the chart; the chart itself did not change. `manifests/calico.yaml` is the documented non-operator install path, and as shipped it does not work at all.

## Change

Ask for `runAsUser: 0` on those two init containers and regenerate the static manifests. `calico-node` and `ebpf-bootstrap` are left at the image default, matching master.

Every static manifest is affected, not just `calico.yaml` — eleven regenerate, the variants without `upgrade-ipam` picking up one line instead of two. The manifest diff is 16 lines, all `runAsUser: 0`, with no incidental churn.

## Result

The manifest install comes up. Verified on a fresh AWS kubeadm cluster against hashrelease `2026-09-04-v3-33-flyover` (`v3.33.0-0.dev-1512-gf59bd1a62d6a`) with nothing preinstalled: patched, the cluster was up in 46 s and then passed all four `programClusterRoutes` values plus the default.

## Test

`charts/test/calico_chart_test.go` renders the chart and asserts `runAsUser: 0` on both init containers. It is master's file minus the two webhook tests, which do not apply here — v3.33's webhooks chart still invokes `component webhook` rather than master's `component webhooks webhook`. Mutation-tested: with the chart hunk reverted the test fails on `upgrade-ipam`. `yaml-lint`, `gofmt` and `go vet` clean.

## Why this was not already on the branch

The fix landed on master inside #13665, an unrelated tiered-RBAC e2e PR, as an incidental change with no ticket and no `cherry-pick-candidate` label — so nothing flagged it for backport.

Found during the v3.33 test cycle, Zephyr OS-R232 / RT-14.

Related: [CORE-13616](https://tigera.atlassian.net/browse/CORE-13616)

```release-note
Fix the static manifests failing to install on a fresh cluster, where install-cni exited with "found no writeable directory" because it ran as a non-root user.
```


[CORE-13616]: https://tigera.atlassian.net/browse/CORE-13616?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ