### PR TITLE
Sync operator CRDs from tigera/operator

### DIFF
--- a/charts/tigera-operator/crds/operator.tigera.io_installations.yaml
+++ b/charts/tigera-operator/crds/operator.tigera.io_installations.yaml
@@ -2712,9 +2712,9 @@ spec:
                                       x-kubernetes-list-type: atomic
                                   type: object
                                 dnsPolicy:
-                                  description:
-                                    DNSPolicy is the DNS policy for the calico-node
-                                    pods.
+                                  description: |-
+                                    DNSPolicy is the DNS policy for the calico-node pods. Defaults to Default, which uses the node's
+                                    own resolver, since calico-node runs before cluster DNS is reachable.
                                   enum:
                                     - ""
                                     - Default
@@ -11560,9 +11560,9 @@ spec:
                                           x-kubernetes-list-type: atomic
                                       type: object
                                     dnsPolicy:
-                                      description:
-                                        DNSPolicy is the DNS policy for the
-                                        calico-node pods.
+                                      description: |-
+                                        DNSPolicy is the DNS policy for the calico-node pods. Defaults to Default, which uses the node's
+                                        own resolver, since calico-node runs before cluster DNS is reachable.
                                       enum:
                                         - ""
                                         - Default

--- a/manifests/operator-crds.yaml
+++ b/manifests/operator-crds.yaml
@@ -11413,9 +11413,9 @@ spec:
                                       x-kubernetes-list-type: atomic
                                   type: object
                                 dnsPolicy:
-                                  description:
-                                    DNSPolicy is the DNS policy for the calico-node
-                                    pods.
+                                  description: |-
+                                    DNSPolicy is the DNS policy for the calico-node pods. Defaults to Default, which uses the node's
+                                    own resolver, since calico-node runs before cluster DNS is reachable.
                                   enum:
                                     - ""
                                     - Default
@@ -20261,9 +20261,9 @@ spec:
                                           x-kubernetes-list-type: atomic
                                       type: object
                                     dnsPolicy:
-                                      description:
-                                        DNSPolicy is the DNS policy for the
-                                        calico-node pods.
+                                      description: |-
+                                        DNSPolicy is the DNS policy for the calico-node pods. Defaults to Default, which uses the node's
+                                        own resolver, since calico-node runs before cluster DNS is reachable.
                                       enum:
                                         - ""
                                         - Default


### PR DESCRIPTION
## Description

I think we might end up doing another patch release for `release-v3.31`. This PR fixes the CRD drift currently on the branch so that we can get hash releases back up. 

---

Bug fix / release tooling. Re-syncs the operator CRDs on `release-v3.31` from `tigera/operator` `release-v1.40`.

`make get-operator-crds` downloads the operator CRDs from a **branch tip**:

```make
curl -fsSL https://raw.githubusercontent.com/tigera/operator/$(OPERATOR_BRANCH)/pkg/crds/operator/$${file} -o $${file}
```

so any CRD change on `release-v1.40` silently makes the committed copies stale. `tigera/operator` commit `f1baf5fa` ("Default calico-node to the node's own DNS resolver", 2026-08-25) expanded the `dnsPolicy` description on the Installation CRD. The last sync on this branch was #13394 (2026-08-12), so every run since has re-downloaded a CRD that differs from the committed one.

That leaves the tree dirty, and the hashrelease pre-build validation runs `make get-operator-crds generate check-dirty` — so the nightly `release-v3.31` hashrelease has failed since 2026-08-25 with:

```
FATAL failed pre-build validation: code generation error, try 'make get-operator-crds generate' to fix
make[1]: *** [lib.Makefile:1246: check-dirty] Error 1
```

**Components affected:** `charts/tigera-operator/crds/` and the generated `manifests/`. No Go code changes.

### Testing

- `make get-operator-crds` — produces exactly the two `dnsPolicy` hunks in `operator.tigera.io_installations.yaml` (the CRD appears twice: top-level and nested).
- `make gen-manifests` — propagates them into `manifests/operator-crds.yaml`. Regenerating *all* manifests changed only that one file, confirming nothing else on the branch was stale.
- Re-ran both on top of this commit and applied `check-dirty`'s own test (`git --no-pager diff --stat` non-empty ⇒ fail): tree is clean, so the gate now passes.
- Verified the committed CRD was byte-identical to the operator's file at `f1baf5fa^`, i.e. that commit is the entire drift.

Only the description text changes — no schema, enum, or validation changes.

### Note for reviewers

Two follow-ups are worth considering separately, out of scope here:

1. **`OPERATOR_BRANCH` is a moving ref.** Pinning it to a tag or SHA would make CRDs change only on a deliberate bump, instead of a release branch silently absorbing upstream edits. As-is, this will recur whenever an operator patch touches a CRD.
2. **The failure is near-undiagnosable from the CI log.** `check-dirty` prints `The following files are dirty` and the diff to **stdout**, but `checkCodeGeneration` calls `makeInDirectoryIgnoreOutput`, and the runner folds only **stderr** into the error (`release/internal/command/commands.go:64`). The job log therefore keeps thousands of lines of `[debug]`/`walk.go` noise and drops the file list entirely. Same code path exists on `master`.

## Related issues/PRs

Previous sync on this branch: #13394

## Todos

- [x] Tests
- [x] Documentation
- [x] Release note

## Release Note

```release-note
None
```

**AI assistance:** Claude Code (Opus 5) — CI log analysis, root-cause investigation, running the sync and manifest regeneration, and drafting this description.
