### PR TITLE
lib/std/log: use slog's Logger directly, adapt logrus as a Handler

### DIFF
--- a/lib/logrusr/adaptor.go
+++ b/lib/logrusr/adaptor.go
@@ -12,18 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package logrusr adapts a *logrus.Logger to the lib/std/log.Logger
-// interface. The name follows the Go logr-ecosystem convention (zapr,
-// klogr, glogr, logrusr) for "<library> adapted to a logger interface".
+// Package logrusr adapts a *logrus.Logger to slog, so callers holding a
+// lib/std/log.Logger (an *slog.Logger) emit through logrus. The name
+// follows the Go logr-ecosystem convention (zapr, klogr, glogr, logrusr)
+// for "<library> adapted to a logger interface".
 //
-// Variadic args to Debug/Info/Warn/Error and With are parsed as slog-style
-// key/value pairs and emitted as logrus fields; a slog.Attr may stand alone.
-// A dangling value with no key (or a non-string, non-Attr arg) is filed
-// under "!BADKEY", matching slog's convention.
+// The adapter is an slog.Handler rather than a Logger: slog.Logger is a
+// concrete shim that already parses variadic args into attributes — so
+// key/value pairs, stand-alone slog.Attrs and slog's "!BADKEY" handling
+// for dangling or non-string keys all come from slog itself, and this
+// package only has to render the resulting attributes as logrus fields.
 package logrusr
 
 import (
 	"context"
+	"log/slog"
 
 	"github.com/sirupsen/logrus"
 
@@ -31,87 +34,125 @@ import (
 )
 
 // New returns a log.Logger that emits through the given *logrus.Logger.
-// The returned Logger and any loggers derived from it via With share the
-// same base — SetLevel / SetOutput on the underlying logrus logger affect
-// all of them.
+// The returned Logger and any loggers derived from it via With or
+// WithGroup share the same base — SetLevel / SetOutput on the underlying
+// logrus logger affect all of them.
 func New(l *logrus.Logger) log.Logger {
 	if l == nil {
 		panic("logrusr.New: logger is nil")
 	}
-	return &adapter{base: l, entry: logrus.NewEntry(l)}
+	// The handler passes slog's call-site PC to the caller-stamping hook
+	// through a private field, so it has to make sure that hook is there
+	// to consume it — otherwise the field would reach the formatter and
+	// show up in the output. Installing twice is a no-op.
+	InstallCallerHook(l)
+	return slog.New(&handler{base: l, entry: logrus.NewEntry(l)})
 }
 
-// adapter implements log.Logger over a *logrus.Entry. With returns a fresh
-// adapter holding a derived entry; the original is never mutated.
-type adapter struct {
+// handler implements slog.Handler over a *logrus.Entry. WithAttrs and
+// WithGroup return a fresh handler holding a derived entry; the original
+// is never mutated.
+//
+// base is kept alongside entry so level checks read the live logrus
+// logger — a SetLevel after the handler is built is still honoured.
+type handler struct {
 	base  *logrus.Logger
 	entry *logrus.Entry
+
+	// prefix is the dotted concatenation of the groups opened by
+	// WithGroup, e.g. "http.request.". logrus fields are flat, so groups
+	// are flattened into the key rather than nested.
+	prefix string
 }
 
-func (a *adapter) Debug(msg string, args ...any) { a.emit(logrus.DebugLevel, msg, args) }
-func (a *adapter) Info(msg string, args ...any)  { a.emit(logrus.InfoLevel, msg, args) }
-func (a *adapter) Warn(msg string, args ...any)  { a.emit(logrus.WarnLevel, msg, args) }
-func (a *adapter) Error(msg string, args ...any) { a.emit(logrus.ErrorLevel, msg, args) }
-
-func (a *adapter) With(args ...any) log.Logger {
-	if len(args) == 0 {
-		return a
-	}
-	return &adapter{base: a.base, entry: a.entry.WithFields(argsToFields(args))}
+func (h *handler) Enabled(_ context.Context, level log.Level) bool {
+	return h.base.IsLevelEnabled(slogToLogrusLevel(level))
 }
 
-func (a *adapter) Enabled(_ context.Context, level log.Level) bool {
-	return a.base.IsLevelEnabled(slogToLogrusLevel(level))
-}
-
-// emit avoids building the fields map for log lines that would be dropped
-// by the level filter.
-func (a *adapter) emit(level logrus.Level, msg string, args []any) {
-	if !a.base.IsLevelEnabled(level) {
-		return
-	}
-	if len(args) == 0 {
-		a.entry.Log(level, msg)
-		return
-	}
-	a.entry.WithFields(argsToFields(args)).Log(level, msg)
-}
-
-// argsToFields parses slog-style key/value args into logrus.Fields.
-func argsToFields(args []any) logrus.Fields {
-	fields := make(logrus.Fields, len(args)/2+1)
-	for i := 0; i < len(args); {
-		switch k := args[i].(type) {
-		case string:
-			if i+1 < len(args) {
-				fields[k] = args[i+1]
-				i += 2
-			} else {
-				fields["!BADKEY"] = k
-				i++
-			}
-		case log.Attr:
-			fields[k.Key] = k.Value.Any()
-			i++
-		default:
-			fields["!BADKEY"] = k
-			i++
+func (h *handler) Handle(_ context.Context, r slog.Record) error {
+	level := slogToLogrusLevel(r.Level)
+	entry := h.entry
+	// slog captured the call site in r.PC. Hand it to the caller-stamping
+	// hook in this package (see fieldCallerPC) so it can resolve that one
+	// frame instead of walking the stack for the first non-logging one.
+	// The field is consumed before the entry is rendered.
+	if r.NumAttrs() > 0 || r.PC != 0 {
+		// Dup once and fill in place. entry.WithFields would build a
+		// second map on top of the one Dup already copies, which for a
+		// bare message is the bulk of the per-line allocation.
+		entry = entry.Dup()
+		r.Attrs(func(a slog.Attr) bool {
+			addAttr(entry.Data, h.prefix, a)
+			return true
+		})
+		if r.PC != 0 {
+			entry.Data[fieldCallerPC] = r.PC
 		}
 	}
-	return fields
+	// We deliberately don't carry r.Time across. logrus stamps the entry
+	// itself at emission, which is what every other logrus caller in this
+	// repo gets; honouring the record's time would need a second
+	// Entry.Dup (and so a second field-map copy) per line, to shave a
+	// sub-microsecond skew and leave this one logger's timestamps derived
+	// differently from the rest of the stream.
+	entry.Log(level, r.Message)
+	return nil
+}
+
+func (h *handler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	if len(attrs) == 0 {
+		return h
+	}
+	fields := make(logrus.Fields, len(attrs))
+	for _, a := range attrs {
+		addAttr(fields, h.prefix, a)
+	}
+	return &handler{base: h.base, entry: h.entry.WithFields(fields), prefix: h.prefix}
+}
+
+func (h *handler) WithGroup(name string) slog.Handler {
+	if name == "" {
+		return h
+	}
+	return &handler{base: h.base, entry: h.entry, prefix: h.prefix + name + "."}
+}
+
+// addAttr renders one slog.Attr into logrus fields under the given key
+// prefix, following the slog.Handler contract: a LogValuer is resolved
+// first, an empty Attr is dropped, a group contributes its members under
+// "<prefix><group key>." (or under the prefix unchanged if its key is
+// empty), and an empty group is dropped along with its key.
+func addAttr(fields logrus.Fields, prefix string, a slog.Attr) {
+	a.Value = a.Value.Resolve()
+	if a.Equal(slog.Attr{}) {
+		return
+	}
+	if a.Value.Kind() != slog.KindGroup {
+		fields[prefix+a.Key] = a.Value.Any()
+		return
+	}
+	members := a.Value.Group()
+	if len(members) == 0 {
+		return
+	}
+	if a.Key != "" {
+		prefix += a.Key + "."
+	}
+	for _, m := range members {
+		addAttr(fields, prefix, m)
+	}
 }
 
 // slogToLogrusLevel maps an slog.Level to the matching logrus.Level for
-// IsLevelEnabled checks. Their numeric encodings don't line up — slog is
-// signed (Debug=-4, Info=0, Warn=4, Error=8) and logrus is unsigned with
-// the opposite ordering (Error=2, Warn=3, Info=4, Debug=5, Trace=6) — so
-// a direct cast would silently produce wrong answers.
+// IsLevelEnabled checks and emission. Their numeric encodings don't line
+// up — slog is signed (Debug=-4, Info=0, Warn=4, Error=8) and logrus is
+// unsigned with the opposite ordering (Error=2, Warn=3, Info=4, Debug=5,
+// Trace=6) — so a direct cast would silently produce wrong answers.
 //
 // slog has no named Trace level; by slog convention, anything finer than
-// LevelDebug (e.g. LevelDebug-4) is "trace-ish". For Enabled queries we
-// map sub-Debug levels to logrus.TraceLevel so existing logrus-Trace
-// gating remains observable through the interface. The Logger interface
-// itself does not expose a Trace emit method — to match slog.
+// LevelDebug (e.g. LevelDebug-4) is "trace-ish". We map sub-Debug levels
+// to logrus.TraceLevel so existing logrus-Trace gating remains observable
+// through slog. slog.Logger itself exposes no Trace emit method.
 func slogToLogrusLevel(level log.Level) logrus.Level {
 	switch {
 	case level >= log.LevelError:
@@ -127,4 +168,4 @@ func slogToLogrusLevel(level log.Level) logrus.Level {
 	}
 }
 
-var _ log.Logger = (*adapter)(nil)
+var _ slog.Handler = (*handler)(nil)

--- a/lib/logrusr/adaptor_bench_test.go
+++ b/lib/logrusr/adaptor_bench_test.go
@@ -1,0 +1,151 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logrusr_test
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/projectcalico/calico/lib/logrusr"
+	log "github.com/projectcalico/calico/lib/std/log"
+)
+
+// Benchmarks for the logrus-backed log.Logger. These deliberately use only
+// the surface that both the old hand-rolled log.Logger interface and the
+// slog.Logger that replaced it share — Debug/Info/With/Enabled — so the
+// same file compiles on either side of the slog migration and the two can
+// be compared directly with benchstat:
+//
+//	go test -run XXX -bench 'Adapter|PackageLevel' -benchmem -count 10 ./lib/logrusr/ > new.txt
+//	git stash && ... > old.txt && benchstat old.txt new.txt
+//
+// The CallerHook variants matter most: caller attribution walks the stack
+// per line, and routing through slog puts two more frames between the call
+// site and the walk.
+
+// newBenchLogger builds a logger writing into a null sink. callerHook
+// selects whether the stack-walking caller attribution is installed, which
+// production configures via ConfigureFormatter but which roughly doubles
+// the cost of a log line.
+func newBenchLogger(level logrus.Level, callerHook bool) log.Logger {
+	base := logrus.New()
+	base.SetLevel(level)
+	base.SetFormatter(&logrusr.Formatter{})
+	base.SetOutput(&logrusr.NullWriter{})
+	if callerHook {
+		logrusr.InstallCallerHook(base)
+	}
+	return logrusr.New(base)
+}
+
+func BenchmarkAdapterInfoNoArgs(b *testing.B) {
+	l := newBenchLogger(logrus.DebugLevel, false)
+	b.ReportAllocs()
+	for b.Loop() {
+		l.Info("Test log")
+	}
+}
+
+func BenchmarkAdapterInfoKeyValues(b *testing.B) {
+	// The hot path: slog parses these varargs into attributes, then the
+	// handler renders them as logrus fields.
+	l := newBenchLogger(logrus.DebugLevel, false)
+	b.ReportAllocs()
+	for b.Loop() {
+		l.Info("Test log", "a", "b", "c", "d", "e", "f", "g", "h")
+	}
+}
+
+func BenchmarkAdapterInfoAttrs(b *testing.B) {
+	// Typed attributes skip slog's any-boxing of keys and values.
+	l := newBenchLogger(logrus.DebugLevel, false)
+	b.ReportAllocs()
+	for b.Loop() {
+		l.Info("Test log",
+			slog.String("a", "b"), slog.String("c", "d"),
+			slog.String("e", "f"), slog.String("g", "h"))
+	}
+}
+
+func BenchmarkAdapterWith(b *testing.B) {
+	// Deriving a logger, e.g. once per request in httpmachinery.
+	l := newBenchLogger(logrus.DebugLevel, false)
+	b.ReportAllocs()
+	for b.Loop() {
+		_ = l.With("requestID", "abc-123")
+	}
+}
+
+func BenchmarkAdapterDerivedInfo(b *testing.B) {
+	// Emitting from an already-derived logger — the common shape for
+	// per-request and per-component loggers.
+	l := newBenchLogger(logrus.DebugLevel, false).With("a", "b", "c", "d")
+	b.ReportAllocs()
+	for b.Loop() {
+		l.Info("Test log")
+	}
+}
+
+func BenchmarkAdapterDisabled(b *testing.B) {
+	// A line dropped by the level filter. This should stay close to free:
+	// slog.Logger asks the handler's Enabled before building the record,
+	// so no attributes are ever materialised.
+	l := newBenchLogger(logrus.WarnLevel, false)
+	b.ReportAllocs()
+	for b.Loop() {
+		l.Debug("Test log", "a", "b", "c", "d", "e", "f", "g", "h")
+	}
+}
+
+func BenchmarkAdapterEnabled(b *testing.B) {
+	l := newBenchLogger(logrus.InfoLevel, false)
+	ctx := context.Background()
+	b.ReportAllocs()
+	for b.Loop() {
+		_ = l.Enabled(ctx, log.LevelDebug)
+	}
+}
+
+func BenchmarkAdapterInfoCallerHook(b *testing.B) {
+	// Caller attribution walks the stack once per line, skipping logrus,
+	// logrusr, log/slog and lib/std/log frames.
+	l := newBenchLogger(logrus.DebugLevel, true)
+	b.ReportAllocs()
+	for b.Loop() {
+		l.Info("Test log")
+	}
+}
+
+func BenchmarkAdapterInfoKeyValuesCallerHook(b *testing.B) {
+	l := newBenchLogger(logrus.DebugLevel, true)
+	b.ReportAllocs()
+	for b.Loop() {
+		l.Info("Test log", "a", "b", "c", "d", "e", "f", "g", "h")
+	}
+}
+
+func BenchmarkPackageLevelInfo(b *testing.B) {
+	// Through the lib/std/log package helpers, which add an atomic load of
+	// the default logger plus one more frame for the caller walk.
+	log.SetDefaultLogger(newBenchLogger(logrus.DebugLevel, true))
+	b.Cleanup(func() { log.SetDefaultLogger(nil) })
+	b.ReportAllocs()
+	for b.Loop() {
+		log.Info("Test log", "a", "b", "c", "d")
+	}
+}

--- a/lib/logrusr/adaptor_test.go
+++ b/lib/logrusr/adaptor_test.go
@@ -70,8 +70,11 @@ func TestSlogAttrSupported(t *testing.T) {
 func TestDanglingKeyGetsBadKey(t *testing.T) {
 	l, buf := newAdapter(t, logrus.DebugLevel)
 	// "user" has no following value — slog's convention is to file the
-	// dangling key under "!BADKEY".
-	l.Info("oops", "user")
+	// dangling key under "!BADKEY". Built as a slice so that go vet's slog
+	// analyser, which now flags malformed pairs at the call site, doesn't
+	// reject the deliberately-bad call.
+	args := []any{"user"}
+	l.Info("oops", args...)
 
 	if !strings.Contains(buf.String(), "!BADKEY=user") {
 		t.Errorf("expected !BADKEY=user in: %s", buf.String())
@@ -81,8 +84,9 @@ func TestDanglingKeyGetsBadKey(t *testing.T) {
 func TestNonStringKeyGetsBadKey(t *testing.T) {
 	l, buf := newAdapter(t, logrus.DebugLevel)
 	// First positional arg is an int, not a string or slog.Attr — file
-	// under !BADKEY.
-	l.Info("oops", 42)
+	// under !BADKEY. Built as a slice to get past go vet, as above.
+	args := []any{42}
+	l.Info("oops", args...)
 
 	if !strings.Contains(buf.String(), "!BADKEY=42") {
 		t.Errorf("expected !BADKEY=42 in: %s", buf.String())

--- a/lib/logrusr/formatter.go
+++ b/lib/logrusr/formatter.go
@@ -42,12 +42,18 @@ import (
 
 // Packages whose frames we skip when reporting a log line's caller.
 // logrus's own getCaller only skips itself, which means wrapper types in
-// this package (RateLimitedLogger, the log.Logger adapter, Summarizer)
-// and in lib/std/log (the slog-shaped facade) would otherwise be reported
-// as the caller instead of the user code.
+// this package (RateLimitedLogger, the slog.Handler adapter, Summarizer),
+// slog's own Logger shim, and the package-level helpers in lib/std/log
+// would otherwise be reported as the caller instead of the user code.
+//
+// slog captures the call site itself in Record.PC, which would be exact
+// and cheaper than this walk, but we can't use it: logrus's Entry.Dup
+// drops Caller before hooks fire, so a pre-stamped frame never survives
+// to the formatter.
 const (
 	logrusPackage  = "github.com/sirupsen/logrus."
 	logrusrPackage = "github.com/projectcalico/calico/lib/logrusr."
+	slogPackage    = "log/slog."
 	stdlogPackage  = "github.com/projectcalico/calico/lib/std/log."
 	maxCallerDepth = 32
 )
@@ -60,13 +66,23 @@ const (
 	// FileNameUnknown is the string used in logs if the filename/line number
 	// cannot be determined.
 	FileNameUnknown = "<nil>"
+
+	// fieldCallerPC carries a log call site's program counter from the
+	// slog handler in this package to the caller-stamping hook below.
+	// slog already captures the call site in Record.PC, so resolving that
+	// one PC is far cheaper than walking the stack to find the first
+	// non-logging frame — but logrus's Entry.Dup drops Caller before
+	// hooks fire, so the PC has to travel in Data, which Dup does copy.
+	// callerHook consumes and removes it; Format skips it either way so
+	// it never reaches the output.
+	fieldCallerPC = "__caller_pc__"
 )
 
 // We don't call logrus.SetReportCaller: logrus's own caller detection
 // only skips its own frames, so wrapper types in this package
-// (RateLimitedLogger, the log.Logger adapter, Summarizer) and the
-// slog-shaped facade in lib/std/log would be reported as the caller
-// instead of the user code.  ConfigureFormatter installs a caller-
+// (RateLimitedLogger, the slog.Handler adapter, Summarizer), slog's
+// Logger shim and the helpers in lib/std/log would be reported as the
+// caller instead of the user code.  ConfigureFormatter installs a caller-
 // stamping hook that walks the stack once per log line, skipping
 // those wrapper packages, and memoises the result on entry.Caller so
 // downstream hooks and Format() are O(1).
@@ -89,8 +105,8 @@ func ConfigureFormatter(componentName string) {
 	installCallerHookOnce()
 }
 
-// callerHook stamps entry.Caller with the first non-logrus / non-logrusr
-// / non-lib-std-log frame it finds on the stack.  logrus dups the entry
+// callerHook stamps entry.Caller with the first frame on the stack that
+// belongs to none of the logging packages above.  logrus dups the entry
 // once before firing any hooks, so we can safely mutate it here without
 // racing other goroutines that may be re-using the original entry.
 //
@@ -105,16 +121,60 @@ func (callerHook) Fire(entry *log.Entry) error {
 	if entry.Caller != nil {
 		return nil
 	}
+	if file, line, ok := callerFromPC(entry); ok {
+		entry.Caller = &runtime.Frame{File: file, Line: line}
+		return nil
+	}
 	file, line := lookupCaller()
 	entry.Caller = &runtime.Frame{File: file, Line: line}
 	return nil
+}
+
+// callerFromPC resolves the call site that the slog handler recorded on
+// the entry, if there is one, and removes it from the entry's fields.
+func callerFromPC(entry *log.Entry) (string, int, bool) {
+	pc, ok := entry.Data[fieldCallerPC].(uintptr)
+	if !ok {
+		return "", 0, false
+	}
+	delete(entry.Data, fieldCallerPC)
+	return resolvePC(pc)
+}
+
+// callerCache memoises the file and line for a call-site PC.  The set of
+// PCs is bounded by the number of log statements in the binary and each
+// one recurs for the life of the process, so resolving a PC once turns
+// caller attribution into a map load — runtime.CallersFrames both costs
+// more than the lookup and allocates.
+var callerCache sync.Map // uintptr -> fileLine
+
+type fileLine struct {
+	file string
+	line int
+}
+
+func resolvePC(pc uintptr) (string, int, bool) {
+	if v, ok := callerCache.Load(pc); ok {
+		fl := v.(fileLine)
+		return fl.file, fl.line, true
+	}
+	// CallersFrames rather than FuncForPC: it reports the innermost
+	// inlined frame, so a log call inlined into its caller is still
+	// attributed to the line that wrote it.
+	frame, _ := runtime.CallersFrames([]uintptr{pc}).Next()
+	if frame.File == "" {
+		return "", 0, false
+	}
+	fl := fileLine{file: path.Base(frame.File), line: frame.Line}
+	callerCache.Store(pc, fl)
+	return fl.file, fl.line, true
 }
 
 var callerHookInstalled sync.Once
 
 func installCallerHookOnce() {
 	callerHookInstalled.Do(func() {
-		log.AddHook(callerHook{})
+		InstallCallerHook(log.StandardLogger())
 	})
 }
 
@@ -123,8 +183,24 @@ func installCallerHookOnce() {
 // standard logger.  Use this for logrus.Logger instances that don't
 // share the standard logger's hook chain (e.g. per-test loggers or
 // stand-alone loggers wired into custom destinations).
+//
+// Installing twice on one logger is a no-op: ConfigureFormatter and
+// logrusr.New both install it, and they are routinely pointed at the
+// same logger.
 func InstallCallerHook(logger *log.Logger) {
+	if hasCallerHook(logger) {
+		return
+	}
 	logger.AddHook(callerHook{})
+}
+
+func hasCallerHook(logger *log.Logger) bool {
+	for _, h := range logger.Hooks[log.InfoLevel] {
+		if _, ok := h.(callerHook); ok {
+			return true
+		}
+	}
+	return false
 }
 
 // ConfigureEarlyLoggingFromEnv installs the Calico logrus formatter, sets
@@ -343,6 +419,9 @@ func GetFileInfo(entry *log.Entry) (string, int) {
 	if entry.Caller != nil {
 		return path.Base(entry.Caller.File), entry.Caller.Line
 	}
+	if file, line, ok := callerFromPC(entry); ok {
+		return file, line
+	}
 	return lookupCaller()
 }
 
@@ -365,6 +444,7 @@ func lookupCaller() (string, int) {
 		fn := frame.Function
 		if !strings.HasPrefix(fn, logrusPackage) &&
 			!strings.HasPrefix(fn, logrusrPackage) &&
+			!strings.HasPrefix(fn, slogPackage) &&
 			!strings.HasPrefix(fn, stdlogPackage) {
 			return path.Base(frame.File), frame.Line
 		}
@@ -401,7 +481,7 @@ func appendKVsAndNewLine(b *bytes.Buffer, data log.Fields) {
 	sort.Strings(keys)
 
 	for _, key := range keys {
-		if key == FieldForceFlush {
+		if key == FieldForceFlush || key == fieldCallerPC {
 			continue
 		}
 		var value = data[key]

--- a/lib/logrusr/handler_test.go
+++ b/lib/logrusr/handler_test.go
@@ -1,0 +1,233 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logrusr_test
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/projectcalico/calico/lib/logrusr"
+)
+
+// These cover the slog.Handler contract that the old log.Logger interface
+// had no equivalent for: groups, group-valued attributes, LogValuer
+// resolution and empty-attribute handling.
+
+func TestWithGroupPrefixesKeys(t *testing.T) {
+	l, buf := newAdapter(t, logrus.DebugLevel)
+	l.WithGroup("http").Info("hit", "code", 200)
+
+	if !strings.Contains(buf.String(), "http.code=200") {
+		t.Errorf("expected http.code=200 in: %s", buf.String())
+	}
+}
+
+func TestWithGroupNests(t *testing.T) {
+	l, buf := newAdapter(t, logrus.DebugLevel)
+	l.WithGroup("http").WithGroup("request").With("id", "abc").Info("hit")
+
+	if !strings.Contains(buf.String(), "http.request.id=abc") {
+		t.Errorf("expected http.request.id=abc in: %s", buf.String())
+	}
+}
+
+func TestWithGroupDoesNotPrefixEarlierAttrs(t *testing.T) {
+	// Attributes attached before a group is opened stay unprefixed —
+	// only what follows the WithGroup lands inside it.
+	l, buf := newAdapter(t, logrus.DebugLevel)
+	l.With("requestID", "abc").WithGroup("http").Info("hit", "code", 200)
+
+	out := buf.String()
+	if !strings.Contains(out, "requestID=abc") {
+		t.Errorf("pre-group attr should be unprefixed, got: %s", out)
+	}
+	if !strings.Contains(out, "http.code=200") {
+		t.Errorf("post-group attr should be prefixed, got: %s", out)
+	}
+}
+
+func TestEmptyGroupNameIgnored(t *testing.T) {
+	// slog.Handler contract: WithGroup("") is a no-op.
+	l, buf := newAdapter(t, logrus.DebugLevel)
+	l.WithGroup("").Info("hit", "code", 200)
+
+	if !strings.Contains(buf.String(), "code=200") {
+		t.Errorf("empty group name should not prefix, got: %s", buf.String())
+	}
+}
+
+func TestGroupValuedAttrFlattened(t *testing.T) {
+	l, buf := newAdapter(t, logrus.DebugLevel)
+	l.Info("hit", slog.Group("http", slog.Int("code", 200), slog.String("method", "GET")))
+
+	out := buf.String()
+	if !strings.Contains(out, "http.code=200") || !strings.Contains(out, "http.method=GET") {
+		t.Errorf("group attr not flattened: %s", out)
+	}
+}
+
+func TestGroupValuedAttrWithEmptyKeyInlined(t *testing.T) {
+	// slog.Handler contract: a group with an empty key contributes its
+	// members directly, with no prefix of its own.
+	l, buf := newAdapter(t, logrus.DebugLevel)
+	l.Info("hit", slog.Group("", slog.Int("code", 200)))
+
+	if !strings.Contains(buf.String(), "code=200") {
+		t.Errorf("empty-keyed group should inline its members: %s", buf.String())
+	}
+}
+
+func TestEmptyGroupDropped(t *testing.T) {
+	// slog.Handler contract: a group with no members is dropped, key and
+	// all — it must not surface as an empty field.
+	l, buf := newAdapter(t, logrus.DebugLevel)
+	l.Info("hit", slog.Group("empty"), slog.Int("code", 200))
+
+	out := buf.String()
+	if strings.Contains(out, "empty") {
+		t.Errorf("empty group should be dropped entirely: %s", out)
+	}
+	if !strings.Contains(out, "code=200") {
+		t.Errorf("sibling attr lost: %s", out)
+	}
+}
+
+func TestEmptyAttrDropped(t *testing.T) {
+	// slog.Handler contract: an Attr{} with no key and no value is dropped.
+	l, buf := newAdapter(t, logrus.DebugLevel)
+	l.Info("hit", slog.Attr{}, slog.Int("code", 200))
+
+	out := buf.String()
+	if !strings.Contains(out, "code=200") {
+		t.Errorf("sibling attr lost: %s", out)
+	}
+	if strings.Contains(out, "!BADKEY") {
+		t.Errorf("empty attr should be dropped, not flagged: %s", out)
+	}
+}
+
+// resolvable reports a different value than its own String, so a test can
+// tell whether the handler called Resolve or just stringified it.
+type resolvable struct{}
+
+func (resolvable) LogValue() slog.Value { return slog.StringValue("resolved") }
+
+func TestLogValuerResolved(t *testing.T) {
+	l, buf := newAdapter(t, logrus.DebugLevel)
+	l.Info("hit", "token", resolvable{})
+
+	if !strings.Contains(buf.String(), "token=resolved") {
+		t.Errorf("LogValuer not resolved: %s", buf.String())
+	}
+}
+
+// captureFormatter records the entry fields a test wants to assert on
+// without going through text rendering.
+type captureFormatter struct {
+	caller string
+	line   int
+	data   logrus.Fields
+}
+
+func (c *captureFormatter) Format(e *logrus.Entry) ([]byte, error) {
+	c.data = e.Data
+	if e.Caller != nil {
+		c.caller = e.Caller.File
+		c.line = e.Caller.Line
+	}
+	return nil, nil
+}
+
+func TestCallerResolvesThroughSlog(t *testing.T) {
+	// The caller hook walks the stack past logrus, logrusr and log/slog.
+	// Without the log/slog entry in that skip list the reported caller is
+	// slog's own logger shim instead of the line below.
+	base := logrus.New()
+	base.SetLevel(logrus.DebugLevel)
+	capture := &captureFormatter{}
+	base.SetFormatter(capture)
+	base.SetOutput(&logrusr.NullWriter{})
+	logrusr.InstallCallerHook(base)
+
+	logrusr.New(base).Info("hit")
+
+	if !strings.HasSuffix(capture.caller, "handler_test.go") {
+		t.Errorf("caller should be this test file, got %q:%d", capture.caller, capture.line)
+	}
+}
+
+func TestCallerPCFieldNeverReachesOutput(t *testing.T) {
+	// The handler smuggles slog's call-site PC to the caller hook through
+	// a private entry field. The hook has to consume it before any
+	// formatter runs — including a stock logrus formatter that knows
+	// nothing about it.
+	l, buf := newAdapter(t, logrus.DebugLevel)
+	l.With("requestID", "abc").Info("hit", "code", 200)
+
+	out := buf.String()
+	if strings.Contains(out, "caller_pc") || strings.Contains(out, "__") {
+		t.Errorf("internal field leaked into output: %s", out)
+	}
+	if !strings.Contains(out, "code=200") || !strings.Contains(out, "requestID=abc") {
+		t.Errorf("real fields lost: %s", out)
+	}
+}
+
+func TestCallerResolvesWithoutHook(t *testing.T) {
+	// GetFileInfo is also reachable without the hook (a formatter running
+	// on an entry nothing stamped); it must resolve the same call site.
+	base := logrus.New()
+	base.SetLevel(logrus.DebugLevel)
+	capture := &captureFormatter{}
+	base.SetFormatter(capture)
+	base.SetOutput(&logrusr.NullWriter{})
+
+	l := logrusr.New(base)
+	base.Hooks = make(logrus.LevelHooks) // drop the hook New installed
+	l.Info("hit")
+
+	file, line := logrusr.GetFileInfo(&logrus.Entry{Data: capture.data})
+	if !strings.HasSuffix(file, "handler_test.go") || line == 0 {
+		t.Errorf("caller should be this test file, got %q:%d", file, line)
+	}
+}
+
+func TestZeroPCFallsBackToStackWalk(t *testing.T) {
+	// A Record built without a PC (slog's own methods always set one, but
+	// a wrapping handler may not) has no call site to carry, so caller
+	// attribution falls back to walking the stack past logrus, logrusr
+	// and log/slog. Without log/slog in that skip list this reports
+	// slog's internals instead of a real frame.
+	base := logrus.New()
+	base.SetLevel(logrus.DebugLevel)
+	capture := &captureFormatter{}
+	base.SetFormatter(capture)
+	base.SetOutput(&logrusr.NullWriter{})
+
+	h := logrusr.New(base).Handler()
+	rec := slog.NewRecord(time.Now(), slog.LevelInfo, "hit", 0)
+	if err := h.Handle(context.Background(), rec); err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+
+	if strings.Contains(capture.caller, "slog") || capture.caller == logrusr.FileNameUnknown {
+		t.Errorf("fallback should skip slog frames, got %q:%d", capture.caller, capture.line)
+	}
+}

--- a/lib/std/log/logger.go
+++ b/lib/std/log/logger.go
@@ -12,11 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package log defines an slog-shaped Logger interface that callers depend
-// on instead of taking a direct dependency on a concrete logging backend.
-// A backend (e.g. lib/logrus) is registered at process start via
-// SetDefaultLogger; until then, package-level calls drop on the floor
-// via the no-op default.
+// Package log re-exports slog's Logger as the logging type callers depend
+// on, so no caller takes a direct dependency on a concrete logging
+// backend. A backend is plugged in as an slog.Handler — see lib/logrusr
+// for the logrus one — and registered at process start via
+// SetDefaultLogger; until then, package-level calls drop on the floor via
+// the discarding default.
+//
+// Logger is an alias, not a distinct type, so a *slog.Logger from anywhere
+// satisfies it and callers can hand ours to any slog-shaped API.
 package log
 
 import (
@@ -24,6 +28,14 @@ import (
 	"log/slog"
 	"sync/atomic"
 )
+
+// Logger is slog's logger. Variadic args follow slog's convention:
+// alternating string keys and values, with Attr permitted as a single
+// arg; odd dangling args and non-string keys are filed under "!BADKEY".
+//
+// Backends implement slog.Handler rather than this type — slog.Logger is
+// a concrete shim over Handler, and Handler is the pluggable half.
+type Logger = *slog.Logger
 
 // Level is the severity of a log line, re-exported from slog so callers
 // don't need to import slog directly.
@@ -37,69 +49,43 @@ const (
 	LevelError = slog.LevelError
 )
 
-// Attr is a structured key/value pair, compatible with slog.Attr. Use it
-// when you want typed attributes; otherwise pass key/value pairs to With
-// / Info / ... directly.
+// Attr is a structured key/value pair, re-exported from slog. Use it when
+// you want typed attributes; otherwise pass key/value pairs to With /
+// Info / ... directly.
 type Attr = slog.Attr
 
 // defaultLogger holds the Logger backing the package-level helpers. It is
 // loaded atomically so SetDefaultLogger can swap it under concurrent
 // readers — including any log calls that fire from init() scope before
 // the backend has finished registering.
-var defaultLogger atomic.Pointer[loggerHolder]
-
-// loggerHolder wraps Logger so atomic.Pointer can store an interface value.
-type loggerHolder struct{ Logger }
+var defaultLogger atomic.Pointer[slog.Logger]
 
 func init() {
-	defaultLogger.Store(&loggerHolder{Logger: &noOpLogger{}})
+	defaultLogger.Store(discard())
 }
 
-// Logger is the slog-shaped logging interface. Variadic args follow slog's
-// convention: alternating string keys and values, with Attr permitted as
-// a single arg. Implementations should treat odd dangling args / non-string
-// keys as slog does (filed under "!BADKEY").
-type Logger interface {
-	Debug(msg string, args ...any)
-	Info(msg string, args ...any)
-	Warn(msg string, args ...any)
-	Error(msg string, args ...any)
-
-	// With returns a derived Logger that carries the given attributes on
-	// every emitted line. The parent is not mutated.
-	With(args ...any) Logger
-
-	// Enabled reports whether a log line at the given level would be
-	// emitted by this Logger. Callers use it to skip expensive argument
-	// preparation for log lines that would be dropped.
-	Enabled(ctx context.Context, level Level) bool
+// discard returns a Logger that drops everything. slog.DiscardHandler
+// reports Enabled false at every level, so callers gating on Enabled skip
+// their argument preparation too.
+func discard() Logger {
+	return slog.New(slog.DiscardHandler)
 }
-
-type noOpLogger struct{}
-
-func (n *noOpLogger) Debug(msg string, args ...any) {}
-func (n *noOpLogger) Info(msg string, args ...any)  {}
-func (n *noOpLogger) Warn(msg string, args ...any)  {}
-func (n *noOpLogger) Error(msg string, args ...any) {}
-
-func (n *noOpLogger) With(args ...any) Logger { return n }
-
-func (n *noOpLogger) Enabled(ctx context.Context, level Level) bool { return false }
 
 // SetDefaultLogger installs the Logger that backs the package-level
 // helpers (Info, Warn, Error, With, Enabled). Safe to call concurrently
 // with logging calls — readers observe either the previous or the new
-// Logger, never a torn value.
+// Logger, never a torn value. A nil Logger restores the discarding
+// default rather than panicking at the first log call.
 func SetDefaultLogger(log Logger) {
 	if log == nil {
-		log = &noOpLogger{}
+		log = discard()
 	}
-	defaultLogger.Store(&loggerHolder{Logger: log})
+	defaultLogger.Store(log)
 }
 
 // Default returns the Logger backing the package-level helpers.
 func Default() Logger {
-	return defaultLogger.Load().Logger
+	return defaultLogger.Load()
 }
 
 func Debug(msg string, args ...any) {
@@ -109,9 +95,11 @@ func Debug(msg string, args ...any) {
 func Info(msg string, args ...any) {
 	Default().Info(msg, args...)
 }
+
 func Warn(msg string, args ...any) {
 	Default().Warn(msg, args...)
 }
+
 func Error(msg string, args ...any) {
 	Default().Error(msg, args...)
 }


### PR DESCRIPTION
`lib/std/log` defined its own slog-shaped `Logger` interface, and `lib/logrusr` implemented it. But `slog.Logger` is already exactly that shim — a concrete front-end that parses variadic args into attributes and delegates to a pluggable `slog.Handler`. Keeping our own interface alongside it meant reimplementing slog's arg parsing, and left callers unable to hand our logger to any slog-shaped API.

This makes `log.Logger` an alias for `*slog.Logger` and moves `lib/logrusr` down to the seam slog actually provides, implementing `slog.Handler`.

### What this changes

- **`lib/std/log`** — the `Logger` interface, `noOpLogger` and the atomic-pointer holder are gone; the default is `slog.DiscardHandler`. The package stays dependency-free.
- **`lib/logrusr`** — the adapter becomes an `slog.Handler`. `argsToFields` is deleted, since slog produces the same `!BADKEY` handling for dangling and non-string keys. Added the parts of the Handler contract logrus has no concept of: groups (flattened to dotted keys), group-valued attributes, `LogValuer` resolution, empty-attr/empty-group dropping.
- **Callers — none.** `Logger` is a type alias, not a defined type, so all 12 importers compile untouched.

`go vet`'s slog analyser now statically catches malformed key/value pairs at every call site in the repo. It immediately flagged the two deliberately-malformed calls in `adaptor_test.go`, which now build their args as a slice.

### Caller attribution

Profiling the emit path showed `lookupCaller` at **80% of the benchmark** — caller attribution walks the stack every line to find the first non-logging frame, and routing through slog added frames to walk past. slog already records the exact call site in `Record.PC`, so we use that instead, memoised per PC.

The PC can't be stamped onto `entry.Caller` directly: logrus's `Entry.Dup` (`entry.go:88`) drops `Caller` before hooks fire. So it travels in the entry's fields under a private key that the caller hook consumes, following the existing `FieldForceFlush` pattern. `logrusr.New` installs that hook, so the field can never reach a formatter that doesn't know to strip it — there's a test pinning that.

### Performance

New `adaptor_bench_test.go` uses only the surface both versions share, so it compiles on master too and benchstats directly. `-count 10`:

| benchmark | sec/op | B/op |
|---|---|---|
| InfoNoArgs | **-54.5%** | +115% |
| InfoKeyValues | **-56.5%** | **-40.0%** |
| InfoAttrs | **-55.5%** | **-35.8%** |
| DerivedInfo | **-51.5%** | +28% |
| Disabled (dropped by level) | **-86.9%** | **-100%** |
| InfoKeyValuesCallerHook | **-57.9%** | **-43.3%** |
| PackageLevelInfo | **-63.6%** | **-43.0%** |
| **geomean** | **-53.1%** | |

Lines dropped by the level filter go from 68ns/1 alloc to 9ns/0, because slog checks `Enabled` before the args escape.

The trade-off: bare-message calls (`log.Info("msg")`) allocate one more `Entry.Dup` than before (+489 B/op) to carry the PC. Every call that carries fields — the common shape in this repo — is both faster and leaner.

### Testing

New tests cover the Handler contract (group prefixing and nesting, group-valued attrs, `LogValuer`, empty attr/group dropping), that the private PC field never reaches output, and that a zero-PC record falls back to the stack walk. Existing `adaptor_test.go` cases pass unchanged — they now assert slog's own behaviour.

`lib/std`, `lib/logrusr`, `lib/httpmachinery`, `lib/kind` and `whisker-backend` all build, vet and test clean, including the whisker-backend FVs.

**Release note:**
```release-note
None
```

**AI assistance:** Claude Code (Opus 5) wrote the change and the benchmarks; I reviewed and verified the results.

By opening this PR you take responsibility for every line in it, and you agree to explain the change yourself during review rather than routing review comments back through an agent. See [AI_POLICY.md](../AI_POLICY.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
