### PR TITLE
[DE-4544] refactor(release): move chart build and publish into their own package

### DIFF
--- a/release/cmd/charts.go
+++ b/release/cmd/charts.go
@@ -1,0 +1,189 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"path/filepath"
+	"sync"
+
+	cli "github.com/urfave/cli/v3"
+
+	"github.com/projectcalico/calico/release/internal/charts"
+	"github.com/projectcalico/calico/release/internal/github"
+	"github.com/projectcalico/calico/release/internal/hashreleaseserver"
+	"github.com/projectcalico/calico/release/internal/pinnedversion"
+	"github.com/projectcalico/calico/release/internal/registry"
+	"github.com/projectcalico/calico/release/internal/utils"
+	"github.com/projectcalico/calico/release/internal/version"
+)
+
+func chartsCommand(cfg *Config) *cli.Command {
+	return &cli.Command{
+		Name:  "charts",
+		Usage: "Build and publish Helm charts",
+		Commands: []*cli.Command{
+			chartsBuildCommand(cfg),
+			chartsPublishCommand(cfg),
+		},
+	}
+}
+
+var chartsBuildFlags = []cli.Flag{helmIndexFlag(envBuildHelmIndex), hashreleaseFlag, releaseBranchPrefixFlag}
+
+var chartsBuildAction = func(cfg *Config) func(context.Context, *cli.Command) error {
+	return func(_ context.Context, c *cli.Command) error {
+		configureLogging("charts-build.log")
+		// Both the chart identity and its options need the pin; generating it
+		// twice would write the pinned-versions file twice.
+		pin := oncePin(pinForBuild)
+		chart, err := pinnedChart(cfg, c, pin)
+		if err != nil {
+			return err
+		}
+		opts, err := chartsBuildOptions(cfg, c, *chart, pin, c.Bool(helmIndexFlagName))
+		if err != nil {
+			return err
+		}
+		opts = append(opts, charts.WithRunner(commandRunner), charts.WithLogsDir(cfg.LogsDir))
+		return charts.Build(*chart, opts...)
+	}
+}
+
+func chartsBuildCommand(cfg *Config) *cli.Command {
+	return &cli.Command{
+		Name:   "build",
+		Usage:  "Build Helm charts",
+		Flags:  chartsBuildFlags,
+		Action: chartsBuildAction(cfg),
+	}
+}
+
+var chartsPublishFlags = []cli.Flag{helmRegistryFlag, localFlag, forceFlag, hashreleaseFlag}
+
+var chartsPublishAction = func(cfg *Config) func(context.Context, *cli.Command) error {
+	return func(_ context.Context, c *cli.Command) error {
+		configureLogging("charts-publish.log")
+		chart, err := pinnedChart(cfg, c, pinForPublish)
+		if err != nil {
+			return err
+		}
+		registries := c.StringSlice(helmRegistryFlag.Name)
+		if len(registries) == 0 {
+			registries = registry.DefaultHelmRegistries
+		}
+		confirm := !c.Bool(localFlag.Name)
+
+		opts := []charts.PublishOption{
+			charts.WithRunner(commandRunner),
+			charts.WithLogsDir(cfg.LogsDir),
+			charts.WithResolver(registryDigestResolver),
+		}
+		published, w, err := publishRecord(cfg, chartsPublishStep, chart.Version(), confirm)
+		if err != nil {
+			return err
+		}
+		opts = append(opts, charts.WithResume(published, c.Bool(forceFlag.Name)))
+		if w != nil {
+			opts = append(opts, charts.WithRecord(w))
+		}
+		return charts.Publish(*chart, registries, confirm, opts...)
+	}
+}
+
+func chartsPublishCommand(cfg *Config) *cli.Command {
+	return &cli.Command{
+		Name:   "publish",
+		Usage:  "Publish Helm charts to their registries",
+		Flags:  chartsPublishFlags,
+		Action: chartsPublishAction(cfg),
+	}
+}
+
+const chartsPublishStep = "charts-publish"
+
+// oncePin memoizes a pin source so several callers in one command share it.
+func oncePin(pin pinned) pinned {
+	var (
+		once sync.Once
+		p    *pinnedversion.Pin
+		err  error
+	)
+	return func(cfg *Config, c *cli.Command) (*pinnedversion.Pin, error) {
+		once.Do(func() { p, err = pin(cfg, c) })
+		return p, err
+	}
+}
+
+var pinnedChart = func(cfg *Config, c *cli.Command, pin pinned) (*charts.Chart, error) {
+	if c.Bool(hashreleaseFlag.Name) {
+		p, err := pin(cfg, c)
+		if err != nil {
+			return nil, err
+		}
+		return &charts.Chart{
+			RepoRoot:       cfg.RepoRootDir,
+			ProductVersion: p.ProductVersion,
+			ChartVersion:   p.ChartVersion,
+			Names:          charts.All(),
+			BaseDir:        p.Hashrelease(baseHashreleaseOutputDir(cfg.RepoRootDir), false).Source,
+		}, nil
+	}
+	ver, _, err := version.VersionsFromManifests(cfg.RepoRootDir)
+	if err != nil {
+		return nil, err
+	}
+	return &charts.Chart{
+		RepoRoot:       cfg.RepoRootDir,
+		ProductVersion: ver.FormattedString(),
+		Names:          charts.All(),
+		BaseDir:        filepath.Join(cfg.OutputDir, ver.FormattedString()),
+	}, nil
+}
+
+// chartsBuildOptions are the settings a build needs beyond the charts
+// themselves. A hashrelease pins its own versions and serves its own charts.
+func chartsBuildOptions(cfg *Config, c *cli.Command, chart charts.Chart, pin pinned, withIndex bool) ([]charts.BuildOption, error) {
+	var opts []charts.BuildOption
+	chartURL, err := releaseURL(chart.ProductVersion)
+	if err != nil {
+		return nil, err
+	}
+	if c.Bool(hashreleaseFlag.Name) {
+		p, err := pin(cfg, c)
+		if err != nil {
+			return nil, err
+		}
+		opts = append(opts, charts.WithModifiedValues(charts.ValueEditsFor(p.ProductVersion, p.Operator.Version)))
+		chartURL = hashreleaseURL(p.ReleaseName)
+	}
+	if withIndex {
+		opts = append(opts, charts.WithIndex(charts.RepoURL(), chartURL,
+			chartsIndexDir(cfg, chart.Version()), cfg.TmpDir))
+	}
+	return opts, nil
+}
+
+func hashreleaseURL(name string) string {
+	return hashreleaseserver.HashreleaseURL(name)
+}
+
+func releaseURL(ver string) (string, error) {
+	return github.DownloadURL(utils.Organization(), utils.Repo(), ver)
+}
+
+var chartsIndexDir = func(cfg *Config, ver string) string {
+	return charts.Dir(cfg.OutputDir, ver)
+}

--- a/release/cmd/charts.go
+++ b/release/cmd/charts.go
@@ -17,16 +17,12 @@ package main
 import (
 	"context"
 	"path/filepath"
-	"sync"
 
 	cli "github.com/urfave/cli/v3"
 
 	"github.com/projectcalico/calico/release/internal/charts"
-	"github.com/projectcalico/calico/release/internal/github"
 	"github.com/projectcalico/calico/release/internal/hashreleaseserver"
-	"github.com/projectcalico/calico/release/internal/pinnedversion"
 	"github.com/projectcalico/calico/release/internal/registry"
-	"github.com/projectcalico/calico/release/internal/utils"
 	"github.com/projectcalico/calico/release/internal/version"
 )
 
@@ -41,13 +37,14 @@ func chartsCommand(cfg *Config) *cli.Command {
 	}
 }
 
-var chartsBuildFlags = []cli.Flag{helmIndexFlag(envBuildHelmIndex), hashreleaseFlag, releaseBranchPrefixFlag}
+var chartsBuildFlags = []cli.Flag{
+	registryFlag, operatorRegistryFlag, operatorImageFlag,
+	helmIndexFlag(envBuildHelmIndex), hashreleaseFlag, releaseBranchPrefixFlag,
+}
 
 var chartsBuildAction = func(cfg *Config) func(context.Context, *cli.Command) error {
 	return func(_ context.Context, c *cli.Command) error {
 		configureLogging("charts-build.log")
-		// Both the chart identity and its options need the pin; generating it
-		// twice would write the pinned-versions file twice.
 		pin := oncePin(pinForBuild)
 		chart, err := pinnedChart(cfg, c, pin)
 		if err != nil {
@@ -91,7 +88,7 @@ var chartsPublishAction = func(cfg *Config) func(context.Context, *cli.Command) 
 			charts.WithLogsDir(cfg.LogsDir),
 			charts.WithResolver(registryDigestResolver),
 		}
-		published, w, err := publishRecord(cfg, chartsPublishStep, chart.Version(), confirm)
+		published, w, err := publishRecord(cfg, charts.PublishStep, chart.Version(), confirm)
 		if err != nil {
 			return err
 		}
@@ -112,21 +109,6 @@ func chartsPublishCommand(cfg *Config) *cli.Command {
 	}
 }
 
-const chartsPublishStep = "charts-publish"
-
-// oncePin memoizes a pin source so several callers in one command share it.
-func oncePin(pin pinned) pinned {
-	var (
-		once sync.Once
-		p    *pinnedversion.Pin
-		err  error
-	)
-	return func(cfg *Config, c *cli.Command) (*pinnedversion.Pin, error) {
-		once.Do(func() { p, err = pin(cfg, c) })
-		return p, err
-	}
-}
-
 var pinnedChart = func(cfg *Config, c *cli.Command, pin pinned) (*charts.Chart, error) {
 	if c.Bool(hashreleaseFlag.Name) {
 		p, err := pin(cfg, c)
@@ -138,7 +120,7 @@ var pinnedChart = func(cfg *Config, c *cli.Command, pin pinned) (*charts.Chart, 
 			ProductVersion: p.ProductVersion,
 			ChartVersion:   p.ChartVersion,
 			Names:          charts.All(),
-			BaseDir:        p.Hashrelease(baseHashreleaseOutputDir(cfg.RepoRootDir), false).Source,
+			BaseDir:        charts.Dir(p.Hashrelease(baseHashreleaseOutputDir(cfg.RepoRootDir), false).Source),
 		}, nil
 	}
 	ver, _, err := version.VersionsFromManifests(cfg.RepoRootDir)
@@ -149,15 +131,15 @@ var pinnedChart = func(cfg *Config, c *cli.Command, pin pinned) (*charts.Chart, 
 		RepoRoot:       cfg.RepoRootDir,
 		ProductVersion: ver.FormattedString(),
 		Names:          charts.All(),
-		BaseDir:        filepath.Join(cfg.OutputDir, ver.FormattedString()),
+		BaseDir:        charts.Dir(filepath.Join(cfg.OutputDir, ver.FormattedString())),
 	}, nil
 }
 
 // chartsBuildOptions are the settings a build needs beyond the charts
 // themselves. A hashrelease pins its own versions and serves its own charts.
-func chartsBuildOptions(cfg *Config, c *cli.Command, chart charts.Chart, pin pinned, withIndex bool) ([]charts.BuildOption, error) {
+var chartsBuildOptions = func(cfg *Config, c *cli.Command, chart charts.Chart, pin pinned, withIndex bool) ([]charts.BuildOption, error) {
 	var opts []charts.BuildOption
-	chartURL, err := releaseURL(chart.ProductVersion)
+	chartURL, err := charts.ChartsURL(chart)
 	if err != nil {
 		return nil, err
 	}
@@ -166,24 +148,15 @@ func chartsBuildOptions(cfg *Config, c *cli.Command, chart charts.Chart, pin pin
 		if err != nil {
 			return nil, err
 		}
-		opts = append(opts, charts.WithModifiedValues(charts.ValueEditsFor(p.ProductVersion, p.Operator.Version)))
-		chartURL = hashreleaseURL(p.ReleaseName)
+		opts = append(opts, charts.WithModifiedValues(charts.ValueEditsFor(p.ProductVersion, p.ProductRegistry, p.Operator.Image, p.Operator.Version, p.Operator.Registry)))
+		chartURL = hashreleaseserver.HashreleaseURL(p.ReleaseName)
 	}
 	if withIndex {
-		opts = append(opts, charts.WithIndex(charts.RepoURL(), chartURL,
-			chartsIndexDir(cfg, chart.Version()), cfg.TmpDir))
+		repoURL, err := charts.RepoURL()
+		if err != nil {
+			return nil, err
+		}
+		opts = append(opts, charts.WithIndex(repoURL, chartURL, chart.BaseDir, cfg.TmpDir))
 	}
 	return opts, nil
-}
-
-func hashreleaseURL(name string) string {
-	return hashreleaseserver.HashreleaseURL(name)
-}
-
-func releaseURL(ver string) (string, error) {
-	return github.DownloadURL(utils.Organization(), utils.Repo(), ver)
-}
-
-var chartsIndexDir = func(cfg *Config, ver string) string {
-	return charts.Dir(cfg.OutputDir, ver)
 }

--- a/release/cmd/charts_test.go
+++ b/release/cmd/charts_test.go
@@ -1,0 +1,436 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	cli "github.com/urfave/cli/v3"
+
+	"github.com/projectcalico/calico/release/internal/charts"
+	"github.com/projectcalico/calico/release/internal/outputs"
+	"github.com/projectcalico/calico/release/internal/pinnedversion"
+	"github.com/projectcalico/calico/release/internal/registry"
+)
+
+// What the chart commands are expected to drive. A product whose charts differ
+// replaces these rather than the assertions, so the suite is shared rather
+// than rewritten.
+var (
+	// The product version, as the manifests carry it.
+	chartsCLITestVersion = "v3.30.0"
+
+	// The version in a chart's file name. A product that qualifies its charts
+	// with a suffix replaces this.
+	chartsCLIChartVersion = chartsCLITestVersion
+
+	// Where a build leaves the packaged charts. A product that writes them
+	// somewhere other than a per-version directory replaces this.
+	chartsCLIChartDir = func(cfg *Config) string {
+		return filepath.Join(cfg.OutputDir, chartsCLITestVersion)
+	}
+
+	// The make target that packages every chart.
+	chartsCLITarget = "chart"
+
+	// A registry to publish to, and the digest a published chart resolves to.
+	chartsCLIRegistry = "quay.test/charts"
+	chartsCLIDigest   = "sha256:aaa"
+
+	// The repository whose index a build merges with.
+	chartsCLIRepoURL = charts.RepoURL()
+
+	// A product serving charts from the repository it indexes replaces this:
+	// there the two URLs coincide.
+	chartsCLICheckDownloadURL = func(t *testing.T, url string) {
+		t.Helper()
+		if url == chartsCLIRepoURL {
+			t.Errorf("expected the download url to differ from the repository url %q", chartsCLIRepoURL)
+		}
+		if !strings.Contains(url, chartsCLITestVersion) {
+			t.Errorf("expected the download url to name the release, got %q", url)
+		}
+	}
+)
+
+// The chart list is a product's own, so a test must not hardcode a member.
+func chartsCLIFirstChart(t *testing.T) string {
+	t.Helper()
+	names := charts.All()
+	if len(names) == 0 {
+		t.Fatal("no release charts to test against")
+	}
+	return names[0]
+}
+
+// runCharts drives the real charts command with a recording runner. It returns
+// the runner and the config, so a test can assert on what reached disk.
+var runCharts = func(t *testing.T, args ...string) (*recordingRunner, *Config) {
+	t.Helper()
+	root := fakeRepo(t, chartsCLITestVersion)
+	cfg := &Config{
+		RepoRootDir: root,
+		TmpDir:      filepath.Join(root, "tmp"),
+		OutputDir:   filepath.Join(root, "_output"),
+		LogsDir:     filepath.Join(root, "_logs"),
+	}
+	// The chart target does not really run, so the packages it would have
+	// written are staged for the steps that read them back.
+	writeFakeCharts(t, cfg)
+	return runChartsIn(t, cfg, args...), cfg
+}
+
+// runChartsIn drives the charts command against an existing config, so a test
+// can run twice over one output directory.
+func runChartsIn(t *testing.T, cfg *Config, args ...string) *recordingRunner {
+	t.Helper()
+	r := &recordingRunner{}
+	prev, prevResolve := commandRunner, registryDigestResolver
+	commandRunner = r
+	registryDigestResolver = func(string) (string, bool, error) { return chartsCLIDigest, true, nil }
+	t.Cleanup(func() { commandRunner, registryDigestResolver = prev, prevResolve })
+
+	cmd := chartsCommand(cfg)
+	if err := cmd.Run(context.Background(), append([]string{"charts"}, args...)); err != nil {
+		t.Fatalf("charts %s: %v", strings.Join(args, " "), err)
+	}
+	return r
+}
+
+func writeFakeCharts(t *testing.T, cfg *Config) {
+	t.Helper()
+	dir := chartsCLIChartDir(cfg)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	for _, name := range charts.All() {
+		path := filepath.Join(dir, charts.FileName(name, chartsCLIChartVersion))
+		if err := os.WriteFile(path, []byte("chart"), 0o644); err != nil {
+			t.Fatalf("write %s: %v", path, err)
+		}
+	}
+}
+
+func TestChartsBuildRunsTheChartTarget(t *testing.T) {
+	r, cfg := runCharts(t, "build", "--no-helm-index")
+
+	if !r.ran(chartsCLITarget) {
+		t.Fatalf("expected the %q target to run", chartsCLITarget)
+	}
+	env := r.envFor(chartsCLITarget)
+	if !slices.Contains(env, "GIT_VERSION="+chartsCLIChartVersion) {
+		t.Error("expected GIT_VERSION in the build environment")
+	}
+	want := "CHART_DESTINATION=" + chartsCLIChartDir(cfg)
+	if !slices.Contains(env, want) {
+		t.Errorf("expected %q in the build environment, got %v", want, env)
+	}
+}
+
+// Building the index reaches the network; opting out must stay offline.
+func TestChartsBuildSkipsTheIndexWhenDisabled(t *testing.T) {
+	r, _ := runCharts(t, "build", "--no-helm-index")
+
+	if r.ran("repo", "index") {
+		t.Error("expected no index build when --no-helm-index is set")
+	}
+	if r.ran("curl") {
+		t.Error("expected no index download when --no-helm-index is set")
+	}
+}
+
+func TestChartsBuildBuildsTheIndexByDefault(t *testing.T) {
+	r, cfg := runCharts(t, "build")
+
+	if !r.ran("repo", "index") {
+		t.Fatal("expected the index to be built by default")
+	}
+	// Merging keeps the entries the repository already served; replacing would
+	// drop every earlier release.
+	if !r.ran("--merge") {
+		t.Error("expected the published index to be merged rather than replaced")
+	}
+	if !r.ran(chartsCLIRepoURL) {
+		t.Errorf("expected the index at %q to be downloaded", chartsCLIRepoURL)
+	}
+	// The index is kept out of the chart directory.
+	// The finished index lands where the caller asked, whatever directory
+	// helm was pointed at to build it.
+	indexDir := chartsIndexDir(cfg, chartsCLIChartVersion)
+	if _, err := os.Stat(filepath.Join(indexDir, "index.yaml")); err != nil {
+		t.Errorf("expected the index in %q: %v", indexDir, err)
+	}
+}
+
+// Swapping these two would point clients at the wrong host.
+func TestChartsBuildIndexPointsAtTheDownloadURL(t *testing.T) {
+	r, _ := runCharts(t, "build")
+
+	var urlArg string
+	for _, args := range r.args {
+		if i := slices.Index(args, "--url"); i >= 0 && i+1 < len(args) {
+			urlArg = args[i+1]
+		}
+	}
+	if urlArg == "" {
+		t.Fatal("expected the index to be given a download url")
+	}
+	chartsCLICheckDownloadURL(t, urlArg)
+}
+
+func TestChartsBuildLogsUnderItsOwnStep(t *testing.T) {
+	r, cfg := runCharts(t, "build", "--no-helm-index")
+
+	want := filepath.Join(cfg.LogsDir, "charts-build", "charts.log")
+	if !slices.Contains(r.logPaths, want) {
+		t.Errorf("expected a build log at %q, got %v", want, r.logPaths)
+	}
+}
+
+func TestChartsPublishPushesEveryChart(t *testing.T) {
+	r, _ := runCharts(t, "publish", "--helm-registry", chartsCLIRegistry)
+
+	for _, name := range charts.All() {
+		if !r.ran("push", charts.FileName(name, chartsCLIChartVersion)) {
+			t.Errorf("expected %s to be pushed", name)
+		}
+	}
+	if !r.ran("push", "oci://"+chartsCLIRegistry) {
+		t.Errorf("expected the push to reach oci://%s", chartsCLIRegistry)
+	}
+}
+
+func TestChartsPublishLocalPushesNothing(t *testing.T) {
+	r, _ := runCharts(t, "publish", "--local", "--helm-registry", chartsCLIRegistry)
+
+	if r.ran("push") {
+		t.Error("expected --local to push nothing")
+	}
+}
+
+func TestChartsPublishLocalRecordsNothing(t *testing.T) {
+	_, cfg := runCharts(t, "publish", "--local", "--helm-registry", chartsCLIRegistry)
+
+	refs, err := outputs.ReadRefs(cfg.OutputDir, chartsPublishStep, chartsCLIChartVersion)
+	if err != nil {
+		t.Fatalf("reading refs: %v", err)
+	}
+	if len(refs) != 0 {
+		t.Errorf("expected a dry run to record nothing, got %v", refs)
+	}
+}
+
+func TestChartsPublishRecordsWhatItPushed(t *testing.T) {
+	_, cfg := runCharts(t, "publish", "--helm-registry", chartsCLIRegistry)
+
+	refs, err := outputs.ReadRefs(cfg.OutputDir, chartsPublishStep, chartsCLITestVersion)
+	if err != nil {
+		t.Fatalf("reading refs: %v", err)
+	}
+	if len(refs) != len(charts.All()) {
+		t.Fatalf("expected one ref per chart, got %d: %v", len(refs), refs)
+	}
+	want := chartsCLIRegistry + "/" + chartsCLIFirstChart(t) + "@" + chartsCLIDigest
+	if !slices.Contains(refs, want) {
+		t.Errorf("expected %q in the record, got %v", want, refs)
+	}
+}
+
+func TestChartsPublishLogsPerChart(t *testing.T) {
+	r, cfg := runCharts(t, "publish", "--helm-registry", chartsCLIRegistry)
+
+	dir := filepath.Join(cfg.LogsDir, "charts-publish")
+	if !slices.ContainsFunc(r.logPaths, func(p string) bool { return strings.HasPrefix(p, dir) }) {
+		t.Errorf("expected publish logs under %q, got %v", dir, r.logPaths)
+	}
+	// A chart goes to several registries, so its log names both.
+	want := chartsCLIFirstChart(t) + "-"
+	if !slices.ContainsFunc(r.logPaths, func(p string) bool {
+		return strings.HasPrefix(filepath.Base(p), want)
+	}) {
+		t.Errorf("expected a log named for %q, got %v", want, r.logPaths)
+	}
+}
+
+func TestChartsPublishResumesFromTheRecord(t *testing.T) {
+	first, cfg := runCharts(t, "publish", "--helm-registry", chartsCLIRegistry)
+	if !first.ran("push") {
+		t.Fatal("expected the first publish to push")
+	}
+
+	// The second run reads the record the first wrote, so every chart is
+	// already published at the digest the registry still serves.
+	second := runChartsIn(t, cfg, "publish", "--helm-registry", chartsCLIRegistry)
+	if second.ran("push") {
+		t.Error("expected a resumed publish to push nothing")
+	}
+}
+
+func TestChartsPublishForceRepublishesOverAMovedDigest(t *testing.T) {
+	_, cfg := runCharts(t, "publish", "--helm-registry", chartsCLIRegistry)
+
+	prev, prevResolve := commandRunner, registryDigestResolver
+	r := &recordingRunner{}
+	commandRunner = r
+	registryDigestResolver = func(string) (string, bool, error) { return "sha256:moved", true, nil }
+	t.Cleanup(func() { commandRunner, registryDigestResolver = prev, prevResolve })
+
+	cmd := chartsCommand(cfg)
+	args := []string{"charts", "publish", "--helm-registry", chartsCLIRegistry, "--force"}
+	if err := cmd.Run(context.Background(), args); err != nil {
+		t.Fatalf("charts publish --force: %v", err)
+	}
+	if !r.ran("push") {
+		t.Error("expected --force to republish over the moved digest")
+	}
+}
+
+// Without --force the disagreement is an error, not a silent republish.
+func TestChartsPublishFailsOnAMovedDigestWithoutForce(t *testing.T) {
+	_, cfg := runCharts(t, "publish", "--helm-registry", chartsCLIRegistry)
+
+	prev, prevResolve := commandRunner, registryDigestResolver
+	r := &recordingRunner{}
+	commandRunner = r
+	registryDigestResolver = func(string) (string, bool, error) { return "sha256:moved", true, nil }
+	t.Cleanup(func() { commandRunner, registryDigestResolver = prev, prevResolve })
+
+	cmd := chartsCommand(cfg)
+	args := []string{"charts", "publish", "--helm-registry", chartsCLIRegistry}
+	err := cmd.Run(context.Background(), args)
+	if err == nil {
+		t.Fatal("expected a moved digest to fail the publish")
+	}
+	if !strings.Contains(err.Error(), "--force") {
+		t.Errorf("expected the error to name --force, got %v", err)
+	}
+	if r.ran("push") {
+		t.Error("expected nothing pushed on a digest disagreement")
+	}
+}
+
+// A hashrelease pins its own versions and serves its own charts.
+func TestChartsBuildForAHashrelease(t *testing.T) {
+	const pinned = "v3.30.0-1-gabc"
+	// Stub the pin, not the resolver: the chart identity and the options it
+	// derives are what this test is for.
+	// Only the build source is stubbed: a build must not read the published pin.
+	prevBuild, prevPublish := pinForBuild, pinForPublish
+	pinForBuild = func(*Config, *cli.Command) (*pinnedversion.Pin, error) {
+		return &pinnedversion.Pin{
+			ProductVersion: pinned,
+			Hash:           "abc123",
+			ReleaseName:    "gentle-otter",
+			Operator:       registry.Component{Version: "v1.40.0-1-gdef"},
+		}, nil
+	}
+	pinForPublish = func(*Config, *cli.Command) (*pinnedversion.Pin, error) {
+		return nil, fmt.Errorf("build must not load the published pin")
+	}
+	t.Cleanup(func() { pinForBuild, pinForPublish = prevBuild, prevPublish })
+
+	// The build verifies what the target packaged, so stage the pinned version.
+	prevVer, prevDir := chartsCLIChartVersion, chartsCLIChartDir
+	chartsCLIChartVersion = pinned
+	chartsCLIChartDir = func(cfg *Config) string {
+		return filepath.Join(baseHashreleaseOutputDir(cfg.RepoRootDir), "abc123")
+	}
+	t.Cleanup(func() { chartsCLIChartVersion, chartsCLIChartDir = prevVer, prevDir })
+
+	r, _ := runCharts(t, "build", "--hashrelease")
+
+	if !r.ran("-i", pinned) {
+		t.Error("expected the chart values rewritten to the pinned version")
+	}
+	if !r.ran("--url", "gentle-otter") {
+		t.Error("expected the index to point at the hashrelease")
+	}
+	if r.ran("--url", "releases/download") {
+		t.Error("expected no GitHub release url for a hashrelease")
+	}
+}
+
+func TestChartsBuildForAReleaseDoesNotRewriteValues(t *testing.T) {
+	r, _ := runCharts(t, "build", "--no-helm-index")
+
+	if r.ran("sed") {
+		t.Error("expected no values rewritten for a release build")
+	}
+}
+
+// A hashrelease's charts sit under the hashrelease output dir, keyed by hash:
+// that is where the hashrelease flow writes them and reads them back.
+func TestHashreleaseChartDirMatchesTheHashreleaseFlow(t *testing.T) {
+	prev := pinForBuild
+	pin := &pinnedversion.Pin{ProductVersion: "v3.30.0-1-gabc", Hash: "abc123", ReleaseName: "gentle-otter"}
+	pinForBuild = func(*Config, *cli.Command) (*pinnedversion.Pin, error) { return pin, nil }
+	t.Cleanup(func() { pinForBuild = prev })
+
+	root := t.TempDir()
+	cfg := &Config{RepoRootDir: root, OutputDir: filepath.Join(root, "release", "_output")}
+	c := &cli.Command{Flags: []cli.Flag{hashreleaseFlag}}
+	if err := c.Run(context.Background(), []string{"x", "--hashrelease"}); err != nil {
+		t.Fatal(err)
+	}
+	chart, err := pinnedChart(cfg, c, pinForBuild)
+	if err != nil {
+		t.Fatalf("pinnedChart: %v", err)
+	}
+	want := pin.Hashrelease(baseHashreleaseOutputDir(root), false).Source
+	if chart.BaseDir != want {
+		t.Errorf("BaseDir = %q, want %q", chart.BaseDir, want)
+	}
+}
+
+// A product may qualify its charts with a suffix, so the chart version and the
+// product version differ. The build stamps and the publish record must both
+// follow the resolved chart version, not the product one.
+func TestChartsFollowTheResolvedChartVersion(t *testing.T) {
+	const suffix = "0"
+	resolved := chartsCLITestVersion + "-" + suffix
+
+	prevChart, prevVer := pinnedChart, chartsCLIChartVersion
+	pinnedChart = func(cfg *Config, c *cli.Command, pin pinned) (*charts.Chart, error) {
+		chart, err := prevChart(cfg, c, pin)
+		if err != nil {
+			return nil, err
+		}
+		chart.ChartVersion = suffix
+		return chart, nil
+	}
+	chartsCLIChartVersion = resolved
+	t.Cleanup(func() { pinnedChart, chartsCLIChartVersion = prevChart, prevVer })
+
+	r, cfg := runCharts(t, "build", "--no-helm-index")
+	if !slices.Contains(r.envFor(chartsCLITarget), "GIT_VERSION="+resolved) {
+		t.Errorf("GIT_VERSION did not follow the chart version, env: %v", r.envFor(chartsCLITarget))
+	}
+
+	runChartsIn(t, cfg, "publish", "--helm-registry", chartsCLIRegistry)
+	// A missing record reads as empty rather than an error, so count the refs.
+	refs, err := outputs.ReadRefs(cfg.OutputDir, chartsPublishStep, resolved)
+	if err != nil {
+		t.Fatalf("reading refs: %v", err)
+	}
+	if len(refs) != len(charts.All()) {
+		t.Errorf("record under %s has %d refs, want %d", resolved, len(refs), len(charts.All()))
+	}
+}

--- a/release/cmd/charts_test.go
+++ b/release/cmd/charts_test.go
@@ -45,7 +45,7 @@ var (
 	// Where a build leaves the packaged charts. A product that writes them
 	// somewhere other than a per-version directory replaces this.
 	chartsCLIChartDir = func(cfg *Config) string {
-		return filepath.Join(cfg.OutputDir, chartsCLITestVersion)
+		return charts.Dir(filepath.Join(cfg.OutputDir, chartsCLITestVersion))
 	}
 
 	// The make target that packages every chart.
@@ -56,14 +56,21 @@ var (
 	chartsCLIDigest   = "sha256:aaa"
 
 	// The repository whose index a build merges with.
-	chartsCLIRepoURL = charts.RepoURL()
+	chartsCLIRepoURL = func(t *testing.T) string {
+		t.Helper()
+		u, err := charts.RepoURL()
+		if err != nil {
+			t.Fatal(err)
+		}
+		return u
+	}
 
 	// A product serving charts from the repository it indexes replaces this:
 	// there the two URLs coincide.
 	chartsCLICheckDownloadURL = func(t *testing.T, url string) {
 		t.Helper()
-		if url == chartsCLIRepoURL {
-			t.Errorf("expected the download url to differ from the repository url %q", chartsCLIRepoURL)
+		if repo := chartsCLIRepoURL(t); url == repo {
+			t.Errorf("expected the download url to differ from the repository url %q", repo)
 		}
 		if !strings.Contains(url, chartsCLITestVersion) {
 			t.Errorf("expected the download url to name the release, got %q", url)
@@ -168,13 +175,11 @@ func TestChartsBuildBuildsTheIndexByDefault(t *testing.T) {
 	if !r.ran("--merge") {
 		t.Error("expected the published index to be merged rather than replaced")
 	}
-	if !r.ran(chartsCLIRepoURL) {
-		t.Errorf("expected the index at %q to be downloaded", chartsCLIRepoURL)
+	if repo := chartsCLIRepoURL(t); !r.ran(repo) {
+		t.Errorf("expected the index at %q to be downloaded", repo)
 	}
-	// The index is kept out of the chart directory.
-	// The finished index lands where the caller asked, whatever directory
-	// helm was pointed at to build it.
-	indexDir := chartsIndexDir(cfg, chartsCLIChartVersion)
+	// The index sits with the charts, so a sweep of the output takes both.
+	indexDir := chartsCLIChartDir(cfg)
 	if _, err := os.Stat(filepath.Join(indexDir, "index.yaml")); err != nil {
 		t.Errorf("expected the index in %q: %v", indexDir, err)
 	}
@@ -229,7 +234,7 @@ func TestChartsPublishLocalPushesNothing(t *testing.T) {
 func TestChartsPublishLocalRecordsNothing(t *testing.T) {
 	_, cfg := runCharts(t, "publish", "--local", "--helm-registry", chartsCLIRegistry)
 
-	refs, err := outputs.ReadRefs(cfg.OutputDir, chartsPublishStep, chartsCLIChartVersion)
+	refs, err := outputs.ReadRefs(cfg.OutputDir, charts.PublishStep, chartsCLIChartVersion)
 	if err != nil {
 		t.Fatalf("reading refs: %v", err)
 	}
@@ -241,7 +246,7 @@ func TestChartsPublishLocalRecordsNothing(t *testing.T) {
 func TestChartsPublishRecordsWhatItPushed(t *testing.T) {
 	_, cfg := runCharts(t, "publish", "--helm-registry", chartsCLIRegistry)
 
-	refs, err := outputs.ReadRefs(cfg.OutputDir, chartsPublishStep, chartsCLITestVersion)
+	refs, err := outputs.ReadRefs(cfg.OutputDir, charts.PublishStep, chartsCLIChartVersion)
 	if err != nil {
 		t.Fatalf("reading refs: %v", err)
 	}
@@ -336,10 +341,15 @@ func TestChartsBuildForAHashrelease(t *testing.T) {
 	prevBuild, prevPublish := pinForBuild, pinForPublish
 	pinForBuild = func(*Config, *cli.Command) (*pinnedversion.Pin, error) {
 		return &pinnedversion.Pin{
-			ProductVersion: pinned,
-			Hash:           "abc123",
-			ReleaseName:    "gentle-otter",
-			Operator:       registry.Component{Version: "v1.40.0-1-gdef"},
+			ProductVersion:  pinned,
+			ProductRegistry: chartsCLIRegistry,
+			Hash:            "abc123",
+			ReleaseName:     "gentle-otter",
+			Operator: registry.Component{
+				Version:  "v1.40.0-1-gdef",
+				Image:    "tigera/operator",
+				Registry: chartsCLIRegistry,
+			},
 		}, nil
 	}
 	pinForPublish = func(*Config, *cli.Command) (*pinnedversion.Pin, error) {
@@ -351,14 +361,18 @@ func TestChartsBuildForAHashrelease(t *testing.T) {
 	prevVer, prevDir := chartsCLIChartVersion, chartsCLIChartDir
 	chartsCLIChartVersion = pinned
 	chartsCLIChartDir = func(cfg *Config) string {
-		return filepath.Join(baseHashreleaseOutputDir(cfg.RepoRootDir), "abc123")
+		return charts.Dir(filepath.Join(baseHashreleaseOutputDir(cfg.RepoRootDir), "abc123"))
 	}
 	t.Cleanup(func() { chartsCLIChartVersion, chartsCLIChartDir = prevVer, prevDir })
 
-	r, _ := runCharts(t, "build", "--hashrelease")
+	r, cfg := runCharts(t, "build", "--hashrelease")
 
-	if !r.ran("-i", pinned) {
-		t.Error("expected the chart values rewritten to the pinned version")
+	values, err := os.ReadFile(filepath.Join(cfg.RepoRootDir, "charts", charts.TigeraOperatorChart, "values.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(values), pinned) {
+		t.Errorf("expected the chart values rewritten to %s, got %q", pinned, values)
 	}
 	if !r.ran("--url", "gentle-otter") {
 		t.Error("expected the index to point at the hashrelease")
@@ -394,7 +408,7 @@ func TestHashreleaseChartDirMatchesTheHashreleaseFlow(t *testing.T) {
 	if err != nil {
 		t.Fatalf("pinnedChart: %v", err)
 	}
-	want := pin.Hashrelease(baseHashreleaseOutputDir(root), false).Source
+	want := charts.Dir(pin.Hashrelease(baseHashreleaseOutputDir(root), false).Source)
 	if chart.BaseDir != want {
 		t.Errorf("BaseDir = %q, want %q", chart.BaseDir, want)
 	}
@@ -426,7 +440,7 @@ func TestChartsFollowTheResolvedChartVersion(t *testing.T) {
 
 	runChartsIn(t, cfg, "publish", "--helm-registry", chartsCLIRegistry)
 	// A missing record reads as empty rather than an error, so count the refs.
-	refs, err := outputs.ReadRefs(cfg.OutputDir, chartsPublishStep, resolved)
+	refs, err := outputs.ReadRefs(cfg.OutputDir, charts.PublishStep, resolved)
 	if err != nil {
 		t.Fatalf("reading refs: %v", err)
 	}

--- a/release/cmd/flags.go
+++ b/release/cmd/flags.go
@@ -161,6 +161,12 @@ var (
 			},
 		}
 	}
+	forceFlag = &cli.BoolFlag{
+		Name:     "force",
+		Category: stepControlCategory,
+		Usage:    "Republish artifacts whose published digest differs from the record.",
+		Sources:  cli.EnvVars("FORCE"),
+	}
 )
 
 // Development flags are flags used to control development behavior of the release process
@@ -249,13 +255,6 @@ var (
 		Category: containerImageCategory,
 		Usage:    "Leave the dev tag in place when retagging.",
 		Sources:  cli.EnvVars("SKIP_DEV_IMAGE_RETAG"),
-	}
-
-	forceFlag = &cli.BoolFlag{
-		Name:     "force",
-		Category: containerImageCategory,
-		Usage:    "Republish images whose published digest differs from the record.",
-		Sources:  cli.EnvVars("FORCE"),
 	}
 
 	// imageReleaseDirsFlag limits a run to some of the directories that ship

--- a/release/cmd/hashrelease.go
+++ b/release/cmd/hashrelease.go
@@ -39,11 +39,19 @@ import (
 
 // parts for generating the pinned version
 var (
+	productRegistry = func(c *cli.Command) string {
+		reg := c.StringSlice(registryFlag.Name)
+		if len(reg) == 0 {
+			return registry.DefaultProductRegistry
+		}
+		return reg[0]
+	}
 	pinConfig = func(cfg *Config, c *cli.Command) pinnedversion.Config {
 		return pinnedversion.Config{
 			Dir:                 cfg.TmpDir,
 			RootDir:             cfg.RepoRootDir,
 			ReleaseBranchPrefix: c.String(releaseBranchPrefixFlag.Name),
+			Registry:            productRegistry(c),
 			Operator: registry.Component{
 				Image:    c.String(operatorImageFlag.Name),
 				Registry: c.String(operatorRegistryFlag.Name),

--- a/release/cmd/images.go
+++ b/release/cmd/images.go
@@ -23,6 +23,7 @@ import (
 	"github.com/projectcalico/calico/release/internal/images"
 	"github.com/projectcalico/calico/release/internal/outputs"
 	"github.com/projectcalico/calico/release/internal/registry"
+	"github.com/projectcalico/calico/release/internal/steps"
 	"github.com/projectcalico/calico/release/internal/utils"
 )
 
@@ -30,7 +31,7 @@ import (
 // Tests replace both.
 var (
 	imagesRunner         command.CommandRunner = &command.RealCommandRunner{}
-	imagesDigestResolver images.DigestResolver = registry.ResolveDigest
+	imagesDigestResolver steps.DigestResolver  = registry.ResolveDigest
 )
 
 var imagesSubCommands = func(cfg *Config) []*cli.Command {
@@ -107,7 +108,7 @@ var (
 				return err
 			}
 
-			var refs images.RefRecorder
+			var refs steps.RefRecorder
 			if !c.Bool(localFlag.Name) {
 				w, err := outputs.NewRefsWriter(cfg.OutputDir, "images-publish", ver.FormattedString())
 				if err != nil {

--- a/release/cmd/images.go
+++ b/release/cmd/images.go
@@ -19,19 +19,9 @@ import (
 
 	cli "github.com/urfave/cli/v3"
 
-	"github.com/projectcalico/calico/release/internal/command"
 	"github.com/projectcalico/calico/release/internal/images"
-	"github.com/projectcalico/calico/release/internal/outputs"
-	"github.com/projectcalico/calico/release/internal/registry"
 	"github.com/projectcalico/calico/release/internal/steps"
 	"github.com/projectcalico/calico/release/internal/utils"
-)
-
-// imagesRunner drives make; imagesDigestResolver looks up a published digest.
-// Tests replace both.
-var (
-	imagesRunner         command.CommandRunner = &command.RealCommandRunner{}
-	imagesDigestResolver steps.DigestResolver  = registry.ResolveDigest
 )
 
 var imagesSubCommands = func(cfg *Config) []*cli.Command {
@@ -61,7 +51,7 @@ var (
 			return images.Build(
 				cfg.RepoRootDir, ver.FormattedString(),
 				images.NarrowVariants(images.BuildVariants, c.StringSlice(imageReleaseDirsFlag.Name)),
-				images.WithRunner(imagesRunner),
+				images.WithRunner(commandRunner),
 				images.WithRegistries(c.StringSlice(registryFlag.Name)...),
 				images.WithArches(c.StringSlice(archFlag.Name)...),
 				images.WithLogsDir(cfg.LogsDir),
@@ -101,23 +91,16 @@ var (
 			if err != nil {
 				return err
 			}
-			// An earlier run of this version records what it published, so a
-			// resume skips the units already done.
-			published, err := outputs.ReadRefs(cfg.OutputDir, "images-publish", ver.FormattedString())
+			published, w, err := publishRecord(cfg, imagesPublishStep, ver.FormattedString(), !c.Bool(localFlag.Name))
 			if err != nil {
 				return err
 			}
-
 			var refs steps.RefRecorder
-			if !c.Bool(localFlag.Name) {
-				w, err := outputs.NewRefsWriter(cfg.OutputDir, "images-publish", ver.FormattedString())
-				if err != nil {
-					return err
-				}
+			if w != nil {
 				refs = w
 			}
 			opts := []images.PublishOption{
-				images.WithRunner(imagesRunner),
+				images.WithRunner(commandRunner),
 				images.WithRegistries(c.StringSlice(registryFlag.Name)...),
 				images.WithArches(c.StringSlice(archFlag.Name)...),
 				images.WithLogsDir(cfg.LogsDir),
@@ -139,11 +122,13 @@ var (
 			return images.Publish(
 				cfg.RepoRootDir, ver.FormattedString(),
 				images.NarrowVariants(images.PublishVariants, dirs),
-				!c.Bool(localFlag.Name), imagesDigestResolver, opts...,
+				!c.Bool(localFlag.Name), registryDigestResolver, opts...,
 			)
 		}
 	}
 )
+
+const imagesPublishStep = "images-publish"
 
 func imagesPublishCommand(cfg *Config) *cli.Command {
 	return &cli.Command{

--- a/release/cmd/images_test.go
+++ b/release/cmd/images_test.go
@@ -16,11 +16,9 @@ package main
 
 import (
 	"context"
-	"os"
 	"path/filepath"
 	"slices"
 	"strings"
-	"sync"
 	"testing"
 
 	cli "github.com/urfave/cli/v3"
@@ -30,107 +28,14 @@ import (
 	"github.com/projectcalico/calico/release/internal/utils"
 )
 
-// recordingRunner runs nothing and records what it was asked to run. Units run
-// concurrently, so recording is locked.
-type recordingRunner struct {
-	mu       sync.Mutex
-	args     [][]string
-	envs     [][]string
-	logPaths []string
-}
-
-func (r *recordingRunner) record(args, env []string, logPath string) (string, error) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	r.args = append(r.args, slices.Clone(args))
-	r.envs = append(r.envs, slices.Clone(env))
-	r.logPaths = append(r.logPaths, logPath)
-	return "", nil
-}
-
-func (r *recordingRunner) Run(_ string, args, env []string) (string, error) {
-	return r.record(args, env, "")
-}
-
-func (r *recordingRunner) RunNoCapture(_ string, args, env []string) error {
-	_, err := r.record(args, env, "")
-	return err
-}
-
-func (r *recordingRunner) RunInDir(_, _ string, args, env []string) (string, error) {
-	if slices.Contains(args, "build-images") {
-		// The publish asks each directory for its image names before recording.
-		if _, err := r.record(args, env, ""); err != nil {
-			return "", err
-		}
-		return "calico calico-windows", nil
-	}
-	return r.record(args, env, "")
-}
-
-func (r *recordingRunner) RunInDirNoCapture(_, _ string, args, env []string) error {
-	_, err := r.record(args, env, "")
-	return err
-}
-
-func (r *recordingRunner) RunInDirToFile(_, _ string, args, env []string, logPath string) (string, error) {
-	return r.record(args, env, logPath)
-}
-
-// envFor returns the environment of the first recorded make call whose args
-// contain every one of want.
-func (r *recordingRunner) envFor(want ...string) []string {
-	for i, args := range r.args {
-		if containsAll(args, want) {
-			return r.envs[i]
-		}
-	}
-	return nil
-}
-
-// ran reports whether any recorded call's args contain every one of want.
-func (r *recordingRunner) ran(want ...string) bool {
-	return slices.ContainsFunc(r.args, func(args []string) bool {
-		return containsAll(args, want)
-	})
-}
-
-func containsAll(args, want []string) bool {
-	for _, w := range want {
-		if !slices.ContainsFunc(args, func(a string) bool { return strings.Contains(a, w) }) {
-			return false
-		}
-	}
-	return true
-}
-
-// fakeRepo writes the two manifests VersionsFromManifests reads, so the image
-// commands can resolve a version without a checkout.
-func fakeRepo(t *testing.T, version string) string {
-	t.Helper()
-	root := t.TempDir()
-	manifests := filepath.Join(root, "manifests", "ocp")
-	if err := os.MkdirAll(manifests, 0o755); err != nil {
-		t.Fatalf("mkdir: %v", err)
-	}
-	write := func(path, content string) {
-		if err := os.WriteFile(filepath.Join(root, "manifests", path), []byte(content), 0o644); err != nil {
-			t.Fatalf("write %s: %v", path, err)
-		}
-	}
-	write(filepath.Join("ocp", "02-tigera-operator.yaml"), "          image: quay.io/calico/calico:"+version+"\n")
-	write("tigera-operator.yaml", "          image: quay.io/calico/operator:"+version+"\n")
-	return root
-}
-
 // runImages drives the real images command with a recording runner.
 func runImages(t *testing.T, root string, args ...string) *recordingRunner {
 	t.Helper()
 	r := &recordingRunner{}
-	prev, prevResolve := imagesRunner, imagesDigestResolver
-	imagesRunner = r
-	imagesDigestResolver = func(string) (string, bool, error) { return "sha256:aaa", true, nil }
-	t.Cleanup(func() { imagesRunner, imagesDigestResolver = prev, prevResolve })
+	prev, prevResolve := commandRunner, registryDigestResolver
+	commandRunner = r
+	registryDigestResolver = func(string) (string, bool, error) { return "sha256:aaa", true, nil }
+	t.Cleanup(func() { commandRunner, registryDigestResolver = prev, prevResolve })
 
 	cfg := &Config{
 		RepoRootDir: root,
@@ -248,10 +153,10 @@ func TestImagesNarrowedKeepsEveryVariant(t *testing.T) {
 // felix is not an image directory, so narrowing a build to it is a mistake
 // worth reporting rather than a build that quietly does nothing.
 func TestImagesRejectsFelixAsAnImageDir(t *testing.T) {
-	prev := imagesRunner
+	prev := commandRunner
 	r := &recordingRunner{}
-	imagesRunner = r
-	t.Cleanup(func() { imagesRunner = prev })
+	commandRunner = r
+	t.Cleanup(func() { commandRunner = prev })
 
 	root := fakeRepo(t, "v3.30.0")
 	cfg := &Config{
@@ -274,9 +179,9 @@ func TestImagesRejectsFelixAsAnImageDir(t *testing.T) {
 // An unknown directory must be rejected: narrowing silently drops what it does
 // not recognise.
 func TestImagesRejectsUnknownReleaseDir(t *testing.T) {
-	prev := imagesRunner
-	imagesRunner = &recordingRunner{}
-	t.Cleanup(func() { imagesRunner = prev })
+	prev := commandRunner
+	commandRunner = &recordingRunner{}
+	t.Cleanup(func() { commandRunner = prev })
 
 	root := fakeRepo(t, "v3.30.0")
 	cfg := &Config{
@@ -337,9 +242,9 @@ func TestImagesPublishSkipDevImageRetag(t *testing.T) {
 // The two retag flags are meaningless apart, so one without the other is an
 // error rather than a silent fresh push.
 func TestImagesPublishRejectsHalfConfiguredRetag(t *testing.T) {
-	prev := imagesRunner
-	imagesRunner = &recordingRunner{}
-	t.Cleanup(func() { imagesRunner = prev })
+	prev := commandRunner
+	commandRunner = &recordingRunner{}
+	t.Cleanup(func() { commandRunner = prev })
 
 	root := fakeRepo(t, "v3.30.0")
 	cfg := &Config{

--- a/release/cmd/main.go
+++ b/release/cmd/main.go
@@ -75,6 +75,7 @@ func Commands(cfg *Config) []*cli.Command {
 		releaseCommand(cfg),
 		branchCommand(cfg),
 		imagesCommand(cfg),
+		chartsCommand(cfg),
 	}
 }
 

--- a/release/cmd/release.go
+++ b/release/cmd/release.go
@@ -37,7 +37,7 @@ import (
 
 func releaseOutputDir(repoRootDir, version string) string {
 	baseOutputDir := filepath.Join(append([]string{repoRootDir}, releaseOutputPath...)...)
-	return filepath.Join(baseOutputDir, "upload", version)
+	return filepath.Join(baseOutputDir, "release", version)
 }
 
 // The release command suite is used to build and publish official releases.
@@ -50,7 +50,7 @@ func releaseCommand(cfg *Config) *cli.Command {
 	}
 }
 
-func releaseSubCommands(cfg *Config) []*cli.Command {
+var releaseSubCommands = func(cfg *Config) []*cli.Command {
 	return []*cli.Command{
 		// Prepare for a release.
 		releasePrepCommand(cfg),

--- a/release/cmd/shared.go
+++ b/release/cmd/shared.go
@@ -29,6 +29,7 @@ import (
 	"github.com/projectcalico/calico/release/internal/command"
 	"github.com/projectcalico/calico/release/internal/outputs"
 	"github.com/projectcalico/calico/release/internal/pinnedversion"
+	"github.com/projectcalico/calico/release/internal/registry"
 	"github.com/projectcalico/calico/release/internal/slack"
 	"github.com/projectcalico/calico/release/internal/utils"
 	"github.com/projectcalico/calico/release/internal/version"
@@ -41,6 +42,9 @@ var (
 	// releaseOutputPath is the directory where all outputs are stored
 	// relative to the repo root
 	releaseOutputPath = []string{utils.ReleaseFolderName, "_output"}
+
+	commandRunner          command.CommandRunner = &command.RealCommandRunner{}
+	registryDigestResolver                       = registry.ResolveDigest
 )
 
 func logPrettifier(f *runtime.Frame) (string, string) {
@@ -168,4 +172,19 @@ var releaseVersion = func(cfg *Config, c *cli.Command) (*version.Version, error)
 		return nil, fmt.Errorf("version from manifest: %w", err)
 	}
 	return &ver, nil
+}
+
+func publishRecord(cfg *Config, step, version string, confirm bool) ([]string, *outputs.RefsWriter, error) {
+	published, err := outputs.ReadRefs(cfg.OutputDir, step, version)
+	if err != nil {
+		return nil, nil, err
+	}
+	if !confirm {
+		return published, nil, nil
+	}
+	w, err := outputs.NewRefsWriter(cfg.OutputDir, step, version)
+	if err != nil {
+		return nil, nil, err
+	}
+	return published, w, nil
 }

--- a/release/cmd/shared.go
+++ b/release/cmd/shared.go
@@ -20,6 +20,7 @@ import (
 	"path"
 	"runtime"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -137,6 +138,19 @@ func slackConfig(c *cli.Command) *slack.Config {
 }
 
 type pinned func(cfg *Config, c *cli.Command) (*pinnedversion.Pin, error)
+
+// oncePin memoizes a pin source so several callers in one command share it.
+func oncePin(pin pinned) pinned {
+	var (
+		once sync.Once
+		p    *pinnedversion.Pin
+		err  error
+	)
+	return func(cfg *Config, c *cli.Command) (*pinnedversion.Pin, error) {
+		once.Do(func() { p, err = pin(cfg, c) })
+		return p, err
+	}
+}
 
 var (
 	loadPin pinned = func(cfg *Config, c *cli.Command) (*pinnedversion.Pin, error) {

--- a/release/cmd/shared_test.go
+++ b/release/cmd/shared_test.go
@@ -118,5 +118,40 @@ var fakeRepo = func(t *testing.T, version string) string {
 	}
 	write(filepath.Join("ocp", "02-tigera-operator.yaml"), "          image: quay.io/calico/calico:"+version+"\n")
 	write("tigera-operator.yaml", "          image: quay.io/calico/operator:"+version+"\n")
+	writeChartValues(t, root)
 	return root
+}
+
+// The values a release rewrites before packaging. Each chart carries the keys
+// its edits target, so a fixture missing one fails the way the real tree would.
+var fakeChartValues = map[string]string{
+	"tigera-operator": `tigeraOperator:
+  image: calico/operator
+  version: master
+  registry: quay.io
+calicoctl:
+  image: quay.io/calico/calico
+  tag: master
+`,
+	"calico": `version: master
+calico:
+  registry: quay.io/calico
+node:
+  registry: quay.io/calico
+flannelMigration:
+  registry: quay.io/calico
+`,
+}
+
+func writeChartValues(t *testing.T, root string) {
+	t.Helper()
+	for chart, values := range fakeChartValues {
+		dir := filepath.Join(root, "charts", chart)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "values.yaml"), []byte(values), 0o644); err != nil {
+			t.Fatalf("write values: %v", err)
+		}
+	}
 }

--- a/release/cmd/shared_test.go
+++ b/release/cmd/shared_test.go
@@ -1,0 +1,122 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// recordingRunner runs nothing and records what it was asked to run. Units run
+// concurrently, so recording is locked.
+type recordingRunner struct {
+	mu       sync.Mutex
+	args     [][]string
+	envs     [][]string
+	logPaths []string
+}
+
+func (r *recordingRunner) record(args, env []string, logPath string) (string, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	// Stand in for helm: `repo index <dir>` writes the index into that dir.
+	if len(args) > 2 && args[0] == "repo" && args[1] == "index" {
+		_ = os.WriteFile(filepath.Join(args[2], "index.yaml"), []byte("entries:"), 0o644)
+	}
+	r.args = append(r.args, slices.Clone(args))
+	r.envs = append(r.envs, slices.Clone(env))
+	r.logPaths = append(r.logPaths, logPath)
+	return "", nil
+}
+
+func (r *recordingRunner) Run(_ string, args, env []string) (string, error) {
+	return r.record(args, env, "")
+}
+
+func (r *recordingRunner) RunNoCapture(_ string, args, env []string) error {
+	_, err := r.record(args, env, "")
+	return err
+}
+
+func (r *recordingRunner) RunInDir(_, _ string, args, env []string) (string, error) {
+	if slices.Contains(args, "build-images") {
+		// The publish asks each directory for its image names before recording.
+		if _, err := r.record(args, env, ""); err != nil {
+			return "", err
+		}
+		return "calico calico-windows", nil
+	}
+	return r.record(args, env, "")
+}
+
+func (r *recordingRunner) RunInDirNoCapture(_, _ string, args, env []string) error {
+	_, err := r.record(args, env, "")
+	return err
+}
+
+func (r *recordingRunner) RunInDirToFile(_, _ string, args, env []string, logPath string) (string, error) {
+	return r.record(args, env, logPath)
+}
+
+// envFor returns the environment of the first recorded make call whose args
+// contain every one of want.
+func (r *recordingRunner) envFor(want ...string) []string {
+	for i, args := range r.args {
+		if containsAll(args, want) {
+			return r.envs[i]
+		}
+	}
+	return nil
+}
+
+// ran reports whether any recorded call's args contain every one of want.
+func (r *recordingRunner) ran(want ...string) bool {
+	return slices.ContainsFunc(r.args, func(args []string) bool {
+		return containsAll(args, want)
+	})
+}
+
+func containsAll(args, want []string) bool {
+	for _, w := range want {
+		if !slices.ContainsFunc(args, func(a string) bool { return strings.Contains(a, w) }) {
+			return false
+		}
+	}
+	return true
+}
+
+// fakeRepo writes the manifests a version is resolved from, so the step
+// commands run without a checkout. It is a var because a product reads a
+// different image name, and may read more than these two files.
+var fakeRepo = func(t *testing.T, version string) string {
+	t.Helper()
+	root := t.TempDir()
+	manifests := filepath.Join(root, "manifests", "ocp")
+	if err := os.MkdirAll(manifests, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	write := func(path, content string) {
+		if err := os.WriteFile(filepath.Join(root, "manifests", path), []byte(content), 0o644); err != nil {
+			t.Fatalf("write %s: %v", path, err)
+		}
+	}
+	write(filepath.Join("ocp", "02-tigera-operator.yaml"), "          image: quay.io/calico/calico:"+version+"\n")
+	write("tigera-operator.yaml", "          image: quay.io/calico/operator:"+version+"\n")
+	return root
+}

--- a/release/deps.txt
+++ b/release/deps.txt
@@ -135,6 +135,7 @@ local:release/internal/slack
 local:release/internal/steps
 local:release/internal/utils
 local:release/internal/version
+local:release/internal/yamledit
 local:release/pkg/manager/calico
 local:release/pkg/manager/operator
 local:release/pkg/tasks

--- a/release/deps.txt
+++ b/release/deps.txt
@@ -87,6 +87,7 @@ local:release/internal/outputs
 local:release/internal/pinnedversion
 local:release/internal/registry
 local:release/internal/slack
+local:release/internal/steps
 local:release/internal/utils
 local:release/internal/version
 local:release/pkg/manager/calico

--- a/release/deps.txt
+++ b/release/deps.txt
@@ -77,9 +77,11 @@ local:lib/logrusr
 local:lib/std/log
 local:release/cmd
 local:release/internal/branch
+local:release/internal/charts
 local:release/internal/ci
 local:release/internal/command
 local:release/internal/defaults
+local:release/internal/github
 local:release/internal/hashreleaseserver
 local:release/internal/images
 local:release/internal/imagescanner

--- a/release/internal/charts/actions.go
+++ b/release/internal/charts/actions.go
@@ -29,6 +29,7 @@ import (
 	"github.com/projectcalico/calico/release/internal/registry"
 	"github.com/projectcalico/calico/release/internal/steps"
 	"github.com/projectcalico/calico/release/internal/utils"
+	"github.com/projectcalico/calico/release/internal/yamledit"
 )
 
 // Build packages every chart the release ships.
@@ -70,7 +71,7 @@ func Build(chart Chart, opts ...BuildOption) error {
 
 // Publish pushes every built chart to every registry. confirm latches the push.
 func Publish(chart Chart, registries []string, confirm bool, opts ...PublishOption) error {
-	s, err := newSettings(publishStep, chart, opts)
+	s, err := newSettings(PublishStep, chart, opts)
 	if err != nil {
 		return err
 	}
@@ -174,13 +175,10 @@ func (s settings) verify() error {
 }
 
 func (s settings) resetTree() {
-	if _, err := s.Runner().RunInDir(s.RepoRoot, "git", []string{"checkout", chartsTreePath}, nil); err != nil {
+	if _, err := s.Runner().RunInDir(s.RepoRoot, "git", []string{"checkout", chartsDirName}, nil); err != nil {
 		s.Logger().WithError(err).Error("Failed to reset changes to charts")
 	}
 }
-
-// chartsTreePath is the tree whose values a build rewrites and a reset restores.
-const chartsTreePath = "charts/"
 
 // The index directory holds only this release's charts, so the entries it adds
 // are what was just built.
@@ -191,7 +189,10 @@ func (s settings) buildIndex() error {
 	}
 	// helm indexes a whole directory, so the staging dir must hold this
 	// release's charts and nothing else.
-	staging := Dir(s.tmpDir, s.Version())
+	staging, err := versionedDir(s.tmpDir, s.Version())
+	if err != nil {
+		return s.Errorf("creating versioned staging dir: %w", err)
+	}
 	if err := os.RemoveAll(staging); err != nil {
 		return s.Errorf("clearing helm index staging dir: %w", err)
 	}
@@ -410,26 +411,7 @@ func (u unit) slug() string {
 
 type ValueEdit struct {
 	Chart string
-	Key   string
-
-	// From is the value being replaced. Set it when the key alone does not
-	// identify the line: a chart may repeat a key, and a bare swap has no key.
-	From string
-
-	Value string
-}
-
-// expr is the sed expression the edit applies. The delimiter is ~ because
-// values carry registries, which contain /.
-func (e ValueEdit) expr() string {
-	from := ".*"
-	if e.From != "" {
-		from = e.From
-	}
-	if e.Key == "" {
-		return fmt.Sprintf("s~%s~%s~g", from, e.Value)
-	}
-	return fmt.Sprintf("s~%s: %s~%s: %s~g", e.Key, from, e.Key, e.Value)
+	yamledit.Edit
 }
 
 // Edits are supplied by the caller: products stamp different charts.
@@ -451,16 +433,21 @@ func ModifyValues(v Values, opts ...Option) error {
 	if err != nil {
 		return err
 	}
+	byChart := map[string][]yamledit.Edit{}
+	var order []string
 	for _, e := range v.Edits {
-		// A keyless edit must name what it replaces, or it would match anything.
-		if e.Chart == "" || e.Value == "" || (e.Key == "" && e.From == "") {
-			return s.Errorf("incomplete chart value edit: %+v", e)
+		if e.Chart == "" {
+			return s.Errorf("chart value edit with no chart: %+v", e)
 		}
-		expr := e.expr()
-		path := filepath.Join(v.RepoRoot, chartsTreePath, e.Chart, "values.yaml")
-		if out, err := s.Runner().Run("sed", []string{"-i", expr, path}, nil); err != nil {
-			s.Logger().Error(out)
-			return s.Errorf("updating %s in %s: %w", e.Key, path, err)
+		if _, seen := byChart[e.Chart]; !seen {
+			order = append(order, e.Chart)
+		}
+		byChart[e.Chart] = append(byChart[e.Chart], e.Edit)
+	}
+	for _, chart := range order {
+		path := filepath.Join(v.RepoRoot, chartsDirName, chart, valuesFileName)
+		if err := yamledit.ApplyToFile(path, byChart[chart]...); err != nil {
+			return s.Errorf("%w", err)
 		}
 	}
 	return nil

--- a/release/internal/charts/actions.go
+++ b/release/internal/charts/actions.go
@@ -1,0 +1,482 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package charts
+
+import (
+	"errors"
+	"fmt"
+	"maps"
+	"net/url"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/projectcalico/calico/release/internal/registry"
+	"github.com/projectcalico/calico/release/internal/steps"
+	"github.com/projectcalico/calico/release/internal/utils"
+)
+
+// Build packages every chart the release ships.
+func Build(chart Chart, opts ...BuildOption) error {
+	s, err := newSettings(buildStep, chart, opts)
+	if err != nil {
+		return err
+	}
+
+	// The edits land in the working tree, so restore it however the build ends.
+	if s.modifyValues != nil {
+		defer s.resetTree()
+		if err := s.modifyValues(); err != nil {
+			return s.Errorf("modifying chart values: %w", err)
+		}
+	}
+
+	s.Logger().WithField("charts", len(s.Names)).Info("Building helm charts")
+	if err := s.build(); err != nil {
+		return err
+	}
+	if err := s.verify(); err != nil {
+		return err
+	}
+	s.Logger().Info("Finished building helm charts")
+
+	if s.index == nil {
+		return nil
+	}
+	s.repoURL, s.chartURL, s.indexDir = s.index.repoURL, s.index.chartURL, s.index.dir
+	s.Logger().Info("Building helm index")
+	if err := s.buildIndex(); err != nil {
+		return err
+	}
+	s.Logger().Info("Finished building helm index")
+
+	return nil
+}
+
+// Publish pushes every built chart to every registry. confirm latches the push.
+func Publish(chart Chart, registries []string, confirm bool, opts ...PublishOption) error {
+	s, err := newSettings(publishStep, chart, opts)
+	if err != nil {
+		return err
+	}
+	if len(registries) == 0 {
+		return s.Errorf("no registries to publish to")
+	}
+	s.registries, s.confirm = registries, confirm
+	if !confirm {
+		// A dry run pushes nothing, so a record would name unpublished charts.
+		s.refs = nil
+	}
+
+	// Fail before pushing, rather than leaving a registry half updated.
+	if err := s.present(); err != nil {
+		return err
+	}
+	units, err := s.pending()
+	if err != nil {
+		return err
+	}
+	if len(units) == 0 {
+		s.Logger().Info("Every chart is already published")
+		return nil
+	}
+	if !confirm {
+		s.Logger().WithField("charts", len(units)).Info("Dry run, not publishing helm charts")
+		return nil
+	}
+
+	s.Logger().WithField("charts", len(units)).Info("Publishing helm charts")
+	pushErr := s.push(units)
+
+	// Record before reporting a failure: a partial publish is the run whose
+	// record decides what a resume still owes.
+	if err := s.record(units); err != nil {
+		return errors.Join(pushErr, err)
+	}
+	if pushErr != nil {
+		return pushErr
+	}
+	s.Logger().Info("Finished publishing helm charts")
+	return nil
+}
+
+func newSettings[O any](step string, chart Chart, opts []O) (settings, error) {
+	s := settings{Chart: chart}
+	s.Apply([]steps.Option{steps.WithName(step), steps.WithDir(chart.RepoRoot)})
+	if err := s.validate(); err != nil {
+		return s, s.Errorf("%w", err)
+	}
+	for _, opt := range opts {
+		if err := applyTo(opt, &s); err != nil {
+			return s, s.Errorf("%w", err)
+		}
+	}
+	if s.resolve == nil {
+		s.resolve = registry.ResolveDigest
+	}
+	return s, nil
+}
+
+func applyTo(opt any, s *settings) error {
+	switch o := opt.(type) {
+	case BuildOption:
+		return o.applyBuild(s)
+	case PublishOption:
+		return o.applyPublish(s)
+	default:
+		return fmt.Errorf("unknown option type %T", opt)
+	}
+}
+
+func (s settings) build() error {
+	if err := os.MkdirAll(s.BaseDir, utils.DirPerms); err != nil {
+		return s.Errorf("creating chart dir: %w", err)
+	}
+	env := append(os.Environ(),
+		utils.Env(utils.EnvGitVersion, s.Version()),
+		utils.Env(utils.EnvChartDestination, s.BaseDir),
+	)
+	env = append(env, s.env...)
+
+	out, err := s.Run("make", []string{"-C", s.RepoRoot, chartTarget}, env, s.LogPath("charts"))
+	if err != nil {
+		// Surface the captured output; the failure cause is usually only there.
+		s.Logger().Error(out)
+		return s.Errorf("building helm charts: %w", err)
+	}
+	return nil
+}
+
+// A chart missing here means the target and the list have drifted apart.
+func (s settings) verify() error {
+	var errs []error
+	for _, chart := range s.Names {
+		if _, err := os.Stat(s.path(chart)); err != nil {
+			errs = append(errs, fmt.Errorf("chart %s was not built: %w", chart, err))
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func (s settings) resetTree() {
+	if _, err := s.Runner().RunInDir(s.RepoRoot, "git", []string{"checkout", chartsTreePath}, nil); err != nil {
+		s.Logger().WithError(err).Error("Failed to reset changes to charts")
+	}
+}
+
+// chartsTreePath is the tree whose values a build rewrites and a reset restores.
+const chartsTreePath = "charts/"
+
+// The index directory holds only this release's charts, so the entries it adds
+// are what was just built.
+func (s settings) buildIndex() error {
+	merged, err := s.downloadIndex()
+	if err != nil {
+		return err
+	}
+	// helm indexes a whole directory, so the staging dir must hold this
+	// release's charts and nothing else.
+	staging := Dir(s.tmpDir, s.Version())
+	if err := os.RemoveAll(staging); err != nil {
+		return s.Errorf("clearing helm index staging dir: %w", err)
+	}
+	if err := os.MkdirAll(staging, utils.DirPerms); err != nil {
+		return s.Errorf("creating helm index staging dir: %w", err)
+	}
+	defer func() {
+		if err := os.RemoveAll(staging); err != nil {
+			s.Logger().WithError(err).Warnf("failed to remove helm index staging dir %s", staging)
+		}
+	}()
+	// The charts are linked in rather than copied.
+	for _, chart := range s.Names {
+		if err := os.Link(s.path(chart), filepath.Join(staging, s.fileName(chart))); err != nil {
+			return s.Errorf("linking %s chart for building helm index: %w", chart, err)
+		}
+	}
+
+	args := []string{
+		"repo", "index", staging,
+		"--url", s.chartURL,
+		"--merge", merged,
+	}
+	// helm stamps entries with the current time; UTC keeps the index stable.
+	env := append(os.Environ(), utils.Env(utils.EnvTZ, "UTC"))
+	if out, err := s.Helm(args, env, s.LogPath("index")); err != nil {
+		s.Logger().Error(out)
+		return s.Errorf("building helm index: %w", err)
+	}
+
+	if err := os.MkdirAll(s.indexDir, utils.DirPerms); err != nil {
+		return s.Errorf("creating helm index dir: %w", err)
+	}
+	if err := utils.CopyFile(filepath.Join(staging, indexFileName), filepath.Join(s.indexDir, indexFileName)); err != nil {
+		return s.Errorf("writing the helm index: %w", err)
+	}
+	return nil
+}
+
+func (s settings) downloadIndex() (string, error) {
+	indexURL, err := url.JoinPath(s.repoURL, indexFileName)
+	if err != nil {
+		return "", s.Errorf("constructing helm index url: %w", err)
+	}
+	dest := filepath.Join(s.tmpDir, indexFileName)
+	if err := os.MkdirAll(filepath.Dir(dest), utils.DirPerms); err != nil {
+		return "", s.Errorf("creating dir for downloaded helm index: %w", err)
+	}
+	if out, err := s.Runner().Run("curl", []string{"-fsSL", "--retry", "3", indexURL, "-o", dest}, nil); err != nil {
+		s.Logger().Error(out)
+		return "", s.Errorf("downloading previous helm index from %s: %w", indexURL, err)
+	}
+	return dest, nil
+}
+
+func (s settings) present() error {
+	var errs []error
+	for _, chart := range s.Names {
+		if _, err := os.Stat(s.path(chart)); err != nil {
+			errs = append(errs, fmt.Errorf("chart %s not built: %w", chart, err))
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// pending drops the charts an earlier run published, so an interrupted release
+// resumes on what is left.
+func (s settings) pending() ([]unit, error) {
+	units := s.units()
+	if s.resume == nil || len(s.resume.published) == 0 {
+		return units, nil
+	}
+
+	recorded := steps.DigestsByRepo(s.resume.published)
+
+	done, err := steps.Go(units, func(u unit) (bool, error) {
+		return s.published(u, recorded)
+	})
+	if err != nil {
+		return nil, err
+	}
+	var out []unit
+	for i, u := range units {
+		if done[i] {
+			s.Logger().WithFields(map[string]any{"chart": u.chart, "registry": u.registry}).
+				Info("Already published, skipping")
+			continue
+		}
+		out = append(out, u)
+	}
+	return out, nil
+}
+
+func (s settings) published(u unit, recorded steps.RecordedDigests) (bool, error) {
+	digests, ok := recorded[u.repo()]
+	if !ok {
+		return false, nil
+	}
+	ref := u.ref(s.Version())
+	got, exists, err := s.resolve(ref)
+	if err != nil {
+		return false, s.Errorf("resolving %s: %w", ref, err)
+	}
+	if !exists {
+		return false, nil
+	}
+	if _, known := digests[got]; known {
+		return true, nil
+	}
+	if s.resume.force {
+		return false, nil
+	}
+	return false, s.Errorf(
+		"%s is published at %s; this release recorded %s. Pass --force to republish over it",
+		ref, got, strings.Join(slices.Sorted(maps.Keys(digests)), ", "))
+}
+
+// Failures are collected, not stopped at: one chart failing must not hide the
+// rest.
+func (s settings) push(units []unit) error {
+	_, err := steps.Go(units, func(u unit) (struct{}, error) {
+		return struct{}{}, s.pushUnit(u)
+	})
+	return err
+}
+
+func (s settings) pushUnit(u unit) error {
+	log := s.Logger().WithFields(map[string]any{"chart": u.chart, "registry": u.registry})
+	args := []string{"push", s.path(u.chart), "oci://" + u.registry}
+	if s.Logger().Logger.IsLevelEnabled(logrus.DebugLevel) {
+		args = append(args, "--debug")
+	}
+
+	for attempt := 0; ; attempt++ {
+		out, err := s.Run(helmBinary, args, nil, s.LogPath(u.slug()))
+		if err == nil {
+			log.Info("Published helm chart")
+			return nil
+		}
+		if attempt < steps.MaxRetries {
+			log.WithError(err).WithField("attempt", attempt).Warn("Publish failed, retrying")
+			continue
+		}
+		log.Error(out)
+		return s.Errorf("publishing %s to %s: %w", u.chart, u.registry, err)
+	}
+}
+
+// record writes the digest refs the publish produced.
+func (s settings) record(units []unit) error {
+	if s.refs == nil {
+		return nil
+	}
+	refs, lookupErr := steps.Go(units, func(u unit) (string, error) {
+		ref := u.ref(s.Version())
+		digest, exists, err := s.resolve(ref)
+		if err != nil {
+			return "", s.Errorf("recording published chart %s: %w", u.chart, err)
+		}
+		if !exists {
+			s.Logger().WithField("chart", ref).Debug("Published chart absent, not recording")
+			return "", nil
+		}
+		return fmt.Sprintf("%s@%s", u.repo(), digest), nil
+	})
+
+	errs := []error{lookupErr}
+	for i, ref := range refs {
+		if ref == "" {
+			continue
+		}
+		if err := s.refs.Add(ref); err != nil {
+			errs = append(errs, s.Errorf("recording published chart %s: %w", units[i].chart, err))
+			break
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func (s settings) fileName(chart string) string {
+	return FileName(chart, s.Version())
+}
+
+func (s settings) path(chart string) string {
+	return filepath.Join(s.BaseDir, s.fileName(chart))
+}
+
+type unit struct {
+	chart    string
+	registry string
+}
+
+func (s settings) units() []unit {
+	out := make([]unit, 0, len(s.Names)*len(s.registries))
+	for _, chart := range s.Names {
+		for _, reg := range s.registries {
+			out = append(out, unit{chart: chart, registry: reg})
+		}
+	}
+	return out
+}
+
+func (u unit) repo() string {
+	return u.registry + "/" + u.chart
+}
+
+// ref names the chart at one version, the form a digest is resolved from.
+func (u unit) ref(version string) string {
+	return u.repo() + ":" + version
+}
+
+// A chart goes to several registries, so the registry is in the name.
+func (u unit) slug() string {
+	return u.chart + "-" + strings.NewReplacer("/", "-", ":", "-").Replace(u.registry)
+}
+
+type ValueEdit struct {
+	Chart string
+	Key   string
+
+	// From is the value being replaced. Set it when the key alone does not
+	// identify the line: a chart may repeat a key, and a bare swap has no key.
+	From string
+
+	Value string
+}
+
+// expr is the sed expression the edit applies. The delimiter is ~ because
+// values carry registries, which contain /.
+func (e ValueEdit) expr() string {
+	from := ".*"
+	if e.From != "" {
+		from = e.From
+	}
+	if e.Key == "" {
+		return fmt.Sprintf("s~%s~%s~g", from, e.Value)
+	}
+	return fmt.Sprintf("s~%s: %s~%s: %s~g", e.Key, from, e.Key, e.Value)
+}
+
+// Edits are supplied by the caller: products stamp different charts.
+type Values struct {
+	RepoRoot string
+	Edits    []ValueEdit
+}
+
+// ModifyValues points the charts at the versions being released. It edits the
+// working tree, so a caller that is not committing calls ResetValues after.
+func ModifyValues(v Values, opts ...Option) error {
+	if v.RepoRoot == "" {
+		return fmt.Errorf("no repository root specified")
+	}
+	if len(v.Edits) == 0 {
+		return fmt.Errorf("no chart values to modify")
+	}
+	s, err := valuesStep(v.RepoRoot, opts)
+	if err != nil {
+		return err
+	}
+	for _, e := range v.Edits {
+		// A keyless edit must name what it replaces, or it would match anything.
+		if e.Chart == "" || e.Value == "" || (e.Key == "" && e.From == "") {
+			return s.Errorf("incomplete chart value edit: %+v", e)
+		}
+		expr := e.expr()
+		path := filepath.Join(v.RepoRoot, chartsTreePath, e.Chart, "values.yaml")
+		if out, err := s.Runner().Run("sed", []string{"-i", expr, path}, nil); err != nil {
+			s.Logger().Error(out)
+			return s.Errorf("updating %s in %s: %w", e.Key, path, err)
+		}
+	}
+	return nil
+}
+
+// Takes no chart set: rewriting the values predates packaging them.
+func valuesStep(repoRoot string, opts []Option) (settings, error) {
+	var s settings
+	s.Apply([]steps.Option{steps.WithName(valuesStepName), steps.WithDir(repoRoot)})
+	for _, opt := range opts {
+		// Option reaches every step, so its build side is just one way in.
+		if err := opt.applyBuild(&s); err != nil {
+			return s, s.Errorf("%w", err)
+		}
+	}
+	return s, nil
+}
+
+const valuesStepName = "charts-values"

--- a/release/internal/charts/charts.go
+++ b/release/internal/charts/charts.go
@@ -1,0 +1,325 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package charts packages the product's Helm charts, builds the repository
+// index over them, and pushes the charts to their registries.
+package charts
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+	"slices"
+
+	"github.com/projectcalico/calico/release/internal/command"
+	"github.com/projectcalico/calico/release/internal/steps"
+)
+
+// The name becomes the log directory, so it is qualified: a bare "build"
+// would collide with another group's.
+const (
+	buildStep   = "charts-build"
+	publishStep = "charts-publish"
+)
+
+const (
+	// chartsDirName holds a release's packaged charts.
+	chartsDirName = "charts"
+
+	// One invocation: a chart may be packaged into another as a sub-chart.
+	chartTarget = "chart"
+
+	indexFileName = "index.yaml"
+
+	// The repository's own helm, so every run uses the same version.
+	helmBinary = "./bin/helm"
+)
+
+// The charts a release ships, and where the product serves them from.
+const (
+	TigeraOperatorChart      = "tigera-operator"
+	ProjectCalicoV1CRDsChart = "crd.projectcalico.org.v1"
+	ProjectCalicoV3CRDsChart = "projectcalico.org.v3"
+)
+
+var RepoURL = func() string {
+	return "https://docs.tigera.io/calico/charts"
+}
+
+// All is the set a release ships. It is a var so a product shipping a
+// different set can replace it.
+var All = func() []string {
+	return []string{
+		TigeraOperatorChart,
+		ProjectCalicoV1CRDsChart,
+		ProjectCalicoV3CRDsChart,
+	}
+}
+
+// Version qualifies the product version when the charts rev separately from
+// it. An empty suffix means the charts share the product version.
+func Version(productVersion, suffix string) string {
+	if suffix == "" {
+		return productVersion
+	}
+	return productVersion + "-" + suffix
+}
+
+// Chart identifies the charts a release ships. One argument rather than
+// several: the fields are same-typed strings a caller could silently swap.
+type Chart struct {
+	RepoRoot string
+
+	ProductVersion string
+
+	ChartVersion string
+
+	Names []string
+
+	BaseDir string
+}
+
+func (c Chart) validate() error {
+	var errs []error
+	if c.RepoRoot == "" {
+		errs = append(errs, fmt.Errorf("no repository root specified"))
+	}
+	if c.ProductVersion == "" {
+		errs = append(errs, fmt.Errorf("no version specified"))
+	}
+	if len(c.Names) == 0 {
+		errs = append(errs, fmt.Errorf("no charts specified"))
+	}
+	if slices.Contains(c.Names, "") {
+		errs = append(errs, fmt.Errorf("chart with no name"))
+	}
+	if c.BaseDir == "" {
+		errs = append(errs, fmt.Errorf("no chart directory specified"))
+	}
+	return errors.Join(errs...)
+}
+
+func (c Chart) Version() string {
+	return Version(c.ProductVersion, c.ChartVersion)
+}
+
+// FileName is the file one chart is packaged into.
+func FileName(chart, chartVersion string) string {
+	name := chart
+	if chartVersion != "" {
+		name = fmt.Sprintf("%s-%s", chart, chartVersion)
+	}
+	return fmt.Sprintf("%s.tgz", name)
+}
+
+// Dir is where a release's charts or their index sit under outputDir. The
+// version keeps one release's charts apart from another's.
+func Dir(outputDir, version string) string {
+	name := chartsDirName
+	if version != "" {
+		name += "-" + version
+	}
+	return filepath.Join(outputDir, name)
+}
+
+// settings is what a verb runs with. A field belongs here only when a verb
+// needs it.
+type settings struct {
+	Chart
+
+	// env is extra environment for products whose charts need more than the
+	// version and destination.
+	env []string
+
+	// modifyValues rewrites chart values to the versions being released. The
+	// tree is restored afterwards.
+	modifyValues func() error
+
+	// index builds the repository index over the charts once they are packaged.
+	index *index
+
+	// repoURL is the Helm repository holding the index to merge with, and
+	// chartURL is where that index tells clients to download charts from.
+	repoURL  string
+	chartURL string
+
+	// indexDir is where the built index lands.
+	indexDir string
+
+	tmpDir string
+
+	registries []string
+
+	confirm bool
+
+	refs steps.RefRecorder
+
+	resolve steps.DigestResolver
+
+	// resume is the record an earlier run left, and how to check it.
+	resume *resume
+
+	steps.Step
+}
+
+func (s *settings) Helm(args []string, env []string, logPath string) (string, error) {
+	return s.Run(helmBinary, args, env, logPath)
+}
+
+// index is where a build writes its repository index.
+type index struct {
+	repoURL  string
+	chartURL string
+	dir      string
+}
+
+// resume is what an interrupted run left behind, and whether to override it.
+type resume struct {
+	published []string
+	force     bool
+}
+
+// A step's options. Option reaches every step; the per-step interfaces let a
+// setting that belongs to one verb be rejected at compile time by the others.
+type (
+	BuildOption   interface{ applyBuild(*settings) error }
+	PublishOption interface{ applyPublish(*settings) error }
+
+	Option interface {
+		applyBuild(*settings) error
+		applyPublish(*settings) error
+	}
+)
+
+// Each adapter must satisfy the interfaces its options are returned as, so a
+// missing apply method fails here rather than at a call site.
+var (
+	_ Option        = setting(nil)
+	_ BuildOption   = buildSetting(nil)
+	_ PublishOption = publishSetting(nil)
+)
+
+type setting func(*settings) error
+
+func (f setting) applyBuild(s *settings) error   { return f(s) }
+func (f setting) applyPublish(s *settings) error { return f(s) }
+
+type buildSetting func(*settings) error
+
+func (f buildSetting) applyBuild(s *settings) error { return f(s) }
+
+type publishSetting func(*settings) error
+
+func (f publishSetting) applyPublish(s *settings) error { return f(s) }
+
+func WithRunner(r command.CommandRunner) Option {
+	return setting(func(s *settings) error {
+		s.Apply([]steps.Option{steps.WithRunner(r)})
+		return nil
+	})
+}
+
+// WithLogsDir gives each invocation its own log file. Concurrent pushes
+// otherwise interleave into one stream.
+func WithLogsDir(dir string) Option {
+	return setting(func(s *settings) error {
+		s.Apply([]steps.Option{steps.WithLogsDir(dir)})
+		return nil
+	})
+}
+
+// WithEnv adds environment to the chart target, for a product whose charts
+// need more than the version and destination.
+func WithEnv(env ...string) BuildOption {
+	return buildSetting(func(s *settings) error {
+		s.env = append(s.env, env...)
+		return nil
+	})
+}
+
+// WithIndex builds the repository index after packaging and leaves it in dir.
+// repoURL holds the index to merge with; chartURL is where it sends clients.
+//
+// helm indexes a whole directory, so the charts are staged under tmpDir to
+// index this release alone, and only the finished index reaches dir.
+func WithIndex(repoURL, chartURL, dir, tmpDir string) BuildOption {
+	return buildSetting(func(s *settings) error {
+		if repoURL == "" || chartURL == "" || dir == "" || tmpDir == "" {
+			return fmt.Errorf("an index needs a repository url, a chart url, a directory and a temp dir")
+		}
+		s.index = &index{repoURL: repoURL, chartURL: chartURL, dir: dir}
+		s.tmpDir = tmpDir
+		return nil
+	})
+}
+
+// WithModifiedValues rewrites the chart values before packaging, restoring the
+// tree afterwards.
+func WithModifiedValues(edits []ValueEdit) BuildOption {
+	return buildSetting(func(s *settings) error {
+		if len(edits) == 0 {
+			return fmt.Errorf("no chart values to modify")
+		}
+		s.modifyValues = func() error {
+			return ModifyValues(Values{RepoRoot: s.RepoRoot, Edits: edits}, WithRunner(s.Runner()))
+		}
+		return nil
+	})
+}
+
+func WithRecord(rec steps.RefRecorder) PublishOption {
+	return publishSetting(func(s *settings) error {
+		if rec == nil {
+			return fmt.Errorf("no recorder to record published charts")
+		}
+		s.refs = rec
+		return nil
+	})
+}
+
+func WithResolver(resolve steps.DigestResolver) PublishOption {
+	return publishSetting(func(s *settings) error {
+		if resolve == nil {
+			return fmt.Errorf("no resolver to read published digests")
+		}
+		s.resolve = resolve
+		return nil
+	})
+}
+
+// WithResume skips the charts an earlier run already published. Without force,
+// a digest that disagrees with the record is an error: the tag moved under us.
+func WithResume(published []string, force bool) PublishOption {
+	return publishSetting(func(s *settings) error {
+		s.resume = &resume{published: published, force: force}
+		return nil
+	})
+}
+
+// ValueEditsFor points the operator and product charts at the versions a
+// release pins.
+var ValueEditsFor = func(productVersion, operatorVersion string) []ValueEdit {
+	return []ValueEdit{
+		{Chart: operatorChartName, Key: "version", Value: operatorVersion},
+		{Chart: operatorChartName, Key: "tag", Value: productVersion},
+		{Chart: productChartName, Key: "version", Value: productVersion},
+	}
+}
+
+// The charts whose values a release rewrites. productChartName renders the
+// manifests rather than shipping, so it is not in the released set.
+const (
+	operatorChartName = "tigera-operator"
+	productChartName  = "calico"
+)

--- a/release/internal/charts/charts.go
+++ b/release/internal/charts/charts.go
@@ -19,28 +19,33 @@ package charts
 import (
 	"errors"
 	"fmt"
+	"net/url"
 	"path/filepath"
 	"slices"
 
 	"github.com/projectcalico/calico/release/internal/command"
+	"github.com/projectcalico/calico/release/internal/github"
 	"github.com/projectcalico/calico/release/internal/steps"
+	"github.com/projectcalico/calico/release/internal/utils"
+	"github.com/projectcalico/calico/release/internal/yamledit"
 )
 
 // The name becomes the log directory, so it is qualified: a bare "build"
 // would collide with another group's.
 const (
-	buildStep   = "charts-build"
-	publishStep = "charts-publish"
+	buildStep = "charts-build"
+
+	// PublishStep names the step, and so the record a resume reads back.
+	PublishStep = "charts-publish"
 )
 
 const (
-	// chartsDirName holds a release's packaged charts.
-	chartsDirName = "charts"
+	chartsDirName  = "charts"
+	indexFileName  = "index.yaml"
+	valuesFileName = "values.yaml"
 
-	// One invocation: a chart may be packaged into another as a sub-chart.
+	// Make target for building the chart.
 	chartTarget = "chart"
-
-	indexFileName = "index.yaml"
 
 	// The repository's own helm, so every run uses the same version.
 	helmBinary = "./bin/helm"
@@ -49,12 +54,28 @@ const (
 // The charts a release ships, and where the product serves them from.
 const (
 	TigeraOperatorChart      = "tigera-operator"
+	CalicoChart              = "calico"
 	ProjectCalicoV1CRDsChart = "crd.projectcalico.org.v1"
 	ProjectCalicoV3CRDsChart = "projectcalico.org.v3"
+
+	// docsURL is the base URL for the docs site
+	docsURL = "https://docs.tigera.io"
 )
 
-var RepoURL = func() string {
-	return "https://docs.tigera.io/calico/charts"
+var RepoURL = func() (string, error) {
+	url, err := url.JoinPath(docsURL, "calico", chartsDirName)
+	if err != nil {
+		return "", fmt.Errorf("charts repo URL: %w", err)
+	}
+	return url, nil
+}
+
+var ChartsURL = func(c Chart) (string, error) {
+	url, err := github.DownloadURL(utils.Organization(), utils.Repo(), c.ProductVersion)
+	if err != nil {
+		return "", fmt.Errorf("charts download URL: %w", err)
+	}
+	return url, nil
 }
 
 // All is the set a release ships. It is a var so a product shipping a
@@ -123,14 +144,18 @@ func FileName(chart, chartVersion string) string {
 	return fmt.Sprintf("%s.tgz", name)
 }
 
-// Dir is where a release's charts or their index sit under outputDir. The
-// version keeps one release's charts apart from another's.
-func Dir(outputDir, version string) string {
-	name := chartsDirName
-	if version != "" {
-		name += "-" + version
+// Dir is where a release's charts or their index sit under outputDir.
+func Dir(outputDir string) string {
+	return filepath.Join(outputDir, chartsDirName)
+}
+
+// versionedDir keeps one release's charts apart from another's, for a directory
+// shared between releases rather than nested under one.
+func versionedDir(outputDir, version string) (string, error) {
+	if version == "" {
+		return "", fmt.Errorf("no version specified")
 	}
-	return filepath.Join(outputDir, name)
+	return fmt.Sprintf("%s-%s", Dir(outputDir), version), nil
 }
 
 // settings is what a verb runs with. A field belongs here only when a verb
@@ -307,19 +332,29 @@ func WithResume(published []string, force bool) PublishOption {
 	})
 }
 
-// ValueEditsFor points the operator and product charts at the versions a
-// release pins.
-var ValueEditsFor = func(productVersion, operatorVersion string) []ValueEdit {
+func operatorChartEdits(productVersion, productRegistry, operatorImage, operatorVersion, operatorRegistry string) []ValueEdit {
 	return []ValueEdit{
-		{Chart: operatorChartName, Key: "version", Value: operatorVersion},
-		{Chart: operatorChartName, Key: "tag", Value: productVersion},
-		{Chart: productChartName, Key: "version", Value: productVersion},
+		{Chart: TigeraOperatorChart, Edit: yamledit.Edit{Key: "tigeraOperator.image", To: operatorImage}},
+		{Chart: TigeraOperatorChart, Edit: yamledit.Edit{Key: "tigeraOperator.version", To: operatorVersion}},
+		{Chart: TigeraOperatorChart, Edit: yamledit.Edit{Key: "tigeraOperator.registry", To: operatorRegistry}},
+		{Chart: TigeraOperatorChart, Edit: yamledit.Edit{Key: "calicoctl.image", To: fmt.Sprintf("%s/calico", productRegistry)}},
+		{Chart: TigeraOperatorChart, Edit: yamledit.Edit{Key: "calicoctl.tag", To: productVersion}},
 	}
 }
 
-// The charts whose values a release rewrites. productChartName renders the
-// manifests rather than shipping, so it is not in the released set.
-const (
-	operatorChartName = "tigera-operator"
-	productChartName  = "calico"
-)
+func calicoChartEdits(productVersion, productRegistry string) []ValueEdit {
+	return []ValueEdit{
+		{Chart: CalicoChart, Edit: yamledit.Edit{Key: "version", To: productVersion}},
+		{Chart: CalicoChart, Edit: yamledit.Edit{Key: "calico.registry", To: productRegistry}},
+		{Chart: CalicoChart, Edit: yamledit.Edit{Key: "node.registry", To: productRegistry}},
+		{Chart: CalicoChart, Edit: yamledit.Edit{Key: "flannelMigration.registry", To: productRegistry}},
+	}
+}
+
+// ValueEditsFor points the operator and product charts at the versions a
+// release pins.
+var ValueEditsFor = func(productVersion, productRegistry, operatorImage, operatorVersion, operatorRegistry string) []ValueEdit {
+	return append(slices.Clone(calicoChartEdits(productVersion, productRegistry)),
+		operatorChartEdits(productVersion, productRegistry, operatorImage, operatorVersion, operatorRegistry)...,
+	)
+}

--- a/release/internal/charts/charts_test.go
+++ b/release/internal/charts/charts_test.go
@@ -1,0 +1,914 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package charts
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/projectcalico/calico/release/internal/steps"
+)
+
+// fakeRunner records every invocation and can fail a command a set number of
+// times before succeeding, to exercise the retry.
+type fakeRunner struct {
+	mu    sync.Mutex
+	calls []call
+	// failures maps a key from failKey to how many times it should fail.
+	failures map[string]int
+	// staged is what the index directory held when helm was asked to index it.
+	staged []string
+	// onRun stands in for a command's side effects on the tree.
+	onRun func(env []string)
+}
+
+type call struct {
+	name string
+	args []string
+	env  []string
+	// logPath is empty when output was captured in memory.
+	logPath string
+}
+
+func (f *fakeRunner) RunInDir(_, name string, args, env []string) (string, error) {
+	return f.record(name, args, env, "")
+}
+
+func (f *fakeRunner) RunInDirToFile(_, name string, args, env []string, logPath string) (string, error) {
+	return f.record(name, args, env, logPath)
+}
+
+func (f *fakeRunner) Run(name string, args, env []string) (string, error) {
+	return f.record(name, args, env, "")
+}
+
+func (f *fakeRunner) record(name string, args, env []string, logPath string) (string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls = append(f.calls, call{name: name, args: slices.Clone(args), env: slices.Clone(env), logPath: logPath})
+	if f.onRun != nil {
+		f.onRun(env)
+	}
+	// Stand in for helm: `repo index <dir>` writes the index into that dir.
+	if name == helmBinary && len(args) > 2 && args[0] == "repo" && args[1] == "index" {
+		if entries, err := os.ReadDir(args[2]); err == nil {
+			for _, e := range entries {
+				f.staged = append(f.staged, e.Name())
+			}
+		}
+		_ = os.WriteFile(filepath.Join(args[2], indexFileName), []byte("entries:"), 0o644)
+	}
+	if n, ok := f.failures[failKey(name, args)]; ok && n > 0 {
+		f.failures[failKey(name, args)] = n - 1
+		return "boom", fmt.Errorf("command failed")
+	}
+	return "ok", nil
+}
+
+func (f *fakeRunner) RunNoCapture(string, []string, []string) error              { return nil }
+func (f *fakeRunner) RunInDirNoCapture(string, string, []string, []string) error { return nil }
+
+// Keyed on chart file plus destination: keying on the command alone could not
+// tell two pushes apart, and would hide a mistargeted one.
+func failKey(name string, args []string) string {
+	if name == helmBinary && len(args) > 2 && args[0] == "push" {
+		return filepath.Base(args[1]) + " " + args[2]
+	}
+	return name
+}
+
+func (f *fakeRunner) pushes() []string {
+	var out []string
+	for _, c := range f.calls {
+		if c.name == helmBinary && len(c.args) > 2 && c.args[0] == "push" {
+			out = append(out, filepath.Base(c.args[1])+" "+c.args[2])
+		}
+	}
+	slices.Sort(out)
+	return out
+}
+
+func (f *fakeRunner) callsTo(name string) []call {
+	var out []call
+	for _, c := range f.calls {
+		if c.name == name {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+func hasEnv(env []string, want string) bool {
+	return slices.Contains(env, want)
+}
+
+// A resolver answering every chart alike cannot catch a skip of the wrong one.
+func resolvesPerChart(digests map[string]string) steps.DigestResolver {
+	return func(ref string) (string, bool, error) {
+		for chart, digest := range digests {
+			if strings.Contains(ref, "/"+chart+":") {
+				return digest, true, nil
+			}
+		}
+		return "", false, nil
+	}
+}
+
+// testChart is a neutral fixture: the package takes the chart list as data, so
+// no product's real chart names belong here.
+func testChart(t *testing.T) Chart {
+	t.Helper()
+	dir := t.TempDir()
+	return Chart{
+		RepoRoot:       dir,
+		ProductVersion: "v3.30.0",
+		Names:          []string{"chart-one", "chart-two"},
+		BaseDir:        filepath.Join(dir, "output"),
+	}
+}
+
+func writeCharts(t *testing.T, c Chart, names ...string) {
+	t.Helper()
+	if err := os.MkdirAll(c.BaseDir, 0o755); err != nil {
+		t.Fatalf("creating chart dir: %v", err)
+	}
+	for _, name := range names {
+		if err := os.WriteFile(filepath.Join(c.BaseDir, FileName(name, c.Version())), []byte("chart"), 0o644); err != nil {
+			t.Fatalf("writing chart %s: %v", name, err)
+		}
+	}
+}
+
+func TestBuildRunsChartTargetOnce(t *testing.T) {
+	c := testChart(t)
+	writeCharts(t, c, c.Names...)
+	f := &fakeRunner{}
+
+	if err := Build(c, WithRunner(f)); err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	// Charts may nest as sub-charts, so make sequences them in one invocation.
+	makes := f.callsTo("make")
+	if len(makes) != 1 {
+		t.Fatalf("expected one make invocation, got %d", len(makes))
+	}
+	if !slices.Contains(makes[0].args, chartTarget) {
+		t.Errorf("expected the %q target, got %v", chartTarget, makes[0].args)
+	}
+	if !hasEnv(makes[0].env, "GIT_VERSION=v3.30.0") {
+		t.Error("expected GIT_VERSION in the build environment")
+	}
+	if !hasEnv(makes[0].env, "CHART_DESTINATION="+c.BaseDir) {
+		t.Error("expected CHART_DESTINATION in the build environment")
+	}
+}
+
+func TestBuildPassesExtraEnv(t *testing.T) {
+	c := testChart(t)
+	writeCharts(t, c, c.Names...)
+	f := &fakeRunner{}
+
+	if err := Build(c, WithRunner(f), WithEnv("RELEASE_STREAM=v3.30")); err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if !hasEnv(f.callsTo("make")[0].env, "RELEASE_STREAM=v3.30") {
+		t.Error("expected the caller's extra environment to reach the target")
+	}
+}
+
+func TestBuildFailsWhenAChartIsMissing(t *testing.T) {
+	c := testChart(t)
+	writeCharts(t, c, "chart-one")
+
+	err := Build(c, WithRunner(&fakeRunner{}))
+	if err == nil {
+		t.Fatal("expected a build that packaged only one chart to fail")
+	}
+	if !strings.Contains(err.Error(), "chart-two") {
+		t.Errorf("expected the missing chart to be named, got %v", err)
+	}
+}
+
+func TestBuildRestoresTreeAfterModifyingValues(t *testing.T) {
+	c := testChart(t)
+	writeCharts(t, c, c.Names...)
+	f := &fakeRunner{}
+
+	if err := Build(c, WithRunner(f), WithModifiedValues([]ValueEdit{{Chart: "chart-one", Key: "version", Value: "v3.30.0"}})); err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if len(f.callsTo("sed")) != 1 {
+		t.Error("expected the values to be modified")
+	}
+	if len(f.callsTo("git")) != 1 {
+		t.Error("expected the chart tree to be restored after the build")
+	}
+}
+
+func TestBuildRestoresTreeWhenBuildFails(t *testing.T) {
+	c := testChart(t)
+	f := &fakeRunner{failures: map[string]int{"make": 1}}
+
+	if err := Build(c, WithRunner(f), WithModifiedValues([]ValueEdit{{Chart: "chart-one", Key: "version", Value: "v3.30.0"}})); err == nil {
+		t.Fatal("expected the build to fail")
+	}
+	if len(f.callsTo("git")) != 1 {
+		t.Error("expected the chart tree to be restored after a failed build")
+	}
+}
+
+// Building the index reaches the network; packaging charts must not.
+func TestBuildDoesNotBuildTheIndex(t *testing.T) {
+	c := testChart(t)
+	writeCharts(t, c, c.Names...)
+	f := &fakeRunner{}
+
+	if err := Build(c, WithRunner(f)); err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if len(f.callsTo("curl")) != 0 {
+		t.Error("expected a build not to download the index")
+	}
+	if len(f.callsTo(helmBinary)) != 0 {
+		t.Error("expected a build not to invoke helm")
+	}
+}
+
+func TestBuildRejectsIncompleteCharts(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		mut  func(*Chart)
+	}{
+		{"no repo root", func(c *Chart) { c.RepoRoot = "" }},
+		{"no version", func(c *Chart) { c.ProductVersion = "" }},
+		{"no charts", func(c *Chart) { c.Names = nil }},
+		{"unnamed chart", func(c *Chart) { c.Names = []string{"chart-one", ""} }},
+		{"no chart dir", func(c *Chart) { c.BaseDir = "" }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c := testChart(t)
+			tc.mut(&c)
+			if err := Build(c, WithRunner(&fakeRunner{})); err == nil {
+				t.Fatal("expected an incomplete chart set to be rejected")
+			}
+		})
+	}
+}
+
+// The step name is the log directory, so the slug is what keeps a build and an
+// index build apart.
+func TestBuildLogsUnderItsOwnStep(t *testing.T) {
+	c := testChart(t)
+	writeCharts(t, c, c.Names...)
+	f := &fakeRunner{}
+	logs := filepath.Join(t.TempDir(), "logs")
+
+	if err := Build(c, WithRunner(f), WithLogsDir(logs)); err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	want := filepath.Join(logs, buildStep, "charts.log")
+	if got := f.callsTo("make")[0].logPath; got != want {
+		t.Errorf("log path: got %q, want %q", got, want)
+	}
+}
+
+func TestBuildWithoutLogsDirCapturesInMemory(t *testing.T) {
+	c := testChart(t)
+	writeCharts(t, c, c.Names...)
+	f := &fakeRunner{}
+
+	if err := Build(c, WithRunner(f)); err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if got := f.callsTo("make")[0].logPath; got != "" {
+		t.Errorf("expected in-memory capture, got log path %q", got)
+	}
+}
+
+const (
+	testRepoURL  = "https://example.test/charts"
+	testChartURL = "https://example.test/download/v3.30.0"
+)
+
+func TestBuildIndexMergesThePublishedIndex(t *testing.T) {
+	c := testChart(t)
+	writeCharts(t, c, c.Names...)
+	f := &fakeRunner{}
+	indexDir := filepath.Join(t.TempDir(), "index")
+
+	if err := Build(c, WithRunner(f),
+		WithIndex(testRepoURL, testChartURL, indexDir, filepath.Join(c.RepoRoot, "tmp"))); err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	curls := f.callsTo("curl")
+	if len(curls) != 1 {
+		t.Fatalf("expected the published index to be downloaded once, got %d", len(curls))
+	}
+	if !slices.Contains(curls[0].args, testRepoURL+"/"+indexFileName) {
+		t.Errorf("expected the repo index url to be fetched, got %v", curls[0].args)
+	}
+
+	helms := f.callsTo(helmBinary)
+	if len(helms) != 1 {
+		t.Fatalf("expected one helm invocation, got %d", len(helms))
+	}
+	// Merging keeps the entries the repository already served; replacing would
+	// drop every earlier release from the index.
+	if !slices.Contains(helms[0].args, "--merge") {
+		t.Error("expected the published index to be merged rather than replaced")
+	}
+	// The index tells clients where to download from, which is not the
+	// repository it was merged from.
+	if !slices.Contains(helms[0].args, testChartURL) {
+		t.Error("expected the index to point at the chart url")
+	}
+	if slices.Contains(helms[0].args, testRepoURL) {
+		t.Error("expected the repo url not to be used as the download url")
+	}
+	// helm indexes a whole directory, so it must be pointed at one holding
+	// only this release's charts, not the output directory.
+	dir := helms[0].args[2]
+	if dir == c.BaseDir {
+		t.Error("expected the index built over a staging dir, not the chart dir")
+	}
+	for _, name := range c.Names {
+		if !slices.Contains(f.staged, FileName(name, c.Version())) {
+			t.Errorf("expected %s staged for the index, got %v", name, f.staged)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(indexDir, indexFileName)); err != nil {
+		t.Errorf("expected the finished index in %s: %v", indexDir, err)
+	}
+}
+
+// helm stamps entries with the current time, so UTC keeps the index stable.
+func TestBuildIndexUsesUTC(t *testing.T) {
+	c := testChart(t)
+	writeCharts(t, c, c.Names...)
+	f := &fakeRunner{}
+
+	if err := Build(c, WithRunner(f),
+		WithIndex(testRepoURL, testChartURL, filepath.Join(t.TempDir(), "index"), t.TempDir())); err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if !hasEnv(f.callsTo(helmBinary)[0].env, "TZ=UTC") {
+		t.Error("expected the index to be built in UTC")
+	}
+}
+
+// Linking fails on an existing file, so a rebuild must clear the old link.
+func TestBuildIndexIsRepeatable(t *testing.T) {
+	c := testChart(t)
+	writeCharts(t, c, c.Names...)
+	indexDir := filepath.Join(t.TempDir(), "index")
+	tmp := t.TempDir()
+
+	for i := range 2 {
+		if err := Build(c, WithRunner(&fakeRunner{}),
+			WithIndex(testRepoURL, testChartURL, indexDir, tmp)); err != nil {
+			t.Fatalf("Build run %d: %v", i, err)
+		}
+	}
+}
+
+// The index builds within the chart build, so the slug is what keeps their
+// logs apart.
+func TestBuildIndexLogsBesideTheCharts(t *testing.T) {
+	c := testChart(t)
+	writeCharts(t, c, c.Names...)
+	f := &fakeRunner{}
+	logs := filepath.Join(t.TempDir(), "logs")
+
+	if err := Build(c, WithRunner(f), WithLogsDir(logs),
+		WithIndex(testRepoURL, testChartURL, filepath.Join(t.TempDir(), "index"), t.TempDir())); err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	want := filepath.Join(logs, buildStep, "index.log")
+	if got := f.callsTo(helmBinary)[0].logPath; got != want {
+		t.Errorf("log path: got %q, want %q", got, want)
+	}
+}
+
+func TestBuildIndexRejectsMissingLocations(t *testing.T) {
+	for _, tc := range []struct{ name, repoURL, chartURL, indexDir string }{
+		{"no repo url", "", testChartURL, "index"},
+		{"no chart url", testRepoURL, "", "index"},
+		{"no index dir", testRepoURL, testChartURL, ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c := testChart(t)
+			if err := Build(c, WithRunner(&fakeRunner{}),
+				WithIndex(tc.repoURL, tc.chartURL, tc.indexDir, t.TempDir())); err == nil {
+				t.Fatal("expected an index build missing a location to be rejected")
+			}
+		})
+	}
+}
+
+func publishable(t *testing.T) Chart {
+	t.Helper()
+	c := testChart(t)
+	writeCharts(t, c, c.Names...)
+	return c
+}
+
+// Each push names its own file: pushing one chart repeatedly would pass a
+// count-only check.
+func TestPublishPushesEveryChartToEveryRegistry(t *testing.T) {
+	c := publishable(t)
+	f := &fakeRunner{}
+
+	if err := Publish(c, []string{"quay.test/charts", "docker.test/charts"}, true, WithRunner(f)); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+
+	want := []string{
+		"chart-one-v3.30.0.tgz oci://docker.test/charts",
+		"chart-one-v3.30.0.tgz oci://quay.test/charts",
+		"chart-two-v3.30.0.tgz oci://docker.test/charts",
+		"chart-two-v3.30.0.tgz oci://quay.test/charts",
+	}
+	if got := f.pushes(); !slices.Equal(got, want) {
+		t.Errorf("pushes:\n got %v\nwant %v", got, want)
+	}
+}
+
+func TestPublishRetriesAFailedPush(t *testing.T) {
+	c := publishable(t)
+	f := &fakeRunner{failures: map[string]int{"chart-one-v3.30.0.tgz oci://quay.test/charts": 1}}
+
+	if err := Publish(c, []string{"quay.test/charts"}, true, WithRunner(f)); err != nil {
+		t.Fatalf("expected the retry to recover the push: %v", err)
+	}
+	if got := len(f.pushes()); got != 3 {
+		t.Errorf("expected the failed push to be retried, got %d pushes", got)
+	}
+}
+
+func TestPublishReportsFailureAfterRetriesExhausted(t *testing.T) {
+	c := publishable(t)
+	f := &fakeRunner{failures: map[string]int{"chart-one-v3.30.0.tgz oci://quay.test/charts": 99}}
+
+	err := Publish(c, []string{"quay.test/charts"}, true, WithRunner(f))
+	if err == nil {
+		t.Fatal("expected the publish to fail")
+	}
+	if !strings.Contains(err.Error(), "chart-one") {
+		t.Errorf("expected the failing chart to be named, got %v", err)
+	}
+	if !slices.Contains(f.pushes(), "chart-two-v3.30.0.tgz oci://quay.test/charts") {
+		t.Error("expected the other chart to be published despite the failure")
+	}
+}
+
+func TestPublishFailsBeforePushingWhenAChartIsMissing(t *testing.T) {
+	c := publishable(t)
+	if err := os.Remove(filepath.Join(c.BaseDir, FileName("chart-two", c.Version()))); err != nil {
+		t.Fatalf("removing chart: %v", err)
+	}
+	f := &fakeRunner{}
+
+	if err := Publish(c, []string{"quay.test/charts"}, true, WithRunner(f)); err == nil {
+		t.Fatal("expected a publish with a missing chart to fail")
+	}
+	if got := f.pushes(); len(got) != 0 {
+		t.Errorf("expected nothing to be pushed, got %v", got)
+	}
+}
+
+func TestPublishRejectsNoRegistries(t *testing.T) {
+	if err := Publish(publishable(t), nil, true, WithRunner(&fakeRunner{})); err == nil {
+		t.Fatal("expected a publish with no registries to be rejected")
+	}
+}
+
+func TestPublishLogsPerChartAndRegistry(t *testing.T) {
+	c := publishable(t)
+	f := &fakeRunner{}
+	logs := filepath.Join(t.TempDir(), "logs")
+
+	if err := Publish(c, []string{"quay.test/charts"}, true, WithRunner(f), WithLogsDir(logs)); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	// A chart goes to several registries, so the slug carries both.
+	want := filepath.Join(logs, publishStep, "chart-one-quay.test-charts.log")
+	if !slices.ContainsFunc(f.callsTo(helmBinary), func(c call) bool { return c.logPath == want }) {
+		t.Errorf("expected a per-chart log at %q", want)
+	}
+}
+
+// recorder collects the refs a publish records.
+type recorder struct {
+	mu   sync.Mutex
+	refs []string
+}
+
+func (r *recorder) Add(refs ...string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.refs = append(r.refs, refs...)
+	return nil
+}
+
+// A resolver answering every chart alike could not catch a mismatched digest.
+func TestPublishRecordsWhatItPushed(t *testing.T) {
+	c := publishable(t)
+	rec := &recorder{}
+
+	err := Publish(c, []string{"quay.test/charts"}, true,
+		WithRunner(&fakeRunner{}),
+		WithResolver(resolvesPerChart(map[string]string{
+			"chart-one": "sha256:aaa",
+			"chart-two": "sha256:bbb",
+		})),
+		WithRecord(rec))
+	if err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+
+	want := []string{
+		"quay.test/charts/chart-one@sha256:aaa",
+		"quay.test/charts/chart-two@sha256:bbb",
+	}
+	if !slices.Equal(rec.refs, want) {
+		t.Errorf("recorded refs:\n got %v\nwant %v", rec.refs, want)
+	}
+}
+
+func TestPublishDryRunPushesAndRecordsNothing(t *testing.T) {
+	c := publishable(t)
+	f := &fakeRunner{}
+	rec := &recorder{}
+
+	if err := Publish(c, []string{"quay.test/charts"}, false,
+		WithRunner(f), WithResolver(resolvesPerChart(map[string]string{"chart-one": "sha256:aaa"})),
+		WithRecord(rec)); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	if got := f.pushes(); len(got) != 0 {
+		t.Errorf("expected a dry run to push nothing, got %v", got)
+	}
+	if len(rec.refs) != 0 {
+		t.Errorf("expected a dry run to record nothing, got %v", rec.refs)
+	}
+}
+
+func TestPublishResumeSkipsChartsAlreadyPublished(t *testing.T) {
+	c := publishable(t)
+	f := &fakeRunner{}
+
+	err := Publish(c, []string{"quay.test/charts"}, true,
+		WithRunner(f),
+		WithResolver(resolvesPerChart(map[string]string{
+			"chart-one": "sha256:aaa",
+			"chart-two": "sha256:bbb",
+		})),
+		WithResume([]string{"quay.test/charts/chart-one@sha256:aaa"}, false))
+	if err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+
+	// Only chart-two is left. A resolver answering every chart alike could not
+	// tell this from skipping the wrong one.
+	want := []string{"chart-two-v3.30.0.tgz oci://quay.test/charts"}
+	if got := f.pushes(); !slices.Equal(got, want) {
+		t.Errorf("pushes:\n got %v\nwant %v", got, want)
+	}
+}
+
+// A digest disagreeing with the record means the tag moved under us.
+func TestPublishResumeFailsOnDigestMismatch(t *testing.T) {
+	c := publishable(t)
+	f := &fakeRunner{}
+
+	err := Publish(c, []string{"quay.test/charts"}, true,
+		WithRunner(f),
+		WithResolver(resolvesPerChart(map[string]string{"chart-one": "sha256:zzz"})),
+		WithResume([]string{"quay.test/charts/chart-one@sha256:aaa"}, false))
+	if err == nil {
+		t.Fatal("expected a digest mismatch to fail the publish")
+	}
+	for _, want := range []string{"chart-one", "sha256:zzz", "sha256:aaa", "--force"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("expected %q in the error, got %v", want, err)
+		}
+	}
+	if got := f.pushes(); len(got) != 0 {
+		t.Errorf("expected nothing pushed on a mismatch, got %v", got)
+	}
+}
+
+func TestPublishResumeForceRepublishesOverAMismatch(t *testing.T) {
+	c := publishable(t)
+	f := &fakeRunner{}
+
+	err := Publish(c, []string{"quay.test/charts"}, true,
+		WithRunner(f),
+		WithResolver(resolvesPerChart(map[string]string{"chart-one": "sha256:zzz"})),
+		WithResume([]string{"quay.test/charts/chart-one@sha256:aaa"}, true))
+	if err != nil {
+		t.Fatalf("Publish with force: %v", err)
+	}
+	if !slices.Contains(f.pushes(), "chart-one-v3.30.0.tgz oci://quay.test/charts") {
+		t.Error("expected force to republish the mismatched chart")
+	}
+}
+
+func TestPublishResumePublishesUnrecordedCharts(t *testing.T) {
+	c := publishable(t)
+	f := &fakeRunner{}
+
+	err := Publish(c, []string{"quay.test/charts"}, true,
+		WithRunner(f),
+		WithResolver(resolvesPerChart(map[string]string{"chart-one": "sha256:aaa"})),
+		WithResume(nil, false))
+	if err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	if got := len(f.pushes()); got != 2 {
+		t.Errorf("expected both charts published with an empty record, got %d", got)
+	}
+}
+
+// Pinned to a literal: deriving it from FileName would pass for any format.
+func TestFileName(t *testing.T) {
+	const want = "chart-one-v3.30.0.tgz"
+	if got := FileName("chart-one", "v3.30.0"); got != want {
+		t.Errorf("FileName = %q, want %q", got, want)
+	}
+}
+
+func TestDir(t *testing.T) {
+	for _, tc := range []struct{ name, outDir, version, want string }{
+		{"no version", "out", "", "out/charts"},
+		{"with version", "out", "v3.30.0", "out/charts-v3.30.0"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := Dir(tc.outDir, tc.version); got != tc.want {
+				t.Errorf("Dir = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// With both charts recorded, resolving the wrong one would skip a chart that
+// never landed.
+func TestPublishResumeJudgesEachChartByItsOwnDigest(t *testing.T) {
+	c := publishable(t)
+	f := &fakeRunner{}
+
+	// chart-one still matches its record; chart-two has moved.
+	err := Publish(c, []string{"quay.test/charts"}, true,
+		WithRunner(f),
+		WithResolver(resolvesPerChart(map[string]string{
+			"chart-one": "sha256:aaa",
+			"chart-two": "sha256:zzz",
+		})),
+		WithResume([]string{
+			"quay.test/charts/chart-one@sha256:aaa",
+			"quay.test/charts/chart-two@sha256:bbb",
+		}, false))
+	if err == nil {
+		t.Fatal("expected chart-two's moved digest to fail the publish")
+	}
+	if !strings.Contains(err.Error(), "chart-two") {
+		t.Errorf("expected chart-two named in the error, got %v", err)
+	}
+	if strings.Contains(err.Error(), "chart-one") {
+		t.Errorf("expected chart-one not to be blamed, got %v", err)
+	}
+}
+
+// A failed lookup must not discard the charts that did land.
+func TestPublishRecordsPartialRefsWhenALookupFails(t *testing.T) {
+	c := publishable(t)
+	rec := &recorder{}
+
+	err := Publish(c, []string{"quay.test/charts"}, true,
+		WithRunner(&fakeRunner{}),
+		WithResolver(func(ref string) (string, bool, error) {
+			if strings.Contains(ref, "chart-two") {
+				return "", false, fmt.Errorf("registry unreachable")
+			}
+			return "sha256:aaa", true, nil
+		}),
+		WithRecord(rec))
+	if err == nil {
+		t.Fatal("expected the failed lookup to be reported")
+	}
+	want := "quay.test/charts/chart-one@sha256:aaa"
+	if !slices.Contains(rec.refs, want) {
+		t.Errorf("expected %q recorded despite the failure, got %v", want, rec.refs)
+	}
+}
+
+// A modify that fails partway has already written some edits.
+func TestBuildRestoresTreeWhenModifyingValuesFails(t *testing.T) {
+	c := testChart(t)
+	f := &fakeRunner{failures: map[string]int{"sed": 1}}
+
+	if err := Build(c, WithRunner(f), WithModifiedValues([]ValueEdit{{Chart: "chart-one", Key: "version", Value: "v3.30.0"}})); err == nil {
+		t.Fatal("expected the build to fail")
+	}
+	if len(f.callsTo("git")) != 1 {
+		t.Errorf("expected the chart tree to be restored, got %d git calls", len(f.callsTo("git")))
+	}
+}
+
+// A release that uploads its whole output directory needs the index inside it.
+func TestBuildLeavesTheIndexWhereAsked(t *testing.T) {
+	c := testChart(t)
+	writeCharts(t, c, c.Names...)
+	// Such a release points the index at its own output directory.
+	indexDir := filepath.Join(c.BaseDir, "charts")
+
+	if err := Build(c, WithRunner(&fakeRunner{}),
+		WithIndex(testRepoURL, testChartURL, indexDir, filepath.Join(c.RepoRoot, "tmp"))); err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(indexDir, indexFileName)); err != nil {
+		t.Errorf("expected the index in %s: %v", indexDir, err)
+	}
+}
+
+// Values are rewritten only when a caller asks, so a plain build leaves the
+// tree alone.
+func TestBuildWithoutModifiedValuesLeavesTheTree(t *testing.T) {
+	c := testChart(t)
+	writeCharts(t, c, c.Names...)
+	f := &fakeRunner{}
+
+	if err := Build(c, WithRunner(f)); err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if got := len(f.callsTo("git")); got != 0 {
+		t.Errorf("expected no tree reset, got %d git calls", got)
+	}
+}
+
+func TestBuildModifiesValuesWhenAsked(t *testing.T) {
+	c := testChart(t)
+	writeCharts(t, c, c.Names...)
+	f := &fakeRunner{}
+
+	if err := Build(c, WithRunner(f), WithModifiedValues([]ValueEdit{
+		{Chart: "chart-one", Key: "version", Value: "v3.30.0"},
+	})); err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if got := len(f.callsTo("sed")); got != 1 {
+		t.Errorf("expected the values rewritten, got %d sed calls", got)
+	}
+	if got := len(f.callsTo("git")); got != 1 {
+		t.Errorf("expected the tree restored, got %d git calls", got)
+	}
+}
+
+// An empty suffix means the charts share the product version; a suffix means
+// they rev separately from it.
+func TestVersion(t *testing.T) {
+	if got := Version("v3.30.0", ""); got != "v3.30.0" {
+		t.Errorf("Version without a suffix = %q, want v3.30.0", got)
+	}
+	if got := Version("v3.30.0", "2"); got != "v3.30.0-2" {
+		t.Errorf("Version with a suffix = %q, want v3.30.0-2", got)
+	}
+}
+
+// The digest ref must name the resolved version, not the bare suffix.
+func TestPublishRefsNameTheResolvedVersion(t *testing.T) {
+	// A suffix is what makes the resolved version differ from the product one.
+	c := testChart(t)
+	c.ChartVersion = "2"
+	writeCharts(t, c, c.Names...)
+	rec := &recorder{}
+	err := Publish(c, []string{"quay.test/charts"}, true,
+		WithRunner(&fakeRunner{}),
+		WithResolver(func(ref string) (string, bool, error) {
+			if !strings.Contains(ref, ":"+c.Version()) {
+				t.Errorf("ref %q does not name version %q", ref, c.Version())
+			}
+			return "sha256:aaa", true, nil
+		}),
+		WithRecord(rec))
+	if err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+}
+
+// The staging dir holds only this run's charts, so a chart dropped from the
+// build does not linger in the next index.
+func TestBuildIndexDropsStaleCharts(t *testing.T) {
+	c := testChart(t)
+	writeCharts(t, c, c.Names...)
+	tmp := t.TempDir()
+
+	stale := filepath.Join(Dir(tmp, c.Version()), "gone-"+c.Version()+".tgz")
+	if err := os.MkdirAll(filepath.Dir(stale), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(stale, []byte("stale"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	f := &fakeRunner{}
+	if err := Build(c, WithRunner(f),
+		WithIndex(testRepoURL, testChartURL, filepath.Join(t.TempDir(), "index"), tmp)); err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if slices.Contains(f.staged, filepath.Base(stale)) {
+		t.Errorf("stale chart %s was indexed, staged: %v", filepath.Base(stale), f.staged)
+	}
+}
+
+// The make target names its output by GIT_VERSION, so a chart version suffix
+// must reach it: otherwise the build looks for a file the target never wrote.
+func TestBuildWithAChartVersionSuffix(t *testing.T) {
+	c := testChart(t)
+	c.ChartVersion = "2"
+
+	var gitVersion string
+	f := &fakeRunner{}
+	if err := os.MkdirAll(c.BaseDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Stage under the name the make target produces for the GIT_VERSION it is given.
+	stage := func(env []string) {
+		for _, e := range env {
+			if v, ok := strings.CutPrefix(e, "GIT_VERSION="); ok {
+				gitVersion = v
+			}
+		}
+		for _, name := range c.Names {
+			_ = os.WriteFile(filepath.Join(c.BaseDir, FileName(name, gitVersion)), []byte("chart"), 0o644)
+		}
+	}
+	f.onRun = stage
+
+	if err := Build(c, WithRunner(f)); err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if want := c.Version(); gitVersion != want {
+		t.Errorf("GIT_VERSION = %q, want %q", gitVersion, want)
+	}
+}
+
+// An edit naming From replaces that value rather than the whole line: a file
+// with two lines under one key needs the old value to tell them apart, and a
+// bare swap has no key at all.
+func TestModifyValuesEditShapes(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		edit ValueEdit
+		want string
+	}{
+		{
+			"by key",
+			ValueEdit{Chart: "chart-one", Key: "version", Value: "v3.30.0"},
+			"s~version: .*~version: v3.30.0~g",
+		},
+		{
+			"by old value under a key",
+			ValueEdit{Chart: "chart-one", Key: "image", From: "quay.io/calico/node", Value: "gcr.io/x/node"},
+			"s~image: quay.io/calico/node~image: gcr.io/x/node~g",
+		},
+		{
+			"bare swap",
+			ValueEdit{Chart: "chart-one", From: "quay.io/calico", Value: "gcr.io/x"},
+			"s~quay.io/calico~gcr.io/x~g",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			f := &fakeRunner{}
+			if err := ModifyValues(Values{RepoRoot: t.TempDir(), Edits: []ValueEdit{tc.edit}}, WithRunner(f)); err != nil {
+				t.Fatalf("ModifyValues: %v", err)
+			}
+			seds := f.callsTo("sed")
+			if len(seds) != 1 {
+				t.Fatalf("expected one sed, got %d", len(seds))
+			}
+			if !slices.Contains(seds[0].args, tc.want) {
+				t.Errorf("expression = %v, want %q", seds[0].args, tc.want)
+			}
+		})
+	}
+}

--- a/release/internal/charts/charts_test.go
+++ b/release/internal/charts/charts_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 
 	"github.com/projectcalico/calico/release/internal/steps"
+	"github.com/projectcalico/calico/release/internal/yamledit"
 )
 
 // fakeRunner records every invocation and can fail a command a set number of
@@ -212,11 +213,13 @@ func TestBuildRestoresTreeAfterModifyingValues(t *testing.T) {
 	writeCharts(t, c, c.Names...)
 	f := &fakeRunner{}
 
-	if err := Build(c, WithRunner(f), WithModifiedValues([]ValueEdit{{Chart: "chart-one", Key: "version", Value: "v3.30.0"}})); err != nil {
+	path := writeChartValues(t, c.RepoRoot, "chart-one", "version: master\n")
+
+	if err := Build(c, WithRunner(f), WithModifiedValues([]ValueEdit{{Chart: "chart-one", Edit: yamledit.Edit{Key: "version", To: "v3.30.0"}}})); err != nil {
 		t.Fatalf("Build: %v", err)
 	}
-	if len(f.callsTo("sed")) != 1 {
-		t.Error("expected the values to be modified")
+	if got, _ := os.ReadFile(path); string(got) != "version: v3.30.0\n" {
+		t.Errorf("values not modified, got %q", got)
 	}
 	if len(f.callsTo("git")) != 1 {
 		t.Error("expected the chart tree to be restored after the build")
@@ -227,7 +230,7 @@ func TestBuildRestoresTreeWhenBuildFails(t *testing.T) {
 	c := testChart(t)
 	f := &fakeRunner{failures: map[string]int{"make": 1}}
 
-	if err := Build(c, WithRunner(f), WithModifiedValues([]ValueEdit{{Chart: "chart-one", Key: "version", Value: "v3.30.0"}})); err == nil {
+	if err := Build(c, WithRunner(f), WithModifiedValues([]ValueEdit{{Chart: "chart-one", Edit: yamledit.Edit{Key: "version", To: "v3.30.0"}}})); err == nil {
 		t.Fatal("expected the build to fail")
 	}
 	if len(f.callsTo("git")) != 1 {
@@ -510,7 +513,7 @@ func TestPublishLogsPerChartAndRegistry(t *testing.T) {
 		t.Fatalf("Publish: %v", err)
 	}
 	// A chart goes to several registries, so the slug carries both.
-	want := filepath.Join(logs, publishStep, "chart-one-quay.test-charts.log")
+	want := filepath.Join(logs, PublishStep, "chart-one-quay.test-charts.log")
 	if !slices.ContainsFunc(f.callsTo(helmBinary), func(c call) bool { return c.logPath == want }) {
 		t.Errorf("expected a per-chart log at %q", want)
 	}
@@ -658,15 +661,23 @@ func TestFileName(t *testing.T) {
 }
 
 func TestDir(t *testing.T) {
-	for _, tc := range []struct{ name, outDir, version, want string }{
-		{"no version", "out", "", "out/charts"},
-		{"with version", "out", "v3.30.0", "out/charts-v3.30.0"},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			if got := Dir(tc.outDir, tc.version); got != tc.want {
-				t.Errorf("Dir = %q, want %q", got, tc.want)
-			}
-		})
+	if got, want := Dir("out"), "out/charts"; got != want {
+		t.Errorf("Dir = %q, want %q", got, want)
+	}
+}
+
+// The version is what keeps one release's charts apart from another's in a
+// shared directory, so an empty one is a caller mistake rather than a default.
+func TestVersionedDir(t *testing.T) {
+	got, err := versionedDir("out", "v3.30.0")
+	if err != nil {
+		t.Fatalf("versionedDir: %v", err)
+	}
+	if want := "out/charts-v3.30.0"; got != want {
+		t.Errorf("versionedDir = %q, want %q", got, want)
+	}
+	if _, err := versionedDir("out", ""); err == nil {
+		t.Error("expected an empty version to be rejected")
 	}
 }
 
@@ -724,9 +735,10 @@ func TestPublishRecordsPartialRefsWhenALookupFails(t *testing.T) {
 // A modify that fails partway has already written some edits.
 func TestBuildRestoresTreeWhenModifyingValuesFails(t *testing.T) {
 	c := testChart(t)
-	f := &fakeRunner{failures: map[string]int{"sed": 1}}
+	f := &fakeRunner{}
+	// No values file to edit, so the modify fails before the build runs.
 
-	if err := Build(c, WithRunner(f), WithModifiedValues([]ValueEdit{{Chart: "chart-one", Key: "version", Value: "v3.30.0"}})); err == nil {
+	if err := Build(c, WithRunner(f), WithModifiedValues([]ValueEdit{{Chart: "chart-one", Edit: yamledit.Edit{Key: "version", To: "v3.30.0"}}})); err == nil {
 		t.Fatal("expected the build to fail")
 	}
 	if len(f.callsTo("git")) != 1 {
@@ -770,13 +782,15 @@ func TestBuildModifiesValuesWhenAsked(t *testing.T) {
 	writeCharts(t, c, c.Names...)
 	f := &fakeRunner{}
 
+	path := writeChartValues(t, c.RepoRoot, "chart-one", "version: master\n")
+
 	if err := Build(c, WithRunner(f), WithModifiedValues([]ValueEdit{
-		{Chart: "chart-one", Key: "version", Value: "v3.30.0"},
+		{Chart: "chart-one", Edit: yamledit.Edit{Key: "version", To: "v3.30.0"}},
 	})); err != nil {
 		t.Fatalf("Build: %v", err)
 	}
-	if got := len(f.callsTo("sed")); got != 1 {
-		t.Errorf("expected the values rewritten, got %d sed calls", got)
+	if got, _ := os.ReadFile(path); string(got) != "version: v3.30.0\n" {
+		t.Errorf("values not rewritten, got %q", got)
 	}
 	if got := len(f.callsTo("git")); got != 1 {
 		t.Errorf("expected the tree restored, got %d git calls", got)
@@ -822,7 +836,11 @@ func TestBuildIndexDropsStaleCharts(t *testing.T) {
 	writeCharts(t, c, c.Names...)
 	tmp := t.TempDir()
 
-	stale := filepath.Join(Dir(tmp, c.Version()), "gone-"+c.Version()+".tgz")
+	staging, err := versionedDir(tmp, c.Version())
+	if err != nil {
+		t.Fatal(err)
+	}
+	stale := filepath.Join(staging, "gone-"+c.Version()+".tgz")
 	if err := os.MkdirAll(filepath.Dir(stale), 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -875,40 +893,49 @@ func TestBuildWithAChartVersionSuffix(t *testing.T) {
 // An edit naming From replaces that value rather than the whole line: a file
 // with two lines under one key needs the old value to tell them apart, and a
 // bare swap has no key at all.
-func TestModifyValuesEditShapes(t *testing.T) {
-	for _, tc := range []struct {
-		name string
-		edit ValueEdit
-		want string
-	}{
-		{
-			"by key",
-			ValueEdit{Chart: "chart-one", Key: "version", Value: "v3.30.0"},
-			"s~version: .*~version: v3.30.0~g",
-		},
-		{
-			"by old value under a key",
-			ValueEdit{Chart: "chart-one", Key: "image", From: "quay.io/calico/node", Value: "gcr.io/x/node"},
-			"s~image: quay.io/calico/node~image: gcr.io/x/node~g",
-		},
-		{
-			"bare swap",
-			ValueEdit{Chart: "chart-one", From: "quay.io/calico", Value: "gcr.io/x"},
-			"s~quay.io/calico~gcr.io/x~g",
-		},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			f := &fakeRunner{}
-			if err := ModifyValues(Values{RepoRoot: t.TempDir(), Edits: []ValueEdit{tc.edit}}, WithRunner(f)); err != nil {
-				t.Fatalf("ModifyValues: %v", err)
-			}
-			seds := f.callsTo("sed")
-			if len(seds) != 1 {
-				t.Fatalf("expected one sed, got %d", len(seds))
-			}
-			if !slices.Contains(seds[0].args, tc.want) {
-				t.Errorf("expression = %v, want %q", seds[0].args, tc.want)
-			}
-		})
+func TestModifyValues(t *testing.T) {
+	root := t.TempDir()
+	path := writeChartValues(t, root, "chart-one", "version: master\nimage: quay.io/calico/node # keep\n")
+
+	err := ModifyValues(Values{RepoRoot: root, Edits: []ValueEdit{
+		{Chart: "chart-one", Edit: yamledit.Edit{Key: "version", To: "v3.30.0"}},
+	}}, WithRunner(&fakeRunner{}))
+	if err != nil {
+		t.Fatalf("ModifyValues: %v", err)
 	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "version: v3.30.0\nimage: quay.io/calico/node # keep\n"
+	if string(got) != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// A key the chart no longer has would otherwise ship an unstamped chart.
+func TestModifyValuesFailsWhenAKeyIsMissing(t *testing.T) {
+	root := t.TempDir()
+	writeChartValues(t, root, "chart-one", "version: master\n")
+
+	err := ModifyValues(Values{RepoRoot: root, Edits: []ValueEdit{
+		{Chart: "chart-one", Edit: yamledit.Edit{Key: "renamed", To: "v3.30.0"}},
+	}}, WithRunner(&fakeRunner{}))
+	if err == nil {
+		t.Fatal("expected a missing key to fail")
+	}
+}
+
+func writeChartValues(t *testing.T, root, chart, content string) string {
+	t.Helper()
+	dir := filepath.Join(root, chartsDirName, chart)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, valuesFileName)
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
 }

--- a/release/internal/github/github.go
+++ b/release/internal/github/github.go
@@ -1,0 +1,26 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package github is how a release reaches GitHub.
+package github
+
+import "net/url"
+
+const baseURL = "https://github.com"
+
+// DownloadURL is where a release's artifacts are downloaded from.
+func DownloadURL(org, repo, version string, file ...string) (string, error) {
+	parts := append([]string{org, repo, "releases", "download", version}, file...)
+	return url.JoinPath(baseURL, parts...)
+}

--- a/release/internal/github/github_test.go
+++ b/release/internal/github/github_test.go
@@ -1,0 +1,39 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package github
+
+import "testing"
+
+// Pinned to literals: deriving them from the builders would pass for any URL.
+func TestDownloadURL(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		file []string
+		want string
+	}{
+		{"release", nil, "https://github.com/projectcalico/calico/releases/download/v3.30.0"},
+		{"artifact", []string{"SHA256SUMS"}, "https://github.com/projectcalico/calico/releases/download/v3.30.0/SHA256SUMS"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := DownloadURL("projectcalico", "calico", "v3.30.0", tc.file...)
+			if err != nil {
+				t.Fatalf("building url: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/release/internal/images/actions.go
+++ b/release/internal/images/actions.go
@@ -23,8 +23,8 @@ import (
 
 	"github.com/sirupsen/logrus"
 
-	"github.com/projectcalico/calico/release/internal/command"
 	"github.com/projectcalico/calico/release/internal/imagescanner"
+	"github.com/projectcalico/calico/release/internal/steps"
 	"github.com/projectcalico/calico/release/internal/utils"
 )
 
@@ -55,7 +55,6 @@ func Archive(repoRoot, version string, variants []Variant, tarDir string, opts .
 	if len(s.Registries) == 0 {
 		return s.Errorf("no registry to archive images from")
 	}
-	s.dir = tarDir
 
 	units := s.units(s.env())
 	s.Logger().WithField("images", len(units)).Info("Archiving container images")
@@ -66,7 +65,7 @@ func Archive(repoRoot, version string, variants []Variant, tarDir string, opts .
 	// Images come from the first registry: an archive holds one copy, whichever
 	// registry it is pulled from.
 	reg := s.Registries[0]
-	if _, err := forEachUnit(units, func(u unit) (unitDone, error) {
+	if _, err := steps.Go(units, func(u unit) (unitDone, error) {
 		return unitDone{}, saveUnit(s, u, reg, tarDir)
 	}); err != nil {
 		return err
@@ -117,7 +116,7 @@ func publishEnv(s settings) []string {
 
 // confirm latches the push: without it the make targets run as a dry run, so it
 // is an argument rather than an option a caller can forget.
-func Publish(repoRoot, version string, variants []Variant, confirm bool, resolve DigestResolver, opts ...PublishOption) error {
+func Publish(repoRoot, version string, variants []Variant, confirm bool, resolve steps.DigestResolver, opts ...PublishOption) error {
 	s, err := newSettings(publishStep, repoRoot, version, variants, opts)
 	if err != nil {
 		return err
@@ -177,7 +176,7 @@ func sendImagesToISS(s settings) {
 // newSettings is generic so each step accepts only its own option type.
 func newSettings[O any](step, repoRoot, version string, variants []Variant, opts []O) (settings, error) {
 	s := settings{RepoRoot: repoRoot, Version: version, Variants: variants}
-	s.Apply([]command.Option{command.WithName(step)})
+	s.Apply([]steps.Option{steps.WithName(step)})
 	if err := s.validate(); err != nil {
 		return s, s.Errorf("%w", err)
 	}
@@ -203,7 +202,7 @@ func applyTo(opt any, s *settings) error {
 }
 
 // unitStateAgainst binds one record, so every unit is judged against the same.
-func (s settings) unitStateAgainst(recorded recordedDigests) func(unit) (bool, error) {
+func (s settings) unitStateAgainst(recorded steps.RecordedDigests) func(unit) (bool, error) {
 	return func(u unit) (bool, error) { return unitState(s, u, recorded) }
 }
 
@@ -213,8 +212,8 @@ func pending(s settings, units []unit) ([]unit, error) {
 	if s.resume == nil {
 		return units, nil
 	}
-	recorded := digestsByRepo(s.resume.published)
-	done, err := forEachUnit(units, s.unitStateAgainst(recorded))
+	recorded := steps.DigestsByRepo(s.resume.published)
+	done, err := steps.Go(units, s.unitStateAgainst(recorded))
 	if err != nil {
 		return nil, err
 	}

--- a/release/internal/images/images.go
+++ b/release/internal/images/images.go
@@ -23,12 +23,12 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
-	"sync"
 
 	"github.com/sirupsen/logrus"
 
 	"github.com/projectcalico/calico/release/internal/command"
 	"github.com/projectcalico/calico/release/internal/imagescanner"
+	"github.com/projectcalico/calico/release/internal/steps"
 	"github.com/projectcalico/calico/release/internal/utils"
 )
 
@@ -145,14 +145,6 @@ func NarrowVariants(variants []Variant, dirs []string) []Variant {
 	return out
 }
 
-type RefRecorder interface {
-	Add(refs ...string) error
-}
-
-// DigestResolver reports the manifest digest of a tag. exists is false with a
-// nil error when the tag is absent; auth and network failures return an error.
-type DigestResolver func(image string) (digest string, exists bool, err error)
-
 // Image is what every step needs to name the images a release ships.
 type Image struct {
 	RepoRoot   string
@@ -161,7 +153,7 @@ type Image struct {
 	Arches     []string
 	Variants   []Variant
 
-	command.Step
+	steps.Step
 }
 
 // settings is what the options write into. Nothing outside the package builds
@@ -173,18 +165,16 @@ type settings struct {
 	// confirm latches the push. Without it the make targets run as a dry run.
 	confirm bool
 
-	dir string
-
 	// pull fetches an image that is not already local, which a release that
 	// did not build its own images needs.
 	pull bool
 
 	retag *retag
 	scan  *ScanRequest
-	refs  RefRecorder
+	refs  steps.RefRecorder
 
 	// resolve reports a published tag's digest. Defaults to the registry.
-	resolve DigestResolver
+	resolve steps.DigestResolver
 
 	// resume is the record an earlier run left, and how to check it.
 	resume *resume
@@ -232,7 +222,7 @@ func (f publishSetting) applyPublish(s *settings) error { return f(s) }
 
 func WithRunner(r command.CommandRunner) Option {
 	return setting(func(s *settings) error {
-		s.Apply([]command.Option{command.WithRunner(r)})
+		s.Apply([]steps.Option{steps.WithRunner(r)})
 		return nil
 	})
 }
@@ -258,7 +248,7 @@ func WithArches(arches ...string) Option {
 // the output captured in memory.
 func WithLogsDir(dir string) Option {
 	return setting(func(s *settings) error {
-		s.Apply([]command.Option{command.WithLogsDir(dir)})
+		s.Apply([]steps.Option{steps.WithLogsDir(dir)})
 		return nil
 	})
 }
@@ -269,7 +259,7 @@ func WithStepName(name string) Option {
 		if name == "" {
 			return fmt.Errorf("no step name given")
 		}
-		s.Apply([]command.Option{command.WithName(name)})
+		s.Apply([]steps.Option{steps.WithName(name)})
 		return nil
 	})
 }
@@ -305,7 +295,7 @@ func WithScan(req *ScanRequest) PublishOption {
 	})
 }
 
-func WithRecord(rec RefRecorder) PublishOption {
+func WithRecord(rec steps.RefRecorder) PublishOption {
 	return publishSetting(func(s *settings) error {
 		if rec == nil {
 			return fmt.Errorf("no recorder given")
@@ -387,7 +377,7 @@ func (c Image) env() []string {
 }
 
 func (s settings) runUnits(units []unit) error {
-	_, err := forEachUnit(units, s.runUnitOnly)
+	_, err := steps.Go(units, s.runUnitOnly)
 	return err
 }
 
@@ -404,19 +394,6 @@ func (s settings) runUnitOnly(u unit) (unitDone, error) {
 // unitDone is the result of a unit that produces nothing to collect.
 type unitDone struct{}
 
-func forEachUnit[T any](units []unit, fn func(unit) (T, error)) ([]T, error) {
-	var (
-		wg   sync.WaitGroup
-		out  = make([]T, len(units))
-		errs = make([]error, len(units))
-	)
-	for i, u := range units {
-		wg.Go(func() { out[i], errs[i] = fn(u) })
-	}
-	wg.Wait()
-	return out, errors.Join(errs...)
-}
-
 func (s settings) runUnit(u unit) error {
 	log := s.Logger().WithFields(logrus.Fields{"variant": u.variant, "component": u.dir, "target": u.target})
 	dir := filepath.Join(s.RepoRoot, u.dir)
@@ -428,7 +405,7 @@ func (s settings) runUnit(u unit) error {
 			log.Debug(out)
 			return nil
 		}
-		if attempt < command.MaxRetries {
+		if attempt < steps.MaxRetries {
 			log.WithError(err).WithField("attempt", attempt).Warn("Image step failed, retrying")
 			continue
 		}
@@ -512,7 +489,7 @@ func (c Image) tagPrefix(u unit) (string, error) {
 // unitState reads the record rather than the registry: the record already names
 // what landed, and a local read costs nothing. done is true when every ref the
 // unit publishes is recorded at the digest the registry currently serves.
-func unitState(s settings, u unit, recorded recordedDigests) (done bool, err error) {
+func unitState(s settings, u unit, recorded steps.RecordedDigests) (done bool, err error) {
 	if s.resume == nil {
 		return false, nil
 	}
@@ -559,26 +536,7 @@ func unitState(s settings, u unit, recorded recordedDigests) (done bool, err err
 	return true, nil
 }
 
-type recordedDigests map[string]map[string]struct{}
-
-// A repo publishes several tags, each at its own digest, so it maps to a SET of
-// digests: a tag counts as published when its digest is in that set.
-func digestsByRepo(refs []string) recordedDigests {
-	out := make(recordedDigests, len(refs))
-	for _, ref := range refs {
-		repo, digest, ok := strings.Cut(ref, "@")
-		if !ok {
-			continue
-		}
-		if out[repo] == nil {
-			out[repo] = map[string]struct{}{}
-		}
-		out[repo][digest] = struct{}{}
-	}
-	return out
-}
-
-func (c Image) publishedRefs(u unit, resolve DigestResolver) ([]string, error) {
+func (c Image) publishedRefs(u unit, resolve steps.DigestResolver) ([]string, error) {
 	names, err := c.imageNames(u)
 	if err != nil {
 		return nil, err
@@ -635,7 +593,7 @@ func record(s settings, units []unit) error {
 	if s.refs == nil {
 		return nil
 	}
-	refs, lookupErr := forEachUnit(units, s.refsFor)
+	refs, lookupErr := steps.Go(units, s.refsFor)
 	// Written even when a lookup failed: a partial publish is exactly the run
 	// whose record decides what a resume still owes. Writing after the lookups
 	// keeps the record in the units' order.

--- a/release/internal/images/images_test.go
+++ b/release/internal/images/images_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 
 	"github.com/projectcalico/calico/release/internal/command"
+	"github.com/projectcalico/calico/release/internal/steps"
 )
 
 // fakeRunner records every make invocation and can fail a component a set number
@@ -36,24 +37,26 @@ type fakeRunner struct {
 }
 
 type call struct {
+	// dir is where the command was run.
+	dir  string
 	args []string
 	env  []string
 	// logPath is empty when the unit's output was captured in memory.
 	logPath string
 }
 
-func (f *fakeRunner) RunInDir(_, _ string, args, env []string) (string, error) {
-	return f.record(args, env, "")
+func (f *fakeRunner) RunInDir(dir, _ string, args, env []string) (string, error) {
+	return f.record(dir, args, env, "")
 }
 
-func (f *fakeRunner) RunInDirToFile(_, _ string, args, env []string, logPath string) (string, error) {
-	return f.record(args, env, logPath)
+func (f *fakeRunner) RunInDirToFile(dir, _ string, args, env []string, logPath string) (string, error) {
+	return f.record(dir, args, env, logPath)
 }
 
-func (f *fakeRunner) record(args, env []string, logPath string) (string, error) {
+func (f *fakeRunner) record(runDir string, args, env []string, logPath string) (string, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	f.calls = append(f.calls, call{args: slices.Clone(args), env: slices.Clone(env), logPath: logPath})
+	f.calls = append(f.calls, call{dir: runDir, args: slices.Clone(args), env: slices.Clone(env), logPath: logPath})
 	dir := args[1]
 	if n, ok := f.failures[dir]; ok && n > 0 {
 		f.failures[dir] = n - 1
@@ -64,7 +67,7 @@ func (f *fakeRunner) record(args, env []string, logPath string) (string, error) 
 
 // Run records too: archiving drives docker through it rather than make.
 func (f *fakeRunner) Run(_ string, args, env []string) (string, error) {
-	return f.record(args, env, "")
+	return f.record("", args, env, "")
 }
 
 func (f *fakeRunner) RunNoCapture(string, []string, []string) error              { return nil }
@@ -444,8 +447,8 @@ func dirArg(args []string) string {
 	return ""
 }
 
-func (r *imageNameRunner) RunInDir(_, _ string, args, env []string) (string, error) {
-	if _, err := r.record(args, env, ""); err != nil {
+func (r *imageNameRunner) RunInDir(dir, _ string, args, env []string) (string, error) {
+	if _, err := r.record(dir, args, env, ""); err != nil {
 		return "", err
 	}
 	if slices.Contains(args, "build-images") {
@@ -466,13 +469,13 @@ func (r *imageNameRunner) RunInDir(_, _ string, args, env []string) (string, err
 // alwaysResolves answers every image with the same digest. Suitable for asking
 // whether anything was recorded, but NOT for anything comparing digests: it
 // cannot tell a repo's tags apart. Use resolvesPerTag for that.
-func alwaysResolves(digest string) DigestResolver {
+func alwaysResolves(digest string) steps.DigestResolver {
 	return func(string) (string, bool, error) { return digest, true, nil }
 }
 
 // resolvesPerTag gives each tag its own digest, as a registry does, so a repo
 // carrying a manifest list and its arch tags holds several distinct digests.
-func resolvesPerTag() DigestResolver {
+func resolvesPerTag() steps.DigestResolver {
 	return func(image string) (string, bool, error) {
 		_, tag, _ := strings.Cut(image, ":")
 		return "sha256:" + strings.Repeat(fmt.Sprintf("%x", len(tag))[:1], 64), true, nil
@@ -480,7 +483,7 @@ func resolvesPerTag() DigestResolver {
 }
 
 // recordingOpts are the options a publish needs to record what it pushed.
-func recordingOpts(f *imageNameRunner, rec RefRecorder, extra ...PublishOption) []PublishOption {
+func recordingOpts(f *imageNameRunner, rec steps.RefRecorder, extra ...PublishOption) []PublishOption {
 	return append([]PublishOption{
 		WithRunner(f),
 		WithRegistries("quay.io/calico"),

--- a/release/internal/pinnedversion/pin.go
+++ b/release/internal/pinnedversion/pin.go
@@ -15,6 +15,7 @@
 package pinnedversion
 
 import (
+	"cmp"
 	"errors"
 	"fmt"
 	"maps"
@@ -79,6 +80,9 @@ type Config struct {
 	// ReleaseBranchPrefix prefixes the release branch, e.g. "release".
 	ReleaseBranchPrefix string
 
+	// ProductRegistry is the regiostry for the product images.
+	Registry string
+
 	// Operator overrides the operator's image and registry.
 	Operator registry.Component
 
@@ -120,6 +124,9 @@ type Pin struct {
 
 	// ProductVersion is the product version in the hashrelease.
 	ProductVersion string
+
+	// ProductRegistry is the registry for the product images in the hashrelease.
+	ProductRegistry string
 
 	// ChartVersion qualifies the chart version when the charts rev with the product version.
 	ChartVersion string
@@ -352,7 +359,6 @@ func (l LocalLoader) source() (*Pin, error) {
 	if err != nil {
 		return nil, err
 	}
-
 	components, err := productComponents(l.Config, productVer)
 	if err != nil {
 		return nil, err
@@ -365,14 +371,15 @@ func (l LocalLoader) source() (*Pin, error) {
 
 	name := releaseName(branch, productVer)
 	return &Pin{
-		ReleaseName:    name,
-		Hash:           hash(productVer, repos),
-		Note:           hashreleaseNote(name, branch, l.Config.Repos),
-		ProductVersion: productVer,
-		ChartVersion:   l.Config.ChartVersion,
-		Operator:       operatorComponent(l.Config, productVer),
-		Components:     components,
-		branch:         branch,
+		ReleaseName:     name,
+		Hash:            hash(productVer, repos),
+		Note:            hashreleaseNote(name, branch, l.Config.Repos),
+		ProductVersion:  productVer,
+		ChartVersion:    l.Config.ChartVersion,
+		ProductRegistry: cmp.Or(l.Config.Registry, registry.DefaultProductRegistry),
+		Operator:        operatorComponent(l.Config, productVer),
+		Components:      components,
+		branch:          branch,
 	}, nil
 }
 

--- a/release/internal/pinnedversion/pin.go
+++ b/release/internal/pinnedversion/pin.go
@@ -26,6 +26,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"go.yaml.in/yaml/v3"
 
+	"github.com/projectcalico/calico/release/internal/charts"
 	"github.com/projectcalico/calico/release/internal/command"
 	"github.com/projectcalico/calico/release/internal/hashreleaseserver"
 	"github.com/projectcalico/calico/release/internal/registry"
@@ -141,10 +142,7 @@ func (p *Pin) ComponentVersion(component string) string {
 // HelmChartVersion returns the chart version: the product version, suffixed
 // with ChartVersion when the charts rev separately from the product.
 func (p *Pin) HelmChartVersion() string {
-	if p.ChartVersion == "" {
-		return p.ProductVersion
-	}
-	return fmt.Sprintf("%s-%s", p.ProductVersion, p.ChartVersion)
+	return charts.Version(p.ProductVersion, p.ChartVersion)
 }
 
 // ReleaseBranch returns the release branch for the pinned product version.

--- a/release/internal/pinnedversion/pinnedversion.go
+++ b/release/internal/pinnedversion/pinnedversion.go
@@ -65,6 +65,7 @@ type PinnedVersion struct {
 	Branch         string                        `yaml:"branch,omitempty"`
 	Hash           string                        `yaml:"full_hash,omitempty"`
 	TigeraOperator registry.Component            `yaml:"tigera-operator"`
+	Registry       string                        `yaml:"registry,omitempty"`
 	Components     map[string]registry.Component `yaml:"components"`
 }
 
@@ -75,14 +76,15 @@ func (p *PinnedVersion) pin() *Pin {
 		branch = branchFromNote(p.Note)
 	}
 	return &Pin{
-		ReleaseName:    p.ReleaseName,
-		Hash:           p.Hash,
-		Note:           p.Note,
-		ProductVersion: p.Title,
-		ChartVersion:   p.HelmRelease,
-		Operator:       p.TigeraOperator,
-		Components:     p.Components,
-		branch:         branch,
+		ReleaseName:     p.ReleaseName,
+		Hash:            p.Hash,
+		Note:            p.Note,
+		ProductVersion:  p.Title,
+		ChartVersion:    p.HelmRelease,
+		Operator:        p.TigeraOperator,
+		ProductRegistry: cmp.Or(p.Registry, registry.DefaultProductRegistry),
+		Components:      p.Components,
+		branch:          branch,
 	}
 }
 
@@ -116,6 +118,7 @@ func pinnedFrom(p *Pin) PinnedVersion {
 			Registry: p.Operator.Registry,
 			Version:  p.Operator.Version,
 		},
+		Registry:   p.ProductRegistry,
 		Components: p.Components,
 	}
 }

--- a/release/internal/pinnedversion/pinnedversion_test.go
+++ b/release/internal/pinnedversion/pinnedversion_test.go
@@ -270,3 +270,14 @@ func TestOperatorComponentHonoursOverrides(t *testing.T) {
 		t.Errorf("version %q, want %q", over.Version, testProductVersion)
 	}
 }
+
+// A pin written before the registry had a field, or one that omitted it as
+// empty, still names the default rather than nothing.
+func TestPinRegistryDefaults(t *testing.T) {
+	if got := (&PinnedVersion{Title: "v3.30.0"}).pin().ProductRegistry; got != registry.DefaultProductRegistry {
+		t.Errorf("omitted registry = %q, want %q", got, registry.DefaultProductRegistry)
+	}
+	if got := (&PinnedVersion{Title: "v3.30.0", Registry: "gcr.io/x"}).pin().ProductRegistry; got != "gcr.io/x" {
+		t.Errorf("set registry = %q, want %q", got, "gcr.io/x")
+	}
+}

--- a/release/internal/registry/registry.go
+++ b/release/internal/registry/registry.go
@@ -14,11 +14,13 @@
 
 package registry
 
-const DefaultCalicoRegistry = "quay.io/calico"
+const defaultCalicoRegistry = "quay.io/calico"
+
+var DefaultProductRegistry = defaultCalicoRegistry
 
 var DefaultCalicoRegistries = []string{
+	defaultCalicoRegistry,
 	"docker.io/calico",
-	DefaultCalicoRegistry,
 	"gcr.io/projectcalico-org",
 	"eu.gcr.io/projectcalico-org",
 	"asia.gcr.io/projectcalico-org",
@@ -27,7 +29,7 @@ var DefaultCalicoRegistries = []string{
 
 // DefaultOperatorRegistries are the registries the operator image publishes to. It
 // ships alongside the other Calico component images, but is not mirrored to GCR.
-var DefaultOperatorRegistries = []string{DefaultCalicoRegistry, "docker.io/calico"}
+var DefaultOperatorRegistries = []string{defaultCalicoRegistry, "docker.io/calico"}
 
 var DefaultHelmRegistries = []string{
 	"quay.io/calico/charts",

--- a/release/internal/steps/step.go
+++ b/release/internal/steps/step.go
@@ -12,13 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package command
+package steps
 
 import (
 	"fmt"
 	"path/filepath"
 
 	"github.com/sirupsen/logrus"
+
+	"github.com/projectcalico/calico/release/internal/command"
 )
 
 // One retry: pushes fail on network flakes often enough to save a run.
@@ -27,7 +29,7 @@ const MaxRetries = 1
 // Step holds what every release step needs. Embedding keeps these unexported,
 // so a zero-value config still runs real commands.
 type Step struct {
-	runner CommandRunner
+	runner command.CommandRunner
 
 	// dir is where commands run. Empty runs them in the current directory.
 	dir string
@@ -41,8 +43,12 @@ type Step struct {
 
 type Option func(*Step)
 
-func WithRunner(r CommandRunner) Option {
+func WithRunner(r command.CommandRunner) Option {
 	return func(s *Step) { s.runner = r }
+}
+
+func WithDir(dir string) Option {
+	return func(s *Step) { s.dir = dir }
 }
 
 func WithName(name string) Option {
@@ -60,9 +66,9 @@ func (s *Step) Apply(opts []Option) {
 }
 
 // Runner defaults to running real commands.
-func (s Step) Runner() CommandRunner {
+func (s Step) Runner() command.CommandRunner {
 	if s.runner == nil {
-		return &RealCommandRunner{}
+		return &command.RealCommandRunner{}
 	}
 	return s.runner
 }

--- a/release/internal/steps/steps.go
+++ b/release/internal/steps/steps.go
@@ -1,0 +1,62 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package steps holds what every release step uses.
+package steps
+
+import (
+	"errors"
+	"strings"
+	"sync"
+)
+
+type RefRecorder interface {
+	Add(refs ...string) error
+}
+
+// DigestResolver reports the manifest digest of a tag. exists is false with a
+// nil error when the tag is absent; auth and network failures return an error.
+type DigestResolver func(ref string) (digest string, exists bool, err error)
+
+// A repo publishes several tags at different digests, so it maps to a set.
+type RecordedDigests map[string]map[string]struct{}
+
+func DigestsByRepo(refs []string) RecordedDigests {
+	out := make(RecordedDigests, len(refs))
+	for _, ref := range refs {
+		repo, digest, ok := strings.Cut(ref, "@")
+		if !ok {
+			continue
+		}
+		if out[repo] == nil {
+			out[repo] = map[string]struct{}{}
+		}
+		out[repo][digest] = struct{}{}
+	}
+	return out
+}
+
+// Go runs fn over every item at once and waits for all of them, so fn must be
+// safe to call concurrently. Results come back in the order the items were
+// given, whatever order they finished in.
+func Go[U, T any](items []U, fn func(U) (T, error)) ([]T, error) {
+	var wg sync.WaitGroup
+	out := make([]T, len(items))
+	errs := make([]error, len(items))
+	for i, item := range items {
+		wg.Go(func() { out[i], errs[i] = fn(item) })
+	}
+	wg.Wait()
+	return out, errors.Join(errs...)
+}

--- a/release/internal/steps/steps_test.go
+++ b/release/internal/steps/steps_test.go
@@ -1,0 +1,76 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package steps
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestDigestsByRepo(t *testing.T) {
+	got := DigestsByRepo([]string{
+		"quay.io/calico/node@sha256:aaa",
+		"quay.io/calico/node@sha256:bbb",
+		"quay.io/calico/cni@sha256:ccc",
+		"not-a-ref",
+	})
+	// One repo, two tags, two digests: a tag counts as published when its
+	// digest is among them.
+	if len(got["quay.io/calico/node"]) != 2 {
+		t.Errorf("node digests = %v, want 2", got["quay.io/calico/node"])
+	}
+	if _, ok := got["quay.io/calico/cni"]["sha256:ccc"]; !ok {
+		t.Errorf("cni digest missing from %v", got)
+	}
+	if len(got) != 2 {
+		t.Errorf("expected the malformed ref to be dropped, got %v", got)
+	}
+}
+
+// Results are indexed, so a slow item cannot reorder the ones after it.
+func TestGoKeepsInputOrder(t *testing.T) {
+	got, err := Go([]int{1, 2, 3}, func(i int) (string, error) {
+		return fmt.Sprintf("v%d", i), nil
+	})
+	if err != nil {
+		t.Fatalf("ForEach: %v", err)
+	}
+	if want := []string{"v1", "v2", "v3"}; !slices.Equal(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+// One failure must not hide the others, nor discard the results that worked.
+func TestGoCollectsEveryError(t *testing.T) {
+	got, err := Go([]int{1, 2, 3}, func(i int) (string, error) {
+		if i%2 == 1 {
+			return "", fmt.Errorf("item %d failed", i)
+		}
+		return "ok", nil
+	})
+	if err == nil {
+		t.Fatal("expected the failures to be reported")
+	}
+	for _, want := range []string{"item 1", "item 3"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("expected %q in %v", want, err)
+		}
+	}
+	if got[1] != "ok" {
+		t.Errorf("expected the successful item kept at its index, got %v", got)
+	}
+}

--- a/release/internal/utils/env.go
+++ b/release/internal/utils/env.go
@@ -38,6 +38,11 @@ const (
 	EnvReleaseRegistries = "RELEASE_REGISTRIES"
 	EnvImageOnly         = "IMAGE_ONLY"
 	EnvSkipDevImageRetag = "SKIP_DEV_IMAGE_RETAG"
+
+	EnvGitVersion = "GIT_VERSION"
+
+	EnvChartDestination = "CHART_DESTINATION"
+	EnvTZ               = "TZ" // EnvTZ fixes the timezone helm stamps index entries with.
 )
 
 func Env(name string, value any) string {

--- a/release/internal/utils/utils.go
+++ b/release/internal/utils/utils.go
@@ -56,18 +56,6 @@ const (
 	// TigeraCompany is the short-form human-facing name of the company, for freeform text fields or branding
 	TigeraCompany = "Tigera"
 
-	// TigeraOperatorChart is the name of the Tigera Operator Helm chart.
-	TigeraOperatorChart = "tigera-operator"
-
-	// ProjectCalicoV1CRDsChart is the name of the crd.projectcalico.org/v1 CRD helm chart.
-	ProjectCalicoV1CRDsChart = "crd.projectcalico.org.v1"
-
-	// ProjectCalicoV3CRDsChart is the name of the projectcalico.org/v3 CRD helm chart.
-	ProjectCalicoV3CRDsChart = "projectcalico.org.v3"
-
-	// CalicoHelmRepoURL is the URL for the Calico Helm charts.
-	CalicoHelmRepoURL = "https://docs.tigera.io/calico/charts"
-
 	// ReleaseBranchPrefix is the prefix for release branches.
 	DefaultReleaseBranchPrefix = "release"
 
@@ -103,15 +91,6 @@ func FilterDirs(have, want []string) []string {
 		}
 	}
 	return out
-}
-
-// AllReleaseCharts returns a list of all Helm charts to be released.
-func AllReleaseCharts() []string {
-	return []string{
-		TigeraOperatorChart,
-		ProjectCalicoV1CRDsChart,
-		ProjectCalicoV3CRDsChart,
-	}
 }
 
 var once sync.Once

--- a/release/internal/yamledit/yamledit.go
+++ b/release/internal/yamledit/yamledit.go
@@ -1,0 +1,205 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package yamledit replaces values in a YAML file without reformatting it.
+package yamledit
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"slices"
+	"strings"
+
+	"go.yaml.in/yaml/v3"
+)
+
+type Edit struct {
+	Key string
+
+	To string
+}
+
+func (e Edit) validate() error {
+	if e.To == "" {
+		return fmt.Errorf("no replacement value")
+	}
+	if e.Key == "" {
+		return fmt.Errorf("no key to replace")
+	}
+	return nil
+}
+
+type span struct{ start, end int }
+
+// Matching nothing is an error: a renamed key would otherwise leave the file
+// unstamped.
+func (e Edit) apply(src []byte) ([]byte, error) {
+	if err := e.validate(); err != nil {
+		return nil, err
+	}
+	spans, err := e.spans(src)
+	if err != nil {
+		return nil, err
+	}
+	if len(spans) == 0 {
+		return nil, fmt.Errorf("key %q matched nothing", e.Key)
+	}
+	var out bytes.Buffer
+	out.Grow(len(src))
+	prev := 0
+	for _, s := range spans {
+		out.Write(src[prev:s.start])
+		out.WriteString(e.To)
+		prev = s.end
+	}
+	out.Write(src[prev:])
+	return out.Bytes(), nil
+}
+
+func ApplyToFile(path string, edits ...Edit) error {
+	src, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("reading %s: %w", path, err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("reading %s: %w", path, err)
+	}
+	out := src
+	for _, e := range edits {
+		if out, err = e.apply(out); err != nil {
+			return fmt.Errorf("editing %s: %w", path, err)
+		}
+	}
+	if bytes.Equal(out, src) {
+		return nil
+	}
+	if err := os.WriteFile(path, out, info.Mode().Perm()); err != nil {
+		return fmt.Errorf("writing %s: %w", path, err)
+	}
+	return nil
+}
+
+func (e Edit) spans(src []byte) ([]span, error) {
+	var docs []*yaml.Node
+	dec := yaml.NewDecoder(bytes.NewReader(src))
+	for {
+		var doc yaml.Node
+		err := dec.Decode(&doc)
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("parsing yaml: %w", err)
+		}
+		docs = append(docs, &doc)
+	}
+	want := strings.Split(e.Key, ".")
+	var spans []span
+	var walk func(n *yaml.Node, path []string) error
+	walk = func(n *yaml.Node, path []string) error {
+		for i, child := range n.Content {
+			at := path
+			if n.Kind == yaml.MappingNode {
+				if i%2 == 0 {
+					continue
+				}
+				at = append(path, n.Content[i-1].Value)
+				if matches(at, want) && child.Kind == yaml.ScalarNode {
+					s, err := valueSpan(src, child)
+					if err != nil {
+						return err
+					}
+					spans = append(spans, s)
+				}
+			}
+			if err := walk(child, at); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	for _, doc := range docs {
+		if err := walk(doc, nil); err != nil {
+			return nil, err
+		}
+	}
+	slices.SortFunc(spans, func(a, b span) int { return a.start - b.start })
+	return spans, nil
+}
+
+func matches(at, want []string) bool {
+	if len(want) == 1 {
+		return at[len(at)-1] == want[0]
+	}
+	return slices.Equal(at, want)
+}
+
+// Reports a quoted scalar's interior, so replacing keeps the quotes.
+func valueSpan(src []byte, n *yaml.Node) (span, error) {
+	if n.Style&(yaml.LiteralStyle|yaml.FoldedStyle) != 0 {
+		return span{}, fmt.Errorf("line %d: cannot replace a block scalar", n.Line)
+	}
+	line, ok := lineSpan(src, n.Line)
+	if !ok {
+		return span{}, fmt.Errorf("line %d is outside the file", n.Line)
+	}
+	start := line.start + n.Column - 1
+	if start > line.end {
+		return span{}, fmt.Errorf("line %d: value starts past the end of its line", n.Line)
+	}
+	rest := src[start:line.end]
+	if n.Style&(yaml.SingleQuotedStyle|yaml.DoubleQuotedStyle) != 0 {
+		end := bytes.IndexByte(rest[1:], rest[0])
+		if end < 0 {
+			return span{}, fmt.Errorf("line %d: unterminated quoted value", n.Line)
+		}
+		return span{start + 1, start + 1 + end}, nil
+	}
+	if i := bytes.Index(rest, []byte(" #")); i >= 0 {
+		rest = rest[:i]
+	}
+	// Inside a flow mapping or sequence the value ends at its separator, not
+	// at the end of the line.
+	if i := bytes.IndexAny(rest, ",}]"); i >= 0 {
+		rest = rest[:i]
+	}
+	rest = bytes.TrimRight(rest, " \t")
+	if len(rest) == 0 {
+		return span{}, fmt.Errorf("line %d: no value to replace", n.Line)
+	}
+	return span{start, start + len(rest)}, nil
+}
+
+func lineSpan(src []byte, line int) (span, bool) {
+	if line < 1 {
+		return span{}, false
+	}
+	start := 0
+	for ; line > 1; line-- {
+		i := bytes.IndexByte(src[start:], '\n')
+		if i < 0 {
+			return span{}, false
+		}
+		start += i + 1
+	}
+	end := len(src)
+	if i := bytes.IndexByte(src[start:], '\n'); i >= 0 {
+		end = start + i
+	}
+	return span{start, end}, true
+}

--- a/release/internal/yamledit/yamledit_test.go
+++ b/release/internal/yamledit/yamledit_test.go
@@ -1,0 +1,288 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package yamledit
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Every shape the editor has to survive, in one file.
+const fixture = `# a heading comment
+apiVersion: v2
+
+tigeraOperator:
+  image: calico/operator
+  version: master # keep this comment
+  registry: quay.io
+
+calicoctl:
+  image: quay.io/calico/calico
+  tag: "master"
+
+# version: commented out
+notes: |
+  version: in a block scalar
+empty:
+`
+
+func TestApplyPreservesEverythingElse(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		edit Edit
+		want string
+	}{
+		{
+			name: "key matched whole, not as a suffix",
+			edit: Edit{Key: "version", To: "v3.30.0"},
+			want: strings.NewReplacer(
+				"  version: master # keep this comment", "  version: v3.30.0 # keep this comment",
+			).Replace(fixture),
+		},
+		{
+			name: "every depth the key appears at",
+			edit: Edit{Key: "image", To: "x"},
+			want: strings.NewReplacer(
+				"  image: calico/operator", "  image: x",
+				"  image: quay.io/calico/calico", "  image: x",
+			).Replace(fixture),
+		},
+		{
+			name: "quotes survive",
+			edit: Edit{Key: "tag", To: "v3.30.0"},
+			want: strings.Replace(fixture, `  tag: "master"`, `  tag: "v3.30.0"`, 1),
+		},
+		{
+			name: "a path pins one of two matching keys",
+			edit: Edit{Key: "tigeraOperator.image", To: "x"},
+			want: strings.Replace(fixture, "  image: calico/operator", "  image: x", 1),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := tc.edit.apply([]byte(fixture))
+			if err != nil {
+				t.Fatalf("Apply: %v", err)
+			}
+			if string(got) != tc.want {
+				t.Errorf("Apply produced:\n%s\nwant:\n%s", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestApplyDoesNotMatchALongerKey(t *testing.T) {
+	got, err := Edit{Key: "version", To: "v3.30.0"}.apply([]byte(fixture))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(got), "apiVersion: v2") {
+		t.Error("apiVersion was rewritten")
+	}
+}
+
+func TestApplyLeavesCommentsAndBlockScalars(t *testing.T) {
+	got, err := Edit{Key: "version", To: "v3.30.0"}.apply([]byte(fixture))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"# version: commented out", "  version: in a block scalar"} {
+		if !strings.Contains(string(got), want) {
+			t.Errorf("expected %q to survive", want)
+		}
+	}
+}
+
+func TestApplyWritesSpecialCharactersVerbatim(t *testing.T) {
+	const to = `a~b&c/d.e`
+	got, err := Edit{Key: "registry", To: to}.apply([]byte(fixture))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(got), "  registry: "+to) {
+		t.Errorf("expected %q written verbatim, got:\n%s", to, got)
+	}
+}
+
+func TestApplyRejectsIncompleteEdits(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		edit Edit
+	}{
+		{"no replacement", Edit{Key: "version"}},
+		{"no key", Edit{To: "x"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := tc.edit.apply([]byte(fixture)); err == nil {
+				t.Error("expected an incomplete edit to be rejected")
+			}
+		})
+	}
+}
+
+func TestApplyRejectsMalformedYAML(t *testing.T) {
+	if _, err := (Edit{Key: "version", To: "x"}).apply([]byte("a:\n\tb: 1\n")); err == nil {
+		t.Error("expected a parse failure")
+	}
+}
+
+func TestApplyRefusesToReplaceABlockScalar(t *testing.T) {
+	if _, err := (Edit{Key: "notes", To: "x"}).apply([]byte(fixture)); err == nil {
+		t.Error("expected a block scalar to be refused")
+	}
+}
+
+func TestApplyToFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "values.yaml")
+	if err := os.WriteFile(path, []byte(fixture), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := ApplyToFile(path, Edit{Key: "version", To: "v3.30.0"}, Edit{Key: "tag", To: "v3.30.0"}); err != nil {
+		t.Fatalf("ApplyToFile: %v", err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(got), "  version: v3.30.0 # keep this comment") {
+		t.Error("first edit did not land")
+	}
+	if !strings.Contains(string(got), `  tag: "v3.30.0"`) {
+		t.Error("second edit did not land")
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Errorf("mode = %v, want 0600", got)
+	}
+}
+
+func TestApplyToFileRejectsAnEditThatMatchesNothing(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "values.yaml")
+	if err := os.WriteFile(path, []byte(fixture), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	err := ApplyToFile(path, Edit{Key: "renamed", To: "x"})
+	if err == nil {
+		t.Fatal("expected an edit matching nothing to fail")
+	}
+	if !strings.Contains(err.Error(), "renamed") {
+		t.Errorf("error does not name the key: %v", err)
+	}
+	got, readErr := os.ReadFile(path)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if string(got) != fixture {
+		t.Error("the file was modified by a failed edit")
+	}
+}
+
+func TestApplyScopesToADottedPath(t *testing.T) {
+	got, err := Edit{Key: "tigeraOperator.image", To: "x"}.apply([]byte(fixture))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(got), "  image: x") {
+		t.Error("expected tigeraOperator.image replaced")
+	}
+	if !strings.Contains(string(got), "  image: quay.io/calico/calico") {
+		t.Error("expected calicoctl.image left alone")
+	}
+}
+
+func TestApplyBareKeyMatchesEveryDepth(t *testing.T) {
+	got, err := Edit{Key: "image", To: "x"}.apply([]byte(fixture))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(got), "calico/operator") || strings.Contains(string(got), "quay.io/calico/calico") {
+		t.Errorf("a matching key was left behind:\n%s", got)
+	}
+}
+
+func TestApplyKeyIsNotASubstring(t *testing.T) {
+	if _, err := (Edit{Key: "Version", To: "x"}).apply([]byte(fixture)); err == nil {
+		t.Error("expected no match: a key must not match inside a longer key")
+	}
+}
+
+func TestApplyMatchesEveryKeyInOneMapping(t *testing.T) {
+	const src = `spec:
+  tag: master
+  other: keep
+`
+	got, err := Edit{Key: "tag", To: "x"}.apply([]byte(src))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(got), "  other: keep") {
+		t.Error("expected the untargeted key untouched")
+	}
+}
+
+// A duplicate key is legal YAML and both copies are values.
+func TestApplyMatchesADuplicatedKey(t *testing.T) {
+	got, err := Edit{Key: "tag", To: "x"}.apply([]byte("spec:\n  tag: one\n  tag: two\n"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := "spec:\n  tag: x\n  tag: x\n"; string(got) != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestApplyMatchesAcrossSiblingMappings(t *testing.T) {
+	const src = `first:
+  tag: master
+second:
+  tag: master
+third:
+  tag: master
+`
+	got, err := Edit{Key: "tag", To: "x"}.apply([]byte(src))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(got), "master") {
+		t.Errorf("a sibling was left behind:\n%s", got)
+	}
+}
+
+// A flow mapping keeps more than the value on its line, so the span must stop
+// at the value rather than run to the end.
+func TestApplyInAFlowMapping(t *testing.T) {
+	got, err := Edit{Key: "tag", To: "X"}.apply([]byte("spec: {tag: a, other: b}\n"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := "spec: {tag: X, other: b}\n"; string(got) != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// Every document is edited, not just the first.
+func TestApplyAcrossDocuments(t *testing.T) {
+	got, err := Edit{Key: "tag", To: "X"}.apply([]byte("tag: a\n---\ntag: b\n"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := "tag: X\n---\ntag: X\n"; string(got) != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}

--- a/release/pkg/manager/calico/manager.go
+++ b/release/pkg/manager/calico/manager.go
@@ -37,6 +37,7 @@ import (
 	"github.com/projectcalico/calico/release/internal/imagescanner"
 	"github.com/projectcalico/calico/release/internal/outputs"
 	"github.com/projectcalico/calico/release/internal/registry"
+	"github.com/projectcalico/calico/release/internal/steps"
 	"github.com/projectcalico/calico/release/internal/utils"
 	"github.com/projectcalico/calico/release/internal/version"
 	"github.com/projectcalico/calico/release/pkg/manager/operator"
@@ -158,7 +159,7 @@ type CalicoManager struct {
 	// directories. Empty means all of them.
 	imageReleaseDirs []string
 
-	resolveDigest images.DigestResolver
+	resolveDigest steps.DigestResolver
 
 	// outputDir is the directory to which we should write release artifacts, and from
 	// which we should read them for publishing.
@@ -1524,7 +1525,7 @@ func (r *CalicoManager) publishContainerImages() error {
 
 // digestResolver reports a published tag's digest, defaulting to the registry.
 // Tests substitute one so they never reach the network.
-func (r *CalicoManager) digestResolver() images.DigestResolver {
+func (r *CalicoManager) digestResolver() steps.DigestResolver {
 	if r.resolveDigest != nil {
 		return r.resolveDigest
 	}

--- a/release/pkg/manager/calico/manager.go
+++ b/release/pkg/manager/calico/manager.go
@@ -33,7 +33,6 @@ import (
 	"github.com/projectcalico/calico/release/internal/branch"
 	"github.com/projectcalico/calico/release/internal/charts"
 	"github.com/projectcalico/calico/release/internal/command"
-	"github.com/projectcalico/calico/release/internal/github"
 	"github.com/projectcalico/calico/release/internal/hashreleaseserver"
 	"github.com/projectcalico/calico/release/internal/images"
 	"github.com/projectcalico/calico/release/internal/imagescanner"
@@ -89,7 +88,6 @@ func NewManager(opts ...Option) *CalicoManager {
 		githubRelease:    true,
 		imageRegistries:  defaultRegistries,
 		helmRegistries:   registry.DefaultHelmRegistries,
-		helmRepoURL:      charts.RepoURL(),
 		operatorRegistry: operator.DefaultRegistries[0],
 		operatorImage:    operator.DefaultImage,
 	}
@@ -151,6 +149,9 @@ type CalicoManager struct {
 
 	// calicoVersion is the version of calico to release.
 	calicoVersion string
+
+	// chartVersion is the version of the helm chart to build.
+	chartVersion string
 
 	// operator variables
 	operatorImage    string
@@ -253,11 +254,6 @@ func releaseImages(images []string, version, registry, operatorImage, operatorVe
 		imgList = append(imgList, fmt.Sprintf("%s/%s:%s", registry, img, version))
 	}
 	return imgList
-}
-
-func (r *CalicoManager) helmChartVersion() string {
-	c := r.chart()
-	return c.Version()
 }
 
 func (r *CalicoManager) PreBuildValidation() error {
@@ -416,7 +412,7 @@ func (r *CalicoManager) BuildMetadata(dir string) error {
 		Version:          r.calicoVersion,
 		OperatorVersion:  r.operatorVersion,
 		Images:           releaseImages(imgs, r.calicoVersion, registry, r.operatorImage, r.operatorVersion, r.operatorRegistry),
-		HelmChartVersion: r.helmChartVersion(),
+		HelmChartVersion: r.chart().Version(),
 	}
 
 	// Render it as yaml and write it to a file.
@@ -605,18 +601,29 @@ func (r *CalicoManager) BuildHelm() error {
 		logrus.Info("Skipping building helm chart and index")
 		return nil
 	}
+	chart := r.chart()
 	opts := []charts.BuildOption{charts.WithRunner(r.runner)}
 	if r.helmIndex {
-		chartURL, err := r.chartURL()
-		if err != nil {
-			return err
+		var chartsURL, repoURL string
+		var err error
+		if r.isHashRelease {
+			chartsURL = r.hashrelease.URL()
+		} else {
+			chartsURL, err = charts.ChartsURL(chart)
+			if err != nil {
+				return fmt.Errorf("charts URL: %w", err)
+			}
 		}
-		opts = append(opts, charts.WithIndex(r.helmRepoURL, chartURL, r.chartIndexDir(), r.tmpDir))
+		repoURL, err = r.helmRepo()
+		if err != nil {
+			return fmt.Errorf("helm repo URL: %w", err)
+		}
+		opts = append(opts, charts.WithIndex(repoURL, chartsURL, r.chartIndexDir(), r.tmpDir))
 	}
 	if r.isHashRelease {
-		opts = append(opts, charts.WithModifiedValues(charts.ValueEditsFor(r.calicoVersion, r.operatorVersion)))
+		opts = append(opts, charts.WithModifiedValues(charts.ValueEditsFor(r.calicoVersion, r.imageRegistries[0], r.operatorImage, r.operatorVersion, r.operatorRegistry)))
 	}
-	return charts.Build(r.chart(), opts...)
+	return charts.Build(chart, opts...)
 }
 
 // chart identifies this release's charts to the charts package.
@@ -624,8 +631,9 @@ func (r *CalicoManager) chart() charts.Chart {
 	return charts.Chart{
 		RepoRoot:       r.repoRoot,
 		ProductVersion: r.calicoVersion,
+		ChartVersion:   r.chartVersion,
 		Names:          charts.All(),
-		BaseDir:        r.uploadDir(),
+		BaseDir:        charts.Dir(r.uploadDir()),
 	}
 }
 
@@ -633,27 +641,21 @@ func (r *CalicoManager) chart() charts.Chart {
 func (r *CalicoManager) modifyHelmChartsValues() error {
 	return charts.ModifyValues(charts.Values{
 		RepoRoot: r.repoRoot,
-		Edits:    charts.ValueEditsFor(r.calicoVersion, r.operatorVersion),
+		Edits:    charts.ValueEditsFor(r.calicoVersion, r.imageRegistries[0], r.operatorImage, r.operatorVersion, r.operatorRegistry),
 	}, charts.WithRunner(r.runner))
 }
 
-// chartURL is where the built index sends clients to download the charts.
-func (r *CalicoManager) chartURL() (string, error) {
-	if r.isHashRelease {
-		return r.hashrelease.URL(), nil
+// helmRepo is the repository whose index a build merges with.
+func (r *CalicoManager) helmRepo() (string, error) {
+	if r.helmRepoURL != "" {
+		return r.helmRepoURL, nil
 	}
-	return github.DownloadURL(r.githubOrg, r.repo, r.calicoVersion)
+	return charts.RepoURL()
 }
 
 // chartIndexDir is where the built index lands.
 func (r *CalicoManager) chartIndexDir() string {
-	var ver string
-	outDir := r.uploadDir()
-	if !r.isHashRelease {
-		outDir = filepath.Dir(outDir)
-		ver = r.helmChartVersion()
-	}
-	return charts.Dir(outDir, ver)
+	return charts.Dir(r.uploadDir())
 }
 
 func (r *CalicoManager) buildOCPBundle() error {
@@ -1560,8 +1562,27 @@ func (r *CalicoManager) publishHelmCharts() error {
 		logrus.Info("Skipping publishing helm charts")
 		return nil
 	}
-	// The manager reaches this only on a real publish run.
-	return charts.Publish(r.chart(), r.helmRegistries, !r.dryRun, charts.WithRunner(r.runner))
+	chart := r.chart()
+	refs, err := outputs.NewRefsWriter(r.outputDir, charts.PublishStep, chart.Version())
+	if err != nil {
+		return fmt.Errorf("chart publish refs writer: %w", err)
+	}
+	// An earlier run of this version records what it published, so a resume
+	// skips the charts already done.
+	published, err := outputs.ReadRefs(r.outputDir, charts.PublishStep, chart.Version())
+	if err != nil {
+		return fmt.Errorf("read published chart refs: %w", err)
+	}
+	opts := []charts.PublishOption{
+		charts.WithRunner(r.runner),
+		charts.WithLogsDir(r.logsDir),
+		charts.WithResolver(r.digestResolver()),
+		charts.WithRecord(refs),
+	}
+	if len(published) > 0 {
+		opts = append(opts, charts.WithResume(published, false))
+	}
+	return charts.Publish(chart, r.helmRegistries, !r.dryRun, opts...)
 }
 
 func (r *CalicoManager) updateHelmChartIndex() error {

--- a/release/pkg/manager/calico/manager.go
+++ b/release/pkg/manager/calico/manager.go
@@ -31,7 +31,9 @@ import (
 	"go.yaml.in/yaml/v3"
 
 	"github.com/projectcalico/calico/release/internal/branch"
+	"github.com/projectcalico/calico/release/internal/charts"
 	"github.com/projectcalico/calico/release/internal/command"
+	"github.com/projectcalico/calico/release/internal/github"
 	"github.com/projectcalico/calico/release/internal/hashreleaseserver"
 	"github.com/projectcalico/calico/release/internal/images"
 	"github.com/projectcalico/calico/release/internal/imagescanner"
@@ -87,7 +89,7 @@ func NewManager(opts ...Option) *CalicoManager {
 		githubRelease:    true,
 		imageRegistries:  defaultRegistries,
 		helmRegistries:   registry.DefaultHelmRegistries,
-		helmRepoURL:      utils.CalicoHelmRepoURL,
+		helmRepoURL:      charts.RepoURL(),
 		operatorRegistry: operator.DefaultRegistries[0],
 		operatorImage:    operator.DefaultImage,
 	}
@@ -254,7 +256,8 @@ func releaseImages(images []string, version, registry, operatorImage, operatorVe
 }
 
 func (r *CalicoManager) helmChartVersion() string {
-	return r.calicoVersion
+	c := r.chart()
+	return c.Version()
 }
 
 func (r *CalicoManager) PreBuildValidation() error {
@@ -597,142 +600,60 @@ func (r *CalicoManager) tagState() *tagCheck {
 	return tc
 }
 
-// modifyHelmChartsValues modifies values in helm charts to use the correct version.
-// This is only necessary for hashreleases or new branch cut.
-func (r *CalicoManager) modifyHelmChartsValues() error {
-	if err := r.modifyOperatorChartValues(); err != nil {
-		return err
-	}
-	if err := r.modifyCalicoChartsValues(); err != nil {
-		return err
-	}
-	return nil
-}
-
-func (r *CalicoManager) modifyOperatorChartValues() error {
-	operatorChartFilePath := filepath.Join(r.repoRoot, "charts", "tigera-operator", "values.yaml")
-	if _, err := r.runner.Run("sed", []string{"-i", fmt.Sprintf(`s/version: .*/version: %s/g`, r.operatorVersion), operatorChartFilePath}, nil); err != nil {
-		logrus.WithError(err).Errorf("Failed to update operator version in %s", operatorChartFilePath)
-		return fmt.Errorf("failed to update operator version in %s: %w", operatorChartFilePath, err)
-	}
-	if _, err := r.runner.Run("sed", []string{"-i", fmt.Sprintf(`s/tag: .*/tag: %s/g`, r.calicoVersion), operatorChartFilePath}, nil); err != nil {
-		logrus.WithError(err).Errorf("Failed to update calicoctl version in %s", operatorChartFilePath)
-		return fmt.Errorf("failed to update calicoctl version in %s: %w", operatorChartFilePath, err)
-	}
-	return nil
-}
-
-func (r *CalicoManager) modifyCalicoChartsValues() error {
-	calicoChartFilePath := filepath.Join(r.repoRoot, "charts", "calico", "values.yaml")
-	if out, err := r.runner.Run("sed", []string{"-i", fmt.Sprintf(`s/version: .*/version: %s/g`, r.calicoVersion), calicoChartFilePath}, nil); err != nil {
-		logrus.Error(out)
-		return fmt.Errorf("failed to update version in %s: %w", calicoChartFilePath, err)
-	}
-	return nil
-}
-
-func (r *CalicoManager) resetCharts() {
-	if _, err := r.runner.RunInDir(r.repoRoot, "git", []string{"checkout", "charts/"}, nil); err != nil {
-		logrus.WithError(err).Error("Failed to reset changes to charts")
-	}
-}
-
 func (r *CalicoManager) BuildHelm() error {
 	if !r.helmCharts {
 		logrus.Info("Skipping building helm chart and index")
 		return nil
 	}
-	if r.isHashRelease {
-		if err := r.modifyHelmChartsValues(); err != nil {
-			return fmt.Errorf("failed to modify helm chart values: %s", err)
+	opts := []charts.BuildOption{charts.WithRunner(r.runner)}
+	if r.helmIndex {
+		chartURL, err := r.chartURL()
+		if err != nil {
+			return err
 		}
-		defer r.resetCharts()
+		opts = append(opts, charts.WithIndex(r.helmRepoURL, chartURL, r.chartIndexDir(), r.tmpDir))
 	}
-
-	// Build the helm chart, passing the version to use.
-	env := append(os.Environ(),
-		fmt.Sprintf("GIT_VERSION=%s", r.calicoVersion),
-		fmt.Sprintf("CHART_DESTINATION=%s", r.uploadDir()),
-	)
-	if err := r.makeInDirectoryIgnoreOutput(r.repoRoot, "chart", env...); err != nil {
-		return fmt.Errorf("failed to build helm chart: %w", err)
-	}
-	if !r.helmIndex {
-		logrus.Info("Skipping building helm index")
-		return nil
-	}
-	chartURL := fmt.Sprintf("https://github.com/%s/%s/releases/download/%s", r.githubOrg, r.repo, r.calicoVersion)
 	if r.isHashRelease {
-		chartURL = r.hashrelease.URL()
+		opts = append(opts, charts.WithModifiedValues(charts.ValueEditsFor(r.calicoVersion, r.operatorVersion)))
 	}
-	if err := r.buildHelmIndex(r.uploadDir(), chartURL); err != nil {
-		return err
-	}
-	return nil
+	return charts.Build(r.chart(), opts...)
 }
 
-// buildHelmIndex builds the helm index for the given charts directory.
-// It downloads the existing helm index, merges in the new chart to create an updated index.
-//
-// For hashreleases, it copies the helm index to charts/ in the upload directory.
-func (r *CalicoManager) buildHelmIndex(chartDir, chartURL string) error {
-	// Download existing helm index.
-	indexURL, err := url.JoinPath(r.helmRepoURL, helmIndexFileName)
-	if err != nil {
-		return fmt.Errorf("construct helm index url: %w", err)
+// chart identifies this release's charts to the charts package.
+func (r *CalicoManager) chart() charts.Chart {
+	return charts.Chart{
+		RepoRoot:       r.repoRoot,
+		ProductVersion: r.calicoVersion,
+		Names:          charts.All(),
+		BaseDir:        r.uploadDir(),
 	}
-	downloadedHelmIndexPath := filepath.Join(r.tmpDir, helmIndexFileName)
-	if out, err := r.runner.Run("curl", []string{"-fsSL", "--retry", "3", indexURL, "-o", downloadedHelmIndexPath}, nil); err != nil {
-		logrus.Error(out)
-		return fmt.Errorf("download previous helm index from %s: %w", indexURL, err)
-	}
+}
 
-	// Create tmp directory for building index and hard-link charts there.
-	tmpChartsDir := filepath.Join(filepath.Dir(r.uploadDir()), fmt.Sprintf("charts-%s", r.helmChartVersion()))
-	if err := os.MkdirAll(tmpChartsDir, utils.DirPerms); err != nil {
-		return fmt.Errorf("create temp dir for building helm index: %w", err)
-	}
-	defer func() {
-		if err := os.RemoveAll(tmpChartsDir); err != nil {
-			logrus.WithError(err).Warnf("failed to remove helm index staging dir %s", tmpChartsDir)
-		}
-	}()
+// modifyHelmChartsValues rewrites the chart values in the tree.
+func (r *CalicoManager) modifyHelmChartsValues() error {
+	return charts.ModifyValues(charts.Values{
+		RepoRoot: r.repoRoot,
+		Edits:    charts.ValueEditsFor(r.calicoVersion, r.operatorVersion),
+	}, charts.WithRunner(r.runner))
+}
 
-	for _, chart := range utils.AllReleaseCharts() {
-		srcChart := filepath.Join(chartDir, fmt.Sprintf("%s-%s.tgz", chart, r.helmChartVersion()))
-		destChart := filepath.Join(tmpChartsDir, fmt.Sprintf("%s-%s.tgz", chart, r.helmChartVersion()))
-		if err := os.Link(srcChart, destChart); err != nil {
-			return fmt.Errorf("linking %s chart to temp dir for building helm index: %w", chart, err)
-		}
-	}
-
-	// Build the new helm index.
-	args := []string{
-		"repo", "index", tmpChartsDir,
-		"--url", chartURL,
-		"--merge", downloadedHelmIndexPath,
-	}
-	env := append(os.Environ(), "TZ=UTC")
-	if out, err := r.runner.RunInDir(r.repoRoot, "./bin/helm", args, env); err != nil {
-		logrus.Error(out)
-		return fmt.Errorf("build helm index: %w", err)
-	}
-
+// chartURL is where the built index sends clients to download the charts.
+func (r *CalicoManager) chartURL() (string, error) {
 	if r.isHashRelease {
-		// For hashreleases, copy the helm index to the upload dir.
-		srcIndex := filepath.Join(tmpChartsDir, helmIndexFileName)
-		destIndex := filepath.Join(r.uploadDir(), "charts", helmIndexFileName)
-
-		// Ensure destination directory exists.
-		if err := os.MkdirAll(filepath.Dir(destIndex), utils.DirPerms); err != nil {
-			return fmt.Errorf("create dest dir for helm index: %w", err)
-		}
-		if err := utils.CopyFile(srcIndex, destIndex); err != nil {
-			return fmt.Errorf("copy helm index to upload dir: %w", err)
-		}
-		return nil
+		return r.hashrelease.URL(), nil
 	}
-	return nil
+	return github.DownloadURL(r.githubOrg, r.repo, r.calicoVersion)
+}
+
+// chartIndexDir is where the built index lands.
+func (r *CalicoManager) chartIndexDir() string {
+	var ver string
+	outDir := r.uploadDir()
+	if !r.isHashRelease {
+		outDir = filepath.Dir(outDir)
+		ver = r.helmChartVersion()
+	}
+	return charts.Dir(outDir, ver)
 }
 
 func (r *CalicoManager) buildOCPBundle() error {
@@ -1430,9 +1351,9 @@ Additional links:
 		"{release_stream}", fmt.Sprintf("v%d.%d", sv.Major(), sv.Minor()),
 		"{release_tar}", fmt.Sprintf("`release-%s.tgz`", r.calicoVersion),
 		"{calico_windows_zip}", fmt.Sprintf("`calico-windows-%s.zip`", r.calicoVersion),
-		"{helm_chart}", fmt.Sprintf("`%s-%s.tgz`", utils.TigeraOperatorChart, r.calicoVersion),
-		"{helm_v1_crd_chart}", fmt.Sprintf("`%s-%s.tgz`", utils.ProjectCalicoV1CRDsChart, r.calicoVersion),
-		"{helm_v3_crd_chart}", fmt.Sprintf("`%s-%s.tgz`", utils.ProjectCalicoV3CRDsChart, r.calicoVersion),
+		"{helm_chart}", fmt.Sprintf("`%s-%s.tgz`", charts.TigeraOperatorChart, r.calicoVersion),
+		"{helm_v1_crd_chart}", fmt.Sprintf("`%s-%s.tgz`", charts.ProjectCalicoV1CRDsChart, r.calicoVersion),
+		"{helm_v3_crd_chart}", fmt.Sprintf("`%s-%s.tgz`", charts.ProjectCalicoV3CRDsChart, r.calicoVersion),
 	}
 	replacer := strings.NewReplacer(formatters...)
 	releaseNote := replacer.Replace(releaseNoteTemplate)
@@ -1625,38 +1546,8 @@ func (r *CalicoManager) publishHelmCharts() error {
 		logrus.Info("Skipping publishing helm charts")
 		return nil
 	}
-	for _, reg := range r.helmRegistries {
-		for _, chart := range utils.AllReleaseCharts() {
-			if err := r.publishHelmChart(filepath.Join(r.uploadDir(), fmt.Sprintf("%s-%s.tgz", chart, r.helmChartVersion())), reg); err != nil {
-				return err
-			}
-		}
-	}
-	return nil
-}
-
-func (r *CalicoManager) publishHelmChart(chart, registry string) error {
-	// We allow for a certain number of retries when publishing each chart to a registry, since
-	// network flakes can occasionally result in images failing to push.
-	maxRetries := 1
-	attempt := 0
-	args := []string{"push", chart, fmt.Sprintf("oci://%s", registry)}
-	if logrus.IsLevelEnabled(logrus.DebugLevel) {
-		args = append(args, "--debug")
-	}
-	for {
-		_, err := r.runner.RunInDir(r.repoRoot, "./bin/helm", args, nil)
-		if err != nil {
-			if attempt < maxRetries {
-				logrus.WithField("attempt", attempt).WithError(err).Warn("Publish failed, retrying")
-				attempt++
-				continue
-			}
-			return fmt.Errorf("publish %s to %s: %s", chart, registry, err)
-		}
-		break
-	}
-	return nil
+	// The manager reaches this only on a real publish run.
+	return charts.Publish(r.chart(), r.helmRegistries, !r.dryRun, charts.WithRunner(r.runner))
 }
 
 func (r *CalicoManager) updateHelmChartIndex() error {
@@ -1668,7 +1559,7 @@ func (r *CalicoManager) updateHelmChartIndex() error {
 		logrus.Info("Skipping updating helm index")
 		return nil
 	}
-	if err := r.s3Cp(filepath.Join(filepath.Dir(r.uploadDir()), fmt.Sprintf("charts-%s", r.helmChartVersion()), helmIndexFileName), fmt.Sprintf("s3://%s/charts/", r.s3Bucket), s3ACLPublicRead...); err != nil {
+	if err := r.s3Cp(filepath.Join(r.chartIndexDir(), helmIndexFileName), fmt.Sprintf("s3://%s/charts/", r.s3Bucket), s3ACLPublicRead...); err != nil {
 		return fmt.Errorf("update helm index: %w", err)
 	}
 	return nil

--- a/release/pkg/manager/calico/manager.go
+++ b/release/pkg/manager/calico/manager.go
@@ -618,7 +618,7 @@ func (r *CalicoManager) BuildHelm() error {
 		if err != nil {
 			return fmt.Errorf("helm repo URL: %w", err)
 		}
-		opts = append(opts, charts.WithIndex(repoURL, chartsURL, r.chartIndexDir(), r.tmpDir))
+		opts = append(opts, charts.WithIndex(repoURL, chartsURL, chart.BaseDir, r.tmpDir))
 	}
 	if r.isHashRelease {
 		opts = append(opts, charts.WithModifiedValues(charts.ValueEditsFor(r.calicoVersion, r.imageRegistries[0], r.operatorImage, r.operatorVersion, r.operatorRegistry)))
@@ -651,11 +651,6 @@ func (r *CalicoManager) helmRepo() (string, error) {
 		return r.helmRepoURL, nil
 	}
 	return charts.RepoURL()
-}
-
-// chartIndexDir is where the built index lands.
-func (r *CalicoManager) chartIndexDir() string {
-	return charts.Dir(r.uploadDir())
 }
 
 func (r *CalicoManager) buildOCPBundle() error {
@@ -1594,7 +1589,7 @@ func (r *CalicoManager) updateHelmChartIndex() error {
 		logrus.Info("Skipping updating helm index")
 		return nil
 	}
-	if err := r.s3Cp(filepath.Join(r.chartIndexDir(), helmIndexFileName), fmt.Sprintf("s3://%s/charts/", r.s3Bucket), s3ACLPublicRead...); err != nil {
+	if err := r.s3Cp(filepath.Join(r.chart().BaseDir, helmIndexFileName), fmt.Sprintf("s3://%s/charts/", r.s3Bucket), s3ACLPublicRead...); err != nil {
 		return fmt.Errorf("update helm index: %w", err)
 	}
 	return nil

--- a/release/pkg/manager/calico/manager_test.go
+++ b/release/pkg/manager/calico/manager_test.go
@@ -973,3 +973,12 @@ func TestBuildE2EBinariesUsesARCHES(t *testing.T) {
 			"e2e build-all should not set VALIDARCHES (lib.Makefile ignores it): %s", e)
 	}
 }
+
+func TestChartIndexDirMatchesUpload(t *testing.T) {
+	out := t.TempDir()
+	r := &CalicoManager{outputDir: filepath.Join(out, "upload", "v3.30.0"), calicoVersion: "v3.30.0"}
+	want := filepath.Join(out, "upload", "charts-v3.30.0")
+	if got := r.chartIndexDir(); got != want {
+		t.Errorf("chartIndexDir() = %q, want %q", got, want)
+	}
+}

--- a/release/pkg/manager/calico/manager_test.go
+++ b/release/pkg/manager/calico/manager_test.go
@@ -26,8 +26,10 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/projectcalico/calico/release/internal/charts"
 	"github.com/projectcalico/calico/release/internal/command"
 	"github.com/projectcalico/calico/release/internal/images"
+	"github.com/projectcalico/calico/release/internal/outputs"
 	"github.com/projectcalico/calico/release/pkg/manager/operator"
 )
 
@@ -976,10 +978,21 @@ func TestBuildE2EBinariesUsesARCHES(t *testing.T) {
 
 func TestChartIndexDirMatchesUpload(t *testing.T) {
 	out := t.TempDir()
-	r := &CalicoManager{outputDir: filepath.Join(out, "upload", "v3.30.0"), calicoVersion: "v3.30.0"}
-	want := filepath.Join(out, "upload", "charts-v3.30.0")
-	if got := r.chartIndexDir(); got != want {
-		t.Errorf("chartIndexDir() = %q, want %q", got, want)
+	for _, tt := range []struct {
+		name        string
+		hashrelease bool
+	}{
+		{name: "release"},
+		{name: "hashrelease", hashrelease: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := filepath.Join(out, "release", "v3.30.0")
+			r := &CalicoManager{outputDir: dir, calicoVersion: "v3.30.0", isHashRelease: tt.hashrelease}
+			want := filepath.Join(dir, "charts")
+			if got := r.chartIndexDir(); got != want {
+				t.Errorf("chartIndexDir() = %q, want %q", got, want)
+			}
+		})
 	}
 }
 
@@ -1011,5 +1024,42 @@ func TestAssertOperatorImageVersion(t *testing.T) {
 			require.Len(t, f.calls, 1)
 			require.Contains(t, f.calls[0], "quay.io/tigera/operator:"+version)
 		})
+	}
+}
+
+// A release publish records what it pushed, so an interrupted run resumes on
+// what is left rather than re-pushing.
+func TestPublishHelmChartsRecordsWhatItPushed(t *testing.T) {
+	out := t.TempDir()
+	f := newFakeRunner()
+	r := &CalicoManager{
+		runner:         f,
+		repoRoot:       "/repo",
+		calicoVersion:  "v3.30.0",
+		outputDir:      filepath.Join(out, "release", "v3.30.0"),
+		helmCharts:     true,
+		helmRegistries: []string{"quay.test/charts"},
+		resolveDigest:  func(string) (string, bool, error) { return "sha256:aaa", true, nil },
+	}
+	for _, name := range charts.All() {
+		path := filepath.Join(r.chart().BaseDir, charts.FileName(name, "v3.30.0"))
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte("chart"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if err := r.publishHelmCharts(); err != nil {
+		t.Fatalf("publishHelmCharts: %v", err)
+	}
+
+	refs, err := outputs.ReadRefs(r.outputDir, charts.PublishStep, "v3.30.0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != len(charts.All()) {
+		t.Errorf("recorded %d refs, want %d", len(refs), len(charts.All()))
 	}
 }

--- a/release/pkg/manager/calico/manager_test.go
+++ b/release/pkg/manager/calico/manager_test.go
@@ -976,7 +976,7 @@ func TestBuildE2EBinariesUsesARCHES(t *testing.T) {
 	}
 }
 
-func TestChartIndexDirMatchesUpload(t *testing.T) {
+func TestChartsAndIndexShareADirectory(t *testing.T) {
 	out := t.TempDir()
 	for _, tt := range []struct {
 		name        string
@@ -989,8 +989,8 @@ func TestChartIndexDirMatchesUpload(t *testing.T) {
 			dir := filepath.Join(out, "release", "v3.30.0")
 			r := &CalicoManager{outputDir: dir, calicoVersion: "v3.30.0", isHashRelease: tt.hashrelease}
 			want := filepath.Join(dir, "charts")
-			if got := r.chartIndexDir(); got != want {
-				t.Errorf("chartIndexDir() = %q, want %q", got, want)
+			if got := r.chart().BaseDir; got != want {
+				t.Errorf("chart().BaseDir = %q, want %q", got, want)
 			}
 		})
 	}

--- a/release/pkg/postrelease/github_test.go
+++ b/release/pkg/postrelease/github_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/go-github/v53/github"
 
+	"github.com/projectcalico/calico/release/internal/charts"
 	"github.com/projectcalico/calico/release/internal/outputs"
 	"github.com/projectcalico/calico/release/internal/utils"
 	"github.com/projectcalico/calico/release/internal/version"
@@ -60,11 +61,13 @@ func TestGitHubRelease(t *testing.T) {
 			"install-calico-windows.ps1",
 			fmt.Sprintf("calico-windows-%s.zip", releaseVersion),
 			fmt.Sprintf("release-%s.tgz", releaseVersion),
-			fmt.Sprintf("tigera-operator-%s.tgz", releaseVersion),
 			"SHA256SUMS",
 			"ocp.tgz",
 			"LICENSE",
 		)
+		for _, name := range charts.All() {
+			expectedAssets = append(expectedAssets, charts.FileName(name, releaseVersion))
+		}
 		actualAssets := getAssets(release)
 		if diff := cmp.Diff(expectedAssets, actualAssets, cmpopts.SortSlices(func(a, b string) bool { return a < b })); diff != "" {
 			t.Errorf("release assets mismatch (-expected +actual):\n%s", diff)

--- a/release/pkg/postrelease/helm_test.go
+++ b/release/pkg/postrelease/helm_test.go
@@ -13,15 +13,20 @@ import (
 	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/chart/loader"
 
+	"github.com/projectcalico/calico/release/internal/charts"
 	"github.com/projectcalico/calico/release/internal/command"
+	"github.com/projectcalico/calico/release/internal/github"
 	"github.com/projectcalico/calico/release/internal/registry"
-	"github.com/projectcalico/calico/release/internal/utils"
 )
 
-func chartURLs(githubOrg, githubRepo, version string) []string {
+func chartURLs(t testing.TB, githubOrg, githubRepo, version string) []string {
+	t.Helper()
 	urls := []string{}
-	for _, chart := range utils.AllReleaseCharts() {
-		u := fmt.Sprintf("https://github.com/%s/%s/releases/download/%s/%s-%s.tgz", githubOrg, githubRepo, version, chart, version)
+	for _, name := range charts.All() {
+		u, err := github.DownloadURL(githubOrg, githubRepo, version, charts.FileName(name, version))
+		if err != nil {
+			t.Fatal(err)
+		}
 		urls = append(urls, u)
 	}
 	return urls
@@ -35,7 +40,7 @@ func TestHelmChart(t *testing.T) {
 	t.Run("github", func(t *testing.T) {
 		t.Parallel()
 
-		for _, url := range chartURLs(githubOrg, githubRepo, releaseVersion) {
+		for _, url := range chartURLs(t, githubOrg, githubRepo, releaseVersion) {
 			resp, err := http.Get(url)
 			if err != nil {
 				t.Fatalf("failed to fetch helm chart: %v", err)
@@ -62,14 +67,14 @@ func TestHelmChart(t *testing.T) {
 
 				dir := t.TempDir()
 				args := []string{
-					"pull", fmt.Sprintf("oci://%s/%s", reg, utils.TigeraOperatorChart),
+					"pull", fmt.Sprintf("oci://%s/%s", reg, charts.TigeraOperatorChart),
 					"--version", releaseVersion,
 				}
 				out, err := command.RunInDir(dir, "helm", args)
 				if err != nil {
-					t.Fatalf("pull %s %s helm chart from %s: %v\nOutput: %s", utils.TigeraOperatorChart, releaseVersion, reg, err, out)
+					t.Fatalf("pull %s %s helm chart from %s: %v\nOutput: %s", charts.TigeraOperatorChart, releaseVersion, reg, err, out)
 				}
-				chart, err := loader.Load(filepath.Join(dir, fmt.Sprintf("%s-%s.tgz", utils.TigeraOperatorChart, releaseVersion)))
+				chart, err := loader.Load(filepath.Join(dir, fmt.Sprintf("%s-%s.tgz", charts.TigeraOperatorChart, releaseVersion)))
 				if err != nil {
 					t.Fatalf("load helm chart from %s: %v", reg, err)
 				}
@@ -89,59 +94,54 @@ func validateChart(t testing.TB, chart *chart.Chart) {
 	}
 }
 
-type helmIndex struct {
-	Entries map[string][]map[string]any `yaml:"entries"`
-}
-
 func TestHelmIndex(t *testing.T) {
 	t.Parallel()
 
 	checkVersion(t, releaseVersion)
 
-	indexURL, err := url.JoinPath(utils.CalicoHelmRepoURL, "index.yaml")
+	indexURL, err := url.JoinPath(charts.RepoURL(), "index.yaml")
 	if err != nil {
-		t.Fatalf("construct helm index url: %v", err)
+		t.Fatal(err)
 	}
 	resp, err := http.Get(indexURL)
 	if err != nil {
 		t.Fatalf("failed to fetch helm index: %v", err)
 	}
-	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("failed to fetch helm index: server returned %s", resp.Status)
-	}
 	defer func() { _ = resp.Body.Close() }()
-	index := helmIndex{}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("fetching helm index: %s", resp.Status)
+	}
+	var index struct {
+		Entries map[string][]map[string]any `yaml:"entries"`
+	}
 	if err := yaml.NewDecoder(resp.Body).Decode(&index); err != nil {
 		t.Fatalf("failed to decode helm index: %v", err)
 	}
-	if len(index.Entries) == 0 {
-		t.Fatalf("helm index is empty")
-	}
-	tigeraOperatorEntries, ok := index.Entries["tigera-operator"]
-	if !ok || len(tigeraOperatorEntries) == 0 {
-		t.Fatalf("helm index does not contain tigera-operator entries")
-	}
-	filteredEntries := slices.Collect(func(yield func(map[string]any) bool) {
-		for _, entry := range tigeraOperatorEntries {
-			if entry["version"].(string) == releaseVersion {
-				yield(entry)
-			}
-		}
-	})
-	if len(filteredEntries) == 0 {
-		t.Fatalf("helm index does not contain tigera-operator entry for version %s", releaseVersion)
-	} else if len(filteredEntries) > 1 {
-		t.Fatalf("helm index contains multiple tigera-operator entries for version %s", releaseVersion)
-	}
-	helmEntry := filteredEntries[0]
-	urls, ok := helmEntry["urls"]
-	if !ok || len(urls.([]any)) == 0 {
-		t.Fatalf("helm index entry for version %s does not contain urls", releaseVersion)
-	}
 
-	for _, url := range chartURLs(githubOrg, githubRepo, releaseVersion) {
-		if !slices.Contains(cast.ToStringSlice(urls), url) {
-			t.Fatalf("helm index entry for version %s does not contain expected URL: %s", releaseVersion, url)
+	// Each chart has its own entry, carrying only its own download url.
+	for _, name := range charts.All() {
+		entries, ok := index.Entries[name]
+		if !ok || len(entries) == 0 {
+			t.Errorf("helm index has no %s entries", name)
+			continue
+		}
+		matching := slices.Collect(func(yield func(map[string]any) bool) {
+			for _, entry := range entries {
+				if entry["version"] == releaseVersion {
+					yield(entry)
+				}
+			}
+		})
+		if len(matching) != 1 {
+			t.Errorf("helm index has %d %s entries for %s, want 1", len(matching), name, releaseVersion)
+			continue
+		}
+		want, err := github.DownloadURL(githubOrg, githubRepo, releaseVersion, charts.FileName(name, releaseVersion))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if urls := cast.ToStringSlice(matching[0]["urls"]); !slices.Contains(urls, want) {
+			t.Errorf("%s entry for %s has urls %v, want %q", name, releaseVersion, urls, want)
 		}
 	}
 }

--- a/release/pkg/postrelease/helm_test.go
+++ b/release/pkg/postrelease/helm_test.go
@@ -99,7 +99,11 @@ func TestHelmIndex(t *testing.T) {
 
 	checkVersion(t, releaseVersion)
 
-	indexURL, err := url.JoinPath(charts.RepoURL(), "index.yaml")
+	repoURL, err := charts.RepoURL()
+	if err != nil {
+		t.Fatal(err)
+	}
+	indexURL, err := url.JoinPath(repoURL, "index.yaml")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/release/pkg/postrelease/images_test.go
+++ b/release/pkg/postrelease/images_test.go
@@ -102,7 +102,7 @@ func TestImagesInMetadata(t *testing.T) {
 
 	var expectedImages []string
 	for image := range strings.SplitSeq(images, " ") {
-		registry := registry.DefaultCalicoRegistry
+		registry := registry.DefaultProductRegistry
 		if registry != "" {
 			registry += "/"
 		}

--- a/release/pkg/postrelease/operator_images_test.go
+++ b/release/pkg/postrelease/operator_images_test.go
@@ -43,7 +43,7 @@ func TestOperatorPrintedImagesInExpectedList(t *testing.T) {
 	}
 
 	// Parse the output and check that every calico image is in our expected list.
-	calicoPrefix := registry.DefaultCalicoRegistry + "/"
+	calicoPrefix := registry.DefaultProductRegistry + "/"
 	var missing []string
 	for line := range strings.SplitSeq(strings.TrimSpace(string(out)), "\n") {
 		line = strings.TrimSpace(line)

--- a/release/pkg/tasks/hashrelease.go
+++ b/release/pkg/tasks/hashrelease.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	"github.com/projectcalico/calico/release/internal/charts"
 	"github.com/projectcalico/calico/release/internal/hashreleaseserver"
 	"github.com/projectcalico/calico/release/internal/pinnedversion"
 	"github.com/projectcalico/calico/release/internal/utils"
@@ -75,17 +76,19 @@ func ReformatHashrelease(pin *pinnedversion.Pin, hashreleaseOutputDir string) er
 	if err := os.MkdirAll(chartsDir, 0o755); err != nil {
 		return err
 	}
-	for _, chart := range utils.AllReleaseCharts() {
-		chartTarball := filepath.Join(hashreleaseOutputDir, fmt.Sprintf("%s-%s.tgz", chart, pin.HelmChartVersion()))
-		chartTarballDst := filepath.Join(chartsDir, fmt.Sprintf("%s.tgz", chart))
+	for _, chart := range charts.All() {
+		versioned := charts.FileName(chart, pin.HelmChartVersion())
+		unversioned := charts.FileName(chart, "")
+		chartTarball := filepath.Join(hashreleaseOutputDir, versioned)
+		chartTarballDst := filepath.Join(chartsDir, unversioned)
 		if err := copyIfExists(chartTarball, chartTarballDst); err != nil {
 			return err
 		}
 	}
 
 	// Keep copy of the Tigera operator chart without version in name in root dir
-	operatorTarball := filepath.Join(hashreleaseOutputDir, fmt.Sprintf("%s-%s.tgz", utils.TigeraOperatorChart, pin.HelmChartVersion()))
-	operatorTarballDst := filepath.Join(hashreleaseOutputDir, fmt.Sprintf("%s.tgz", utils.TigeraOperatorChart))
+	operatorTarball := filepath.Join(hashreleaseOutputDir, charts.FileName(charts.TigeraOperatorChart, pin.HelmChartVersion()))
+	operatorTarballDst := filepath.Join(hashreleaseOutputDir, charts.FileName(charts.TigeraOperatorChart, ""))
 	if err := copyIfExists(operatorTarball, operatorTarballDst); err != nil {
 		return err
 	}


### PR DESCRIPTION
Helm chart build and publish move out of the release manager into `release/internal/charts`, invocable as `release charts build` and `release charts publish`. This follows the images step, so the two read the same way: a config plus functional options, per-verb option types the compiler checks, per-unit log files, and a digest record a publish can resume from. The machinery both steps share now lives in `release/internal/steps`, which is what the changes under `internal/images` are — imports and moved type definitions, no behaviour change. Chart identity moves out of `internal/utils` so `internal/charts` owns it, and the chart-version rule has one implementation the pin calls into. A new `internal/github` builds the GitHub URLs the release needs.

**Release note:**
```release-note
None
```

**AI assistance:** Claude Code wrote most of the change and its tests.
