### PR TITLE
Resolve the operator namespace on first use rather than at startup

### DIFF
--- a/operator/pkg/common/operator_namespace.go
+++ b/operator/pkg/common/operator_namespace.go
@@ -16,39 +16,41 @@ package common
 
 import (
 	"os"
+	"sync"
 
 	"github.com/cloudflare/cfssl/log"
 	"k8s.io/apimachinery/pkg/types"
 )
 
-var namespace = ""
+var (
+	namespace = ""
 
-func init() {
-	v, ok := os.LookupEnv("OPERATOR_NAMESPACE")
-	if ok {
-		namespace = v
-		return
-	}
-	body, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
-	if err != nil {
-		log.Errorf("Failed to read namespace file: %v", err)
-	} else {
-		namespace = string(body)
-		return
-	}
+	// namespaceOnce ensures that namespace is initialized only once.
+	namespaceOnce sync.Once
+)
 
-	namespace = "tigera-operator"
+// OperatorNamespace returns the namespace the operator is running in: OPERATOR_NAMESPACE if
+// set, else the service account's namespace file, else the default "tigera-operator".
+// Resolved on the first call.
+func OperatorNamespace() string {
+	namespaceOnce.Do(func() {
+		namespace = getNamespace()
+	})
+	return namespace
 }
 
-// OperatorNamespace returns the namespace the operator is running in.
-// The value returned is based on the following priority (these are evaluated at startup):
-//
-//	If the OPERATOR_NAMESPACE environment variable is non-empty then that is return.
-//	If the file /var/run/secrets/kubernetes.io/serviceaccount/namespace is non-empty
-//	then the contents is returned.
-//	The default "tigera-operator" is returned.
-func OperatorNamespace() string {
-	return namespace
+func getNamespace() string {
+	if v, ok := os.LookupEnv("OPERATOR_NAMESPACE"); ok {
+		return v
+	}
+
+	body, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
+	if err != nil {
+		// Absent outside a cluster, where the default is the right answer anyway.
+		log.Infof("Failed to read namespace file, using default: %v", err)
+		return "tigera-operator"
+	}
+	return string(body)
 }
 
 // OperatorName returns the name of the operator deployment.

--- a/operator/pkg/common/operator_namespace_test.go
+++ b/operator/pkg/common/operator_namespace_test.go
@@ -1,0 +1,32 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"os"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+)
+
+var _ = ginkgo.Describe("Operator namespace tests", func() {
+	ginkgo.It("should read the namespace from the environment variable once", func() {
+		gomega.Expect(os.Setenv("OPERATOR_NAMESPACE", "tigera-operator-env-var")).NotTo(gomega.HaveOccurred())
+		gomega.Expect(OperatorNamespace()).To(gomega.Equal("tigera-operator-env-var"))
+		gomega.Expect(os.Setenv("OPERATOR_NAMESPACE", "other-value")).NotTo(gomega.HaveOccurred())
+		gomega.Expect(OperatorNamespace()).To(gomega.Equal("tigera-operator-env-var"))
+		gomega.Expect(os.Unsetenv("OPERATOR_NAMESPACE")).NotTo(gomega.HaveOccurred())
+	})
+})


### PR DESCRIPTION
Running the operator binary with `--print-images`, `--version` or `--print-calico-crds` logs an error about a missing service account namespace file before it prints anything, because the namespace is resolved when the package loads rather than when something asks for it. This resolves it on first use instead, and drops the missing-file log to info, since off-cluster the fallback default is the right answer.

**Release note:**
```release-note
None
```

**AI assistance:** Claude Code (Opus 5) wrote the change and the test.

By opening this PR you take responsibility for every line in it, and you agree to explain the change yourself during review rather than routing review comments back through an agent. See [AI_POLICY.md](../AI_POLICY.md).
