### PR TITLE
Pull the rapidclient image instead of assuming it is on the node

### DIFF
--- a/.semaphore/end-to-end/scripts/phases/load_images.sh
+++ b/.semaphore/end-to-end/scripts/phases/load_images.sh
@@ -4,46 +4,41 @@
 # PR CI has no registry push credential (fork PRs are untrusted), so an image
 # built from the PR source cannot be pushed to quay for the nodes to pull. For
 # the rapidclient image (used by the packet-size and maglev tests) we instead
-# build it locally and import it straight into each node's container runtime:
-#   - worker nodes  -> containerd `k8s.io` namespace (pods run it, PullPolicy=Never)
+# build it locally under the tag the tests already use and import it into each
+# node's container runtime:
+#   - cluster nodes -> containerd `k8s.io` namespace (pods run it)
 #   - external node -> docker (maglev runs it via `docker run`)
-# and export RAPIDCLIENT_TAG so images.RapidClientImage() pins that exact copy.
+# Pods use ImagePullPolicy: IfNotPresent, so the imported copy is used as-is.
 #
 # Scope: only the local-binary gcp-kubeadm PR path. Node access here relies on the
 # gcp-kubeadm CRC terraform outputs + master_ssh_key, which don't exist on other
-# providers; those runs skip this phase and fall back to the published :latest
-# (unchanged behaviour). Scheduled runs (no RUN_LOCAL_TESTS) test the published
-# hashrelease images, so they also skip and use :latest.
+# providers; those runs skip this phase and pull the published image. Scheduled
+# runs (no RUN_LOCAL_TESTS) test the published hashrelease images, so they also
+# skip.
 #
 # Required env:
 #   BZ_LOCAL_DIR, HOME
 # Optional env (set by the gcp-kubeadm block / configure.sh):
-#   RUN_LOCAL_TESTS, PROVISIONER, SEMAPHORE_GIT_PR_NUMBER, SEMAPHORE_GIT_SHA,
-#   EXT_IP, EXT_KEY, EXT_USER
-# Exports consumed by later phases:
-#   RAPIDCLIENT_TAG, K8S_E2E_DOCKER_EXTRA_FLAGS
+#   RUN_LOCAL_TESTS, PROVISIONER, EXT_IP, EXT_KEY, EXT_USER
 #
 # Sourced from body_*.sh (inherits `set -eo pipefail`, so any build/load failure
-# aborts the job — preferable to a later ErrImageNeverPull mid-test).
+# aborts the job, rather than silently testing the published image instead of the
+# PR's).
 
 if [[ -z "${RUN_LOCAL_TESTS:-}" || "${PROVISIONER:-}" != "gcp-kubeadm" ]]; then
   echo "[INFO] load_images: skipping (only for local-binary gcp-kubeadm PR builds;" \
        "PROVISIONER=${PROVISIONER:-unset}, RUN_LOCAL_TESTS=${RUN_LOCAL_TESTS:-unset})." \
-       "Tests will use the published rapidclient :latest."
+       "Tests will pull the published rapidclient image."
 else
-  # Immutable, unique per PR (falls back to the commit sha off-PR). Pods pin this
-  # tag with ImagePullPolicy=Never, so it must match what we import below exactly.
-  if [[ -n "${SEMAPHORE_GIT_PR_NUMBER:-}" ]]; then
-    _tag="pr-${SEMAPHORE_GIT_PR_NUMBER}"
-  else
-    _tag="e2e-${SEMAPHORE_GIT_SHA:0:12}"
-  fi
-  _img="quay.io/tigeradev/rapidclient:${_tag}"
+
+  # Must match rapidClientImage in e2e/pkg/utils/images/images.go: the pods look up
+  # this exact reference, and IfNotPresent then uses what we import below.
+  _img="quay.io/tigeradev/rapidclient:latest"
 
   echo "[INFO] load_images: building ${_img} from local source (no registry push)"
-  make -C "${HOME}/calico/e2e/images/rapidclient" image TAG_NAME="${_tag}"
+  make -C "${HOME}/calico/e2e/images/rapidclient" image TAG_NAME="latest"
 
-  # --- worker nodes: import into containerd's k8s.io namespace ---------------
+  # --- cluster nodes: import into containerd's k8s.io namespace --------------
   _plat="${BZ_LOCAL_DIR}/crc/kubeadm/1.6"
   _key="${_plat}/master_ssh_key"
   _tf_out="${_plat}/terraform_output.json"
@@ -51,10 +46,11 @@ else
   if [[ ! -f "${_key}" ]]; then echo "[ERROR] load_images: ssh key ${_key} not found"; exit 1; fi
   _ssh_opts=(-i "${_key}" -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o ConnectTimeout=30)
 
-  mapfile -t _node_ips < <(jq -r '.node_connect_commands.value[]' "${_tf_out}" \
-                             | grep -oE 'ubuntu@[0-9.]+' | cut -d@ -f2)
+  # Infra nodes are schedulable on some platforms, so a pod can land on one.
+  mapfile -t _node_ips < <(jq -r '.node_connect_commands.value[]?, .infra_node_connect_commands.value[]?' "${_tf_out}" \
+                             | grep -oE 'ubuntu@[0-9.]+' | cut -d@ -f2 | sort -u)
   if [[ ${#_node_ips[@]} -eq 0 ]]; then
-    echo "[ERROR] load_images: no worker node IPs parsed from ${_tf_out}"; exit 1
+    echo "[ERROR] load_images: no node IPs parsed from ${_tf_out}"; exit 1
   fi
 
   # Serialize the image once and reuse the tarball for every node (docker save is
@@ -65,7 +61,7 @@ else
   trap 'rm -f "${_tar}"' EXIT
   docker save "${_img}" -o "${_tar}"
 
-  echo "[INFO] load_images: importing into containerd on ${#_node_ips[@]} worker node(s): ${_node_ips[*]}"
+  echo "[INFO] load_images: importing into containerd on ${#_node_ips[@]} node(s): ${_node_ips[*]}"
   for _ip in "${_node_ips[@]}"; do
     echo "[INFO]   -> ${_ip} (containerd)"
     ssh "${_ssh_opts[@]}" "ubuntu@${_ip}" -- 'sudo ctr -n k8s.io images import -' < "${_tar}"
@@ -82,9 +78,5 @@ else
   rm -f "${_tar}"
   trap - EXIT  # cleanup done on the happy path; don't leak the trap into run_tests.sh
 
-  # Pin the tests to the loaded image and forward the tag into the e2e container
-  # (run_tests.sh passes ${K8S_E2E_DOCKER_EXTRA_FLAGS} to its `docker run`).
-  export RAPIDCLIENT_TAG="${_tag}"
-  export K8S_E2E_DOCKER_EXTRA_FLAGS="--env RAPIDCLIENT_TAG ${K8S_E2E_DOCKER_EXTRA_FLAGS:-}"
-  echo "[INFO] load_images: RAPIDCLIENT_TAG=${RAPIDCLIENT_TAG} (pods pin this tag, ImagePullPolicy=Never)"
+  echo "[INFO] load_images: ${_img} loaded; pods will use it instead of pulling"
 fi

--- a/Makefile
+++ b/Makefile
@@ -243,15 +243,10 @@ E2E_JUNIT_REPORT ?= e2e_conformance.xml
 K8S_NETPOL_SUPPORTED_FEATURES ?= "ClusterNetworkPolicy,ClusterNetworkPolicyNamedPorts"
 K8S_NETPOL_UNSUPPORTED_FEATURES ?= ""
 
-# rapidclient (packet-size / maglev helper image) for the kind e2e lanes. Fork PRs
-# can't push to quay, so the packet-size lane (e2e-test-bpf) builds the image from PR
-# source and loads it straight into the kind nodes + external node; pods then pin this
-# exact tag with ImagePullPolicy=Never (see images.RapidClientImage / packet_size.go).
-# This mirrors the gcp-kubeadm side-load in .semaphore/.../load_images.sh (pr-<N>).
-# ?= so the gcp path's own RAPIDCLIENT_TAG wins if it ever runs through here; exported
-# so the ginkgo e2e process (which reads os.Getenv) inherits it across the sub-make.
-RAPIDCLIENT_TAG ?= kind-e2e
-export RAPIDCLIENT_TAG
+# rapidclient helper image for the packet-size and maglev specs. e2e-test-bpf loads
+# a PR-built copy into the kind nodes under the tag the tests use, so
+# PullIfNotPresent finds it. Keep in sync with images.go.
+RAPIDCLIENT_TAG := latest
 RAPIDCLIENT_IMAGE := quay.io/tigeradev/rapidclient
 EXTERNAL_NODE_NAME ?= kind-external-node
 
@@ -300,10 +295,8 @@ e2e-test-bpf:
 		E2E_TEST_CONFIG=$(REPO_ROOT)/e2e/config/kind/bpf.yaml
 
 ## Build the rapidclient helper image from PR source and load it into the kind
-## nodes so the packet-size server pods (ImagePullPolicy=Never) find it. Note:
-## unlike the rest of the kind image flow (local registry + PullAlways), rapidclient
-## is loaded directly with `kind load` to match the containerd-import + PullNever
-## model that images.RapidClientImage()/packet_size.go already use for gcp.
+## nodes, so the packet-size server pods use the PR build rather than pulling
+## the published image.
 .PHONY: kind-load-rapidclient
 kind-load-rapidclient:
 	$(MAKE) -C e2e/images/rapidclient image TAG_NAME=$(RAPIDCLIENT_TAG)

--- a/e2e/images/rapidclient/DESIGN.md
+++ b/e2e/images/rapidclient/DESIGN.md
@@ -98,30 +98,23 @@ CI trigger are unchanged.
 
 ### One image, two modes (`images.go`)
 
-Both consumers use the same image, so a single env-aware helper composes the ref
-and reports whether the image was loaded onto the nodes (see *Image delivery*):
+Both consumers use the same image, so a single reference serves both:
 
 ```go
-const rapidClientRepo = "quay.io/tigeradev/rapidclient"
+const rapidClientImage = "quay.io/tigeradev/rapidclient:latest"
 
-// RapidClientImage returns the image ref and whether it was pre-loaded onto the
-// test nodes (RAPIDCLIENT_TAG set by a CI lane) rather than pulled from quay.
-func RapidClientImage() (ref string, preloaded bool) {
-    if tag := os.Getenv("RAPIDCLIENT_TAG"); tag != "" {
-        return rapidClientRepo + ":" + tag, true
-    }
-    return rapidClientRepo + ":latest", false
+// RapidClientImage returns the rapidclient image reference.
+func RapidClientImage() string {
+    return rapidClientImage
 }
 ```
 
 Consumers:
 
 - `packet_size.go` — `withPacketSizeServer` sets the server pod's image, clears
-  `Args`, adds `MODE=server`, and sets the readiness path to `/length/1`. When
-  `preloaded`, it sets `ImagePullPolicy: Never` so a missing/failed load fails
-  loudly instead of masking with a stale published image. `PORT` is left unset,
-  so the server defaults to 5000 (matching the base conncheck server pod's
-  container port).
+  `Args`, adds `MODE=server`, and sets the readiness path to `/length/1`. `PORT`
+  is left unset, so the server defaults to 5000 (matching the base conncheck
+  server pod's container port).
 - `maglev.go` — runs `client` mode on the external node via
   `sudo docker run … -url … -port …`. `MODE` is unset, so it defaults to `client`
   and the flags parse as before; only the image ref changes.
@@ -220,30 +213,30 @@ job (authenticated via the `quay-tigeradev-hashrelease` secret), triggered by th
 
 ### Image delivery to test nodes
 
-Fork PR builds have no registry push credential, so the image built *from the PR
-under test* cannot be pushed to quay for nodes to pull; a `:latest` reference
-would silently run the previously-published image. Each CI lane that exercises the
-image therefore builds it from PR source and loads it directly onto its nodes,
-pinning the exact tag via `RAPIDCLIENT_TAG` (pods use `ImagePullPolicy: Never`).
+Pods use `ImagePullPolicy: IfNotPresent`, so the image is pulled from quay unless
+it is already on the node. Fork PR builds have no registry push credential, so a
+lane that wants to exercise the image *as built from the PR under test* builds it
+locally under the same `:latest` tag and loads it onto its nodes, where
+`IfNotPresent` uses it as-is.
 
 - **gcp-kubeadm** (`.semaphore/end-to-end/scripts/phases/load_images.sh`): builds
-  `rapidclient:pr-<N>`, `docker save`s it once, `ctr -n k8s.io images import`s it
-  onto every worker node's containerd and `docker load`s it onto the external
-  node, then exports `RAPIDCLIENT_TAG` (forwarded into the e2e container via
-  `K8S_E2E_DOCKER_EXTRA_FLAGS`). Runs only when `RUN_LOCAL_TESTS` and
-  `PROVISIONER=gcp-kubeadm` (it depends on the CRC terraform outputs + SSH key);
-  otherwise it no-ops.
+  the image, `docker save`s it once, `ctr -n k8s.io images import`s it onto every
+  cluster and infra node's containerd, and `docker load`s it onto the external
+  node. Runs only when `RUN_LOCAL_TESTS` and `PROVISIONER=gcp-kubeadm` (it depends
+  on the CRC terraform outputs + SSH key); otherwise it no-ops. A failed import
+  aborts the job, so the PR's build is never silently swapped for the published
+  one.
 - **kind** (`e2e-test-bpf`, the sig-calico BPF lane that runs packet-size): builds
-  `rapidclient:kind-e2e`, `kind load docker-image`s it into the kind nodes, and
-  `docker load`s it into the external node's inner docker daemon (a `dind`
-  container). `RAPIDCLIENT_TAG=kind-e2e` is exported by the root `Makefile` so the
-  ginkgo process inherits it. The non-BPF `e2e-test` lane (`kind/conformance.yaml` focus
-  `Conformance && sig-calico`) does not run packet-size, and the CNP lane uses a
-  separate test binary, so only `e2e-test-bpf` is wired.
+  the image, `kind load docker-image`s it into the kind nodes, and `docker load`s
+  it into the external node's inner docker daemon (a `dind` container). The non-BPF
+  `e2e-test` lane (`kind/conformance.yaml` focus `Conformance && sig-calico`) does
+  not run packet-size, and the CNP lane uses a separate test binary, so only
+  `e2e-test-bpf` is wired.
 
-When `RAPIDCLIENT_TAG` is unset — other providers, scheduled hashrelease runs,
-local dev — `RapidClientImage()` reports `preloaded=false` and the published
-`:latest` is used with the default pull policy.
+Every other lane — other providers, scheduled hashrelease runs, local dev — pulls
+the published image. The tag is named in three places (`images.go`, the root
+`Makefile`, and `load_images.sh`); `TestRapidClientImageIsConsistent` fails if they
+drift apart.
 
 ## Edge cases & failure modes
 
@@ -263,8 +256,9 @@ local dev — `RapidClientImage()` reports `preloaded=false` and the published
   dropped `-p=`/`--port=` override is by design.
 - **Manifest-list regression** is caught by the post-publish guard asserting the
   tag covers every arch in `ARCHES`.
-- **Missing node load with `RAPIDCLIENT_TAG` set** surfaces immediately as
-  `ErrImageNeverPull` (pods use `PullNever`) rather than a silent stale pull.
+- **Missing node load on a PR lane** aborts the job in `load_images.sh` under
+  `set -eo pipefail`, rather than letting the pods fall back to the published
+  image and test the wrong build.
 
 ## Testing
 

--- a/e2e/images/rapidclient/DESIGN.md
+++ b/e2e/images/rapidclient/DESIGN.md
@@ -34,10 +34,9 @@ Motivations:
 - Altering `Packet Size Verification` test logic or assertions. `server` mode is
   a like-for-like replacement of the flask server.
 - Altering the maglev client invocation. The `docker run … -url … -port …` call
-  in `maglev.go` is unchanged except for its image ref (now via
-  `RapidClientImage()`).
-- Digest-pinning the published image. CI runs against a per-lane tag loaded onto
-  the nodes (see *Image delivery to test nodes*); pinning the published `:latest`
+  in `maglev.go` is unchanged except for its image ref (now `images.RapidClient`).
+- Digest-pinning the published image. The PR lanes load their own build over the
+  same tag (see *Image delivery to test nodes*); pinning the published `:latest`
   to an immutable digest is separate future hardening.
 - Deleting `tigera/k8s-e2e/images/flask`. This binary stops *referencing* the
   flask image; retiring it there is a follow-up.
@@ -101,12 +100,7 @@ CI trigger are unchanged.
 Both consumers use the same image, so a single reference serves both:
 
 ```go
-const rapidClientImage = "quay.io/tigeradev/rapidclient:latest"
-
-// RapidClientImage returns the rapidclient image reference.
-func RapidClientImage() string {
-    return rapidClientImage
-}
+RapidClient = "quay.io/tigeradev/rapidclient:latest"
 ```
 
 Consumers:
@@ -273,7 +267,7 @@ drift apart.
 
 ## Rollout & follow-ups
 
-- The multi-mode binary, multi-arch publish, `RapidClientImage()` switch, and the
+- The multi-mode binary, multi-arch publish, `images.RapidClient` switch, and the
   per-lane image loads land together so the packet-size suite runs against the
   PR-built server atomically, without a registry push.
 - **Follow-up — retire the flask image.** Once packet-size is green on arm64, drop

--- a/e2e/images/rapidclient/README.md
+++ b/e2e/images/rapidclient/README.md
@@ -113,7 +113,7 @@ Response: {"output":"backend-pod-5\n"}
 
 ## How the e2e tests get this image
 
-The tests reference the image via `images.RapidClientImage()`
+The tests reference the image via `images.RapidClient`
 (`e2e/pkg/utils/images/images.go`), which is a single pinned reference:
 `quay.io/tigeradev/rapidclient:latest`. Pods use `ImagePullPolicy: IfNotPresent`,
 so a copy already on the node wins over a pull.

--- a/e2e/images/rapidclient/README.md
+++ b/e2e/images/rapidclient/README.md
@@ -114,18 +114,17 @@ Response: {"output":"backend-pod-5\n"}
 ## How the e2e tests get this image
 
 The tests reference the image via `images.RapidClientImage()`
-(`e2e/pkg/utils/images/images.go`), which is env-driven:
+(`e2e/pkg/utils/images/images.go`), which is a single pinned reference:
+`quay.io/tigeradev/rapidclient:latest`. Pods use `ImagePullPolicy: IfNotPresent`,
+so a copy already on the node wins over a pull.
 
-- **PR CI on gcp-kubeadm:** PR builds have no registry push credential, so
-  `.semaphore/end-to-end/scripts/phases/load_images.sh` builds this image from the
-  PR source and imports it straight into each node's containerd (and the external
-  node's docker), then exports `RAPIDCLIENT_TAG` (e.g. `pr-13105`). The tests pin
-  that tag with `ImagePullPolicy: Never`.
-- **Everything else** (other providers, scheduled runs, local dev): `RAPIDCLIENT_TAG`
-  is unset and the tests use the published `quay.io/tigeradev/rapidclient:latest`.
-  If you change this image and want a non-gcp-kubeadm run to use your build, publish
-  it (post-merge `push-images/e2e-test.yml` promotion) or set `RAPIDCLIENT_TAG`
-  yourself to a tag the cluster can pull.
+- **PR CI on gcp-kubeadm and the kind BPF lane:** PR builds have no registry push
+  credential, so `.semaphore/end-to-end/scripts/phases/load_images.sh` (and
+  `make kind-load-rapidclient`) build this image from the PR source under the same
+  tag and load it onto the nodes. The pods then run your build.
+- **Everything else** (other providers, scheduled runs, local dev): the published
+  image is pulled. If you change this image and want such a run to use your build,
+  publish it through the post-merge `push-images/e2e-test.yml` promotion.
 
 ## Integration with Tests
 

--- a/e2e/pkg/tests/networking/maglev.go
+++ b/e2e/pkg/tests/networking/maglev.go
@@ -587,7 +587,7 @@ func (m *MaglevTests) sendRequestsAndGatherStats(extNode *externalnode.Client, u
 
 	// The external node runs this image via plain `docker run`, so docker pulls it
 	// unless load_images.sh already loaded it there.
-	rapidClient := images.RapidClientImage()
+	rapidClient := images.RapidClient
 
 	for i := range totalRequests {
 		// Use external node to run rapidclient with netexec endpoint to get hostname

--- a/e2e/pkg/tests/networking/maglev.go
+++ b/e2e/pkg/tests/networking/maglev.go
@@ -585,10 +585,9 @@ func (m *MaglevTests) sendRequestsAndGatherStats(extNode *externalnode.Client, u
 	uniqueBackends := make(map[string]int)
 	totalRequests := m.maglevConfig.NumberOfRequests
 
-	// The external node runs this image via plain `docker run`; on gcp-kubeadm PR
-	// CI it was side-loaded into the external node's docker (RAPIDCLIENT_TAG),
-	// otherwise docker pulls the published :latest.
-	rapidClient, _ := images.RapidClientImage()
+	// The external node runs this image via plain `docker run`, so docker pulls it
+	// unless load_images.sh already loaded it there.
+	rapidClient := images.RapidClientImage()
 
 	for i := range totalRequests {
 		// Use external node to run rapidclient with netexec endpoint to get hostname

--- a/e2e/pkg/tests/networking/packet_size.go
+++ b/e2e/pkg/tests/networking/packet_size.go
@@ -92,7 +92,7 @@ func generatePacketLengths(mtu int) (getLengths, postLengths, udpLengths []int) 
 // server.
 func withPacketSizeServer(pod *v1.Pod) {
 	for i := range pod.Spec.Containers {
-		pod.Spec.Containers[i].Image = images.RapidClientImage()
+		pod.Spec.Containers[i].Image = images.RapidClient
 		pod.Spec.Containers[i].Args = nil
 
 		// The rapidclient image is multi-mode; MODE=server selects the HTTP/UDP

--- a/e2e/pkg/tests/networking/packet_size.go
+++ b/e2e/pkg/tests/networking/packet_size.go
@@ -89,19 +89,12 @@ func generatePacketLengths(mtu int) (getLengths, postLengths, udpLengths []int) 
 
 // withPacketSizeServer is a conncheck server pod customizer that replaces the
 // default image with the multi-mode rapidclient image run as the packet-size
-// server. See images.RapidClientImage for the endpoints the server exposes and
-// the side-load/pull-policy contract.
+// server.
 func withPacketSizeServer(pod *v1.Pod) {
-	image, preloaded := images.RapidClientImage()
 	for i := range pod.Spec.Containers {
-		pod.Spec.Containers[i].Image = image
+		pod.Spec.Containers[i].Image = images.RapidClientImage()
 		pod.Spec.Containers[i].Args = nil
-		// When the image was side-loaded into the nodes' containerd (PR CI on
-		// gcp-kubeadm), it is not in any registry — pin to the loaded copy and
-		// fail loudly if it is somehow absent rather than pulling a stale one.
-		if preloaded {
-			pod.Spec.Containers[i].ImagePullPolicy = v1.PullNever
-		}
+
 		// The rapidclient image is multi-mode; MODE=server selects the HTTP/UDP
 		// dataplane server.
 		pod.Spec.Containers[i].Env = append(pod.Spec.Containers[i].Env,

--- a/e2e/pkg/utils/images/images.go
+++ b/e2e/pkg/utils/images/images.go
@@ -66,38 +66,15 @@ const (
 	CalicoBIRD = "calico/bird:v0.3.3-211-g9111ec3c"
 )
 
-// rapidClientRepo is the multi-mode rapidclient image (client mode by default;
-// MODE=server runs the packet-size HTTP/UDP dataplane server). Both the Maglev
-// client and the packet-size server use this single image; the mode is selected
-// at pod-creation time. See e2e/images/rapidclient/ (and its DESIGN.md).
-//
-// Client mode (default): a Tigera-built HTTP client that reuses a fixed source
-// port across rapid sequential connections — needed for Maglev tests where the
-// load-balancer hash depends on the source port staying the same (curl, wget and
-// agnhost don't expose source-port control).
-//
-// Server mode (MODE=server): an HTTP/UDP server for tests that need controlled
-// payload sizes (MTU boundary, fragmentation, encap overhead). Endpoints, all on
-// the same port (default 5000): GET /length/<N> returns exactly N bytes; POST
-// /post returns the number of bytes received; UDP echoes received datagrams.
-const rapidClientRepo = "quay.io/tigeradev/rapidclient"
+// rapidClientImage is the multi-mode rapidclient helper: client mode for Maglev,
+// MODE=server for the packet-size dataplane server (see
+// e2e/images/rapidclient/DESIGN.md). Keep the tag in sync with the root Makefile
+// and load_images.sh.
+const rapidClientImage = "quay.io/tigeradev/rapidclient:latest"
 
-// RapidClientImage returns the rapidclient image reference and whether it was
-// side-loaded onto the e2e nodes.
-//
-// PR CI cannot push images to a registry (fork PRs get no push credential), so on
-// gcp-kubeadm the phases/load_images.sh e2e phase builds rapidclient from the PR
-// source and imports it directly into each node's containerd, then exports
-// RAPIDCLIENT_TAG (e.g. "pr-13105"). When that env is set we return the pinned tag
-// and preloaded=true; callers creating pods MUST then set ImagePullPolicy: Never
-// so a missing/failed load fails loudly instead of silently pulling a stale
-// published image. When it is unset (other providers, local dev) we fall back to
-// the published :latest and default pull behaviour — preserving prior behaviour.
-func RapidClientImage() (ref string, preloaded bool) {
-	if tag := os.Getenv("RAPIDCLIENT_TAG"); tag != "" {
-		return rapidClientRepo + ":" + tag, true
-	}
-	return rapidClientRepo + ":latest", false
+// RapidClientImage returns the rapidclient image reference.
+func RapidClientImage() string {
+	return rapidClientImage
 }
 
 // Get client image and powershell command based on windows OS version

--- a/e2e/pkg/utils/images/images.go
+++ b/e2e/pkg/utils/images/images.go
@@ -64,18 +64,13 @@ const (
 
 	// CalicoBIRD: Calico BIRD 1.x. Keep in sync with BIRD_VERSION in metadata.mk.
 	CalicoBIRD = "calico/bird:v0.3.3-211-g9111ec3c"
+
+	// RapidClient is the multi-mode rapidclient helper: client mode for Maglev,
+	// MODE=server for the packet-size dataplane server (see
+	// e2e/images/rapidclient/DESIGN.md). Keep the tag in sync with the root
+	// Makefile and load_images.sh.
+	RapidClient = "quay.io/tigeradev/rapidclient:latest"
 )
-
-// rapidClientImage is the multi-mode rapidclient helper: client mode for Maglev,
-// MODE=server for the packet-size dataplane server (see
-// e2e/images/rapidclient/DESIGN.md). Keep the tag in sync with the root Makefile
-// and load_images.sh.
-const rapidClientImage = "quay.io/tigeradev/rapidclient:latest"
-
-// RapidClientImage returns the rapidclient image reference.
-func RapidClientImage() string {
-	return rapidClientImage
-}
 
 // Get client image and powershell command based on windows OS version
 func WindowsClientImage() string {

--- a/e2e/pkg/utils/images/images_test.go
+++ b/e2e/pkg/utils/images/images_test.go
@@ -31,10 +31,10 @@ const seedScript = "../../../../.argoci/scripts/phases/seed_images.sh"
 // notSeeded holds the images the seed script deliberately leaves out, with the
 // reason. Anything else declared in images.go has to be in the script.
 var notSeeded = map[string]string{
-	"Porter":          "runs on Windows nodes, which the seed script does not reach",
-	"KubeVirtUbuntu":  "a containerDisk, pulled only by the KubeVirt lane",
-	"CalicoBIRD":      "run through docker on the external node, not as a pod",
-	"rapidClientRepo": "built from source and side-loaded by phases/load_images.sh",
+	"Porter":           "runs on Windows nodes, which the seed script does not reach",
+	"KubeVirtUbuntu":   "a containerDisk, pulled only by the KubeVirt lane",
+	"CalicoBIRD":       "run through docker on the external node, not as a pod",
+	"rapidClientImage": "pulled from quay, and side-loaded from source by phases/load_images.sh on the PR lane",
 }
 
 func TestWorkloadImagesAreSeeded(t *testing.T) {
@@ -60,6 +60,41 @@ func TestWorkloadImagesAreSeeded(t *testing.T) {
 		if !strings.Contains(string(script), ref) {
 			t.Errorf("%s (%s) is not in %s; add it there, or record why it is exempt in notSeeded",
 				name, ref, seedScript)
+		}
+	}
+}
+
+func TestRapidClientImageIsConsistent(t *testing.T) {
+	ref, ok := declaredImages(t)["rapidClientImage"]
+	if !ok {
+		t.Fatal("images.go no longer declares rapidClientImage")
+	}
+	repo, tag, ok := strings.Cut(ref, ":")
+	if !ok {
+		t.Fatalf("rapidClientImage %q has no tag", ref)
+	}
+
+	// The side-loaded copy is only used when every one of these names the same
+	// reference the pods ask for.
+	want := map[string][]string{
+		"../../../../Makefile": {
+			"RAPIDCLIENT_IMAGE := " + repo,
+			"RAPIDCLIENT_TAG := " + tag,
+		},
+		"../../../../.semaphore/end-to-end/scripts/phases/load_images.sh": {
+			`_img="` + ref + `"`,
+			`TAG_NAME="` + tag + `"`,
+		},
+	}
+	for path, refs := range want {
+		content, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+		for _, expected := range refs {
+			if !strings.Contains(string(content), expected) {
+				t.Errorf("%s does not contain %q, so its copy of the image no longer matches %s", path, expected, ref)
+			}
 		}
 	}
 }

--- a/e2e/pkg/utils/images/images_test.go
+++ b/e2e/pkg/utils/images/images_test.go
@@ -31,10 +31,10 @@ const seedScript = "../../../../.argoci/scripts/phases/seed_images.sh"
 // notSeeded holds the images the seed script deliberately leaves out, with the
 // reason. Anything else declared in images.go has to be in the script.
 var notSeeded = map[string]string{
-	"Porter":           "runs on Windows nodes, which the seed script does not reach",
-	"KubeVirtUbuntu":   "a containerDisk, pulled only by the KubeVirt lane",
-	"CalicoBIRD":       "run through docker on the external node, not as a pod",
-	"rapidClientImage": "pulled from quay, and side-loaded from source by phases/load_images.sh on the PR lane",
+	"Porter":         "runs on Windows nodes, which the seed script does not reach",
+	"KubeVirtUbuntu": "a containerDisk, pulled only by the KubeVirt lane",
+	"CalicoBIRD":     "run through docker on the external node, not as a pod",
+	"RapidClient":    "pulled from quay, and side-loaded from source by phases/load_images.sh on the PR lane",
 }
 
 func TestWorkloadImagesAreSeeded(t *testing.T) {
@@ -65,13 +65,13 @@ func TestWorkloadImagesAreSeeded(t *testing.T) {
 }
 
 func TestRapidClientImageIsConsistent(t *testing.T) {
-	ref, ok := declaredImages(t)["rapidClientImage"]
+	ref, ok := declaredImages(t)["RapidClient"]
 	if !ok {
-		t.Fatal("images.go no longer declares rapidClientImage")
+		t.Fatal("images.go no longer declares RapidClient")
 	}
 	repo, tag, ok := strings.Cut(ref, ":")
 	if !ok {
-		t.Fatalf("rapidClientImage %q has no tag", ref)
+		t.Fatalf("RapidClient %q has no tag", ref)
 	}
 
 	// The side-loaded copy is only used when every one of these names the same


### PR DESCRIPTION
The packet size specs fail on the master and v3.33 e2e lanes because their pods never get an image, 948 failed cases between 6 August and 8 September. The tests read a build-time default as proof that a lane had side-loaded the helper image onto the nodes, so they told kubelet never to pull it, on clusters where nothing had been loaded.

The tests now name one published image and let kubelet pull it, and the lanes that build that image from PR source load it under the same tag so the pods use their copy.

Related: [CORE-13575](https://tigera.atlassian.net/browse/CORE-13575)

```release-note
None
```


[CORE-13575]: https://tigera.atlassian.net/browse/CORE-13575?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ