### PR TITLE
[v3.32] felix/fv: wait for Felix to be ready before asserting on status files

### DIFF
--- a/felix/fv/pod_setup_wait_test.go
+++ b/felix/fv/pod_setup_wait_test.go
@@ -62,13 +62,18 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ Pod setup status wait", []a
 			}
 		}
 
-		It("should receive DataplaneInSync message from the dataplane", func() {
+		startFelixAndWaitForInSync := func() {
 			tc.Felixes[0].TriggerDelayedStart()
+			tc.Felixes[0].WaitForReady()
 			Eventually(dataplaneInSyncReceivedC, "10s").Should(BeClosed(), "receipt of DataplaneInSync message not seen in logs")
+		}
+
+		It("should receive DataplaneInSync message from the dataplane", func() {
+			startFelixAndWaitForInSync()
 		})
 
 		It("should create endpoint-status files in a directory named endpoint-status with the specified directory prefix", func() {
-			tc.Felixes[0].TriggerDelayedStart()
+			startFelixAndWaitForInSync()
 			var filenames [2]string
 			var statCmds [2]func() error
 			for i := range dummyWorkloads {
@@ -102,8 +107,7 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ Pod setup status wait", []a
 			tc.Felixes[0].Exec("touch", name)
 
 			By("Waiting for Felix's status file reporter to come in-sync")
-			tc.Felixes[0].TriggerDelayedStart()
-			Eventually(dataplaneInSyncReceivedC, "10s").Should(BeClosed(), "receipt of DataplaneInSync message not seen in logs")
+			startFelixAndWaitForInSync()
 
 			By("checking if the stale file has been cleaned up")
 			fileExists := func() bool {
@@ -111,7 +115,7 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ Pod setup status wait", []a
 				_, err := tc.Felixes[0].ExecOutput("stat", name)
 				return err == nil
 			}
-			Eventually(fileExists).Should(BeFalse(), "Stale file was not cleaned up by Felix")
+			Eventually(fileExists, "10s", "500ms").Should(BeFalse(), "Stale file was not cleaned up by Felix")
 		})
 
 		It("should re-use pre-existing files after a restart", func() {
@@ -132,11 +136,10 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ Pod setup status wait", []a
 			By("creating a file with the determined name before Felix starts")
 			expectedFilename := filepath.Join("/tmp/endpoint-status", filename)
 			tc.Felixes[0].Exec("mkdir", "/tmp/endpoint-status")
-			tc.Felixes[0].Exec("touch", filename)
+			tc.Felixes[0].Exec("touch", expectedFilename)
 
 			By("waiting for Felix's status file reporter to become in-sync")
-			tc.Felixes[0].TriggerDelayedStart()
-			Eventually(dataplaneInSyncReceivedC, "10s").Should(BeClosed(), "receipt of DataplaneInSync message not seen in logs")
+			startFelixAndWaitForInSync()
 
 			output, err := tc.Felixes[0].ExecOutput("cat", expectedFilename)
 			Expect(err).NotTo(HaveOccurred(), "stat call failed while trying to create a file")


### PR DESCRIPTION
**Cherry-pick history**
- Pick onto **release-v3.32**: projectcalico/calico#13815

Waits for Felix to be ready before the assertions in the `Pod setup status wait` FV suite, so their 10s deadlines no longer have to cover Felix start-up too — which is what times out on a loaded CI runner. CORE-13626

### Conflict resolved by hand — please read

The pick did not apply cleanly. On this branch the `should create endpoint-status files` test called `TriggerDelayedStart()` with no in-sync wait at all, where master already had one, so that hunk had no match.

Resolved to match master's end state: the test now calls the shared helper, which gives it both the readiness wait and an in-sync wait it previously lacked. That is a little more than a pure pick, and it is deliberate — with no in-sync wait, that test's `statCmds` 10s deadline had to cover the whole of Felix start-up, which makes it the most exposed test on this branch, not the least.

Everything else matches master. The file is now identical to master's apart from the copyright header, which this branch keeps at 2025.

Verified on this branch: `go vet ./felix/fv/` clean, and the focused suite passes — `make -C felix fv GINKGO_FOCUS="Pod setup status wait"` ran 8 of 1177 specs, 8 passed, 0 failed. That covers the resolved test above. `WaitForReady` exists here with the same 10s/90s-under-BPF behaviour as on master.

**Release note:**
```release-note
None
```

**AI assistance:** Claude Code (Opus 5) performed the cherry-pick, resolved the conflict, and wrote this description.

By opening this PR you take responsibility for every line in it, and you agree to explain the change yourself during review rather than routing review comments back through an agent. See [AI_POLICY.md](../AI_POLICY.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<details>
<summary><b>Cherry-Pick PR details</b></summary>

- **Original PR ID**: 13815
- **Original Commit SHA**: 372fa68b70
- **Source Repo**: `projectcalico/calico`
- **Target Repo**: `projectcalico/calico`
- **Target Branch**: `release-v3.32`
</details>
