### PR TITLE
[v3.33] argoci: set RUN_AS_ROOT so the e2e test container starts

### DIFF
--- a/.argoci/scripts/phases/run_tests.sh
+++ b/.argoci/scripts/phases/run_tests.sh
@@ -106,11 +106,19 @@ if [[ -n "${E2E_BINARY:-}" ]]; then
     fi
   fi
 
+  # The go-build entrypoint useradds LOCAL_USER_ID and su-execs to that account,
+  # which cannot work when the runner is already root. RUN_AS_ROOT skips it.
+  run_as_root_env=()
+  if [[ "$(id -u)" -eq 0 ]]; then
+    run_as_root_env=(-e RUN_AS_ROOT=true)
+  fi
+
   # Capture the exit code so the JUnit copy below runs even when tests fail
   # (set -e would otherwise bail out before the cp).
   e2e_rc=0
   docker run --rm --init --net=host \
     -e LOCAL_USER_ID="$(id -u)" \
+    "${run_as_root_env[@]}" \
     -e GOCACHE=/go-cache \
     -e GOPATH=/go \
     -e KUBECONFIG=/kubeconfig \


### PR DESCRIPTION
Bug fix, same change as #13834 (master) — `release-v3.33` needs it independently because the branch was cut before the fix existed anywhere.

The scheduled `e2e-windows` lane uploads testsuites with **zero tests** — the `calico/go-build` container exits at its entrypoint before ginkgo starts. Its `k8s-e2e-tests.log` is 83 bytes:

```
Starting with UID: 0
useradd: UID 0 is not unique
su-exec: getpwnam(user): Success
```

The entrypoint creates a `user` account with `useradd -u ${LOCAL_USER_ID}` and re-execs through `su-exec user`. `run_tests.sh:113` passes `LOCAL_USER_ID="$(id -u)"`, and ArgoCI runners execute as root, so `useradd` fails because root already owns UID 0, `su-exec` then cannot resolve the account, and the container exits.

Only windows is affected: it is the only lane setting `RUN_LOCAL_TESTS`, which selects `calico/go-build` to run the binary it just built. Every other lane takes the hashrelease path into `golang:*-bookworm`, which has no such entrypoint.

The image supports `RUN_AS_ROOT` to skip account creation, so set it when the runner is already root.

### Lineage

The fix landed on `release-v3.32` as #13651 (thanks @BatoulSarvi), after this branch was cut, and never reached master — so neither master nor `release-v3.33` has it. Confirmed by observation: the `e2e-windows-release-v3-33` run of 2026-09-04 produced the 83-byte log on both Azure cells and zero cases in Lens, while `e2e-windows-release-v3-32` on the same date produced 15,774 bytes of test output.

Raising this alongside the master PR rather than waiting, since the v3.33 windows cell has never produced a test case and burns two Azure clusters a week doing it. Happy to close this and take a cherry-pick of #13834 instead if you'd prefer the usual master-first lineage — in which case the merge-queue bot will want an `Original Commit SHA` line pointing at #13834's merge commit.

### Testing done

Reproduced and fixed against the real image:

```
$ docker run --rm -e LOCAL_USER_ID=0 calico/go-build:1.26.5-llvm21.1.8-k8s1.36.2 echo TESTS-WOULD-RUN
Starting with UID: 0
useradd: UID 0 is not unique
su-exec: getpwnam(user): Success
rc=1

$ docker run --rm -e LOCAL_USER_ID=0 -e RUN_AS_ROOT=true calico/go-build:1.26.5-llvm21.1.8-k8s1.36.2 echo TESTS-WOULD-RUN
TESTS-WOULD-RUN
rc=0
```

`bash -n` clean. The end-to-end check is next Friday's windows run producing a non-empty junit; it cannot be verified pre-merge, since the lane only runs on its cron.

**Release note:**
```release-note
None
```

**AI assistance:** Claude Code (Opus 5) — investigation and diagnosis (OTEL trace and GCS artifact analysis, branch comparison), and drafted this change and description.



**Original Commit SHA**: 95d07f442772ba83d9932e2837e85f981e3284c6
