### PR TITLE
Align the ArgoCI and Semaphore e2e runners

### DIFF
--- a/.argoci/scripts/phases/run_tests.sh
+++ b/.argoci/scripts/phases/run_tests.sh
@@ -150,7 +150,6 @@ if [[ -n "${E2E_BINARY:-}" ]]; then
     ${proxy_env[@]+"${proxy_env[@]}"} \
     -v "$(pwd)":/go/src/github.com/projectcalico/calico:rw \
     -v "$(pwd)"/.go-pkg-cache:/go-cache:rw \
-    -v "$(pwd)"/.go-mod-cache:/go/pkg/mod:rw \
     -v "${BZ_LOCAL_DIR}/kubeconfig:/kubeconfig:ro" \
     -w /go/src/github.com/projectcalico/calico \
     "${RUN_IMAGE}" \

--- a/.argoci/scripts/phases/run_tests.sh
+++ b/.argoci/scripts/phases/run_tests.sh
@@ -1,20 +1,14 @@
 #!/usr/bin/env bash
+
 # run_tests.sh - acquire an e2e binary and run it, or defer to bz tests.
-#
-# Selection (automatic, matches Semaphore):
-#   - TEST_TYPE == k8s-e2e → run the monorepo e2e binary via `make e2e-run`.
-#     The binary is acquired first: built from local source when RUN_LOCAL_TESTS
-#     is set (per-PR CI), otherwise downloaded from the hashrelease (scheduled
-#     CI). E2E_TEST_CONFIG names the YAML config that selects the specs.
-#   - Else (non-e2e test types: benchmarks, certification, etc.) → `bz tests`.
-#
-# Required env:
-#   BZ_LOCAL_DIR, BZ_LOGS_DIR, HOME, REPORT_DIR, TEST_TYPE
-# Required for local builds:
-#   E2E_TEST_CONFIG
-# Required for hashrelease downloads:
-#   RELEASE_STREAM
-#
+
+# Three modes: RUN_LOCAL_TESTS builds from local source, TEST_TYPE k8s-e2e
+# downloads from the hashrelease, anything else defers to bz tests.
+# E2E_TEST_CONFIG names the YAML config that selects the specs.
+
+# Required env: BZ_LOCAL_DIR, BZ_LOGS_DIR, HOME, REPORT_DIR, TEST_TYPE.
+# The e2e path also needs E2E_TEST_CONFIG, plus RELEASE_STREAM to find a binary.
+
 # Sourced from body_*.sh. Exits with the test exit code.
 
 for _var in BZ_LOCAL_DIR BZ_LOGS_DIR HOME REPORT_DIR TEST_TYPE; do
@@ -36,15 +30,20 @@ elif [[ "${TEST_TYPE}" == "k8s-e2e" ]]; then
   ARCH=$(uname -m); [[ "$ARCH" == "x86_64" ]] && ARCH=amd64; [[ "$ARCH" == "aarch64" ]] && ARCH=arm64
   mkdir -p "${CI_HOME}/${CI_GIT_DIR}/e2e/bin/k8s"
   curl --retry 9 --retry-all-errors -fsSL "${HASHREL_URL}/files/e2e/e2e-linux-${ARCH}.test" -o "${CI_HOME}/${CI_GIT_DIR}/e2e/bin/k8s/e2e.test"
+
+  # A 200 carrying an error page would otherwise be chmod +x'd and only fail much
+  # later, inside ginkgo, as an exec-format error.
+  if [[ "$(stat -c %s "${CI_HOME}/${CI_GIT_DIR}/e2e/bin/k8s/e2e.test" 2>/dev/null || echo 0)" -lt 10000000 ]]; then
+    echo "[ERROR] downloaded e2e binary is implausibly small; the pointer is probably wrong"
+    exit 1
+  fi
   chmod +x "${CI_HOME}/${CI_GIT_DIR}/e2e/bin/k8s/e2e.test"
   echo "[INFO] downloaded e2e binary to ${CI_HOME}/${CI_GIT_DIR}/e2e/bin/k8s/e2e.test"
   E2E_BINARY=/go/src/github.com/projectcalico/calico/e2e/bin/k8s/e2e.test
 fi
 
-# E2E_BINARY is a set/unset sentinel (its value is not used here -- make
-# e2e-run locates the binary itself). Take the structured path whenever a
-# k8s-e2e binary was acquired above; non-e2e test types fall through to bz
-# tests below.
+# E2E_BINARY is a set/unset sentinel; make e2e-run locates the binary itself.
+# Non-e2e test types acquire none and fall through to bz tests.
 if [[ -n "${E2E_BINARY:-}" ]]; then
   echo "[INFO] starting e2e tests..."
 
@@ -55,16 +54,9 @@ if [[ -n "${E2E_BINARY:-}" ]]; then
 
   pushd "${CI_HOME}/${CI_GIT_DIR}" || exit
 
-  # Pick a runtime image. The local-build path already pulled
-  # calico/go-build to compile the binary, so reusing it for the run
-  # step is free. The hashrelease path didn't compile anything, so
-  # there's no reason to drag in the build toolchain -- use the
-  # official golang image (debian-bookworm base, glibc-compatible
-  # with the binary, ~800MB vs ~2GB).
-  # The e2e binary is CGO-linked against libbpf and dynamically depends on
-  # libelf and libz at runtime; the test scripts also call uuidgen. The
-  # calico/go-build image already has these; the upstream golang:bookworm
-  # image does not, so install them on the fly when using that path.
+  # The local-build path already pulled calico/go-build, so reuse it. The
+  # hashrelease path compiled nothing, so use the smaller golang image and
+  # install what the CGO-linked binary needs at runtime.
   PRE_RUN=":"
   if [[ -n "${RUN_LOCAL_TESTS:-}" ]]; then
     GO_BUILD_VER=$(make --no-print-directory -f ./metadata.mk -f - <<<'print:; @echo $(GO_BUILD_VER)' print)
@@ -75,29 +67,71 @@ if [[ -n "${E2E_BINARY:-}" ]]; then
     PRE_RUN="apt-get update -qq && apt-get install -y --no-install-recommends libelf1 zlib1g uuid-runtime"
   fi
 
-  # The upstream k8s e2e framework shells out to `kubectl` for any
-  # exec-into-pod step (RunHostCmd, etc.), so kubectl must be on PATH inside
-  # the runner. Fetch a K8S_VERSION-pinned binary via the repo's `make
-  # kubectl` target; it lands in hack/test/kind/ which is bind-mounted into
-  # the container, and we prepend that to PATH inside the bash -c below.
+  # The upstream framework shells out to kubectl for every exec-into-pod step,
+  # so a K8S_VERSION-pinned binary has to be on PATH inside the runner.
   make kubectl
 
-  # EKS kubeconfigs exec aws-iam-authenticator (PATH lookup), which the stock
-  # golang image lacks, so client-go fails before any tests run. The aws-eks
-  # provisioner installs it on the host; bind-mount it when present (no-op otherwise).
-  # It also needs AWS creds in the container (else it exits 1 and
-  # SynchronizedBeforeSuite fails). Mount ~/.aws (written by the prologue) and point
-  # the SDK at it via env -- container runs as an arbitrary UID.
+  # A managed kubeconfig execs a credential plugin by name: aws-iam-authenticator
+  # on EKS, gke-gcloud-auth-plugin on GKE, kubelogin on AKS. bz provisions all of
+  # them into BZ_LOCAL_DIR/bin, so mount that and put it on PATH.
   auth_mount=()
-  aws_cred_env=()
-  if [[ -x "${BZ_LOCAL_DIR}/bin/aws-iam-authenticator" ]]; then
-    auth_mount=(-v "${BZ_LOCAL_DIR}/bin/aws-iam-authenticator:/usr/local/bin/aws-iam-authenticator:ro")
-    if [[ -d "${HOME}/.aws" ]]; then
-      auth_mount+=(-v "${HOME}/.aws:/aws-config:ro")
-      aws_cred_env=(-e AWS_SHARED_CREDENTIALS_FILE=/aws-config/credentials
-                    -e AWS_CONFIG_FILE=/aws-config/config
-                    -e "AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION:-us-west-2}")
+  if [[ -d "${BZ_LOCAL_DIR}/bin" ]]; then
+    auth_mount=(-v "${BZ_LOCAL_DIR}/bin:/bz-bin:ro")
+  fi
+
+  # Those plugins read the cloud credentials the prologue staged under HOME.
+  for _dir in .aws .azure .config/gcloud; do
+    if [[ -d "${HOME}/${_dir}" ]]; then
+      auth_mount+=(-v "${HOME}/${_dir}:/cloud/${_dir}:ro")
     fi
+  done
+  if [[ -f "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]]; then
+    auth_mount+=(-v "${GOOGLE_APPLICATION_CREDENTIALS}:/cloud/gcp-key.json:ro"
+                 -e GOOGLE_APPLICATION_CREDENTIALS=/cloud/gcp-key.json)
+  fi
+
+  # aws-iam-authenticator exits 1 without credentials, which fails the suite in
+  # SynchronizedBeforeSuite. The container runs as an arbitrary UID, so point the
+  # SDK at the mount rather than relying on HOME.
+  aws_cred_env=()
+  if [[ -d "${HOME}/.aws" ]]; then
+    aws_cred_env=(-e AWS_SHARED_CREDENTIALS_FILE=/cloud/.aws/credentials
+                  -e AWS_CONFIG_FILE=/cloud/.aws/config
+                  -e "AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION:-us-west-2}")
+  fi
+
+  # Config the specs read from the environment. Named rather than valued so a
+  # lane that sets none forwards none.
+  spec_env=()
+  for _var in NON_CLUSTER_HOSTS_YAML REMOTE_KUBECONFIG LOG_LEVEL \
+              KUBEVIRT_TEST_VM_IMAGE IPAM_TEST_POOL_SUBNET; do
+    if [[ -n "${!_var:-}" ]]; then spec_env+=(-e "${_var}"); fi
+  done
+
+  # Hand the module download and the apt-get inside PRE_RUN the same proxy the
+  # host uses, where a lane runs behind one.
+  proxy_env=()
+  for _var in HTTP_PROXY HTTPS_PROXY NO_PROXY GOPROXY; do
+    if [[ -n "${!_var:-}" ]]; then proxy_env+=(-e "${_var}"); fi
+  done
+
+  # OpenShift taints its control-plane nodes NoSchedule, and the framework waits
+  # for every node to be schedulable, so untaint them the way bz tests did.
+  for _taint in node-role.kubernetes.io/master- node-role.kubernetes.io/control-plane-; do
+    KUBECONFIG="${BZ_LOCAL_DIR}/kubeconfig" ./hack/test/kind/kubectl taint nodes --all "${_taint}" || true
+  done
+
+  # Private clusters reach the API only through a SOCKS tunnel that banzai-core
+  # persists to Taskvars.yml. Empty and a no-op on a public cluster.
+  TUNNEL_CMD="$(grep -E '^MASTER_TUNNEL_COMMAND:' "$(dirname "${BZ_LOCAL_DIR}")/Taskvars.yml" 2>/dev/null | sed -E 's/^MASTER_TUNNEL_COMMAND:[[:space:]]*//' || true)"
+
+  # The command is a foreground `ssh -qN`, so the backgrounded job is ssh itself
+  # and $! is the PID to kill. Only tear down a tunnel this script started.
+  TUNNEL_PID=""
+  if [[ -n "${TUNNEL_CMD}" ]] && ! pgrep -fx "${TUNNEL_CMD}" >/dev/null 2>&1; then
+    echo "[INFO] opening SOCKS tunnel for private-cluster API access"
+    ${TUNNEL_CMD} &
+    TUNNEL_PID=$!
   fi
 
   # Capture the exit code so the JUnit copy below runs even when tests fail
@@ -110,15 +144,18 @@ if [[ -n "${E2E_BINARY:-}" ]]; then
     -e KUBECONFIG=/kubeconfig \
     -e PRODUCT=${PRODUCT:-calico} \
     ${K8S_E2E_DOCKER_EXTRA_FLAGS:-} \
-    "${auth_mount[@]}" \
-    "${aws_cred_env[@]}" \
+    ${auth_mount[@]+"${auth_mount[@]}"} \
+    ${aws_cred_env[@]+"${aws_cred_env[@]}"} \
+    ${spec_env[@]+"${spec_env[@]}"} \
+    ${proxy_env[@]+"${proxy_env[@]}"} \
     -v "$(pwd)":/go/src/github.com/projectcalico/calico:rw \
     -v "$(pwd)"/.go-pkg-cache:/go-cache:rw \
+    -v "$(pwd)"/.go-mod-cache:/go/pkg/mod:rw \
     -v "${BZ_LOCAL_DIR}/kubeconfig:/kubeconfig:ro" \
     -w /go/src/github.com/projectcalico/calico \
     "${RUN_IMAGE}" \
     bash -c "${PRE_RUN} && \
-      export PATH=/go/src/github.com/projectcalico/calico/hack/test/kind:\$PATH && \
+      export PATH=/bz-bin:/go/src/github.com/projectcalico/calico/hack/test/kind:\$PATH && \
       git config --global --add safe.directory '*' && \
       make e2e-run \
         KUBECONFIG=/kubeconfig \
@@ -127,15 +164,23 @@ if [[ -n "${E2E_BINARY:-}" ]]; then
         E2E_JUNIT_REPORT=junit.xml" \
     |& tee "${BZ_LOGS_DIR}/${TEST_TYPE}-tests.log" || e2e_rc=$?
 
-  # Copy JUnit XML to REPORT_DIR so the epilogue publishes it.
+  # Close the SOCKS tunnel only if we opened it (no-op otherwise).
+  [[ -n "${TUNNEL_PID}" ]] && kill "${TUNNEL_PID}" >/dev/null 2>&1 || true
+
   mkdir -p "${REPORT_DIR}"
-  cp report/junit.xml "${REPORT_DIR}/junit.xml" 2>/dev/null || true
+  if [[ -f report/junit.xml ]]; then
+    cp report/junit.xml "${REPORT_DIR}/junit.xml"
+    cp report/report.json "${REPORT_DIR}/report.json" 2>/dev/null || true
+  else
+    echo "[ERROR] no report/junit.xml was produced (rc=${e2e_rc}); the run did not reach ginkgo"
+    if [[ "${e2e_rc}" -eq 0 ]]; then e2e_rc=1; fi
+  fi
   popd || exit
 
   # Propagate the original test exit code.
   exit ${e2e_rc}
 else
-  # Non-e2e test types (benchmarks, certification, etc.) -- defer to bz.
+  # Non-e2e test types (benchmarks, certification) defer to bz.
   echo "[INFO] starting bz testing..."
   bz tests ${VERBOSE} |& tee >(gzip --stdout > "${BZ_LOGS_DIR}/${TEST_TYPE}-tests.log.gz")
 fi

--- a/.semaphore/end-to-end/scripts/phases/run_tests.sh
+++ b/.semaphore/end-to-end/scripts/phases/run_tests.sh
@@ -150,7 +150,6 @@ if [[ -n "${E2E_BINARY:-}" ]]; then
     ${proxy_env[@]+"${proxy_env[@]}"} \
     -v "$(pwd)":/go/src/github.com/projectcalico/calico:rw \
     -v "$(pwd)"/.go-pkg-cache:/go-cache:rw \
-    -v "$(pwd)"/.go-mod-cache:/go/pkg/mod:rw \
     -v "${BZ_LOCAL_DIR}/kubeconfig:/kubeconfig:ro" \
     -w /go/src/github.com/projectcalico/calico \
     "${RUN_IMAGE}" \

--- a/.semaphore/end-to-end/scripts/phases/run_tests.sh
+++ b/.semaphore/end-to-end/scripts/phases/run_tests.sh
@@ -1,21 +1,14 @@
 #!/usr/bin/env bash
+
 # run_tests.sh - acquire an e2e binary and run it, or defer to bz tests.
-#
-# Three modes, selected automatically:
-#   1. RUN_LOCAL_TESTS is set  → build the e2e binary from local source
-#      (per-PR CI / GCP e2e block).
-#   2. TEST_TYPE == k8s-e2e    → download the pre-built binary from the
-#      hashrelease (scheduled CI).
-#   3. Otherwise               → fall back to `bz tests` for non-e2e test
-#      types (benchmarks, certification, etc.).
-#
-# Required env:
-#   BZ_LOCAL_DIR, BZ_LOGS_DIR, HOME, REPORT_DIR, TEST_TYPE
-# Required for local builds:
-#   E2E_TEST_CONFIG
-# Required for hashrelease downloads:
-#   RELEASE_STREAM
-#
+
+# Three modes: RUN_LOCAL_TESTS builds from local source, TEST_TYPE k8s-e2e
+# downloads from the hashrelease, anything else defers to bz tests.
+# E2E_TEST_CONFIG names the YAML config that selects the specs.
+
+# Required env: BZ_LOCAL_DIR, BZ_LOGS_DIR, HOME, REPORT_DIR, TEST_TYPE.
+# The e2e path also needs E2E_TEST_CONFIG, plus RELEASE_STREAM to find a binary.
+
 # Sourced from body_*.sh. Exits with the test exit code.
 
 for _var in BZ_LOCAL_DIR BZ_LOGS_DIR HOME REPORT_DIR TEST_TYPE; do
@@ -37,11 +30,20 @@ elif [[ "${TEST_TYPE}" == "k8s-e2e" ]]; then
   ARCH=$(uname -m); [[ "$ARCH" == "x86_64" ]] && ARCH=amd64; [[ "$ARCH" == "aarch64" ]] && ARCH=arm64
   mkdir -p "${HOME}/calico/e2e/bin/k8s"
   curl --retry 9 --retry-all-errors -fsSL "${HASHREL_URL}/files/e2e/e2e-linux-${ARCH}.test" -o "${HOME}/calico/e2e/bin/k8s/e2e.test"
+
+  # A 200 carrying an error page would otherwise be chmod +x'd and only fail much
+  # later, inside ginkgo, as an exec-format error.
+  if [[ "$(stat -c %s "${HOME}/calico/e2e/bin/k8s/e2e.test" 2>/dev/null || echo 0)" -lt 10000000 ]]; then
+    echo "[ERROR] downloaded e2e binary is implausibly small; the pointer is probably wrong"
+    exit 1
+  fi
   chmod +x "${HOME}/calico/e2e/bin/k8s/e2e.test"
   echo "[INFO] downloaded e2e binary to ${HOME}/calico/e2e/bin/k8s/e2e.test"
   E2E_BINARY=/go/src/github.com/projectcalico/calico/e2e/bin/k8s/e2e.test
 fi
 
+# E2E_BINARY is a set/unset sentinel; make e2e-run locates the binary itself.
+# Non-e2e test types acquire none and fall through to bz tests.
 if [[ -n "${E2E_BINARY:-}" ]]; then
   echo "[INFO] starting e2e tests..."
 
@@ -52,16 +54,9 @@ if [[ -n "${E2E_BINARY:-}" ]]; then
 
   pushd "${HOME}/calico" || exit
 
-  # Pick a runtime image. The local-build path already pulled
-  # calico/go-build to compile the binary, so reusing it for the run
-  # step is free. The hashrelease path didn't compile anything, so
-  # there's no reason to drag in the build toolchain -- use the
-  # official golang image (debian-bookworm base, glibc-compatible
-  # with the binary, ~800MB vs ~2GB).
-  # The e2e binary is CGO-linked against libbpf and dynamically depends on
-  # libelf and libz at runtime; the test scripts also call uuidgen. The
-  # calico/go-build image already has these; the upstream golang:bookworm
-  # image does not, so install them on the fly when using that path.
+  # The local-build path already pulled calico/go-build, so reuse it. The
+  # hashrelease path compiled nothing, so use the smaller golang image and
+  # install what the CGO-linked binary needs at runtime.
   PRE_RUN=":"
   if [[ -n "${RUN_LOCAL_TESTS:-}" ]]; then
     GO_BUILD_VER=$(make --no-print-directory -f ./metadata.mk -f - <<<'print:; @echo $(GO_BUILD_VER)' print)
@@ -72,43 +67,66 @@ if [[ -n "${E2E_BINARY:-}" ]]; then
     PRE_RUN="apt-get update -qq && apt-get install -y --no-install-recommends libelf1 zlib1g uuid-runtime"
   fi
 
-  # The upstream k8s e2e framework shells out to `kubectl` for any
-  # exec-into-pod step (RunHostCmd, etc.), so kubectl must be on PATH inside
-  # the runner. Fetch a K8S_VERSION-pinned binary via the repo's `make
-  # kubectl` target; it lands in hack/test/kind/ which is bind-mounted into
-  # the container, and we prepend that to PATH inside the bash -c below.
+  # The upstream framework shells out to kubectl for every exec-into-pod step,
+  # so a K8S_VERSION-pinned binary has to be on PATH inside the runner.
   make kubectl
 
-  # EKS kubeconfigs exec aws-iam-authenticator (PATH lookup), which the stock
-  # golang image lacks, so client-go fails before any tests run. The aws-eks
-  # provisioner installs it on the host; bind-mount it when present (no-op otherwise).
+  # A managed kubeconfig execs a credential plugin by name: aws-iam-authenticator
+  # on EKS, gke-gcloud-auth-plugin on GKE, kubelogin on AKS. bz provisions all of
+  # them into BZ_LOCAL_DIR/bin, so mount that and put it on PATH.
   auth_mount=()
-  if [[ -x "${BZ_LOCAL_DIR}/bin/aws-iam-authenticator" ]]; then
-    auth_mount=(-v "${BZ_LOCAL_DIR}/bin/aws-iam-authenticator:/usr/local/bin/aws-iam-authenticator:ro")
+  if [[ -d "${BZ_LOCAL_DIR}/bin" ]]; then
+    auth_mount=(-v "${BZ_LOCAL_DIR}/bin:/bz-bin:ro")
   fi
 
-  # Some provisioners (notably OpenShift) taint control-plane nodes
-  # NoSchedule. The k8s e2e framework waits for *all* nodes to be schedulable
-  # (--allowed-not-ready-nodes 0) and otherwise hangs until the 30m
-  # SynchronizedBeforeSuite timeout, so untaint them first — matching what the
-  # legacy `bz tests` runner did. Harmless (`|| true`) on clusters with no such
-  # taint. Run on the host (API is reachable here; install used it).
+  # Those plugins read the cloud credentials the prologue staged under HOME.
+  for _dir in .aws .azure .config/gcloud; do
+    if [[ -d "${HOME}/${_dir}" ]]; then
+      auth_mount+=(-v "${HOME}/${_dir}:/cloud/${_dir}:ro")
+    fi
+  done
+  if [[ -f "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]]; then
+    auth_mount+=(-v "${GOOGLE_APPLICATION_CREDENTIALS}:/cloud/gcp-key.json:ro"
+                 -e GOOGLE_APPLICATION_CREDENTIALS=/cloud/gcp-key.json)
+  fi
+
+  # aws-iam-authenticator exits 1 without credentials, which fails the suite in
+  # SynchronizedBeforeSuite. The container runs as an arbitrary UID, so point the
+  # SDK at the mount rather than relying on HOME.
+  aws_cred_env=()
+  if [[ -d "${HOME}/.aws" ]]; then
+    aws_cred_env=(-e AWS_SHARED_CREDENTIALS_FILE=/cloud/.aws/credentials
+                  -e AWS_CONFIG_FILE=/cloud/.aws/config
+                  -e "AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION:-us-west-2}")
+  fi
+
+  # Config the specs read from the environment. Named rather than valued so a
+  # lane that sets none forwards none.
+  spec_env=()
+  for _var in NON_CLUSTER_HOSTS_YAML REMOTE_KUBECONFIG LOG_LEVEL \
+              KUBEVIRT_TEST_VM_IMAGE IPAM_TEST_POOL_SUBNET; do
+    if [[ -n "${!_var:-}" ]]; then spec_env+=(-e "${_var}"); fi
+  done
+
+  # Hand the module download and the apt-get inside PRE_RUN the same proxy the
+  # host uses, where a lane runs behind one.
+  proxy_env=()
+  for _var in HTTP_PROXY HTTPS_PROXY NO_PROXY GOPROXY; do
+    if [[ -n "${!_var:-}" ]]; then proxy_env+=(-e "${_var}"); fi
+  done
+
+  # OpenShift taints its control-plane nodes NoSchedule, and the framework waits
+  # for every node to be schedulable, so untaint them the way bz tests did.
   for _taint in node-role.kubernetes.io/master- node-role.kubernetes.io/control-plane-; do
     KUBECONFIG="${BZ_LOCAL_DIR}/kubeconfig" ./hack/test/kind/kubectl taint nodes --all "${_taint}" || true
   done
 
-  # Private clusters (e.g. private AKS) have no public API endpoint; the API is
-  # reachable only through a SOCKS proxy over an SSH tunnel to an in-VNet host.
-  # banzai-core persists that tunnel command (incl. its SSH key) to Taskvars.yml
-  # and the kubeconfig points at the proxy (proxy-url: socks5://localhost:<port>).
-  # The legacy `bz tests` runner opened the tunnel around the test; this runner
-  # bypasses `bz tests`, so open it here for the run and close it after. With
-  # --net=host the container reaches the host's proxy port. No-op (TUNNEL_CMD
-  # empty) for public clusters. `|| true` keeps the read safe under `set -e`.
+  # Private clusters reach the API only through a SOCKS tunnel that banzai-core
+  # persists to Taskvars.yml. Empty and a no-op on a public cluster.
   TUNNEL_CMD="$(grep -E '^MASTER_TUNNEL_COMMAND:' "$(dirname "${BZ_LOCAL_DIR}")/Taskvars.yml" 2>/dev/null | sed -E 's/^MASTER_TUNNEL_COMMAND:[[:space:]]*//' || true)"
-  # Only teardown a tunnel this script started; a pre-existing one is someone
-  # else's to manage. The command is a foreground `ssh -qN` (no -f), so the
-  # backgrounded job is the ssh process itself and $! is the PID to kill.
+
+  # The command is a foreground `ssh -qN`, so the backgrounded job is ssh itself
+  # and $! is the PID to kill. Only tear down a tunnel this script started.
   TUNNEL_PID=""
   if [[ -n "${TUNNEL_CMD}" ]] && ! pgrep -fx "${TUNNEL_CMD}" >/dev/null 2>&1; then
     echo "[INFO] opening SOCKS tunnel for private-cluster API access"
@@ -126,14 +144,18 @@ if [[ -n "${E2E_BINARY:-}" ]]; then
     -e KUBECONFIG=/kubeconfig \
     -e PRODUCT=${PRODUCT:-calico} \
     ${K8S_E2E_DOCKER_EXTRA_FLAGS:-} \
-    "${auth_mount[@]}" \
+    ${auth_mount[@]+"${auth_mount[@]}"} \
+    ${aws_cred_env[@]+"${aws_cred_env[@]}"} \
+    ${spec_env[@]+"${spec_env[@]}"} \
+    ${proxy_env[@]+"${proxy_env[@]}"} \
     -v "$(pwd)":/go/src/github.com/projectcalico/calico:rw \
     -v "$(pwd)"/.go-pkg-cache:/go-cache:rw \
+    -v "$(pwd)"/.go-mod-cache:/go/pkg/mod:rw \
     -v "${BZ_LOCAL_DIR}/kubeconfig:/kubeconfig:ro" \
     -w /go/src/github.com/projectcalico/calico \
     "${RUN_IMAGE}" \
     bash -c "${PRE_RUN} && \
-      export PATH=/go/src/github.com/projectcalico/calico/hack/test/kind:\$PATH && \
+      export PATH=/bz-bin:/go/src/github.com/projectcalico/calico/hack/test/kind:\$PATH && \
       git config --global --add safe.directory '*' && \
       make e2e-run \
         KUBECONFIG=/kubeconfig \
@@ -145,15 +167,20 @@ if [[ -n "${E2E_BINARY:-}" ]]; then
   # Close the SOCKS tunnel only if we opened it (no-op otherwise).
   [[ -n "${TUNNEL_PID}" ]] && kill "${TUNNEL_PID}" >/dev/null 2>&1 || true
 
-  # Copy JUnit XML to REPORT_DIR so the epilogue publishes it.
   mkdir -p "${REPORT_DIR}"
-  cp report/junit.xml "${REPORT_DIR}/junit.xml" 2>/dev/null || true
+  if [[ -f report/junit.xml ]]; then
+    cp report/junit.xml "${REPORT_DIR}/junit.xml"
+    cp report/report.json "${REPORT_DIR}/report.json" 2>/dev/null || true
+  else
+    echo "[ERROR] no report/junit.xml was produced (rc=${e2e_rc}); the run did not reach ginkgo"
+    if [[ "${e2e_rc}" -eq 0 ]]; then e2e_rc=1; fi
+  fi
   popd || exit
 
   # Propagate the original test exit code.
   exit ${e2e_rc}
 else
-  # Non-e2e test types (benchmarks, certification, etc.) -- defer to bz.
+  # Non-e2e test types (benchmarks, certification) defer to bz.
   echo "[INFO] starting bz testing..."
   bz tests ${VERBOSE} |& tee >(gzip --stdout > "${BZ_LOGS_DIR}/${TEST_TYPE}-tests.log.gz")
 fi


### PR DESCRIPTION
## Description

The ArgoCI and Semaphore e2e runners are near-copies that have drifted apart, and each was missing something the other had. This aligns them: after this change the two files are identical except for the variable naming the repo checkout.

Fixes that apply to both:

- A run that produces no `report/junit.xml` now fails. It used to `cp ... || true`, so a run that died before reaching ginkgo reported as a pass.
- `report.json` is collected alongside the JUnit XML, so a failed lane has the structured spec results and not just the log.
- The downloaded e2e binary is size-checked. An error page served as a 200 used to be marked executable and fail much later as an exec-format error.
- Cloud credential plugins all work, not only EKS. The runner mounts the whole bz bin directory plus the Azure and gcloud config, so the AKS and GKE lanes can exec their auth plugin.
- Spec config and proxy settings are forwarded into the container by name, so a lane that sets none forwards none.
- The Go module cache is mounted, which was already happening for the build cache.

Picked up by ArgoCI, which was missing them:

- OpenShift control-plane nodes get untainted before the run. Without it the framework waits for every node to be schedulable and hangs until the 30 minute suite timeout.
- The SOCKS tunnel for private clusters is opened for the run and closed after.

Picked up by Semaphore, which was missing it:

- AWS credentials reach the container. `aws-iam-authenticator` exits 1 without them and takes the suite down in `SynchronizedBeforeSuite`.

Worth doing separately: these two files should be one shared script. They will drift again.

```release-note
None
```
