### PR TITLE
Don't treat a borrowed workload IP as remote in the route manager

### DIFF
--- a/felix/dataplane/linux/ipip_mgr_test.go
+++ b/felix/dataplane/linux/ipip_mgr_test.go
@@ -350,6 +350,37 @@ var _ = Describe("IPIPManager", func() {
 		Expect(rt.currentRoutes[dataplanedefs.IPIPIfaceName]).To(HaveLen(0))
 	})
 
+	It("should program no tunnel route for a local workload that borrowed a remote block's IP", func() {
+		By("Sending host updates")
+		ipipMgr.OnUpdate(&proto.HostMetadataUpdate{
+			Hostname: "node1",
+			Ipv4Addr: "172.0.0.2",
+		})
+		ipipMgr.OnUpdate(&proto.HostMetadataUpdate{
+			Hostname: "node2",
+			Ipv4Addr: "172.0.2.2",
+		})
+
+		By("Sending a local workload holding an IP borrowed from node2's block")
+		// The calc graph flags a borrowed IP both ways and sets LocalWorkload.
+		ipipMgr.OnUpdate(&proto.RouteUpdate{
+			Types:         proto.RouteType_REMOTE_WORKLOAD | proto.RouteType_LOCAL_WORKLOAD,
+			IpPoolType:    proto.IPPoolType_IPIP,
+			Dst:           "10.0.1.1/32",
+			DstNodeName:   "node1",
+			DstNodeIp:     "172.0.0.2",
+			LocalWorkload: true,
+			Borrowed:      true,
+		})
+
+		err := ipipMgr.CompleteDeferredWork()
+		Expect(err).NotTo(HaveOccurred())
+
+		// Treating it as remote yields an onlink route via our own address, which
+		// the kernel rejects forever.
+		Expect(rt.currentRoutes[dataplanedefs.IPIPIfaceName]).To(BeEmpty())
+	})
+
 	It("should only program black hole routes for local endpoints", func() {
 		ipipMgr.OnUpdate(&proto.HostMetadataUpdate{
 			Hostname: "node1",

--- a/felix/dataplane/linux/route_mgr.go
+++ b/felix/dataplane/linux/route_mgr.go
@@ -185,7 +185,7 @@ func (m *routeManager) OnUpdate(protoBufMsg any) {
 		m.deleteRoute(msg.Dst)
 
 		// Process remote IPAM blocks.
-		if isType(msg, proto.RouteType_REMOTE_WORKLOAD) && msg.IpPoolType == m.ippoolType {
+		if isRemoteWorkload(msg) && msg.IpPoolType == m.ippoolType {
 			m.logCtx.WithField("msg", msg).Debug("Route manager received route update")
 			m.routesByDest[msg.Dst] = msg
 			m.routesDirty = true
@@ -261,6 +261,12 @@ func (m *routeManager) vxlanEnabled() bool {
 
 func isType(msg *proto.RouteUpdate, t proto.RouteType) bool {
 	return msg.Types&t == t
+}
+
+// A borrowed IP is flagged both local and remote; LocalWorkload is the calc
+// graph's tie-break and wins.
+func isRemoteWorkload(msg *proto.RouteUpdate) bool {
+	return isType(msg, proto.RouteType_REMOTE_WORKLOAD) && !msg.LocalWorkload
 }
 
 func (m *routeManager) routeIsLocalBlock(msg *proto.RouteUpdate) bool {

--- a/felix/proto/felixbackend.pb.go
+++ b/felix/proto/felixbackend.pb.go
@@ -5015,9 +5015,11 @@ type RouteUpdate struct {
 	// The name of the node holding this destination, if this route targets a calico node.
 	DstNodeName string `protobuf:"bytes,4,opt,name=dst_node_name,json=dstNodeName,proto3" json:"dst_node_name,omitempty"`
 	// IP of the node holding this destination.
-	DstNodeIp     string      `protobuf:"bytes,5,opt,name=dst_node_ip,json=dstNodeIp,proto3" json:"dst_node_ip,omitempty"`
-	SameSubnet    bool        `protobuf:"varint,7,opt,name=same_subnet,json=sameSubnet,proto3" json:"same_subnet,omitempty"`
-	NatOutgoing   bool        `protobuf:"varint,8,opt,name=nat_outgoing,json=natOutgoing,proto3" json:"nat_outgoing,omitempty"`
+	DstNodeIp   string `protobuf:"bytes,5,opt,name=dst_node_ip,json=dstNodeIp,proto3" json:"dst_node_ip,omitempty"`
+	SameSubnet  bool   `protobuf:"varint,7,opt,name=same_subnet,json=sameSubnet,proto3" json:"same_subnet,omitempty"`
+	NatOutgoing bool   `protobuf:"varint,8,opt,name=nat_outgoing,json=natOutgoing,proto3" json:"nat_outgoing,omitempty"`
+	// Set when a live local WEP holds this IP. Decides locality when types has
+	// both LOCAL_WORKLOAD and REMOTE_WORKLOAD, as a borrowed IP does.
 	LocalWorkload bool        `protobuf:"varint,9,opt,name=local_workload,json=localWorkload,proto3" json:"local_workload,omitempty"`
 	TunnelType    *TunnelType `protobuf:"bytes,10,opt,name=tunnel_type,json=tunnelType,proto3" json:"tunnel_type,omitempty"`
 	Borrowed      bool        `protobuf:"varint,11,opt,name=borrowed,proto3" json:"borrowed,omitempty"`

--- a/felix/proto/felixbackend.proto
+++ b/felix/proto/felixbackend.proto
@@ -640,6 +640,8 @@ message RouteUpdate {
   string dst_node_ip = 5;
   bool same_subnet = 7;
   bool nat_outgoing = 8;
+  // Set when a live local WEP holds this IP. Decides locality when types has
+  // both LOCAL_WORKLOAD and REMOTE_WORKLOAD, as a borrowed IP does.
   bool local_workload = 9;
   TunnelType tunnel_type = 10;
   bool borrowed = 11;


### PR DESCRIPTION
## Problem

A pod whose IP is borrowed from another node's IPAM block makes Felix on the hosting node install an onlink route via the node's **own** address on `tunl0`. The kernel rejects it with EINVAL and Felix retries forever — measured 7554 occurrences in ~7 minutes, 3416 log lines/60s on the affected node against 1-2 on every other node.

```
[WARNING] felix/route_table.go 1614: Encountered some errors when trying to update routes. Will retry.
  errors="192.168.249.100/32(tos=0 metric=0): kernelRoute{Type=1, Scope=0, Src=<nil>, Protocol=80,
  OnLink=true, GW=172.16.102.15, Ifindex=4, mtu 8981}(tunl0): invalid argument" table="IPv4:254"
```

`172.16.102.15` is the node's own address.

Pod connectivity is unaffected — the correct `cali*` route is programmed and traffic flows. The cost is a permanent netlink retry loop, a flooded log, and `Failed to synchronize routing table` asserted on every pass, which will mask real route-programming failures on that node.

## Cause

`l3_route_resolver.go` flags a borrowed IP as **both** `LOCAL_WORKLOAD` and `REMOTE_WORKLOAD` — the block belongs to the other node, the live WEP is here — and sets `LocalWorkload` specifically to break the tie. Its own comment says so: *"Flag that there's a live WEP on this IP; this avoids confusion in the dataplane if we have borrowed IPs (which get flagged as both local and remote!)."*

`route_mgr.go` tested only the type bitmask (`msg.Types & t == t`), so the remote branch matched a local workload. `route_mgr.go` then hands the route to `tunnelRoute()`, which looks up the destination node's IP — this node — and builds an onlink target with `GW` set to self.

The BPF route manager already gets this right, checking `GetLocalWorkload()` ahead of the `REMOTE_WORKLOAD` branch. This change makes the iptables route manager agree.

## Change

Add `isRemoteWorkload()`, which honours `LocalWorkload`, and use it for the remote-IPAM-block branch.

## Not a v3.33 regression in the code, but a v3.33 exposure

The same test is present on release-v3.32. `ipipManager.OnUpdate` forwards to the route manager only `if m.dpConfig.ProgramIPIPClusterRoutes`, which is false under v3.32's default and true under v3.33's — so v3.33 turns the path on. Confirmed on a live cluster: flipping the same cluster with the same pod to BIRD mode took it from 3416 lines/60s to 1.

## Test

`ipip_mgr_test.go` gains a spec sending a local workload with a borrowed IP (both type bits, `LocalWorkload: true`) and asserting no route on the tunnel device. Mutation-tested — reverting the one-line change fails exactly that spec, while the pre-existing *remote* borrowed-IP spec still passes. Full `felix ut` green (64 suites), `golangci-lint` 0 issues.

## Left alone deliberately

Two other sites ask the same question and are **not** covered by the repro, so I have not touched them:

- `route_mgr.go` `isRemoteTunnelRoute()` — `REMOTE_TUNNEL && REMOTE_WORKLOAD`, reachable only if a local WEP shares an IP with a remote node's tunnel.
- `dataplane/windows/vxlan_mgr.go:73` — same bitmask test, same latent defect on Windows.

Happy to fold either in if a reviewer prefers.

Found during the v3.33 test cycle, Zephyr OS-R232 / RT-1, on cluster `tomas-routes-a`. Reachable by any user of `cni.projectcalico.org/ipAddrs`, and naturally whenever IPAM borrows on a busy node.

Related: [CORE-13566](https://tigera.atlassian.net/browse/CORE-13566)

**Release note:**
```release-note
Fix Felix retrying an invalid tunnel route forever for a local pod whose IP was borrowed from another node's IPAM block.
```

**AI assistance:** Claude Code — investigation, patch and test authored with it; reviewed and verified by me.


[CORE-13566]: https://tigera.atlassian.net/browse/CORE-13566?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ