### PR TITLE
fix(release): stop concurrent image builds from corrupting each other

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,7 @@ clean:
 	$(MAKE) -C confd clean
 	$(MAKE) -C felix clean
 	$(MAKE) -C cmd/calico clean
+	$(MAKE) -C istio clean
 	$(MAKE) -C kube-controllers clean
 	$(MAKE) -C libcalico-go clean
 	$(MAKE) -C node clean
@@ -53,6 +54,7 @@ clean:
 	$(MAKE) -C third_party/envoy-gateway clean
 	$(MAKE) -C third_party/envoy-proxy clean
 	$(MAKE) -C third_party/envoy-ratelimit clean
+	$(MAKE) -C whisker clean
 	rm -rf ./bin .stamp.*
 
 check-go-mod:

--- a/cmd/calico/Makefile
+++ b/cmd/calico/Makefile
@@ -40,7 +40,7 @@ IMAGE_TAG = latest
 
 .PHONY: clean
 clean:
-	rm -rf bin .image.created-*
+	rm -rf bin .image.created-* .release-*
 	-docker image rm -f $$(docker images $(CALICO_IMAGE) -a -q) 2>/dev/null
 
 .PHONY: ut

--- a/cmd/calico/Makefile
+++ b/cmd/calico/Makefile
@@ -105,7 +105,7 @@ cd: image-all cd-common
 .PHONY: release-build release-publish
 release-build: .release-$(VERSION).created
 .release-$(VERSION).created:
-	$(MAKE) clean image-all RELEASE=true
+	$(MAKE) image-all RELEASE=true
 	$(MAKE) retag-build-images-with-registries RELEASE=true IMAGETAG=$(VERSION)
 	$(MAKE) retag-build-images-with-registries RELEASE=true IMAGETAG=latest
 	touch $@

--- a/felix/Makefile
+++ b/felix/Makefile
@@ -561,10 +561,10 @@ cd: cd-common
 ###############################################################################
 # Release
 ###############################################################################
-## Produces a clean build of release artifacts at the specified version.
+## Produces release artifacts at the specified version. Clean first for a fresh build.
 release-build: .release-$(VERSION).created
 .release-$(VERSION).created:
-	$(MAKE) clean build bin/calico-bpf
+	$(MAKE) build bin/calico-bpf
 	touch $@
 
 ###############################################################################

--- a/istio/Makefile
+++ b/istio/Makefile
@@ -191,7 +191,7 @@ cd: image-all cd-common
 release-build: .release-$(VERSION).created
 
 .release-$(VERSION).created:
-	$(MAKE) clean image-all RELEASE=true
+	$(MAKE) image-all RELEASE=true
 	$(MAKE) retag-build-images-with-registries IMAGETAG=$(VERSION) RELEASE=true
 	$(MAKE) retag-build-images-with-registries IMAGETAG=latest RELEASE=true
 	touch $@

--- a/lib.Makefile
+++ b/lib.Makefile
@@ -2042,15 +2042,18 @@ else
 DOCKER_MANIFEST = echo [DRY RUN] $(DOCKER_MANIFEST_CMD)
 endif
 
+# Named per component so concurrent builds do not remove each other's builder.
+WINDOWS_BUILDER = $(if $(notdir $(CURDIR)),calico-windows-builder-$(notdir $(CURDIR)),calico-windows-builder)
+
 # Clean up the docker builder used to create Windows image tarballs.
 .PHONY: clean-windows-builder
 clean-windows-builder:
-	-docker buildx rm calico-windows-builder
+	-docker buildx rm $(WINDOWS_BUILDER)
 
 # Set up the docker builder used to create Windows image tarballs.
 .PHONY: setup-windows-builder
 setup-windows-builder: clean-windows-builder
-	docker buildx create --name=calico-windows-builder --use --platform windows/amd64
+	docker buildx create --name=$(WINDOWS_BUILDER) --platform windows/amd64
 
 # FIXME: Use WINDOWS_HPC_VERSION and image instead of nanoserver and WINDOWS_VERSIONS when containerd v1.6 is EOL'd
 # .PHONY: image-windows release-windows
@@ -2113,6 +2116,7 @@ windows-sub-image-%: var-require-all-GIT_VERSION-WINDOWS_IMAGE-WINDOWS_DIST-WIND
 	# ensure dir for windows image tars exits
 	-mkdir -p $(WINDOWS_DIST)
 	docker buildx build \
+		--builder $(WINDOWS_BUILDER) \
 		--platform windows/amd64 \
 		--output=type=docker,dest=$(CURDIR)/$(WINDOWS_DIST)/$(WINDOWS_IMAGE)-$(GIT_VERSION)-$*.tar \
 		$(DOCKER_PULL) \

--- a/lib.Makefile
+++ b/lib.Makefile
@@ -2043,7 +2043,7 @@ DOCKER_MANIFEST = echo [DRY RUN] $(DOCKER_MANIFEST_CMD)
 endif
 
 # Named per component so concurrent builds do not remove each other's builder.
-WINDOWS_BUILDER = $(if $(notdir $(CURDIR)),calico-windows-builder-$(notdir $(CURDIR)),calico-windows-builder)
+WINDOWS_BUILDER = calico-windows-builder-$(notdir $(CURDIR))
 
 # Clean up the docker builder used to create Windows image tarballs.
 .PHONY: clean-windows-builder

--- a/node/Makefile
+++ b/node/Makefile
@@ -417,10 +417,10 @@ cd: image-all cd-common
 ###############################################################################
 # Release
 ###############################################################################
-## Produces a clean build of release artifacts at the specified version.
+## Produces release artifacts at the specified version. Clean first for a fresh build.
 release-build: .release-$(VERSION).created
 .release-$(VERSION).created:
-	$(MAKE) clean image-all RELEASE=true
+	$(MAKE) image-all RELEASE=true
 	$(MAKE) retag-build-images-with-registries RELEASE=true IMAGETAG=$(VERSION)
 	# Generate the `latest` node images.
 	$(MAKE) retag-build-images-with-registries RELEASE=true IMAGETAG=latest

--- a/node/Makefile
+++ b/node/Makefile
@@ -189,10 +189,6 @@ $(LIBBPF_A): $(shell find ../felix/bpf-gpl/libbpf -type f -name '*.[ch]')
 
 filesystem/usr/lib/calico/bpf: $(shell find ../felix/bpf-gpl -type f) $(shell find ../felix/bpf-apache -type f)
 	rm -rf filesystem/usr/lib/calico/bpf/ && mkdir -p filesystem/usr/lib/calico/bpf/
-	# Clean stale build artifacts that may reference headers from a previous
-	# build environment (e.g., Docker container with different clang version).
-	make -C ../felix/bpf-gpl clean
-	make -C ../felix/bpf-apache clean
 	make -C ../felix build-bpf ARCH=$(ARCH)
 	cp -r ../felix/bpf-gpl/bin/* $@
 	cp -r ../felix/bpf-apache/bin/* $@

--- a/release/cmd/images_test.go
+++ b/release/cmd/images_test.go
@@ -244,8 +244,11 @@ func TestImagesNarrowedToBuildOnlyDir(t *testing.T) {
 	r := runImages(t, fakeRepo(t, "v3.30.0"),
 		"build", "--registry", "quay.io/calico", "--image-release-dir", "felix")
 
-	if len(r.args) != 1 || !r.ran("felix", "release-build") {
-		t.Fatalf("expected a single felix build, ran: %v", r.args)
+	if !r.ran("felix", "release-build") {
+		t.Fatalf("expected a felix build, ran: %v", r.args)
+	}
+	if !r.ran("clean") {
+		t.Fatalf("expected a clean before the build, ran: %v", r.args)
 	}
 }
 

--- a/release/internal/images/actions.go
+++ b/release/internal/images/actions.go
@@ -28,6 +28,12 @@ import (
 	"github.com/projectcalico/calico/release/internal/utils"
 )
 
+// build targets
+const (
+	buildBPF = "build-bpf"
+	image    = "image"
+)
+
 func Build(repoRoot, version string, variants []Variant, opts ...BuildOption) error {
 	s, err := newSettings(buildStep, repoRoot, version, variants, opts)
 	if err != nil {
@@ -37,10 +43,13 @@ func Build(repoRoot, version string, variants []Variant, opts ...BuildOption) er
 	if err := s.clean(); err != nil {
 		return err
 	}
+	if err := s.prelude(); err != nil {
+		return err
+	}
 
 	units := s.units(s.env())
 	s.Logger().WithField("images", len(units)).Info("Building container images")
-	if err := s.runUnits(units); err != nil {
+	if err := s.runBuildUnits(units); err != nil {
 		return err
 	}
 	s.Logger().Info("Finished building container images")

--- a/release/internal/images/actions.go
+++ b/release/internal/images/actions.go
@@ -28,10 +28,13 @@ import (
 	"github.com/projectcalico/calico/release/internal/utils"
 )
 
-// build targets
 const (
+	// build targets
 	buildBPF = "build-bpf"
-	image    = "image"
+
+	// These name the prelude's and the clean's log files apart from a unit's.
+	preludeVariant = "prelude"
+	cleanVariant   = "clean"
 )
 
 func Build(repoRoot, version string, variants []Variant, opts ...BuildOption) error {
@@ -40,7 +43,8 @@ func Build(repoRoot, version string, variants []Variant, opts ...BuildOption) er
 		return err
 	}
 
-	if err := s.clean(); err != nil {
+	gate := newDirGate()
+	if err := s.clean(gate); err != nil {
 		return err
 	}
 	if err := s.prelude(); err != nil {
@@ -49,7 +53,7 @@ func Build(repoRoot, version string, variants []Variant, opts ...BuildOption) er
 
 	units := s.units(s.env())
 	s.Logger().WithField("images", len(units)).Info("Building container images")
-	if err := s.runBuildUnits(units); err != nil {
+	if err := s.runBuildUnits(units, gate); err != nil {
 		return err
 	}
 	s.Logger().Info("Finished building container images")

--- a/release/internal/images/actions.go
+++ b/release/internal/images/actions.go
@@ -34,6 +34,10 @@ func Build(repoRoot, version string, variants []Variant, opts ...BuildOption) er
 		return err
 	}
 
+	if err := s.clean(); err != nil {
+		return err
+	}
+
 	units := s.units(s.env())
 	s.Logger().WithField("images", len(units)).Info("Building container images")
 	if err := s.runUnits(units); err != nil {

--- a/release/internal/images/images.go
+++ b/release/internal/images/images.go
@@ -392,6 +392,31 @@ func (s settings) runUnits(units []unit) error {
 	return err
 }
 
+// A directory's units build in one tree, so they run one at a time. Publish
+// shares only a registry and stays on runUnits.
+func (s settings) runBuildUnits(units []unit) error {
+	var (
+		mu    sync.Mutex
+		locks = map[string]*sync.Mutex{}
+	)
+	dirLock := func(dir string) *sync.Mutex {
+		mu.Lock()
+		defer mu.Unlock()
+		if locks[dir] == nil {
+			locks[dir] = &sync.Mutex{}
+		}
+		return locks[dir]
+	}
+
+	_, err := forEachUnit(units, func(u unit) (unitDone, error) {
+		l := dirLock(u.dir)
+		l.Lock()
+		defer l.Unlock()
+		return unitDone{}, s.runUnit(u)
+	})
+	return err
+}
+
 // Components share build trees, so a clean during the fan-out would delete
 // what another unit is building. The root target cleans every component.
 func (s settings) clean() error {
@@ -402,6 +427,86 @@ func (s settings) clean() error {
 		return s.Errorf("clean: %w", err)
 	}
 	return nil
+}
+
+// preludeSteps is work more than one component's build writes. Building it
+// once up front leaves each of those builds a cache hit instead of a race.
+var preludeSteps = []preludeStep{
+	// build-bpf depends on libbpf, so it covers both.
+	{dir: utils.FelixDir, target: buildBPF, neededBy: []string{utils.FelixDir, utils.NodeDir}},
+	{dir: utils.NFTablesDir, target: image, neededBy: []string{utils.IstioDir, utils.NodeDir}},
+}
+
+type preludeStep struct {
+	dir    string
+	target string
+
+	// neededBy is every release directory whose build writes this output.
+	neededBy []string
+}
+
+// prelude builds the shared work before the units fan out, once per named
+// architecture because each step's make target takes a single ARCH.
+func (s settings) prelude() error {
+	steps := narrowPrelude(preludeSteps, VariantDirs(s.Variants))
+	if len(steps) == 0 {
+		return nil
+	}
+	// No arch named leaves ARCH unset, so each component applies its own
+	// default rather than one chosen here.
+	arches := s.Arches
+	if len(arches) == 0 {
+		arches = []string{""}
+	}
+	for _, step := range steps {
+		for _, arch := range arches {
+			if err := s.runPrelude(step, arch); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (s settings) runPrelude(step preludeStep, arch string) error {
+	log := s.Logger().WithFields(logrus.Fields{"component": step.dir, "target": step.target})
+	slug := "prelude-" + preludeSlug(step.dir)
+	args := []string{"-C", filepath.Join(s.RepoRoot, step.dir), step.target}
+	if arch != "" {
+		log = log.WithField("arch", arch)
+		slug += "-" + arch
+		args = append(args, "ARCH="+arch)
+	}
+	log.Info("Building shared work before the image builds")
+
+	out, err := s.Run("make", args, s.env(), s.LogPath(slug))
+	if err != nil {
+		log.Error(out)
+		return s.Errorf("prelude %s in %s: %w", step.target, step.dir, err)
+	}
+	return nil
+}
+
+func preludeSlug(dir string) string {
+	return strings.ReplaceAll(filepath.Clean(dir), string(filepath.Separator), "-")
+}
+
+// A step is only worth building up front while two of its directories still
+// build it; a lone writer races nobody.
+func narrowPrelude(steps []preludeStep, dirs []string) []preludeStep {
+	var out []preludeStep
+	for _, step := range steps {
+		writers := 0
+		for _, dir := range step.neededBy {
+			if slices.Contains(dirs, dir) {
+				writers++
+			}
+		}
+		if writers > 1 {
+			out = append(out, step)
+		}
+	}
+	return out
 }
 
 // runUnitOnly adapts runUnit to forEachUnit, which wants a result per unit.

--- a/release/internal/images/images.go
+++ b/release/internal/images/images.go
@@ -394,39 +394,63 @@ func (s settings) runUnits(units []unit) error {
 
 // A directory's units build in one tree, so they run one at a time. Publish
 // shares only a registry and stays on runUnits.
-func (s settings) runBuildUnits(units []unit) error {
-	var (
-		mu    sync.Mutex
-		locks = map[string]*sync.Mutex{}
-	)
-	dirLock := func(dir string) *sync.Mutex {
-		mu.Lock()
-		defer mu.Unlock()
-		if locks[dir] == nil {
-			locks[dir] = &sync.Mutex{}
-		}
-		return locks[dir]
-	}
-
+func (s settings) runBuildUnits(units []unit, g *dirGate) error {
 	_, err := forEachUnit(units, func(u unit) (unitDone, error) {
-		l := dirLock(u.dir)
-		l.Lock()
-		defer l.Unlock()
+		defer g.hold(u.dir)()
 		return unitDone{}, s.runUnit(u)
 	})
 	return err
 }
 
-// Components share build trees, so a clean during the fan-out would delete
-// what another unit is building. The root target cleans every component.
-func (s settings) clean() error {
-	s.Logger().Info("Cleaning before build")
-	out, err := s.Run("make", []string{"-C", s.RepoRoot, "clean"}, s.env(), s.LogPath("clean"))
-	if err != nil {
-		s.Logger().Error(out)
-		return s.Errorf("clean: %w", err)
+// dirGate keeps two make invocations out of one directory at a time. Cleans and
+// builds share it: node's clean reaches into felix's tree.
+type dirGate struct {
+	mu    sync.Mutex
+	locks map[string]*sync.Mutex
+}
+
+func newDirGate() *dirGate { return &dirGate{locks: map[string]*sync.Mutex{}} }
+
+func (g *dirGate) hold(dir string) func() {
+	g.mu.Lock()
+	if g.locks[dir] == nil {
+		g.locks[dir] = &sync.Mutex{}
 	}
-	return nil
+	l := g.locks[dir]
+	g.mu.Unlock()
+
+	l.Lock()
+	return l.Unlock
+}
+
+// clean runs each build directory's own clean, never the root target: that one
+// also cleans release/, whose _output and tmp this run is using.
+//
+// node's clean reaches into felix's tree, so the cleans take the same
+// per-directory lock the builds do.
+func (s settings) clean(g *dirGate) error {
+	dirs := VariantDirs(s.Variants)
+	s.Logger().WithField("components", len(dirs)).Info("Cleaning before build")
+
+	var errs []error
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+	for _, dir := range dirs {
+		wg.Go(func() {
+			if err := s.cleanDir(dir, g); err != nil {
+				mu.Lock()
+				errs = append(errs, err)
+				mu.Unlock()
+			}
+		})
+	}
+	wg.Wait()
+	return errors.Join(errs...)
+}
+
+func (s settings) cleanDir(dir string, g *dirGate) error {
+	defer g.hold(dir)()
+	return s.runUnit(unit{variant: cleanVariant, dir: dir, target: "clean", env: s.env()})
 }
 
 // preludeSteps is work more than one component's build writes. Building it
@@ -434,7 +458,6 @@ func (s settings) clean() error {
 var preludeSteps = []preludeStep{
 	// build-bpf depends on libbpf, so it covers both.
 	{dir: utils.FelixDir, target: buildBPF, neededBy: []string{utils.FelixDir, utils.NodeDir}},
-	{dir: utils.NFTablesDir, target: image, neededBy: []string{utils.IstioDir, utils.NodeDir}},
 }
 
 type preludeStep struct {
@@ -468,27 +491,15 @@ func (s settings) prelude() error {
 	return nil
 }
 
+// A prelude step runs as a unit so it gets the same retry and log naming.
 func (s settings) runPrelude(step preludeStep, arch string) error {
-	log := s.Logger().WithFields(logrus.Fields{"component": step.dir, "target": step.target})
-	slug := "prelude-" + preludeSlug(step.dir)
-	args := []string{"-C", filepath.Join(s.RepoRoot, step.dir), step.target}
+	variant := preludeVariant
+	target := step.target
 	if arch != "" {
-		log = log.WithField("arch", arch)
-		slug += "-" + arch
-		args = append(args, "ARCH="+arch)
+		variant += "-" + arch
+		target += " ARCH=" + arch
 	}
-	log.Info("Building shared work before the image builds")
-
-	out, err := s.Run("make", args, s.env(), s.LogPath(slug))
-	if err != nil {
-		log.Error(out)
-		return s.Errorf("prelude %s in %s: %w", step.target, step.dir, err)
-	}
-	return nil
-}
-
-func preludeSlug(dir string) string {
-	return strings.ReplaceAll(filepath.Clean(dir), string(filepath.Separator), "-")
+	return s.runUnit(unit{variant: variant, dir: step.dir, target: target, env: s.env()})
 }
 
 // A step is only worth building up front while two of its directories still

--- a/release/internal/images/images.go
+++ b/release/internal/images/images.go
@@ -392,6 +392,18 @@ func (s settings) runUnits(units []unit) error {
 	return err
 }
 
+// Components share build trees, so a clean during the fan-out would delete
+// what another unit is building. The root target cleans every component.
+func (s settings) clean() error {
+	s.Logger().Info("Cleaning before build")
+	out, err := s.Run("make", []string{"-C", s.RepoRoot, "clean"}, s.env(), s.LogPath("clean"))
+	if err != nil {
+		s.Logger().Error(out)
+		return s.Errorf("clean: %w", err)
+	}
+	return nil
+}
+
 // runUnitOnly adapts runUnit to forEachUnit, which wants a result per unit.
 func (s settings) runUnitOnly(u unit) (unitDone, error) {
 	return unitDone{}, s.runUnit(u)

--- a/release/internal/images/images_test.go
+++ b/release/internal/images/images_test.go
@@ -17,11 +17,14 @@ package images
 import (
 	"errors"
 	"fmt"
+	"os/exec"
 	"path"
+	"path/filepath"
 	"slices"
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/projectcalico/calico/release/internal/command"
 )
@@ -292,6 +295,213 @@ func TestLogPaths(t *testing.T) {
 			t.Errorf("log paths\n got %v\nwant %v", got, want)
 		}
 	})
+}
+
+// overlapRunner reports which calls were in flight at once, which the order
+// fakeRunner records cannot show.
+type overlapRunner struct {
+	mu       sync.Mutex
+	inFlight map[string]bool
+	// sawTogether is every pair of directories that overlapped.
+	sawTogether map[string]bool
+	// afterBuild counts prelude or clean calls that ran once a unit had started,
+	// prelude those that built shared work before the fan-out.
+	afterBuild   int
+	prelude      int
+	buildRunning bool
+}
+
+func newOverlapRunner() *overlapRunner {
+	return &overlapRunner{inFlight: map[string]bool{}, sawTogether: map[string]bool{}}
+}
+
+func (o *overlapRunner) RunInDirToFile(_, _ string, args, env []string, _ string) (string, error) {
+	return o.record(args)
+}
+
+func (o *overlapRunner) RunInDir(_, _ string, args, env []string) (string, error) {
+	return o.record(args)
+}
+
+func (o *overlapRunner) Run(_ string, args, _ []string) (string, error) { return o.record(args) }
+
+func (o *overlapRunner) record(args []string) (string, error) {
+	dir, shared := dirOf(args), isShared(args)
+
+	o.mu.Lock()
+	if shared {
+		if o.buildRunning {
+			o.afterBuild++
+		} else if !slices.Contains(args, "clean") {
+			o.prelude++
+		}
+	}
+	if !shared {
+		o.buildRunning = true
+	}
+	for other := range o.inFlight {
+		o.sawTogether[pairKey(dir, other)] = true
+	}
+	o.inFlight[dir] = true
+	o.mu.Unlock()
+
+	// Give a concurrent unit a chance to observe this one in flight.
+	time.Sleep(time.Millisecond)
+
+	o.mu.Lock()
+	delete(o.inFlight, dir)
+	o.mu.Unlock()
+	return "ok", nil
+}
+
+func (o *overlapRunner) overlapped(a, b string) bool {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	return o.sawTogether[pairKey(a, b)]
+}
+
+func (o *overlapRunner) RunNoCapture(string, []string, []string) error              { return nil }
+func (o *overlapRunner) RunInDirNoCapture(string, string, []string, []string) error { return nil }
+
+// A unit is identified by its directory and variant, so a directory's two
+// image kinds are told apart.
+func dirOf(args []string) string {
+	dir := filepath.Base(args[1])
+	if slices.Contains(args, "release-windows") || slices.Contains(args, "image-windows") {
+		return dir + "-windows"
+	}
+	return dir
+}
+
+// clean and the prelude are the sequential work that must precede every unit.
+func isShared(args []string) bool {
+	if slices.Contains(args, "clean") {
+		return true
+	}
+	for _, step := range preludeSteps {
+		if slices.Contains(args, step.target) {
+			return true
+		}
+	}
+	return false
+}
+
+func pairKey(a, b string) string {
+	if a > b {
+		a, b = b, a
+	}
+	return a + "|" + b
+}
+
+// A directory's units write one tree, so its image kinds run one at a time.
+func TestBuildSerialisesUnitsInOneDirectory(t *testing.T) {
+	o := newOverlapRunner()
+	if err := Build(testRepoRoot, testVersion, ossVariants(), buildOpts(o)...); err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if o.overlapped("node", "node-windows") {
+		t.Error("node's standard and windows units overlapped")
+	}
+}
+
+// Serialising a directory must not serialise the whole build.
+func TestBuildStillRunsIndependentDirsTogether(t *testing.T) {
+	o := newOverlapRunner()
+	variants := []Variant{{
+		Name:        "standard",
+		Target:      "release-build",
+		ReleaseDirs: []string{"whisker", "third_party/envoy-proxy", "third_party/envoy-gateway"},
+	}}
+	if err := Build(testRepoRoot, testVersion, variants, buildOpts(o)...); err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if !o.overlapped("whisker", "envoy-proxy") && !o.overlapped("whisker", "envoy-gateway") &&
+		!o.overlapped("envoy-proxy", "envoy-gateway") {
+		t.Error("independent directories were serialised")
+	}
+}
+
+// A step whose log path collided with another's would lose its output.
+func TestPreludeLogPathsAreDistinct(t *testing.T) {
+	seen := map[string]string{}
+	for _, step := range preludeSteps {
+		slug := preludeSlug(step.dir)
+		if other, dup := seen[slug]; dup {
+			t.Errorf("%s and %s share the log name %s", other, step.dir, slug)
+		}
+		seen[slug] = step.dir
+	}
+}
+
+// The shared work has to be finished before any unit can reach it.
+func TestPreludeCompletesBeforeAnyUnitRuns(t *testing.T) {
+	if len(preludeSteps) == 0 {
+		t.Skip("no prelude steps in this repo")
+	}
+	// Every writer of the first step, so narrowPrelude keeps it.
+	o := newOverlapRunner()
+	variants := []Variant{{
+		Name:        "standard",
+		Target:      "release-build",
+		ReleaseDirs: slices.Clone(preludeSteps[0].neededBy),
+	}}
+	if err := Build(testRepoRoot, testVersion, variants, buildOpts(o)...); err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if o.prelude == 0 {
+		t.Fatal("no prelude step ran before the fan-out")
+	}
+	if o.afterBuild > 0 {
+		t.Errorf("%d shared steps ran after a unit had started", o.afterBuild)
+	}
+}
+
+// The prelude only removes a race while its targets still resolve. A rename
+// would otherwise leave it silently building nothing.
+func TestPreludeTargetsResolve(t *testing.T) {
+	repoRoot, err := command.GitDir()
+	if err != nil {
+		t.Fatalf("repo root: %v", err)
+	}
+	for _, step := range preludeSteps {
+		t.Run(step.dir+"/"+step.target, func(t *testing.T) {
+			cmd := exec.Command("make", "-n", step.target)
+			cmd.Dir = filepath.Join(repoRoot, step.dir)
+			if out, err := cmd.CombinedOutput(); err != nil {
+				t.Errorf("make -n %s in %s: %v\n%s", step.target, step.dir, err, out)
+			}
+		})
+	}
+}
+
+// A step is only worth building up front while two directories still build it.
+// The steps are a fixture: the production table differs between repos.
+func TestNarrowPrelude(t *testing.T) {
+	steps := []preludeStep{
+		{dir: "shared-a", target: "build-a", neededBy: []string{"one", "two"}},
+		{dir: "shared-b", target: "build-b", neededBy: []string{"two", "three"}},
+	}
+	for _, tc := range []struct {
+		name string
+		dirs []string
+		want []string
+	}{
+		{"every writer present keeps every step", []string{"one", "two", "three"}, []string{"shared-a", "shared-b"}},
+		{"a lone writer races nobody", []string{"two"}, nil},
+		{"one step's writers survive", []string{"one", "two"}, []string{"shared-a"}},
+		{"the other step's writers survive", []string{"two", "three"}, []string{"shared-b"}},
+		{"a dir needing none of it", []string{"unrelated"}, nil},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var got []string
+			for _, step := range narrowPrelude(steps, tc.dirs) {
+				got = append(got, step.dir)
+			}
+			if !slices.Equal(got, tc.want) {
+				t.Errorf("narrowPrelude(%v)\n got %v\nwant %v", tc.dirs, got, tc.want)
+			}
+		})
+	}
 }
 
 // Components share build trees, so a clean must never land mid-build.

--- a/release/internal/images/images_test.go
+++ b/release/internal/images/images_test.go
@@ -283,6 +283,7 @@ func TestLogPaths(t *testing.T) {
 		}
 		slices.Sort(got)
 		want := []string{
+			"/logs/images-build/clean.log",
 			"/logs/images-build/cmd-calico.log",
 			"/logs/images-build/node-windows.log",
 			"/logs/images-build/node.log",
@@ -291,6 +292,32 @@ func TestLogPaths(t *testing.T) {
 			t.Errorf("log paths\n got %v\nwant %v", got, want)
 		}
 	})
+}
+
+// Components share build trees, so a clean must never land mid-build.
+func TestBuildCleansBeforeAnyUnitRuns(t *testing.T) {
+	f := &fakeRunner{}
+	if err := Build(testRepoRoot, testVersion, ossVariants(), buildOpts(f)...); err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	var cleans, builds int
+	for _, c := range f.calls {
+		if slices.Contains(c.args, "clean") {
+			if builds > 0 {
+				t.Errorf("clean %v ran after a build started", c.args)
+			}
+			cleans++
+			continue
+		}
+		builds++
+	}
+	if cleans == 0 {
+		t.Error("no clean ran before the build")
+	}
+	if builds == 0 {
+		t.Error("no unit was built")
+	}
 }
 
 // Scoping the release dirs must scope the work.

--- a/release/internal/images/images_test.go
+++ b/release/internal/images/images_test.go
@@ -286,8 +286,9 @@ func TestLogPaths(t *testing.T) {
 		}
 		slices.Sort(got)
 		want := []string{
-			"/logs/images-build/clean.log",
+			"/logs/images-build/cmd-calico-clean.log",
 			"/logs/images-build/cmd-calico.log",
+			"/logs/images-build/node-clean.log",
 			"/logs/images-build/node-windows.log",
 			"/logs/images-build/node.log",
 		}
@@ -423,13 +424,14 @@ func TestBuildStillRunsIndependentDirsTogether(t *testing.T) {
 
 // A step whose log path collided with another's would lose its output.
 func TestPreludeLogPathsAreDistinct(t *testing.T) {
+	s := settings{}
 	seen := map[string]string{}
 	for _, step := range preludeSteps {
-		slug := preludeSlug(step.dir)
-		if other, dup := seen[slug]; dup {
-			t.Errorf("%s and %s share the log name %s", other, step.dir, slug)
+		p := s.logPath(unit{variant: preludeVariant, dir: step.dir})
+		if other, dup := seen[p]; dup {
+			t.Errorf("%s and %s share the log name %s", other, step.dir, p)
 		}
-		seen[slug] = step.dir
+		seen[p] = step.dir
 	}
 }
 
@@ -501,6 +503,42 @@ func TestNarrowPrelude(t *testing.T) {
 				t.Errorf("narrowPrelude(%v)\n got %v\nwant %v", tc.dirs, got, tc.want)
 			}
 		})
+	}
+}
+
+// The tool's own _output and tmp live under release/, and it is mid-run.
+func TestBuildNeverCleansTheReleaseDir(t *testing.T) {
+	f := &fakeRunner{}
+	if err := Build(testRepoRoot, testVersion, ossVariants(), buildOpts(f)...); err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	for _, c := range f.calls {
+		if !slices.Contains(c.args, "clean") {
+			continue
+		}
+		if dir := c.args[1]; dir == testRepoRoot || strings.HasSuffix(dir, "/release") {
+			t.Errorf("clean reached %s, which holds the running tool's output", dir)
+		}
+	}
+}
+
+// Each build directory cleans its own tree, so nothing cleans a component
+// this run is not rebuilding.
+func TestCleanCoversExactlyTheBuildDirs(t *testing.T) {
+	f := &fakeRunner{}
+	variants := NarrowVariants(BuildVariants, []string{"whisker"})
+	if err := Build(testRepoRoot, testVersion, variants, buildOpts(f)...); err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	var cleaned []string
+	for _, c := range f.calls {
+		if slices.Contains(c.args, "clean") {
+			cleaned = append(cleaned, c.args[1])
+		}
+	}
+	want := []string{filepath.Join(testRepoRoot, "whisker")}
+	if !slices.Equal(cleaned, want) {
+		t.Errorf("cleaned %v, want %v", cleaned, want)
 	}
 }
 

--- a/release/internal/utils/utils.go
+++ b/release/internal/utils/utils.go
@@ -116,6 +116,25 @@ func AllReleaseCharts() []string {
 
 var once sync.Once
 
+// build directories
+const (
+	FelixDir                 = "felix"
+	CmdCalicoDir             = "cmd/calico"
+	IstioDir                 = "istio"
+	NodeDir                  = "node"
+	CNIPluginDir             = "cni-plugin"
+	ThirdPartyCNIDir         = "third_party/cni-plugins"
+	ThirdPartyEnvoyGateway   = "third_party/envoy-gateway"
+	ThirdPartyEnvoyProxy     = "third_party/envoy-proxy"
+	ThirdPartyEnvoyRatelimit = "third_party/envoy-ratelimit"
+	WhiskerDir               = "whisker"
+
+	NFTablesDir = "hack/rpms/nftables"
+	// OperatorDir is the operator's component directory. It publishes to registries of
+	// its own, so it is named apart from the list rather than added to it.
+	OperatorDir = "operator"
+)
+
 var (
 	// ImageReleaseDirs enumerates the component directories whose Makefiles
 	// publish standalone images via release-build/release-publish.
@@ -123,19 +142,15 @@ var (
 	// apiserver, dikastes, webhooks, typha, goldmane, guardian,
 	// whisker-backend, key-cert-provisioner, CSI, flexvol, Linux CNI) live
 	// under cmd/calico and are not listed here.
-	// OperatorDir is the operator's component directory. It publishes to registries of
-	// its own, so it is named apart from the list rather than added to it.
-	OperatorDir = "operator"
-
 	ImageReleaseDirs = []string{
-		"cmd/calico",
-		"istio",
-		"node",
-		"third_party/cni-plugins",
-		"third_party/envoy-gateway",
-		"third_party/envoy-proxy",
-		"third_party/envoy-ratelimit",
-		"whisker",
+		CmdCalicoDir,
+		IstioDir,
+		NodeDir,
+		ThirdPartyCNIDir,
+		ThirdPartyEnvoyGateway,
+		ThirdPartyEnvoyProxy,
+		ThirdPartyEnvoyRatelimit,
+		WhiskerDir,
 	}
 
 	// WindowsReleaseDirs enumerates component directories that ship a
@@ -144,8 +159,8 @@ var (
 	// Windows image — their Linux counterparts are bundled into the
 	// combined calico image.
 	WindowsReleaseDirs = []string{
-		"cni-plugin",
-		"node",
+		CNIPluginDir,
+		NodeDir,
 	}
 
 	releaseImages    = []string{}

--- a/release/internal/utils/utils.go
+++ b/release/internal/utils/utils.go
@@ -118,16 +118,16 @@ var once sync.Once
 
 // build directories
 const (
-	FelixDir                 = "felix"
-	CmdCalicoDir             = "cmd/calico"
-	IstioDir                 = "istio"
-	NodeDir                  = "node"
-	CNIPluginDir             = "cni-plugin"
-	ThirdPartyCNIDir         = "third_party/cni-plugins"
-	ThirdPartyEnvoyGateway   = "third_party/envoy-gateway"
-	ThirdPartyEnvoyProxy     = "third_party/envoy-proxy"
-	ThirdPartyEnvoyRatelimit = "third_party/envoy-ratelimit"
-	WhiskerDir               = "whisker"
+	FelixDir                    = "felix"
+	CmdCalicoDir                = "cmd/calico"
+	IstioDir                    = "istio"
+	NodeDir                     = "node"
+	CNIPluginDir                = "cni-plugin"
+	ThirdPartyCNIDir            = "third_party/cni-plugins"
+	ThirdPartyEnvoyGatewayDir   = "third_party/envoy-gateway"
+	ThirdPartyEnvoyProxyDir     = "third_party/envoy-proxy"
+	ThirdPartyEnvoyRatelimitDir = "third_party/envoy-ratelimit"
+	WhiskerDir                  = "whisker"
 
 	NFTablesDir = "hack/rpms/nftables"
 	// OperatorDir is the operator's component directory. It publishes to registries of
@@ -147,9 +147,9 @@ var (
 		IstioDir,
 		NodeDir,
 		ThirdPartyCNIDir,
-		ThirdPartyEnvoyGateway,
-		ThirdPartyEnvoyProxy,
-		ThirdPartyEnvoyRatelimit,
+		ThirdPartyEnvoyGatewayDir,
+		ThirdPartyEnvoyProxyDir,
+		ThirdPartyEnvoyRatelimitDir,
 		WhiskerDir,
 	}
 

--- a/release/pkg/manager/calico/manager.go
+++ b/release/pkg/manager/calico/manager.go
@@ -1304,7 +1304,8 @@ func (r *CalicoManager) buildBinaries() error {
 	// as part of its image release-build target.
 	m := map[string]string{"calicoctl": "build-all"}
 	if !r.images {
-		m["felix"] = "release-build"
+		// The image build cleans felix itself; without it nothing else does.
+		m["felix"] = "clean release-build"
 	}
 	env := append(os.Environ(),
 		fmt.Sprintf("VERSION=%s", r.calicoVersion),

--- a/release/pkg/manager/calico/manager_test.go
+++ b/release/pkg/manager/calico/manager_test.go
@@ -662,6 +662,7 @@ func TestImageStepsWriteLogFiles(t *testing.T) {
 		want []string
 	}{
 		{"build", (*CalicoManager).buildContainerImages, []string{
+			"/logs/images-build/node-clean.log",
 			"/logs/images-build/node-windows.log",
 			"/logs/images-build/node.log",
 		}},

--- a/third_party/cni-plugins/Makefile
+++ b/third_party/cni-plugins/Makefile
@@ -171,7 +171,7 @@ cd: image-all cd-common
 .PHONY: release-build release-publish
 release-build: .release-$(VERSION).created
 .release-$(VERSION).created:
-	$(MAKE) clean image-all RELEASE=true
+	$(MAKE) image-all RELEASE=true
 	$(MAKE) retag-build-images-with-registries IMAGETAG=$(VERSION) RELEASE=true
 	# Generate the `latest` images.
 	$(MAKE) retag-build-images-with-registries IMAGETAG=latest RELEASE=true

--- a/third_party/envoy-gateway/Makefile
+++ b/third_party/envoy-gateway/Makefile
@@ -88,7 +88,7 @@ cd: image-all cd-common
 .PHONY: release-build release-publish
 release-build: .release-$(VERSION).created
 .release-$(VERSION).created:
-	$(MAKE) clean image-all RELEASE=true
+	$(MAKE) image-all RELEASE=true
 	$(MAKE) retag-build-images-with-registries IMAGETAG=$(VERSION) RELEASE=true
 	# Generate the `latest` images.
 	$(MAKE) retag-build-images-with-registries IMAGETAG=latest RELEASE=true

--- a/third_party/envoy-proxy/Makefile
+++ b/third_party/envoy-proxy/Makefile
@@ -63,7 +63,7 @@ cd: image-all cd-common
 .PHONY: release-build release-publish
 release-build: .release-$(VERSION).created
 .release-$(VERSION).created:
-	$(MAKE) clean image-all RELEASE=true
+	$(MAKE) image-all RELEASE=true
 	$(MAKE) retag-build-images-with-registries IMAGETAG=$(VERSION) RELEASE=true
 	# Generate the `latest` images.
 	$(MAKE) retag-build-images-with-registries IMAGETAG=latest RELEASE=true

--- a/third_party/envoy-ratelimit/Makefile
+++ b/third_party/envoy-ratelimit/Makefile
@@ -81,7 +81,7 @@ cd: image-all cd-common
 .PHONY: release-build release-publish
 release-build: .release-$(VERSION).created
 .release-$(VERSION).created:
-	$(MAKE) clean image-all RELEASE=true
+	$(MAKE) image-all RELEASE=true
 	$(MAKE) retag-build-images-with-registries IMAGETAG=$(VERSION) RELEASE=true
 	# Generate the `latest` images.
 	$(MAKE) retag-build-images-with-registries IMAGETAG=latest RELEASE=true

--- a/whisker/Makefile
+++ b/whisker/Makefile
@@ -67,7 +67,7 @@ ut: image-nginx-test
 
 .PHONY: clean
 clean:
-	rm -rf bin dist node_modules *.created *.published
+	rm -rf bin dist node_modules *.created *.published .release-*
 
 ###############################################################################
 # Release

--- a/whisker/Makefile
+++ b/whisker/Makefile
@@ -77,7 +77,7 @@ cd: image-all cd-common
 
 release-build: .release-$(VERSION).created
 .release-$(VERSION).created:
-	$(MAKE) clean image-all RELEASE=true
+	$(MAKE) image-all RELEASE=true
 	$(MAKE) retag-build-images-with-registries RELEASE=true IMAGETAG=$(VERSION)
 	$(MAKE) retag-build-images-with-registries RELEASE=true IMAGETAG=latest
 	touch $@


### PR DESCRIPTION
Concurrent image builds no longer corrupt each other, and the Windows buildx builder is no longer shared between components.

The release tool builds every component at once, but several build into another component's tree: node compiles felix's BPF programs and libbpf in felix's own directory, node and istio build the same nftables RPM, and each `release-build` opened with its own `clean`. The tool now cleans once before the fan-out, builds the shared work up front, and stops a directory's own image kinds from building at the same time. The Windows builder is named per component and passed with `--builder` instead of selected globally with `--use`, which also stops a Windows build redirecting unrelated Linux builds on the same host.

**Release note:**
```release-note
None
```

**AI assistance:** Claude Code.

By opening this PR you take responsibility for every line in it, and you agree to explain the change yourself during review rather than routing review comments back through an agent. See [AI_POLICY.md](../AI_POLICY.md).
