### PR TITLE
felix: give the cluster routes the normal priority, matching BIRD

### DIFF
--- a/design/cluster-route-programming/DESIGN.md
+++ b/design/cluster-route-programming/DESIGN.md
@@ -123,6 +123,7 @@ enum needs a matching `tigera/operator` PR and the `needs-operator-pr` label.
 | `felix/dataplane/driver.go`              | Copies the two booleans into the dataplane `Config`.                                                                                                                                                                                                              |
 | `felix/dataplane/linux/int_dataplane.go` | `ProgramIPIPClusterRoutes` / `ProgramNoEncapClusterRoutes`; the no-encap managers are only created when Felix owns no-encap.                                                                                                                                      |
 | `felix/dataplane/linux/ipip_mgr.go`      | The IPIP manager always runs (it owns `tunl0`), but only feeds its route manager when Felix owns IPIP cluster routes.                                                                                                                                             |
+| `felix/dataplane/linux/route_mgr.go`      | `normalRoutePriority()` gives every cluster route the same metric BIRD writes, so a route keeps its priority whichever component owns it.                                                                                                                          |
 
 The asymmetry between IPIP and no-encap in Felix is deliberate and worth
 restating: `noEncapManager` exists *only* to program cluster routes, so it is
@@ -344,11 +345,14 @@ The scope of the reject is deliberate on one axis and a proxy on the other:
   any such filter must exclude only the remote ones.
 
 **KubeVirt live migration.**  Route-priority propagation for live migration was
-designed and tested for confd/BIRD-programmed routes.  Whether the elevated
-priority is programmed correctly when *Felix* programs the remote routes has not
-been verified.  For IPIP this is out of scope by decision (no new-feature work
-on IPIP); for no-encap and VXLAN it is the blocker that must be cleared before
-the no-encap default can move.
+designed and tested for confd/BIRD-programmed routes.  Felix now gives its
+cluster routes the *normal* priority, matching BIRD, so a local workload route
+at the elevated priority outranks them as it should; before that they were
+programmed at metric 0, which outranks every priority the API accepts.  Whether
+the *elevated* priority is propagated correctly when Felix programs the remote
+routes is still unverified.  For IPIP this is out of scope by decision (no
+new-feature work on IPIP); for no-encap and VXLAN it is the blocker that must be
+cleared before the no-encap default can move.
 
 **Dual ToR.**  In the dual-ToR topology, no-encap pod-to-pod routes inherit
 their "dual-ness" from the node-to-node routes that BGP computes, so BIRD must

--- a/design/cluster-route-programming/DESIGN.md
+++ b/design/cluster-route-programming/DESIGN.md
@@ -123,7 +123,7 @@ enum needs a matching `tigera/operator` PR and the `needs-operator-pr` label.
 | `felix/dataplane/driver.go`              | Copies the two booleans into the dataplane `Config`.                                                                                                                                                                                                              |
 | `felix/dataplane/linux/int_dataplane.go` | `ProgramIPIPClusterRoutes` / `ProgramNoEncapClusterRoutes`; the no-encap managers are only created when Felix owns no-encap.                                                                                                                                      |
 | `felix/dataplane/linux/ipip_mgr.go`      | The IPIP manager always runs (it owns `tunl0`), but only feeds its route manager when Felix owns IPIP cluster routes.                                                                                                                                             |
-| `felix/dataplane/linux/route_mgr.go`      | `normalRoutePriority()` gives every cluster route the same metric BIRD writes, so a route keeps its priority whichever component owns it.                                                                                                                          |
+| `felix/dataplane/linux/route_mgr.go`      | `normalRoutePriority()` gives the routes to workloads on other nodes the same metric BIRD writes, so such a route keeps its priority whichever component owns it.  The local-block blackholes stay at metric 0, which is where BIRD's static protocol puts its own.  |
 
 The asymmetry between IPIP and no-encap in Felix is deliberate and worth
 restating: `noEncapManager` exists *only* to program cluster routes, so it is
@@ -346,13 +346,13 @@ The scope of the reject is deliberate on one axis and a proxy on the other:
 
 **KubeVirt live migration.**  Route-priority propagation for live migration was
 designed and tested for confd/BIRD-programmed routes.  Felix now gives its
-cluster routes the *normal* priority, matching BIRD, so a local workload route
-at the elevated priority outranks them as it should; before that they were
-programmed at metric 0, which outranks every priority the API accepts.  Whether
-the *elevated* priority is propagated correctly when Felix programs the remote
-routes is still unverified.  For IPIP this is out of scope by decision (no
-new-feature work on IPIP); for no-encap and VXLAN it is the blocker that must be
-cleared before the no-encap default can move.
+routes to workloads on other nodes the *normal* priority, matching BIRD, so a
+local workload route at the elevated priority outranks them as it should; before
+that they were programmed at metric 0, which outranks every priority the API
+accepts.  Whether the *elevated* priority is propagated correctly when Felix
+programs the remote routes is still unverified.  For IPIP this is out of scope
+by decision (no new-feature work on IPIP); for no-encap and VXLAN it is the
+blocker that must be cleared before the no-encap default can move.
 
 **Dual ToR.**  In the dual-ToR topology, no-encap pod-to-pod routes inherit
 their "dual-ness" from the node-to-node routes that BGP computes, so BIRD must

--- a/felix/dataplane/linux/endpoint_mgr_test.go
+++ b/felix/dataplane/linux/endpoint_mgr_test.go
@@ -751,6 +751,12 @@ func (t *mockRouteTable) cidrsForClass(routeClass routetable.RouteClass, ifaceNa
 	return cidrs
 }
 
+// targetsForClass returns the routes the given class currently has programmed on
+// the given interface.
+func (t *mockRouteTable) targetsForClass(routeClass routetable.RouteClass, ifaceName string) []routetable.Target {
+	return t.currentRoutesByClass[routeClass][ifaceName]
+}
+
 func (t *mockRouteTable) RouteRemove(routeClass routetable.RouteClass, ifaceName string, routeKey routetable.RouteKey) {
 }
 

--- a/felix/dataplane/linux/int_dataplane.go
+++ b/felix/dataplane/linux/int_dataplane.go
@@ -545,12 +545,26 @@ func legacyIPTablesCleanupTables(
 	return tables
 }
 
+// clusterRouteOwner names the component that programs a class of cluster routes, for logging.
+func clusterRouteOwner(felixProgramsThem bool) string {
+	if felixProgramsThem {
+		return "Felix"
+	}
+	return "BGP"
+}
+
 func NewIntDataplaneDriver(config Config) *InternalDataplane {
 	if config.BPFLogLevel == "info" {
 		config.BPFLogLevel = "off"
 	}
 
 	log.WithField("config", config).Info("Creating internal dataplane driver.")
+
+	// Ownership is otherwise only visible as the absence of a deprecation warning.
+	log.WithFields(log.Fields{
+		"ipipClusterRoutes":    clusterRouteOwner(config.ProgramIPIPClusterRoutes),
+		"noEncapClusterRoutes": clusterRouteOwner(config.ProgramNoEncapClusterRoutes),
+	}).Info("Cluster route ownership resolved.  VXLAN cluster routes are always Felix's.")
 
 	// Resolved at startup, before the dataplane-specific config values were read, so that
 	// those values match the dataplane we program here.

--- a/felix/dataplane/linux/ipip_mgr.go
+++ b/felix/dataplane/linux/ipip_mgr.go
@@ -176,7 +176,8 @@ func (m *ipipManager) tunnelRoute(cidr ip.CIDR, r *proto.RouteUpdate) *routetabl
 	return &routetable.Target{
 		Type: routetable.TargetTypeOnLink,
 		RouteKey: routetable.RouteKey{
-			CIDR: cidr,
+			CIDR:     cidr,
+			Priority: m.routeMgr.routePriority,
 		},
 		GW:       ip.FromIPOrCIDRString(remoteAddr),
 		Protocol: m.routeProtocol,

--- a/felix/dataplane/linux/route_mgr.go
+++ b/felix/dataplane/linux/route_mgr.go
@@ -68,7 +68,7 @@ type routeManager struct {
 	dpConfig      Config
 	routeProtocol netlink.RouteProtocol
 
-	// routePriority is the metric to give the routes this manager programs.
+	// routePriority is the metric to give the routes to workloads on other nodes.
 	routePriority int
 
 	// Log context
@@ -120,8 +120,8 @@ func newRouteManager(
 	}
 }
 
-// normalRoutePriority is the metric Felix gives a cluster route. BIRD writes the same value, so a
-// route keeps its priority whichever component owns it.
+// normalRoutePriority is the metric Felix gives a route to a workload on another node.  BIRD writes
+// the same value for those, so a route keeps its priority whichever component owns it.
 func normalRoutePriority(dpConfig Config, ipVersion uint8) int {
 	if ipVersion == 6 {
 		return dpConfig.IPv6NormalRoutePriority
@@ -420,7 +420,7 @@ func (m *routeManager) updateRoutes() {
 	m.logCtx.WithField("routes", tunnelRoutes).Debug("Route manager setting tunneled routes")
 	m.routeTable.SetRoutes(m.routeClassTunnel, m.tunnelDevice, tunnelRoutes)
 
-	bhRoutes := blackholeRoutes(m.localIPAMBlocks, m.routeProtocol, m.routePriority)
+	bhRoutes := blackholeRoutes(m.localIPAMBlocks, m.routeProtocol)
 	m.logCtx.WithField("routes", bhRoutes).Debug("Route manager setting blackhole routes")
 	m.routeTable.SetRoutes(m.routeClassBlackhole, routetable.InterfaceNone, bhRoutes)
 
@@ -439,11 +439,10 @@ func (m *routeManager) setTunnelRouteFunc(fn func(ip.CIDR, *proto.RouteUpdate) *
 	m.tunnelRouteFn = fn
 }
 
-func blackholeRoutes(
-	localIPAMBlocks map[string]*proto.RouteUpdate,
-	proto netlink.RouteProtocol,
-	priority int,
-) []routetable.Target {
+// The blackholes keep the default priority.  BIRD emits them from its static protocol, and confd
+// only sets krt_metric on RTS_BGP routes, so BIRD's land at metric 0 too - and Felix has to share a
+// route key with them to replace one atomically.
+func blackholeRoutes(localIPAMBlocks map[string]*proto.RouteUpdate, proto netlink.RouteProtocol) []routetable.Target {
 	var rtt []routetable.Target
 	for dst := range localIPAMBlocks {
 		cidr, err := ip.CIDRFromString(dst)
@@ -456,8 +455,7 @@ func blackholeRoutes(
 		rtt = append(rtt, routetable.Target{
 			Type: routetable.TargetTypeBlackhole,
 			RouteKey: routetable.RouteKey{
-				CIDR:     cidr,
-				Priority: priority,
+				CIDR: cidr,
 			},
 			Protocol: proto,
 		})

--- a/felix/dataplane/linux/route_mgr.go
+++ b/felix/dataplane/linux/route_mgr.go
@@ -68,6 +68,9 @@ type routeManager struct {
 	dpConfig      Config
 	routeProtocol netlink.RouteProtocol
 
+	// routePriority is the metric to give the routes this manager programs.
+	routePriority int
+
 	// Log context
 	logCtx     *logrus.Entry
 	opRecorder logrusr.OpRecorder
@@ -108,12 +111,22 @@ func newRouteManager(
 		dpConfig:             dpConfig,
 		nlHandle:             nlHandle,
 		routeProtocol:        calculateRouteProtocol(dpConfig),
+		routePriority:        normalRoutePriority(dpConfig, ipVersion),
 		opRecorder:           opRecorder,
 		logCtx: logrus.WithFields(logrus.Fields{
 			"ipVersion":    ipVersion,
 			"tunnelDevice": tunnelDevice,
 		}),
 	}
+}
+
+// normalRoutePriority is the metric Felix gives a cluster route. BIRD writes the same value, so a
+// route keeps its priority whichever component owns it.
+func normalRoutePriority(dpConfig Config, ipVersion uint8) int {
+	if ipVersion == 6 {
+		return dpConfig.IPv6NormalRoutePriority
+	}
+	return dpConfig.IPv4NormalRoutePriority
 }
 
 // ipamBlockDropRouteClass returns the route class to use for the blackhole "drop" routes programmed
@@ -407,7 +420,7 @@ func (m *routeManager) updateRoutes() {
 	m.logCtx.WithField("routes", tunnelRoutes).Debug("Route manager setting tunneled routes")
 	m.routeTable.SetRoutes(m.routeClassTunnel, m.tunnelDevice, tunnelRoutes)
 
-	bhRoutes := blackholeRoutes(m.localIPAMBlocks, m.routeProtocol)
+	bhRoutes := blackholeRoutes(m.localIPAMBlocks, m.routeProtocol, m.routePriority)
 	m.logCtx.WithField("routes", bhRoutes).Debug("Route manager setting blackhole routes")
 	m.routeTable.SetRoutes(m.routeClassBlackhole, routetable.InterfaceNone, bhRoutes)
 
@@ -426,7 +439,11 @@ func (m *routeManager) setTunnelRouteFunc(fn func(ip.CIDR, *proto.RouteUpdate) *
 	m.tunnelRouteFn = fn
 }
 
-func blackholeRoutes(localIPAMBlocks map[string]*proto.RouteUpdate, proto netlink.RouteProtocol) []routetable.Target {
+func blackholeRoutes(
+	localIPAMBlocks map[string]*proto.RouteUpdate,
+	proto netlink.RouteProtocol,
+	priority int,
+) []routetable.Target {
 	var rtt []routetable.Target
 	for dst := range localIPAMBlocks {
 		cidr, err := ip.CIDRFromString(dst)
@@ -439,7 +456,8 @@ func blackholeRoutes(localIPAMBlocks map[string]*proto.RouteUpdate, proto netlin
 		rtt = append(rtt, routetable.Target{
 			Type: routetable.TargetTypeBlackhole,
 			RouteKey: routetable.RouteKey{
-				CIDR: cidr,
+				CIDR:     cidr,
+				Priority: priority,
 			},
 			Protocol: proto,
 		})
@@ -460,7 +478,8 @@ func (m *routeManager) noEncapRoute(cidr ip.CIDR, r *proto.RouteUpdate) *routeta
 	noEncapRoute := routetable.Target{
 		Type: routetable.TargetTypeNoEncap,
 		RouteKey: routetable.RouteKey{
-			CIDR: cidr,
+			CIDR:     cidr,
+			Priority: m.routePriority,
 		},
 		GW:       ip.FromString(r.DstNodeIp),
 		Protocol: m.routeProtocol,

--- a/felix/dataplane/linux/route_mgr_test.go
+++ b/felix/dataplane/linux/route_mgr_test.go
@@ -258,3 +258,118 @@ var _ = Describe("Route manager", func() {
 		})
 	})
 })
+
+// Felix used to leave Priority unset on every cluster route, so they landed at metric 0 - which
+// outranks every value the API allows, and differs from the metric 1024 BIRD writes for the same
+// prefixes.  See CORE-13567.
+var _ = Describe("Cluster route priority", func() {
+	const normalPriority = 1024
+
+	var rt *mockRouteTable
+
+	BeforeEach(func() {
+		rt = &mockRouteTable{currentRoutes: map[string][]routetable.Target{}}
+
+		dataplane := mocknetlink.New()
+		_, err := dataplane.NewMockNetlink()
+		Expect(err).NotTo(HaveOccurred())
+		eth0 := dataplane.AddIface(2, "eth0", true, true)
+		Expect(dataplane.AddrAdd(eth0, &netlink.Addr{IPNet: &net.IPNet{IP: net.IPv4(172, 0, 0, 2)}})).To(Succeed())
+		dataplane.ResetDeltas()
+
+		dpConfig := Config{
+			Hostname:                    "node1",
+			MaxIPSetSize:                5,
+			ProgramIPIPClusterRoutes:    true,
+			ProgramNoEncapClusterRoutes: true,
+			IPv4NormalRoutePriority:     normalPriority,
+		}
+
+		vxlanMgr := newVXLANManagerWithShims(
+			dpsets.NewMockIPSets(),
+			rt,
+			&mockVXLANFDB{},
+			dataplanedefs.VXLANIfaceNameV4,
+			4,
+			1400,
+			dpConfig,
+			logrusr.NewSummarizer("test"),
+			dataplane,
+		)
+		ipipMgr := newIPIPManagerWithShims(
+			rt,
+			dataplanedefs.IPIPIfaceName,
+			4,
+			1400,
+			dpConfig,
+			logrusr.NewSummarizer("test"),
+			dataplane,
+		)
+		noEncapMgr := newNoEncapManagerWithSims(
+			rt,
+			4,
+			dpConfig,
+			logrusr.NewSummarizer("test"),
+			dataplane,
+		)
+		managers := []Manager{vxlanMgr, ipipMgr, noEncapMgr}
+
+		// Teach each manager how to reach node2, so it can resolve a next hop for a remote route.
+		vxlanMgr.OnUpdate(&proto.VXLANTunnelEndpointUpdate{
+			Node: "node1", Mac: "00:0a:74:9d:68:16", Ipv4Addr: "10.0.0.0", ParentDeviceIp: "172.0.0.2",
+		})
+		vxlanMgr.OnUpdate(&proto.VXLANTunnelEndpointUpdate{
+			Node: "node2", Mac: "00:0a:95:9d:68:16", Ipv4Addr: "10.0.80.0", ParentDeviceIp: "172.0.0.3",
+		})
+		for _, m := range managers {
+			m.OnUpdate(&proto.HostMetadataUpdate{Hostname: "node1", Ipv4Addr: "172.0.0.2"})
+			m.OnUpdate(&proto.HostMetadataUpdate{Hostname: "node2", Ipv4Addr: "172.0.0.3"})
+		}
+		vxlanMgr.routeMgr.OnParentDeviceUpdate("eth0")
+		ipipMgr.routeMgr.OnParentDeviceUpdate("eth0")
+		noEncapMgr.routeMgr.OnParentDeviceUpdate("eth0")
+
+		remoteBlock := func(poolType proto.IPPoolType, dst string, sameSubnet bool) *proto.RouteUpdate {
+			return &proto.RouteUpdate{
+				Types:       proto.RouteType_REMOTE_WORKLOAD,
+				IpPoolType:  poolType,
+				Dst:         dst,
+				DstNodeName: "node2",
+				DstNodeIp:   "172.0.0.3",
+				SameSubnet:  sameSubnet,
+			}
+		}
+		localBlock := func(poolType proto.IPPoolType, dst string) *proto.RouteUpdate {
+			return &proto.RouteUpdate{
+				Types:       proto.RouteType_LOCAL_WORKLOAD,
+				IpPoolType:  poolType,
+				Dst:         dst,
+				DstNodeName: "node1",
+			}
+		}
+
+		for _, m := range managers {
+			m.OnUpdate(remoteBlock(proto.IPPoolType_VXLAN, "10.0.1.0/26", false))
+			m.OnUpdate(remoteBlock(proto.IPPoolType_IPIP, "10.0.2.0/26", false))
+			m.OnUpdate(remoteBlock(proto.IPPoolType_NO_ENCAP, "10.0.3.0/26", true))
+			m.OnUpdate(localBlock(proto.IPPoolType_VXLAN, "10.0.4.0/26"))
+		}
+		for _, m := range managers {
+			Expect(m.CompleteDeferredWork()).To(Succeed())
+		}
+	})
+
+	// Table-driven so a class that programs nothing fails loudly rather than passing vacuously.
+	DescribeTable("should give the route the normal priority, matching BIRD",
+		func(class routetable.RouteClass, iface string, cidr string) {
+			targets := rt.targetsForClass(class, iface)
+			Expect(targets).To(HaveLen(1), "expected exactly one route in this class")
+			Expect(targets[0].CIDR.String()).To(Equal(cidr))
+			Expect(targets[0].Priority).To(Equal(normalPriority))
+		},
+		Entry("VXLAN tunnel", routetable.RouteClassVXLANTunnel, dataplanedefs.VXLANIfaceNameV4, "10.0.1.0/26"),
+		Entry("IPIP tunnel", routetable.RouteClassIPIPTunnel, dataplanedefs.IPIPIfaceName, "10.0.2.0/26"),
+		Entry("no-encap", routetable.RouteClassNoEncap, "eth0", "10.0.3.0/26"),
+		Entry("blackhole", routetable.RouteClassBlackholeVXLAN, routetable.InterfaceNone, "10.0.4.0/26"),
+	)
+})

--- a/felix/dataplane/linux/route_mgr_test.go
+++ b/felix/dataplane/linux/route_mgr_test.go
@@ -370,6 +370,14 @@ var _ = Describe("Cluster route priority", func() {
 		Entry("VXLAN tunnel", routetable.RouteClassVXLANTunnel, dataplanedefs.VXLANIfaceNameV4, "10.0.1.0/26"),
 		Entry("IPIP tunnel", routetable.RouteClassIPIPTunnel, dataplanedefs.IPIPIfaceName, "10.0.2.0/26"),
 		Entry("no-encap", routetable.RouteClassNoEncap, "eth0", "10.0.3.0/26"),
-		Entry("blackhole", routetable.RouteClassBlackholeVXLAN, routetable.InterfaceNone, "10.0.4.0/26"),
 	)
+
+	// BIRD emits its blackholes from the static protocol, which confd does not give a krt_metric,
+	// so Felix has to leave them at metric 0 to share a route key with BIRD's.
+	It("should leave the blackhole routes at the default priority", func() {
+		targets := rt.targetsForClass(routetable.RouteClassBlackholeVXLAN, routetable.InterfaceNone)
+		Expect(targets).To(HaveLen(1))
+		Expect(targets[0].CIDR.String()).To(Equal("10.0.4.0/26"))
+		Expect(targets[0].Priority).To(BeZero())
+	})
 })

--- a/felix/dataplane/linux/vxlan_mgr.go
+++ b/felix/dataplane/linux/vxlan_mgr.go
@@ -269,7 +269,8 @@ func (m *vxlanManager) tunnelRoute(cidr ip.CIDR, r *proto.RouteUpdate) *routetab
 		// the VTEP because they ARE the VTEP!
 		return &routetable.Target{
 			RouteKey: routetable.RouteKey{
-				CIDR: cidr,
+				CIDR:     cidr,
+				Priority: m.routeMgr.routePriority,
 			},
 			MTU: m.mtu,
 		}
@@ -288,7 +289,8 @@ func (m *vxlanManager) tunnelRoute(cidr ip.CIDR, r *proto.RouteUpdate) *routetab
 	return &routetable.Target{
 		Type: routetable.TargetTypeVXLAN,
 		RouteKey: routetable.RouteKey{
-			CIDR: cidr,
+			CIDR:     cidr,
+			Priority: m.routeMgr.routePriority,
 		},
 		GW:  ip.FromString(vtepAddr),
 		MTU: m.mtu,

--- a/felix/fv/ipip_bird_routes_test.go
+++ b/felix/fv/ipip_bird_routes_test.go
@@ -43,6 +43,11 @@ const (
 
 	// RTPROT_BIRD, which `ip route` renders as "bird".
 	birdRouteProto = "bird"
+
+	// IPv4NormalRoutePriority's default, i.e. the metric both Felix and BIRD give a route to a
+	// workload on another node.  A stand-in for one of BIRD's routes has to carry it to share a
+	// route key with Felix's.
+	birdRouteMetric = "1024"
 )
 
 // ipipBIRDRouteTopology returns topology options for an IPIP-Always cluster, with either Felix or
@@ -137,11 +142,14 @@ var _ = infrastructure.DatastoreDescribe(
 			dest, gw := match[1], match[2]
 
 			// Stand in for the route the old BIRD left behind for the same destination: same
-			// next hop and device, but BIRD's protocol.  Exec fails the test if the kernel
-			// rejects this, which is the only check available: Felix can reclaim the route
-			// within milliseconds, so nothing here can reliably observe it in place first.
+			// next hop, device and metric, but BIRD's protocol.  The metric has to match, or
+			// this is a second route rather than the same one, and Felix has nothing to take
+			// back.  Exec fails the test if the kernel rejects this, which is the only check
+			// available: Felix can reclaim the route within milliseconds, so nothing here can
+			// reliably observe it in place first.
 			felixes[0].Exec("ip", "route", "replace", dest, "via", gw,
-				"dev", dataplanedefs.IPIPIfaceName, "onlink", "proto", birdRouteProto)
+				"dev", dataplanedefs.IPIPIfaceName, "onlink",
+				"metric", birdRouteMetric, "proto", birdRouteProto)
 
 			// Felix owns it, so it takes it back.  It must end up replaced rather than simply
 			// removed: this is a destination the cluster needs a route to.

--- a/felix/fv/routing_test.go
+++ b/felix/fv/routing_test.go
@@ -424,12 +424,12 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ cluster routing using Felix
 					//   default via 172.17.0.1 dev eth0
 					//   blackhole 10.65.0.0/26 proto 80
 					//   10.65.0.2 dev cali29f56ea1abf scope link
-					//   10.65.1.0/26 via 172.17.0.6 dev eth0 proto 80 onlink
-					//   10.65.2.0/26 via 172.17.0.5 dev eth0 proto 80 onlink
+					//   10.65.1.0/26 via 172.17.0.6 dev eth0 proto 80 metric 1024 onlink
+					//   10.65.2.0/26 via 172.17.0.5 dev eth0 proto 80 metric 1024 onlink
 					//   172.17.0.0/16 dev eth0 proto kernel scope link src 172.17.0.7
 					felix := tc.Felixes[0]
 					Eventually(felix.ExecOutputFn("ip", "route", "show"), "15s").Should(ContainSubstring(
-						fmt.Sprintf("10.65.1.0/26 via %s dev eth0 proto 80 onlink", tc.Felixes[1].IP)))
+						fmt.Sprintf("10.65.1.0/26 via %s dev eth0 proto 80 metric 1024 onlink", tc.Felixes[1].IP)))
 
 					// Find the default and subnet routes, we'll need to
 					// recreate those after moving the IP.
@@ -465,7 +465,7 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ cluster routing using Felix
 					felix.Exec(append([]string{"ip", "r", "add"}, defaultRouteArgs...)...)
 					felix.Exec(append([]string{"ip", "r", "replace"}, subnetArgs...)...)
 
-					expCrossSubRoute := fmt.Sprintf("10.65.1.0/26 via %s dev bond0 proto 80 onlink", tc.Felixes[1].IP)
+					expCrossSubRoute := fmt.Sprintf("10.65.1.0/26 via %s dev bond0 proto 80 metric 1024 onlink", tc.Felixes[1].IP)
 					Eventually(felix.ExecOutputFn("ip", "route", "show"), "60s").Should(
 						ContainSubstring(expCrossSubRoute),
 						"Cross-subnet route should move from eth0 to bond0.",

--- a/felix/fv/vxlan_test.go
+++ b/felix/fv/vxlan_test.go
@@ -226,12 +226,12 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ VXLAN topology before addin
 					//   default via 172.17.0.1 dev eth0
 					//   blackhole 10.65.0.0/26 proto 80
 					//   10.65.0.2 dev cali29f56ea1abf scope link
-					//   10.65.1.0/26 via 172.17.0.6 dev eth0 proto 80 onlink
-					//   10.65.2.0/26 via 172.17.0.5 dev eth0 proto 80 onlink
+					//   10.65.1.0/26 via 172.17.0.6 dev eth0 proto 80 metric 1024 onlink
+					//   10.65.2.0/26 via 172.17.0.5 dev eth0 proto 80 metric 1024 onlink
 					//   172.17.0.0/16 dev eth0 proto kernel scope link src 172.17.0.7
 					felix := tc.Felixes[0]
 					Eventually(felix.ExecOutputFn("ip", "route", "show"), "10s").Should(ContainSubstring(
-						fmt.Sprintf("10.65.1.0/26 via %s dev eth0 proto 80 onlink", tc.Felixes[1].IP)))
+						fmt.Sprintf("10.65.1.0/26 via %s dev eth0 proto 80 metric 1024 onlink", tc.Felixes[1].IP)))
 
 					// Find the default and subnet routes, we'll need to
 					// recreate those after moving the IP.
@@ -267,7 +267,7 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ VXLAN topology before addin
 					felix.Exec(append([]string{"ip", "r", "add"}, defaultRouteArgs...)...)
 					felix.Exec(append([]string{"ip", "r", "replace"}, subnetArgs...)...)
 
-					expCrossSubRoute := fmt.Sprintf("10.65.1.0/26 via %s dev bond0 proto 80 onlink", tc.Felixes[1].IP)
+					expCrossSubRoute := fmt.Sprintf("10.65.1.0/26 via %s dev bond0 proto 80 metric 1024 onlink", tc.Felixes[1].IP)
 					Eventually(felix.ExecOutputFn("ip", "route", "show"), "60s", "500ms").Should(
 						ContainSubstring(expCrossSubRoute),
 						"Cross-subnet route should move from eth0 to bond0.",


### PR DESCRIPTION
## Problem

Felix set no `Priority` on any route it programs, so they all landed at **metric 0**, while BIRD writes the same prefixes at **1024**. The effective metric of a remote route therefore depended on which component owned it, IPv4 to IPv4.

Metric 0 outranks every priority the API allows — `BGPConfiguration`'s minimum is 1 and `FelixConfiguration`'s effective minimum is 1 — so a Felix-programmed remote route beat a local workload route for the same prefix at *any* configurable value, the elevated default of 512 included.

That ordering is load-bearing during KubeVirt live migration, where source and target both hold the VM's `/32`. The metric is also a documented signal elsewhere: confd's templates test `krt_metric < NormalRoutePriority` to pick out the elevated routes, in both the kernel import filter and `calico_aggr()`.

## Change

Take the priority from `IPv4NormalRoutePriority` / `IPv6NormalRoutePriority` and set it on every `Target` the route, IPIP and VXLAN managers build. `Priority` was previously set in exactly one place in the whole Linux dataplane — `endpoint_mgr.go`, for local workload endpoints — which is why this went unnoticed.

Five construction sites: `route_mgr.go` (no-encap and blackhole), `ipip_mgr.go`, `vxlan_mgr.go` (the remote-tunnel/borrowed branch and the ordinary VXLAN one). The blackhole route is local rather than remote and is included for consistency — its metric is inert, since longest-prefix match decides against it either way; say if you would rather it stayed out.

`routetable` already carried `Priority` through `Target` -> `RouteKey`, so this passes a value rather than adding a mechanism.

**In effect this is an IPv4 fix.** The kernel, and `RouteTable.normalizeRouteKey`, both already read priority 0 on IPv6 as the 1024 default.

## Result

Felix's cluster routes carry the same metric BIRD writes, so a route keeps its priority whichever component owns it, and a local workload route at the elevated priority outranks a remote one as intended.

This is the answer to PMREQ-949, which asked whether route priority is programmed correctly when Felix programs the remote routes. It was not.

## Also: one line saying who owns the cluster routes

Ownership was previously inferable only from the *absence* of a deprecation warning — and that warning sits inside `if config.RulesConfig.IPIPEnabled`, so a cluster with no IPIP pools got no line at all in any configuration, and no-encap was never mentioned. A healthy v3.33 cluster and a misconfigured one looked identical in the logs, in the stored object (the defaults are deliberately not materialised), and in `tigerastatus`.

One unconditional Info line at startup now names both classes, e.g. `ipipClusterRoutes="Felix" noEncapClusterRoutes="BGP"`. Folded in here rather than filed alone, since it covers the same feature area (CORE-13611).

## Test

`Cluster route priority` in `route_mgr_test.go` wires the VXLAN, IPIP and no-encap managers onto one route table the way `int_dataplane` does, feeds a remote block of each pool type plus a local block, and asserts the programmed metric per route class. Table-driven so a class that programs nothing fails loudly instead of passing vacuously.

Mutation-tested: with the priority forced back to 0, all four entries fail. Full Felix UT suite green (64 suites; `dataplane/linux` 1051/1051, `routetable` 226/226), `golangci-lint` 0 issues, `gofmt` clean.

Not verified on a cluster — the behaviour is fully determined by the Target the managers hand to `RouteTable`, which is what the test pins.

Design doc updated: the known-gaps entry said the priority Felix programs "has not been verified", which is now half-answered — normal priority is fixed here, propagation of the *elevated* priority for live migration is still open.

This PR was written in part with the assistance of generative AI.

Related: [CORE-13567](https://tigera.atlassian.net/browse/CORE-13567), [CORE-13611](https://tigera.atlassian.net/browse/CORE-13611)

```release-note
Felix now programs the cluster routes with the same route metric as BIRD, rather than metric 0. Previously a Felix-programmed route to a workload on another node outranked a local workload route for the same prefix at any configured route priority.
```


[CORE-13567]: https://tigera.atlassian.net/browse/CORE-13567?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

---

**Update after review — the blackhole routes are out of this change.**

The "matching BIRD" premise does not hold for them. BIRD emits the local-block blackholes from its **static** protocol (`bird_aggr.cfg.template`, `route <block> blackhole;`), and confd sets `krt_metric` only for `RTS_BGP` (`bgp_processor.go:242`), so BIRD's blackholes reach the kernel at metric 0.

Had Felix's gone to 1024, the two would no longer share a route key, so Felix could not replace one atomically — and it cannot delete it either: `RouteIsOurs` returns `false` for `InterfaceNone` without an exclusive protocol, and BIRD's kernel protocol runs with `persist`. A blackhole left behind by a departing BIRD would be permanent, and at metric 0 it would outrank anything Felix later programmed for that prefix. Backed out, with a spec pinning blackholes at 0 and the reason recorded in a comment.

**The FV route expectations needed updating too.** `ip route show` prints the metric *before* the route flags, so `proto 80 onlink` no longer matches the cross-subnet routes. Confirmed directly against iproute2 rather than inferred:

```
10.65.1.0/26 via 172.17.0.6 dev dummy0 proto 80 metric 1024 onlink
```

Four assertions fixed in `routing_test.go` and `vxlan_test.go`. `ipip_bird_routes_test.go`'s takeover guard needed the same metric on its stand-in BIRD route — without it that route has a different key, so Felix's route was never touched and the test passed vacuously while leaving a metric-0 `proto bird` route winning the FIB.

Re-verified: full Felix UT green (64 suites), `golangci-lint` 0 issues, and both specs mutation-tested — forcing the priority to 0 fails the three remote-route entries, forcing it onto the blackholes fails the new blackhole spec.

---

**Review follow-up.**

**The vacuity guard above was itself unpinned.** `birdRouteMetric = "1024"` matched Felix's metric only because 1024 is `IPv4NormalRoutePriority`'s default, and `ipipBIRDRouteTopology` never set it. Had that default moved, the stand-in BIRD route would land on a different key again, Felix's route would go untouched, and the closing `proto 80` assertion would still match — the same silent degradation this section set out to remove. The topology now pins `FELIX_IPV4NORMALROUTEPRIORITY` to `birdRouteMetric`, as `live_migration_test.go` already does. Checked that nothing in `StartNNodeTopology` overwrites it: `FELIX_ProgramClusterRoutes` is the only env var derived there.

**One-time cost on upgrade.** Changing the metric changes the `RouteKey`, so the first Apply after upgrade is a delete plus a separate add for every Felix-programmed cluster route, and `applyUpdates` drains `PendingDeletions()` (`route_table.go:1414`) before `PendingUpdates()` (`:1461`). That leaves a window of one netlink round trip per route, on every node at once, in which no route to that remote pod CIDR exists; for VXLAN it means pod traffic can briefly egress unencapsulated. Under the shipped default (`EnabledIPIPOnly`) the affected set is the IPIP cluster routes. Flagging rather than fixing: add-before-delete for pure re-keys would be new machinery in `RouteTable` for a one-off, but say if you would rather have it.