### PR TITLE
Wait longer for kube-controllers to publish its running config

### DIFF
--- a/e2e/pkg/tests/hostendpoints/auto_hostendpoints.go
+++ b/e2e/pkg/tests/hostendpoints/auto_hostendpoints.go
@@ -337,7 +337,7 @@ func updateHostEndpointConfig(client ctrlclient.Client, desiredKCC v3.KubeContro
 			return fmt.Errorf("failed to toggle auto-creation of host endpoints")
 		}
 		return nil
-	}, 5*time.Second, 1*time.Second).Should(BeNil())
+	}, 2*time.Minute, 2*time.Second).Should(BeNil())
 }
 
 // getHostEndpointConfig returns the HostEndpoint config from a KCC, or nil if


### PR DESCRIPTION
The auto host endpoint tests toggle the host endpoint config on the default KubeControllersConfiguration and then wait five seconds for the running config in its status to catch up. That wait spans a kube-controllers restart, which takes longer than five seconds on a real cluster, so the suite fails during setup with "failed to toggle auto-creation of host endpoints". Two minutes instead.

Seen on a GCP kubeadm e2e lane.

```release-note
None
```
