### PR TITLE
argoci: set RUN_AS_ROOT so the e2e test container starts

### DIFF
--- a/.argoci/scripts/phases/run_tests.sh
+++ b/.argoci/scripts/phases/run_tests.sh
@@ -100,11 +100,19 @@ if [[ -n "${E2E_BINARY:-}" ]]; then
     fi
   fi
 
+  # The go-build entrypoint useradds LOCAL_USER_ID and su-execs to that account,
+  # which cannot work when the runner is already root. RUN_AS_ROOT skips it.
+  run_as_root_env=()
+  if [[ "$(id -u)" -eq 0 ]]; then
+    run_as_root_env=(-e RUN_AS_ROOT=true)
+  fi
+
   # Capture the exit code so the JUnit copy below runs even when tests fail
   # (set -e would otherwise bail out before the cp).
   e2e_rc=0
   docker run --rm --init --net=host \
     -e LOCAL_USER_ID="$(id -u)" \
+    "${run_as_root_env[@]}" \
     -e GOCACHE=/go-cache \
     -e GOPATH=/go \
     -e KUBECONFIG=/kubeconfig \


### PR DESCRIPTION
Bug fix. The scheduled `e2e-windows` lane on master uploads testsuites with **zero tests** — the `calico/go-build` container exits at its entrypoint before ginkgo starts. Its `k8s-e2e-tests.log` is 83 bytes:

```
Starting with UID: 0
useradd: UID 0 is not unique
su-exec: getpwnam(user): Success
```

The entrypoint creates a `user` account with `useradd -u ${LOCAL_USER_ID}` and re-execs through `su-exec user`. `run_tests.sh:107` passes `LOCAL_USER_ID="$(id -u)"`, and ArgoCI runners execute as root, so `useradd` fails because root already owns UID 0, `su-exec` then cannot resolve the account, and the container exits.

Only windows is affected: it is the only lane setting `RUN_LOCAL_TESTS`, which selects `calico/go-build` to run the binary it just built (`run_tests.sh:77`). Every other lane takes the hashrelease path into `golang:*-bookworm` (`:80`), which has no such entrypoint.

The image supports `RUN_AS_ROOT` to skip account creation, so set it when the runner is already root. Non-root runners (Semaphore agents) keep the existing behaviour.

**This is a forward-port.** The same fix landed on `release-v3.32` as #13651 (thanks @BatoulSarvi) but never reached master, so master's Argo windows lane has produced no test cases since the ArgoCI migration. The `windows.yml` results visible in Lens for `master_hashrel` — 4,579 cases — all come from the unmigrated Semaphore pipeline, which is why the gap wasn't obvious. `release-v3.33` needs it too and is in a companion PR.

### Testing done

Reproduced and fixed against the real image:

```
$ docker run --rm -e LOCAL_USER_ID=0 calico/go-build:1.26.5-llvm21.1.8-k8s1.36.2 echo TESTS-WOULD-RUN
Starting with UID: 0
useradd: UID 0 is not unique
su-exec: getpwnam(user): Success
rc=1

$ docker run --rm -e LOCAL_USER_ID=0 -e RUN_AS_ROOT=true calico/go-build:1.26.5-llvm21.1.8-k8s1.36.2 echo TESTS-WOULD-RUN
TESTS-WOULD-RUN
rc=0
```

`bash -n` clean. The end-to-end check is the next scheduled windows run producing a non-empty junit — this cannot be verified pre-merge, since the lane only runs on its cron.

Found while auditing why `release-v3.33` e2e results were sparse: the windows cell provisions two Azure clusters, installs, collects diags and destroys, running zero tests, and it looks like a normal run unless you notice the missing junit.

**Release note:**
```release-note
None
```

**AI assistance:** Claude Code (Opus 5) — investigation and diagnosis (OTEL trace and GCS artifact analysis, branch comparison), and drafted this change and description.
