### PR TITLE
Publish the operator image with the push targets the monorepo defines

### DIFF
--- a/operator/Makefile
+++ b/operator/Makefile
@@ -330,7 +330,7 @@ release-publish: operator-release-prereqs var-require-all-VERSION bin/crane
 	@if $(REPO_ROOT)/hack/image-published $(CRANE_CMD) "$(DEV_REGISTRIES)" "$(BUILD_IMAGES)" "$(VERSION)" "$(VALIDARCHES)"; then \
 		echo "$(BUILD_IMAGES):$(VERSION) is already published, skipping"; \
 	else \
-		$(MAKE) push-all push-manifests push-non-manifests IMAGETAG=$(VERSION); \
+		$(MAKE) push-images-to-registries push-manifests IMAGETAG=$(VERSION) RELEASE=$(RELEASE) CONFIRM=$(CONFIRM); \
 	fi
 
 # operator-release-prereqs checks the environment on top of lib.Makefile's own


### PR DESCRIPTION
Hashrelease publish fails when it reaches the operator image, with `No rule to make target 'push-all'`. The operator's publish step came over from its old standalone build harness, which defined its own push targets; the monorepo does not have them. This switches it to the push targets every other component uses, and passes the release flag through so a real release doesn't get a quay expiry stamped on its images.

Nothing short of a real publish runs the target, so there's no test here.

**Release note:**
```release-note
None
```

**AI assistance:** Claude Code, for the log triage and the change.

By opening this PR you take responsibility for every line in it, and you agree to explain the change yourself during review rather than routing review comments back through an agent. See [AI_POLICY.md](../AI_POLICY.md).
