### PR TITLE
Split the branch tag publish by image variant

### DIFF
--- a/lib.Makefile
+++ b/lib.Makefile
@@ -2127,7 +2127,7 @@ windows-sub-image-%: var-require-all-GIT_VERSION-WINDOWS_IMAGE-WINDOWS_DIST-WIND
 		--build-arg=WINDOWS_VERSION=$* \
 		-f Dockerfile.windows .
 
-.PHONY: image-windows release-windows release-windows-with-tag
+.PHONY: image-windows release-windows release-windows-with-tag retag-windows-image-with-registries
 image-windows: setup-windows-builder var-require-all-WINDOWS_VERSIONS
 	for version in $(WINDOWS_VERSIONS); do \
 		$(MAKE) windows-sub-image-$${version}; \
@@ -2154,6 +2154,14 @@ release-windows-with-tag: var-require-one-of-CONFIRM-DRYRUN var-require-all-IMAG
 		done; \
 		$(DOCKER_MANIFEST) push --purge $${manifest_image}; \
 		$(RELEASE_PY3) $(QUAY_SET_EXPIRY_SCRIPT) add --expiry-days=$(QUAY_EXPIRE_DAYS) $${manifest_image} $${all_images} || true; \
+	done;
+
+# retag-windows-image-with-registries copies the Windows image from DEV_TAG to
+# IMAGETAG in each registry. Windows images are single-arch manifests built by
+# buildx, so they have no local per-arch images to retag.
+retag-windows-image-with-registries: var-require-one-of-CONFIRM-DRYRUN var-require-all-DEV_REGISTRIES-WINDOWS_IMAGE-DEV_TAG-IMAGETAG bin/crane
+	for registry in $(DEV_REGISTRIES); do \
+		$(CRANE) cp $${registry}/$(WINDOWS_IMAGE):$(DEV_TAG) $${registry}/$(WINDOWS_IMAGE):$(IMAGETAG); \
 	done;
 
 release-windows: var-require-one-of-CONFIRM-DRYRUN var-require-all-DEV_REGISTRIES-WINDOWS_IMAGE var-require-one-of-VERSION-BRANCH_NAME bin/crane

--- a/release/internal/images/images.go
+++ b/release/internal/images/images.go
@@ -43,9 +43,9 @@ const (
 const (
 	StandardVariant = "standard"
 
-	// windowsVariant is named apart from the rest and published without
+	// WindowsVariant is named apart from the rest and published without
 	// per-architecture tags.
-	windowsVariant = "windows"
+	WindowsVariant = "windows"
 )
 
 var (
@@ -56,7 +56,7 @@ var (
 			ReleaseDirs: slices.Clone(utils.ImageReleaseDirs),
 		},
 		{
-			Name:        windowsVariant,
+			Name:        WindowsVariant,
 			Target:      "image-windows",
 			ReleaseDirs: slices.Clone(utils.WindowsReleaseDirs),
 		},
@@ -68,7 +68,7 @@ var (
 			ReleaseDirs: slices.Clone(utils.ImageReleaseDirs),
 		},
 		{
-			Name:        windowsVariant,
+			Name:        WindowsVariant,
 			Target:      "release-windows",
 			ReleaseDirs: slices.Clone(utils.WindowsReleaseDirs),
 		},
@@ -484,7 +484,7 @@ func (c Image) imageNames(u unit) ([]string, error) {
 		return nil, fmt.Errorf("reading images in %s: %w", u.dir, err)
 	}
 
-	wantWindows := u.variant == windowsVariant
+	wantWindows := u.variant == WindowsVariant
 	var names []string
 	for name := range strings.FieldsSeq(out) {
 		if strings.HasSuffix(name, windowsImageSuffix) == wantWindows {
@@ -620,7 +620,7 @@ func (c Image) unitTags(u unit) ([]string, error) {
 	if prefix != "" {
 		prefix += "-"
 	}
-	if u.variant == windowsVariant {
+	if u.variant == WindowsVariant {
 		return []string{prefix + c.Version}, nil
 	}
 	tags := []string{prefix + c.Version}

--- a/release/internal/images/images_test.go
+++ b/release/internal/images/images_test.go
@@ -521,7 +521,7 @@ func TestPublishRecordsWindowsIndexOnly(t *testing.T) {
 	f := &imageNameRunner{images: "node node-windows"}
 	rec := &fakeRecorder{}
 	err := Publish(testRepoRoot, testVersion,
-		[]Variant{{Name: windowsVariant, Target: "release-windows", ReleaseDirs: []string{"node"}}},
+		[]Variant{{Name: WindowsVariant, Target: "release-windows", ReleaseDirs: []string{"node"}}},
 		true, alwaysResolves("sha256:bbb"), recordingOpts(f, rec)...)
 	if err != nil {
 		t.Fatalf("Publish: %v", err)
@@ -660,7 +660,7 @@ func TestArchiveSavesEveryVariantsImages(t *testing.T) {
 	dir := t.TempDir()
 	err := Archive(testRepoRoot, testVersion, []Variant{
 		{Name: StandardVariant, Target: "release-publish", ReleaseDirs: []string{"node"}},
-		{Name: windowsVariant, Target: "release-windows", ReleaseDirs: []string{"node"}},
+		{Name: WindowsVariant, Target: "release-windows", ReleaseDirs: []string{"node"}},
 	}, dir, archiveOpts(f)...)
 	if err != nil {
 		t.Fatalf("Archive: %v", err)

--- a/release/pkg/manager/calico/manager.go
+++ b/release/pkg/manager/calico/manager.go
@@ -58,6 +58,10 @@ var (
 	s3ACLPublicRead = []string{"--acl", "public-read"}
 
 	branchTagTarget = "retag-build-images-with-registries push-images-to-registries push-manifests"
+
+	// Windows images are published as a single manifest, so their branch tag
+	// is a registry-side copy rather than a retag of local arch images.
+	windowsBranchTagTarget = "retag-windows-image-with-registries"
 )
 
 func NewManager(opts ...Option) *CalicoManager {
@@ -1571,11 +1575,18 @@ func (r *CalicoManager) publishBranchTag() error {
 	// them as its children.
 	if err := images.Publish(
 		r.repoRoot, branch,
-		images.NarrowVariants([]images.Variant{{
-			Name:        images.StandardVariant,
-			Target:      branchTagTarget,
-			ReleaseDirs: images.VariantDirs(images.PublishVariants),
-		}}, r.imageReleaseDirs),
+		images.NarrowVariants([]images.Variant{
+			{
+				Name:        images.StandardVariant,
+				Target:      branchTagTarget,
+				ReleaseDirs: images.VariantDirs(images.StandardVariants(images.PublishVariants)),
+			},
+			{
+				Name:        images.WindowsVariant,
+				Target:      windowsBranchTagTarget,
+				ReleaseDirs: slices.Clone(utils.WindowsReleaseDirs),
+			},
+		}, r.imageReleaseDirs),
 		!r.dryRun, r.digestResolver(),
 		images.WithRunner(r.runner),
 		images.WithRegistries(registry),

--- a/release/pkg/manager/calico/manager_test.go
+++ b/release/pkg/manager/calico/manager_test.go
@@ -688,6 +688,7 @@ func TestImageStepsWriteLogFiles(t *testing.T) {
 		}},
 		{"publish", (*CalicoManager).publishContainerImages, []string{
 			// The branch tag is a second publish, so it logs under its own step.
+			"/logs/images-publish-branch/node-windows.log",
 			"/logs/images-publish-branch/node.log",
 			"/logs/images-publish/node-windows.log",
 			"/logs/images-publish/node.log",
@@ -820,6 +821,27 @@ func TestPublishContainerImagesBranchTag(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// cni-plugin ships only a Windows image, so the standard branch tag target
+// there retags arch images that were never built.
+func TestPublishBranchTagSplitsWindowsFromStandard(t *testing.T) {
+	f := newFakeRunner()
+	if err := imageManager(t, f, "").publishContainerImages(); err != nil {
+		t.Fatalf("publishContainerImages: %v", err)
+	}
+	if got := "make -C /repo/cni-plugin " + branchTagTarget; f.ran(got) {
+		t.Errorf("branch tag ran %q, which has no arch images to retag (calls: %v)", got, f.calls)
+	}
+	want := "make -C /repo/cni-plugin " + windowsBranchTagTarget
+	if !f.ran(want) {
+		t.Errorf("did not run %q, ran: %v", want, f.calls)
+	}
+
+	// The copy is registry side, so it needs the tag it copies from.
+	if env := f.envFor(want); !slices.Contains(env, "DEV_TAG=v3.30.0") {
+		t.Errorf("windows branch tag env = %v, want DEV_TAG=v3.30.0", env)
 	}
 }
 


### PR DESCRIPTION
Publishing a hashrelease or a release fails while moving the branch tag onto the images it just published. The branch tag step ran the Linux retag target in every directory that ships an image, including the Windows-only ones, where the per-architecture images it retags are never built. Windows images now get their branch tag by copying the already published image within the registry.

```release-note
None
```
