### PR TITLE
Build felix in the binary step so the image build stops corrupting itself

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,7 @@ clean:
 	$(MAKE) -C confd clean
 	$(MAKE) -C felix clean
 	$(MAKE) -C cmd/calico clean
+	$(MAKE) -C istio clean
 	$(MAKE) -C kube-controllers clean
 	$(MAKE) -C libcalico-go clean
 	$(MAKE) -C node clean
@@ -53,6 +54,7 @@ clean:
 	$(MAKE) -C third_party/envoy-gateway clean
 	$(MAKE) -C third_party/envoy-proxy clean
 	$(MAKE) -C third_party/envoy-ratelimit clean
+	$(MAKE) -C whisker clean
 	rm -rf ./bin .stamp.*
 
 check-go-mod:

--- a/cmd/calico/Makefile
+++ b/cmd/calico/Makefile
@@ -40,7 +40,7 @@ IMAGE_TAG = latest
 
 .PHONY: clean
 clean:
-	rm -rf bin .image.created-*
+	rm -rf bin .image.created-* .release-*
 	-docker image rm -f $$(docker images $(CALICO_IMAGE) -a -q) 2>/dev/null
 
 .PHONY: ut
@@ -101,11 +101,11 @@ cd: image-all cd-common
 ###############################################################################
 # Release
 ###############################################################################
-## Produces a clean build of the combined calico image at the specified version.
+## Produces the combined calico image at the specified version. Clean first for a fresh build.
 .PHONY: release-build release-publish
 release-build: .release-$(VERSION).created
 .release-$(VERSION).created:
-	$(MAKE) clean image-all RELEASE=true
+	$(MAKE) image-all RELEASE=true
 	$(MAKE) retag-build-images-with-registries RELEASE=true IMAGETAG=$(VERSION)
 	$(MAKE) retag-build-images-with-registries RELEASE=true IMAGETAG=latest
 	touch $@

--- a/felix/Makefile
+++ b/felix/Makefile
@@ -561,10 +561,10 @@ cd: cd-common
 ###############################################################################
 # Release
 ###############################################################################
-## Produces a clean build of release artifacts at the specified version.
+## Produces release artifacts at the specified version. Clean first for a fresh build.
 release-build: .release-$(VERSION).created
 .release-$(VERSION).created:
-	$(MAKE) clean build bin/calico-bpf
+	$(MAKE) build bin/calico-bpf
 	touch $@
 
 ###############################################################################

--- a/istio/Makefile
+++ b/istio/Makefile
@@ -191,7 +191,7 @@ cd: image-all cd-common
 release-build: .release-$(VERSION).created
 
 .release-$(VERSION).created:
-	$(MAKE) clean image-all RELEASE=true
+	$(MAKE) image-all RELEASE=true
 	$(MAKE) retag-build-images-with-registries IMAGETAG=$(VERSION) RELEASE=true
 	$(MAKE) retag-build-images-with-registries IMAGETAG=latest RELEASE=true
 	touch $@

--- a/lib.Makefile
+++ b/lib.Makefile
@@ -2042,15 +2042,20 @@ else
 DOCKER_MANIFEST = echo [DRY RUN] $(DOCKER_MANIFEST_CMD)
 endif
 
+# Named per component so two components' Windows builds do not remove each other's.
+WINDOWS_BUILDER = calico-windows-builder-$(notdir $(CURDIR))
+
 # Clean up the docker builder used to create Windows image tarballs.
 .PHONY: clean-windows-builder
 clean-windows-builder:
+	-docker buildx rm $(WINDOWS_BUILDER)
+	# Drain the shared builder earlier releases left selected on the host with --use.
 	-docker buildx rm calico-windows-builder
 
 # Set up the docker builder used to create Windows image tarballs.
 .PHONY: setup-windows-builder
 setup-windows-builder: clean-windows-builder
-	docker buildx create --name=calico-windows-builder --use --platform windows/amd64
+	docker buildx create --name=$(WINDOWS_BUILDER) --platform windows/amd64
 
 # FIXME: Use WINDOWS_HPC_VERSION and image instead of nanoserver and WINDOWS_VERSIONS when containerd v1.6 is EOL'd
 # .PHONY: image-windows release-windows
@@ -2113,6 +2118,7 @@ windows-sub-image-%: var-require-all-GIT_VERSION-WINDOWS_IMAGE-WINDOWS_DIST-WIND
 	# ensure dir for windows image tars exits
 	-mkdir -p $(WINDOWS_DIST)
 	docker buildx build \
+		--builder $(WINDOWS_BUILDER) \
 		--platform windows/amd64 \
 		--output=type=docker,dest=$(CURDIR)/$(WINDOWS_DIST)/$(WINDOWS_IMAGE)-$(GIT_VERSION)-$*.tar \
 		$(DOCKER_PULL) \

--- a/node/Makefile
+++ b/node/Makefile
@@ -417,10 +417,10 @@ cd: image-all cd-common
 ###############################################################################
 # Release
 ###############################################################################
-## Produces a clean build of release artifacts at the specified version.
+## Produces release artifacts at the specified version. Clean first for a fresh build.
 release-build: .release-$(VERSION).created
 .release-$(VERSION).created:
-	$(MAKE) clean image-all RELEASE=true
+	$(MAKE) image-all RELEASE=true
 	$(MAKE) retag-build-images-with-registries RELEASE=true IMAGETAG=$(VERSION)
 	# Generate the `latest` node images.
 	$(MAKE) retag-build-images-with-registries RELEASE=true IMAGETAG=latest

--- a/release/cmd/images_test.go
+++ b/release/cmd/images_test.go
@@ -176,13 +176,16 @@ func TestImagesPublishLatchesConfirm(t *testing.T) {
 	}
 }
 
-// felix is built but never published, and a build must not latch either
-// publish flag.
-func TestImagesBuildRunsFelixAndDoesNotPublish(t *testing.T) {
+// felix ships binaries and no image, so the image build leaves it alone. A
+// build must also not latch either publish flag.
+func TestImagesBuildSkipsFelixAndDoesNotPublish(t *testing.T) {
 	r := runImages(t, fakeRepo(t, "v3.30.0"), "build", "--registry", "quay.io/calico")
 
-	if !r.ran("felix", "release-build") {
-		t.Errorf("build did not run felix, ran: %v", r.args)
+	if r.ran("felix") {
+		t.Errorf("image build reached felix, ran: %v", r.args)
+	}
+	if !r.ran("node", "release-build") {
+		t.Fatalf("no image build ran at all, ran: %v", r.args)
 	}
 	for _, env := range r.envs {
 		for _, latch := range []string{"CONFIRM=true", "DRYRUN=true", "RELEASE=true"} {
@@ -239,13 +242,29 @@ func TestImagesNarrowedKeepsEveryVariant(t *testing.T) {
 	}
 }
 
-// felix is build-only: accepted for a build, absent from a publish.
-func TestImagesNarrowedToBuildOnlyDir(t *testing.T) {
-	r := runImages(t, fakeRepo(t, "v3.30.0"),
-		"build", "--registry", "quay.io/calico", "--image-release-dir", "felix")
+// felix is not an image directory, so narrowing a build to it is a mistake
+// worth reporting rather than a build that quietly does nothing.
+func TestImagesRejectsFelixAsAnImageDir(t *testing.T) {
+	prev := imagesRunner
+	r := &recordingRunner{}
+	imagesRunner = r
+	t.Cleanup(func() { imagesRunner = prev })
 
-	if len(r.args) != 1 || !r.ran("felix", "release-build") {
-		t.Fatalf("expected a single felix build, ran: %v", r.args)
+	root := fakeRepo(t, "v3.30.0")
+	cfg := &Config{
+		RepoRootDir: root,
+		TmpDir:      filepath.Join(root, "tmp"),
+		OutputDir:   filepath.Join(root, "_output"),
+		LogsDir:     filepath.Join(root, "_logs"),
+	}
+	cmd := imagesCommand(cfg)
+	err := cmd.Run(context.Background(),
+		[]string{"images", "build", "--registry", "quay.io/calico", "--image-release-dir", "felix"})
+	if err == nil {
+		t.Fatal("expected felix to be rejected as an image release dir")
+	}
+	if len(r.args) != 0 {
+		t.Errorf("ran make anyway: %v", r.args)
 	}
 }
 

--- a/release/internal/images/images.go
+++ b/release/internal/images/images.go
@@ -50,11 +50,10 @@ const (
 
 var (
 	BuildVariants = []Variant{
-		// felix ships an image that is built but never published on its own
 		{
 			Name:        StandardVariant,
 			Target:      "release-build",
-			ReleaseDirs: append(slices.Clone(utils.ImageReleaseDirs), "felix"),
+			ReleaseDirs: slices.Clone(utils.ImageReleaseDirs),
 		},
 		{
 			Name:        windowsVariant,

--- a/release/pkg/manager/calico/manager.go
+++ b/release/pkg/manager/calico/manager.go
@@ -1300,11 +1300,12 @@ func (r *CalicoManager) buildBinaries() error {
 		logrus.Info("Skipping building binaries")
 		return nil
 	}
-	// calicoctl needs to build unconditionally; everything else is produced
-	// as part of its image release-build target.
-	m := map[string]string{"calicoctl": "build-all"}
-	if !r.images {
-		m["felix"] = "release-build"
+
+	// calicoctl and felix ship binaries and no image, so nothing in the image
+	// step produces them.
+	m := map[string]string{
+		"calicoctl": "build-all",
+		"felix":     "release-build",
 	}
 	env := append(os.Environ(),
 		fmt.Sprintf("VERSION=%s", r.calicoVersion),

--- a/release/pkg/manager/calico/manager_test.go
+++ b/release/pkg/manager/calico/manager_test.go
@@ -610,6 +610,27 @@ func unitCalls(f *fakeRunner, target string) []string {
 	return out
 }
 
+// felix builds no image, so the binary step is the only thing that produces
+// felix/bin/calico-bpf for the release tarball.
+func TestBuildBinariesBuildsFelixWhateverTheImagesFlagIs(t *testing.T) {
+	for _, images := range []bool{true, false} {
+		t.Run(fmt.Sprintf("images=%t", images), func(t *testing.T) {
+			f := newFakeRunner()
+			m := imageManager(t, f, "")
+			m.images = images
+			m.binaries = true
+			if err := m.buildBinaries(); err != nil {
+				t.Fatalf("buildBinaries: %v", err)
+			}
+			for _, want := range []string{"make -C /repo/felix release-build", "make -C /repo/calicoctl build-all"} {
+				if !f.ran(want) {
+					t.Errorf("did not run %q, ran: %v", want, f.calls)
+				}
+			}
+		})
+	}
+}
+
 func imageManager(t *testing.T, f *fakeRunner, logsDir string) *CalicoManager {
 	t.Helper()
 	// A publish asks each directory for its image names before recording refs.

--- a/third_party/cni-plugins/Makefile
+++ b/third_party/cni-plugins/Makefile
@@ -171,7 +171,7 @@ cd: image-all cd-common
 .PHONY: release-build release-publish
 release-build: .release-$(VERSION).created
 .release-$(VERSION).created:
-	$(MAKE) clean image-all RELEASE=true
+	$(MAKE) image-all RELEASE=true
 	$(MAKE) retag-build-images-with-registries IMAGETAG=$(VERSION) RELEASE=true
 	# Generate the `latest` images.
 	$(MAKE) retag-build-images-with-registries IMAGETAG=latest RELEASE=true

--- a/third_party/envoy-gateway/Makefile
+++ b/third_party/envoy-gateway/Makefile
@@ -88,7 +88,7 @@ cd: image-all cd-common
 .PHONY: release-build release-publish
 release-build: .release-$(VERSION).created
 .release-$(VERSION).created:
-	$(MAKE) clean image-all RELEASE=true
+	$(MAKE) image-all RELEASE=true
 	$(MAKE) retag-build-images-with-registries IMAGETAG=$(VERSION) RELEASE=true
 	# Generate the `latest` images.
 	$(MAKE) retag-build-images-with-registries IMAGETAG=latest RELEASE=true

--- a/third_party/envoy-proxy/Makefile
+++ b/third_party/envoy-proxy/Makefile
@@ -63,7 +63,7 @@ cd: image-all cd-common
 .PHONY: release-build release-publish
 release-build: .release-$(VERSION).created
 .release-$(VERSION).created:
-	$(MAKE) clean image-all RELEASE=true
+	$(MAKE) image-all RELEASE=true
 	$(MAKE) retag-build-images-with-registries IMAGETAG=$(VERSION) RELEASE=true
 	# Generate the `latest` images.
 	$(MAKE) retag-build-images-with-registries IMAGETAG=latest RELEASE=true

--- a/third_party/envoy-ratelimit/Makefile
+++ b/third_party/envoy-ratelimit/Makefile
@@ -81,7 +81,7 @@ cd: image-all cd-common
 .PHONY: release-build release-publish
 release-build: .release-$(VERSION).created
 .release-$(VERSION).created:
-	$(MAKE) clean image-all RELEASE=true
+	$(MAKE) image-all RELEASE=true
 	$(MAKE) retag-build-images-with-registries IMAGETAG=$(VERSION) RELEASE=true
 	# Generate the `latest` images.
 	$(MAKE) retag-build-images-with-registries IMAGETAG=latest RELEASE=true

--- a/whisker/Makefile
+++ b/whisker/Makefile
@@ -67,7 +67,7 @@ ut: image-nginx-test
 
 .PHONY: clean
 clean:
-	rm -rf bin dist node_modules *.created *.published
+	rm -rf bin dist node_modules *.created *.published .release-*
 
 ###############################################################################
 # Release
@@ -77,7 +77,7 @@ cd: image-all cd-common
 
 release-build: .release-$(VERSION).created
 .release-$(VERSION).created:
-	$(MAKE) clean image-all RELEASE=true
+	$(MAKE) image-all RELEASE=true
 	$(MAKE) retag-build-images-with-registries RELEASE=true IMAGETAG=$(VERSION)
 	$(MAKE) retag-build-images-with-registries RELEASE=true IMAGETAG=latest
 	touch $@


### PR DESCRIPTION
## Description

Concurrent image builds corrupt each other because one component's build writes into another component's tree. The cause is that felix sits in the concurrent image build list while shipping no image at all.

- felix's `release-build` produces binaries, not an image, and felix has no publish target. It moves to the binary step, alongside calicoctl.
- node is the only component that reaches into felix's tree, so with felix out of the image list there is nothing left to order.
- The `release-build` recipes no longer clean first. A release builds a fresh checkout, and one component's clean reaches into another's tree mid-build.
- Each component gets its own Windows buildx builder, named and passed with `--builder` rather than selected globally with `--use`. That also stops a Windows build redirecting unrelated Linux builds on the same host.

`make clean` at the repo root picks up istio and whisker, which it was missing. A local fresh build now depends on it rather than on the recipes.

Two overlaps are left, both pre-existing and neither with an observed failure: node and istio each build the same nftables RPM (content-addressed and guarded, so it costs a duplicate rpmbuild rather than a wrong result), and node's Linux and Windows units are two makes in one tree.

### Testing

- `make -C release ut` passes.
- Built felix, cmd/calico and node together on a fresh worktree, then cmd/calico and node concurrently, through `release images build --arch amd64`.

**Release note:**
```release-note
None
```

**AI assistance:** This PR was written in part with the assistance of generative AI.
