### PR TITLE
[release-v3.32] winfv: fix reboot race in Windows node prep

### DIFF
--- a/process/testing/aso/install-kubeadm.sh
+++ b/process/testing/aso/install-kubeadm.sh
@@ -325,6 +325,34 @@ function prepare_windows_configuration() {
   echo "Windows configuration files prepared"
 }
 
+function get_boot_time() {
+  local windows_connect_command="$1"
+  ${windows_connect_command} "(Get-CimInstance Win32_OperatingSystem).LastBootUpTime.ToFileTimeUtc()" 2>/dev/null | tr -d '\r' || true
+}
+
+# Wait until the node reports a boot time different from the one captured
+# before the reboot was triggered.  A plain SSH probe is not enough: Windows
+# can take tens of seconds to sever connections after Restart-Computer, so a
+# probe can reconnect to the still-shutting-down node and the next setup step
+# then runs mid-shutdown.
+function wait_for_reboot() {
+  local windows_connect_command="$1"
+  local pre_boot_time="$2"
+
+  echo "Waiting for node to reboot (boot time before reboot: ${pre_boot_time})..."
+  for _ in $(seq 1 60); do
+    local boot_time
+    boot_time=$(get_boot_time "$windows_connect_command")
+    if [[ -n "${boot_time}" && "${boot_time}" != "${pre_boot_time}" ]]; then
+      echo "Node is back up with new boot time ${boot_time}."
+      return 0
+    fi
+    sleep 10
+  done
+  echo "Node did not come back with a new boot time within 10 minutes"
+  return 1
+}
+
 function prepare_windows_node() {
   local windows_eip="$1"
   local node_index="$2"  # Optional, for display purposes
@@ -350,16 +378,31 @@ function prepare_windows_node() {
   echo "Copying Windows files to node..."
   scp -r -i "${SSH_KEY_FILE}" -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ./windows/* "aso@${windows_eip}:c:\\k\\"
 
-  # Enable containers feature (requires reboot)
+  # Enable containers feature (usually requires a reboot).  Capture the boot
+  # time first so wait_for_reboot can prove the reboot completed.
   echo "Enabling Windows Containers feature..."
-  ${windows_connect_command} "c:\\k\\enable-containers-with-reboot.ps1 -Force"
+  local pre_boot_time
+  pre_boot_time=$(get_boot_time "$windows_connect_command")
+  if [[ -z "${pre_boot_time}" ]]; then
+    echo "ERROR: failed to read boot time from Windows node ${display_name}"
+    return 1
+  fi
 
-  # Wait for node to come back online after reboot
-  sleep 10
-  echo "Waiting for node to be ready after reboot..."
-  retry_command 60 "${windows_connect_command} Write-Host 'Node is ready'"
+  local enable_output
+  enable_output=$(${windows_connect_command} "c:\\k\\enable-containers-with-reboot.ps1 -Force" || true)
+  echo "${enable_output}"
 
-  # Install containerd
+  if [[ "${enable_output}" == *"Restart computer"* ]]; then
+    if ! wait_for_reboot "$windows_connect_command" "$pre_boot_time"; then
+      echo "ERROR: Windows node ${display_name} did not reboot after enabling the Containers feature"
+      return 1
+    fi
+  else
+    echo "Containers feature did not require a reboot."
+  fi
+
+  # Install containerd.  The Containers-feature reboot has already completed,
+  # so this must not need another reboot; the script fails if one is pending.
   echo "Installing containerd..."
   if ! ${windows_connect_command} "c:\\k\\install-containerd.ps1 -ContainerDVersion ${CONTAINERD_VERSION} -Force"; then
     echo "ERROR: Failed to install containerd on Windows node ${display_name}"
@@ -367,10 +410,13 @@ function prepare_windows_node() {
     return 1
   fi
 
-  # Wait for node to come back online after reboot
-  sleep 10
-  echo "Waiting for node to be ready after reboot..."
-  retry_command 60 "${windows_connect_command} Write-Host 'Node is ready'"
+  # Fail fast here, rather than much later in PrepareNode.ps1, if containerd
+  # didn't come up.
+  echo "Verifying containerd service..."
+  if ! ${windows_connect_command} "if (-not (Get-Service containerd -ErrorAction SilentlyContinue)) { exit 1 }"; then
+    echo "ERROR: containerd service is not present on Windows node ${display_name}"
+    return 1
+  fi
 
   echo "Windows node ${display_name} prepared successfully"
   echo

--- a/process/testing/aso/windows/enable-containers-with-reboot.ps1
+++ b/process/testing/aso/windows/enable-containers-with-reboot.ps1
@@ -89,6 +89,8 @@ if ($global:RebootRequired)
         exit
     }
 
+    # install-kubeadm.sh matches this marker to decide whether to wait for the
+    # node's boot time to change; keep the two in sync.
     Write-Output "Restart computer ..."
 
     try

--- a/process/testing/aso/windows/install-containerd.ps1
+++ b/process/testing/aso/windows/install-containerd.ps1
@@ -1,5 +1,6 @@
 # This script is adapated from https://raw.githubusercontent.com/microsoft/Windows-Containers/Main/helpful_tools/Install-ContainerdRuntime/install-containerd-runtime.ps1
 # Reference: https://learn.microsoft.com/en-us/virtualization/windowscontainers/quick-start/set-up-environment?tabs=containerd
+# Tigera modifications Copyright (c) 2026 Tigera, Inc. All rights reserved.
 
 
 ############################################################
@@ -102,64 +103,7 @@ $global:RebootRequired = $false
 
 $global:ErrorFile = "$pwd\install-container-runtime.err"
 
-$global:BootstrapTask = "ContainerBootstrap"
-
 $global:HyperVImage = "NanoServer"
-
-function
-Restart-And-Run()
-{
-    Test-Admin
-
-    Write-Output "Restart is required; restarting now..."
-
-    $argList = $script:MyInvocation.Line.replace($script:MyInvocation.InvocationName, "")
-
-    #
-    # Update .\ to the invocation directory for the bootstrap
-    #
-    $scriptPath = $script:MyInvocation.MyCommand.Path
-
-    $argList = $argList -replace "\.\\", "$pwd\"
-
-    if ((Split-Path -Parent -Path $scriptPath) -ne $pwd)
-    {
-        $sourceScriptPath = $scriptPath
-        $scriptPath = "$pwd\$($script:MyInvocation.MyCommand.Name)"
-
-        Copy-Item $sourceScriptPath $scriptPath
-    }
-
-    Write-Output "Creating scheduled task action ($scriptPath $argList)..."
-    $action = New-ScheduledTaskAction -Execute "powershell.exe" -Argument "-NoExit $scriptPath $argList"
-
-    Write-Output "Creating scheduled task trigger..."
-    $trigger = New-ScheduledTaskTrigger -AtLogOn
-
-    Write-Output "Registering script to re-run at next user logon..."
-    Register-ScheduledTask -TaskName $global:BootstrapTask -Action $action -Trigger $trigger -RunLevel Highest | Out-Null
-
-    try
-    {
-        if ($Force)
-        {
-            Restart-Computer -Force
-        }
-        else
-        {
-            Restart-Computer
-        }
-    }
-    catch
-    {
-        Write-Error $_
-
-        Write-Output "Please restart your computer manually to continue script execution."
-    }
-
-    exit
-}
-
 
 function
 Install-Feature
@@ -292,21 +236,13 @@ Install-ContainerDHost
 
     if ($global:RebootRequired)
     {
-        if ($NoRestart)
-        {
-            Write-Warning "A reboot is required; stopping script execution"
-            exit
-        }
-
-        Restart-And-Run
-    }
-
-    #
-    # Unregister the bootstrap task, if it was previously created
-    #
-    if ($null -ne (Get-ScheduledTask -TaskName $global:BootstrapTask -ErrorAction SilentlyContinue))
-    {
-        Unregister-ScheduledTask -TaskName $global:BootstrapTask -Confirm:$false
+        # The caller (install-kubeadm.sh) reboots the node via
+        # enable-containers-with-reboot.ps1 and waits for that reboot to
+        # complete before running this script, so a pending reboot here means
+        # that wait went wrong.  This script used to reboot and re-run itself
+        # via an at-logon scheduled task, but nothing ever logs on to a
+        # headless CI node, so that path silently left containerd uninstalled.
+        throw "A reboot is still pending; expected enable-containers-with-reboot.ps1 to have completed it before this script runs."
     }
 
     #
@@ -742,4 +678,7 @@ try
 catch
 {
     Write-Error $_
+    # Make the failure visible to the calling shell; without this the script
+    # exits 0 and the caller carries on without containerd.
+    exit 1
 }


### PR DESCRIPTION
Cherry-pick of #13530 onto `release-v3.32`. Clean pick — the three `process/testing/aso/` scripts were byte-identical to pre-fix master on this branch, and the resulting files match post-fix master exactly.

Original description:

Fixes a flake in the Windows FV node-prep sequence. `install-kubeadm.sh` rebooted the node via `enable-containers-with-reboot.ps1`, slept 10s, then probed with SSH. Windows can take longer than that to sever connections, so the probe could reconnect to the still-shutting-down node and `install-containerd.ps1` then ran mid-shutdown. It saw a pending reboot, tried to reboot again (failing with "A system shutdown is in progress"), registered an at-logon scheduled task to re-run itself — which never fires on a headless CI node — and exited 0. containerd was never installed, and the job failed much later in `PrepareNode.ps1` with "ContainerD service was not detected".

Changes:
- Wait for the node's boot time (`Win32_OperatingSystem.LastBootUpTime`) to change after triggering the reboot, which proves the reboot completed, instead of sleep + SSH probe.
- Remove the at-logon scheduled-task re-run machinery from `install-containerd.ps1`; it can never work over headless SSH. A pending reboot at that point is now a hard error.
- `install-containerd.ps1` now exits non-zero when it fails instead of swallowing the error, and the caller verifies the containerd service exists right after the install step, so failures surface immediately rather than 20 minutes later.

CI-infrastructure-only change; exercised by the Windows FV jobs themselves. Shell syntax checked with `bash -n`; PowerShell parse-checked with the PS language parser.

**Release note:**
```release-note
None
```

AI assistance: written with Claude Code.