### PR TITLE
fix(app-policy): make SyncClient.inSync race free

### DIFF
--- a/app-policy/Makefile
+++ b/app-policy/Makefile
@@ -57,7 +57,7 @@ proto/healthz.pb.go: proto/healthz.proto
 ## Run the tests in a container. Useful for CI, Mac dev
 ut: protobuf
 	mkdir -p report
-	$(DOCKER_RUN) $(CALICO_BUILD) /bin/bash -c "cd /go/src/$(PACKAGE_NAME) && gotestsum --junitfile report/app_policy_ut.xml -- -v ./..."
+	$(DOCKER_RUN) $(CALICO_BUILD) /bin/bash -c "cd /go/src/$(PACKAGE_NAME) && gotestsum --junitfile report/app_policy_ut.xml -- -v -race ./..."
 
 ###############################################################################
 # CI

--- a/app-policy/syncher/syncserver.go
+++ b/app-policy/syncher/syncserver.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2025 Tigera, Inc. All rights reserved.
+// Copyright (c) 2018-2026 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@ package syncher
 
 import (
 	"context"
+	"sync/atomic"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -37,7 +38,7 @@ type SyncClient struct {
 	target           string
 	dialOpts         []grpc.DialOption
 	subscriptionType string
-	inSync           bool
+	inSync           atomic.Bool
 	storeManager     policystore.PolicyStoreManager
 }
 
@@ -79,7 +80,7 @@ func (s *SyncClient) Sync(cxt context.Context) {
 	for {
 		select {
 		case <-cxt.Done():
-			s.inSync = false
+			s.inSync.Store(false)
 			return
 		default:
 			inSync := make(chan struct{})
@@ -89,19 +90,19 @@ func (s *SyncClient) Sync(cxt context.Context) {
 			// Block until we receive InSync message, or cancelled.
 			select {
 			case <-inSync:
-				s.inSync = true
+				s.inSync.Store(true)
 			// Also catch the case where syncStore ends before it gets an InSync message.
 			case <-done:
 				// pass
 			case <-cxt.Done():
-				s.inSync = false
+				s.inSync.Store(false)
 				return
 			}
 
 			// Block until syncStore() ends (e.g. disconnected), or cancelled.
 			select {
 			case <-done:
-				s.inSync = false
+				s.inSync.Store(false)
 				// pass
 			case <-cxt.Done():
 				return
@@ -110,7 +111,7 @@ func (s *SyncClient) Sync(cxt context.Context) {
 			select {
 			case <-time.After(PolicySyncRetryTime):
 			case <-cxt.Done():
-				s.inSync = false
+				s.inSync.Store(false)
 				return
 			}
 		}
@@ -130,7 +131,7 @@ func (s *SyncClient) syncStore(cxt context.Context, inSync chan<- struct{}, done
 	stream, err := client.Sync(cxt, &proto.SyncRequest{})
 	if err != nil {
 		log.Warnf("failed to synchronize with Policy Sync server: %v", err)
-		s.inSync = false
+		s.inSync.Store(false)
 		return
 	}
 	log.Info("Starting synchronization with Policy Sync server")
@@ -143,7 +144,7 @@ func (s *SyncClient) syncStore(cxt context.Context, inSync chan<- struct{}, done
 		log.WithFields(log.Fields{"proto": update}).Debug("Received sync API Update")
 		switch update.Payload.(type) {
 		case *proto.ToDataplane_InSync:
-			s.inSync = true
+			s.inSync.Store(true)
 			s.storeManager.OnInSync()
 		default:
 			s.storeManager.DoWithLock(func(ps *policystore.PolicyStore) {
@@ -155,5 +156,5 @@ func (s *SyncClient) syncStore(cxt context.Context, inSync chan<- struct{}, done
 
 // Readiness returns whether the SyncClient is InSync.
 func (s *SyncClient) Readiness() bool {
-	return s.inSync
+	return s.inSync.Load()
 }


### PR DESCRIPTION
`SyncClient.inSync` was a plain `bool` shared by three goroutines. `Sync` writes it. The `syncStore` goroutine that `Sync` starts writes it too. `Readiness` reads it from a gRPC health handler, registered in `pkg/dikastes/dikastes.go` as `health.NewHealthCheckService(syncClient)`. So there's a write/write race and a read/write race. It's now an `atomic.Bool`.

`TestSyncRestart` and `TestSyncCancelAfterInSync` already catch this. `go test -race -run TestSyncRestart ./app-policy/syncher/` fires 5 runs out of 5, naming the write at `syncserver.go:146` in `syncStore` against the read in `Readiness`. Over repeated runs the write at `:104` in `Sync` shows up too.

Nothing ever saw it because the `ut` target in `app-policy/Makefile` ran `gotestsum -- -v ./...` with no `-race`. This adds `-race` to that target, so the tests already in the repo guard the fix.

Test plan, run in `calico/go-build:1.27.0-llvm21.1.8-k8s1.37.0` with `GOOS=linux`:

- Before the fix, `go test -race ./app-policy/...`: `syncher` fails on the race, `checker`, `health` and `policystore` pass.
- After the fix, `go test -race -count=4 ./app-policy/...`: all four packages pass. `pkg/dikastes` has no test files.
- `go vet ./app-policy/...` and `gofmt` clean.

So `-race` costs nothing else in this component today.

**Release note:**
```release-note
Fixed a data race on the Dikastes policy sync readiness flag, which could report a stale readiness result to health checks.
```

**AI assistance:** This PR was written in part with the assistance of generative AI.

By opening this PR you take responsibility for every line in it, and you agree to explain the change yourself during review rather than routing review comments back through an agent. See [AI_POLICY.md](../AI_POLICY.md).
