### PR TITLE
Restore operator CRD drift detection in the upstream sync

### DIFF
--- a/.github/workflows/sync-generated-files.yml
+++ b/.github/workflows/sync-generated-files.yml
@@ -4,8 +4,8 @@
 # drifted.
 #
 # Runs hourly, but a cheap drift check up front skips the heavy regen unless
-# something actually changed: a recent merge, or the CNI pin falling behind
-# upstream.
+# something actually changed: a recent merge, an operator CRD update on a
+# release branch, or the CNI pin falling behind upstream.
 ---
 name: Sync upstream
 on:  # yamllint disable-line rule:truthy
@@ -27,14 +27,16 @@ jobs:
       - name: Discover branches
         id: branches
         run: |
-          # Get master + the two most recent release branches (by semver).
+          # Get master + the three most recent release branches (by semver).
+          # Three because the oldest of them still gets hashreleases, and those
+          # gate on check-dirty.
           # Pipe to jq separately so --slurp combines all pages before filtering.
           # Using --jq with --paginate applies the filter per-page, which can
           # produce multiple JSON arrays and break $GITHUB_OUTPUT.
           branches=$(gh api repos/${{ github.repository }}/branches --paginate | jq -sc '
             [flatten[] | select(.name | test("^release-v[0-9]+\\.[0-9]+$")) | .name]
             | sort_by(ltrimstr("release-v") | split(".") | map(tonumber))
-            | .[-2:]
+            | .[-3:]
             | ["master"] + .
           ')
           echo "branches=${branches}" >> "$GITHUB_OUTPUT"
@@ -66,7 +68,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          recent=false; cni=false; cni_sha=
+          recent=false; operator=false; cni=false; cni_sha=
 
           force=false
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
@@ -81,6 +83,19 @@ jobs:
             recent=true
           fi
 
+          # operator: release branches curl the operator's CRDs from
+          # tigera/operator, so they drift on the operator's schedule, not this
+          # branch's. Master has no such target -- it builds them in tree. Probe
+          # with SKIP_FIX_CHANGED so it stays Docker-free, then revert the
+          # probe's writes; the real run redoes them.
+          if grep -q '^get-operator-crds:' Makefile; then
+            make get-operator-crds SKIP_FIX_CHANGED=true
+            if [ "$force" = true ] || ! git diff --quiet; then
+              operator=true
+            fi
+            git checkout -- .
+          fi
+
           # cni: pin behind upstream. Capture the target SHA here so the bump
           # step doesn't have to query again (and can't race a moving upstream).
           repo=projectcalico/containernetworking-plugins
@@ -91,9 +106,10 @@ jobs:
             cni=true
           fi
 
-          echo "drift: recent=$recent cni=$cni"
+          echo "drift: recent=$recent operator=$operator cni=$cni"
           {
             echo "recent=$recent"
+            echo "operator=$operator"
             echo "cni=$cni"
             echo "cni_sha=$cni_sha"
           } >> "$GITHUB_OUTPUT"
@@ -101,7 +117,7 @@ jobs:
       # make generate is the heavy step, so it only runs when something it
       # actually regenerates drifted. A CNI-only bump skips it entirely.
       - name: Install tools
-        if: steps.drift.outputs.recent == 'true'
+        if: steps.drift.outputs.recent == 'true' || steps.drift.outputs.operator == 'true'
         run: make bin/helm bin/yq
 
       - name: Bump CNI plugin pin
@@ -116,12 +132,19 @@ jobs:
           echo "Bumping CNI_VERSION to $CNI_SHA"
           sed -i "s/^CNI_VERSION=.*/CNI_VERSION=$CNI_SHA/" metadata.mk
 
+      # Only release branches have this target, and only some of them fold it
+      # into generate, so run it explicitly. It has to come first either way:
+      # gen-manifests reads the CRDs it writes.
+      - name: Sync operator CRDs
+        if: steps.drift.outputs.operator == 'true'
+        run: make get-operator-crds
+
       - name: Regenerate
-        if: steps.drift.outputs.recent == 'true'
+        if: steps.drift.outputs.recent == 'true' || steps.drift.outputs.operator == 'true'
         run: make generate
 
       - uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0  # v8.1.0
-        if: steps.drift.outputs.recent == 'true' || steps.drift.outputs.cni == 'true'
+        if: steps.drift.outputs.recent == 'true' || steps.drift.outputs.operator == 'true' || steps.drift.outputs.cni == 'true'
         id: cpr
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -132,6 +155,7 @@ jobs:
           body: |
             Automated sync into `${{ matrix.branch }}`:
 
+            - Operator CRDs pulled from `tigera/operator` (release branches only)
             - Regenerated files (`make generate`)
             - CNI plugin pin (`CNI_VERSION`) bumped to the latest upstream commit
 


### PR DESCRIPTION
## Description

The nightly `release-v3.31` hashrelease has failed on `check-dirty` since 2026-08-25, because nothing re-syncs that branch's copy of the operator CRDs any more. Two causes, both in this workflow:

- Operator drift detection went away with the cross-repo fetches in #13674. Right for master, which builds the CRDs in tree, but the scheduled workflow runs master's copy of the file for every branch in the matrix, and release branches still curl theirs from `tigera/operator`. The only remaining regen trigger was a commit on the branch within the last two hours, and CRD drift is external to the branch.
- The matrix covered master plus the two newest release branches. `release-v3.33` was cut on 2026-08-14, pushing `release-v3.31` out while its hashreleases kept running.

The fix:

- restore the drift probe, guarded on the target existing so master skips it
- run `make get-operator-crds` explicitly before `make generate`, since v3.31's generate doesn't fold it in
- widen the window to three release branches

### Testing

Ran the probe against fresh checkouts of each branch in the new matrix:

- master: no `get-operator-crds` target, probe skips
- `release-v3.31`: reports drift, the same six-line change as #13823
- `release-v3.32`: clean, so formatting alone doesn't trip it
- every case reverts its own writes, leaving the tree clean for the real run

Branch discovery now returns `["master","release-v3.31","release-v3.32","release-v3.33"]`, and yamllint passes.

Related: #13823, [CORE-13636](https://tigera.atlassian.net/browse/CORE-13636)

```release-note
None
```


[CORE-13636]: https://tigera.atlassian.net/browse/CORE-13636?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ