### PR TITLE
Fix the release build broken by the branch tag merge

### DIFF
--- a/release/pkg/manager/calico/manager.go
+++ b/release/pkg/manager/calico/manager.go
@@ -1588,19 +1588,21 @@ func (r *CalicoManager) publishBranchTag() error {
 
 	// The operator publishes to its own registries, so it takes a pass of its own.
 	if err := images.Publish(
-		r.repoRoot, tag,
+		r.repoRoot, branch,
 		[]images.Variant{{
 			Name:        images.StandardVariant,
-			Target:      "retag-build-images-with-registries push-images-to-registries push-manifests",
+			Target:      branchTagTarget,
 			ReleaseDirs: []string{utils.OperatorDir},
 		}},
-		true, r.digestResolver(),
+		!r.dryRun, r.digestResolver(),
 		images.WithRunner(r.runner),
 		images.WithRegistries(operator.DefaultRegistries...),
 		images.WithArches(r.architectures...),
 		images.WithLogsDir(r.logsDir),
+		images.WithStepName("images-publish-branch-operator"),
+		images.WithRetag(operator.DefaultRegistries[0], r.calicoVersion, true),
 	); err != nil {
-		return fmt.Errorf("publish branch %s tag operator image: %w", tag, err)
+		return fmt.Errorf("publish branch %s tag operator image: %w", branch, err)
 	}
 	return nil
 }


### PR DESCRIPTION
Master does not compile. `publishBranchTag` was rewritten while #13757 was open, renaming `tag` to `branch` and adding dry-run and retag handling. The operator branch tag publish from that PR merged cleanly as text but referenced the old variable, so `make -C release bin/release` fails:

```
pkg/manager/calico/manager.go:1591:15: undefined: tag
pkg/manager/calico/manager.go:1603:65: undefined: tag
```

That breaks the hashrelease job on master.

The operator pass now takes the same `branch`, `branchTagTarget`, `!r.dryRun` and retag handling the component pass uses, with its own registries and step name.

Verified `make -C release bin/release` produces the binary and the branch tag tests pass.

```release-note
None
```

**AI assistance:** Claude Code wrote this fix, and wrote the change that broke it.
