### PR TITLE
Allow forwarded kubelet traffic in the HEP datapath test

### DIFF
--- a/e2e/pkg/tests/networking/hep_datapath.go
+++ b/e2e/pkg/tests/networking/hep_datapath.go
@@ -393,9 +393,9 @@ var _ = describe.CalicoDescribe(
 			}
 
 			if applyOnForward {
-				// On AKS and EKS the apiserver tunnels through an agent pod, so the HEP
-				// node dials other nodes' kubelets and that traffic is forwarded.
-				// Must land before the first AOF policy, which default-denies it.
+				// On managed Kubernetes, Konnectivity carries control-plane to node
+				// connections, so the HEP node dials other nodes' kubelets over forwarded
+				// traffic. Must land before the first AOF policy, which default-denies it.
 				kubeletForwardPolicy := hepBuildKubeletGNP(utils.GenerateRandomName("hep-kubelet-aof"), true)
 				fwdCtx, fwdCancel := context.WithTimeout(context.Background(), 30*time.Second)
 				defer fwdCancel()

--- a/e2e/pkg/tests/networking/hep_datapath.go
+++ b/e2e/pkg/tests/networking/hep_datapath.go
@@ -393,8 +393,8 @@ var _ = describe.CalicoDescribe(
 			}
 
 			if applyOnForward {
-				// On managed clusters the apiserver tunnels through an agent pod, so the
-				// HEP node dials other nodes' kubelets and that traffic is forwarded.
+				// On AKS and EKS the apiserver tunnels through an agent pod, so the HEP
+				// node dials other nodes' kubelets and that traffic is forwarded.
 				// Must land before the first AOF policy, which default-denies it.
 				kubeletForwardPolicy := hepBuildKubeletGNP(utils.GenerateRandomName("hep-kubelet-aof"), true)
 				fwdCtx, fwdCancel := context.WithTimeout(context.Background(), 30*time.Second)

--- a/e2e/pkg/tests/networking/hep_datapath.go
+++ b/e2e/pkg/tests/networking/hep_datapath.go
@@ -340,28 +340,40 @@ var _ = describe.CalicoDescribe(
 			By("Verifying connectivity with no HEP")
 			checkConnection(ct, clientPod, target, baseline)
 
-			// Create a GNP allowing kubectl exec to port 10250 on the HEP node.
-			// This must exist before the HEP to avoid breaking kubectl exec.
+			// Allow the kubelet exec path before the HEP lands. On managed clusters the
+			// apiserver tunnels through an agent pod here, so this node also dials other
+			// nodes' kubelets.
+			kubeletPorts := []numorstring.Port{numorstring.SinglePort(10250)}
 			kubeletPolicy := &v3.GlobalNetworkPolicy{
 				ObjectMeta: metav1.ObjectMeta{Name: utils.GenerateRandomName("hep-kubelet")},
 				Spec: v3.GlobalNetworkPolicySpec{
 					Order:          ptr.To(800.0),
 					Selector:       `hep == "node0"`,
-					ApplyOnForward: false,
-					Ingress: []v3.Rule{{
-						Action:   v3.Allow,
-						Protocol: protocolTCP(),
-						Destination: v3.EntityRule{
-							Ports: []numorstring.Port{numorstring.SinglePort(10250)},
+					ApplyOnForward: applyOnForward,
+					Ingress: []v3.Rule{
+						{
+							Action:      v3.Allow,
+							Protocol:    protocolTCP(),
+							Destination: v3.EntityRule{Ports: kubeletPorts},
 						},
-					}},
-					Egress: []v3.Rule{{
-						Action:   v3.Allow,
-						Protocol: protocolTCP(),
-						Source: v3.EntityRule{
-							Ports: []numorstring.Port{numorstring.SinglePort(10250)},
+						{
+							Action:   v3.Allow,
+							Protocol: protocolTCP(),
+							Source:   v3.EntityRule{Ports: kubeletPorts},
 						},
-					}},
+					},
+					Egress: []v3.Rule{
+						{
+							Action:   v3.Allow,
+							Protocol: protocolTCP(),
+							Source:   v3.EntityRule{Ports: kubeletPorts},
+						},
+						{
+							Action:      v3.Allow,
+							Protocol:    protocolTCP(),
+							Destination: v3.EntityRule{Ports: kubeletPorts},
+						},
+					},
 				},
 			}
 			createCtx, createCancel := context.WithTimeout(context.Background(), 30*time.Second)

--- a/e2e/pkg/tests/networking/hep_datapath.go
+++ b/e2e/pkg/tests/networking/hep_datapath.go
@@ -340,42 +340,9 @@ var _ = describe.CalicoDescribe(
 			By("Verifying connectivity with no HEP")
 			checkConnection(ct, clientPod, target, baseline)
 
-			// Allow the kubelet exec path before the HEP lands. On managed clusters the
-			// apiserver tunnels through an agent pod here, so this node also dials other
-			// nodes' kubelets.
-			kubeletPorts := []numorstring.Port{numorstring.SinglePort(10250)}
-			kubeletPolicy := &v3.GlobalNetworkPolicy{
-				ObjectMeta: metav1.ObjectMeta{Name: utils.GenerateRandomName("hep-kubelet")},
-				Spec: v3.GlobalNetworkPolicySpec{
-					Order:          ptr.To(800.0),
-					Selector:       `hep == "node0"`,
-					ApplyOnForward: applyOnForward,
-					Ingress: []v3.Rule{
-						{
-							Action:      v3.Allow,
-							Protocol:    protocolTCP(),
-							Destination: v3.EntityRule{Ports: kubeletPorts},
-						},
-						{
-							Action:   v3.Allow,
-							Protocol: protocolTCP(),
-							Source:   v3.EntityRule{Ports: kubeletPorts},
-						},
-					},
-					Egress: []v3.Rule{
-						{
-							Action:   v3.Allow,
-							Protocol: protocolTCP(),
-							Source:   v3.EntityRule{Ports: kubeletPorts},
-						},
-						{
-							Action:      v3.Allow,
-							Protocol:    protocolTCP(),
-							Destination: v3.EntityRule{Ports: kubeletPorts},
-						},
-					},
-				},
-			}
+			// Create a GNP allowing kubectl exec to port 10250 on the HEP node.
+			// This must exist before the HEP to avoid breaking kubectl exec.
+			kubeletPolicy := hepBuildKubeletGNP(utils.GenerateRandomName("hep-kubelet"), false)
 			createCtx, createCancel := context.WithTimeout(context.Background(), 30*time.Second)
 			defer createCancel()
 			Expect(cli.Create(createCtx, kubeletPolicy)).To(Succeed())
@@ -423,6 +390,23 @@ var _ = describe.CalicoDescribe(
 			} else {
 				By("Verifying HEP does not block forwarded traffic without AOF policy")
 				checkConnection(ct, clientPod, target, baseline)
+			}
+
+			if applyOnForward {
+				// On managed clusters the apiserver tunnels through an agent pod, so the
+				// HEP node dials other nodes' kubelets and that traffic is forwarded.
+				// Must land before the first AOF policy, which default-denies it.
+				kubeletForwardPolicy := hepBuildKubeletGNP(utils.GenerateRandomName("hep-kubelet-aof"), true)
+				fwdCtx, fwdCancel := context.WithTimeout(context.Background(), 30*time.Second)
+				defer fwdCancel()
+				Expect(cli.Create(fwdCtx, kubeletForwardPolicy)).To(Succeed())
+				DeferCleanup(func() {
+					cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 10*time.Second)
+					defer cleanupCancel()
+					if err := cli.Delete(cleanupCtx, kubeletForwardPolicy); err != nil && !apierrors.IsNotFound(err) {
+						framework.Logf("WARNING: failed to delete kubelet forward policy: %v", err)
+					}
+				})
 			}
 
 			// Create the allow GNP (order 500).
@@ -519,6 +503,33 @@ var _ = describe.CalicoDescribe(
 		})
 	},
 )
+
+// hepBuildKubeletGNP creates a GlobalNetworkPolicy allowing the kubelet exec path
+// on the HEP node, in both the kubelet's own role and as a client of another node's.
+func hepBuildKubeletGNP(name string, applyOnForward bool) *v3.GlobalNetworkPolicy {
+	ports := []numorstring.Port{numorstring.SinglePort(10250)}
+	toKubelet := v3.Rule{
+		Action:      v3.Allow,
+		Protocol:    protocolTCP(),
+		Destination: v3.EntityRule{Ports: ports},
+	}
+	fromKubelet := v3.Rule{
+		Action:   v3.Allow,
+		Protocol: protocolTCP(),
+		Source:   v3.EntityRule{Ports: ports},
+	}
+
+	return &v3.GlobalNetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: v3.GlobalNetworkPolicySpec{
+			Order:          ptr.To(800.0),
+			Selector:       `hep == "node0"`,
+			ApplyOnForward: applyOnForward,
+			Ingress:        []v3.Rule{toKubelet, fromKubelet},
+			Egress:         []v3.Rule{fromKubelet, toKubelet},
+		},
+	}
+}
 
 // hepBuildGNP creates a GlobalNetworkPolicy for HEP testing.
 func hepBuildGNP(name string, order float64, applyOnForward bool, direction string, action v3.Action) *v3.GlobalNetworkPolicy {


### PR DESCRIPTION
## Description

The Host Endpoint Datapath test carves out port 10250 so that applying a host endpoint to node0 doesn't take out `kubectl exec`. The carve-out only covers node0 acting as the kubelet, and only for host traffic:

- ingress allows destination port 10250, egress allows source port 10250
- ApplyOnForward is off, so forwarded traffic gets nothing

On managed Kubernetes, Konnectivity carries control-plane to node connections. Its agent is a pod, so when it lands on node0 that node becomes the client of another node's kubelet, and the packets are forwarded with 10250 as the destination. The ApplyOnForward=true scenarios deny them, so every exec into a pod on a far node returns a 504 and the connectivity check times out.

Two carve-outs now, sharing one builder, each allowing 10250 as source and destination in both directions:

- the existing one before the HostEndpoint, still ApplyOnForward=false, for the node's own kubelet
- a second one with ApplyOnForward=true, created only in the AOF scenarios and only after the check that a bare HEP leaves forwarded traffic alone, so it lands before the first policy that default-denies that traffic and never masks the earlier assertion

Fixes CORE-13580.

Verified on a throwaway AKS cluster (3 nodes, azure CNI overlay, iptables, master hashrelease), matching the `azr-aks-w-overlay` job the failures come from. Applying the scenario's policy set by hand and exec'ing into a pod on a node that hosts no agent:

| carve-out | execs that succeed |
|---|---|
| master's | 0 of 12, with the ticket's exact `code 504` error |
| this PR's | 12 of 12 |
| master's again | 0 of 12 |
| ApplyOnForward flipped, master's rules | 0 of 12 |

So both the ApplyOnForward change and the destination-port rules are needed. The focused suite is 30 of 30 on that cluster.

**Release note:**
```release-note
None
```

**AI assistance:** Claude Code, for the Lens failure analysis, the change, and the cluster verification.
