### PR TITLE
Set the publish latch when publishing the operator image

### DIFF
--- a/release/pkg/manager/operator/manager.go
+++ b/release/pkg/manager/operator/manager.go
@@ -74,6 +74,10 @@ type OperatorManager struct {
 	// validate indicates if we should run validation
 	validate bool
 
+	// dryRun leaves the publish latch open, so the make targets echo the pushes
+	// and exit 0 rather than publishing.
+	dryRun bool
+
 	// architectures is the list of architectures for which we should build images.
 	// If empty, we build for all.
 	architectures []string
@@ -230,6 +234,13 @@ func (o *OperatorManager) PrePublishValidation() error {
 
 func (o *OperatorManager) Publish() error {
 	env, logFields := o.env()
+	if o.dryRun {
+		env = append(env, utils.EnvTrue(utils.EnvDryRun))
+	} else {
+		env = append(env, utils.EnvTrue(utils.EnvConfirm))
+	}
+	logFields["dry_run"] = o.dryRun
+
 	logrus.WithFields(logFields).Info("Publishing operator")
 	out, err := o.make("release-publish", env)
 	if err != nil {

--- a/release/pkg/manager/operator/manager_test.go
+++ b/release/pkg/manager/operator/manager_test.go
@@ -15,14 +15,84 @@
 package operator
 
 import (
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
+// envRecorder is a command.CommandRunner that records the environment each
+// command was given, so a test can assert what reached make.
+type envRecorder struct {
+	envs [][]string
+}
+
+func (e *envRecorder) Run(_ string, _ []string, env []string) (string, error) {
+	e.envs = append(e.envs, env)
+	return "", nil
+}
+
+func (e *envRecorder) RunNoCapture(_ string, _ []string, env []string) error {
+	e.envs = append(e.envs, env)
+	return nil
+}
+
+func (e *envRecorder) RunInDir(_, _ string, _ []string, env []string) (string, error) {
+	e.envs = append(e.envs, env)
+	return "", nil
+}
+
+func (e *envRecorder) RunInDirNoCapture(_, _ string, _ []string, env []string) error {
+	e.envs = append(e.envs, env)
+	return nil
+}
+
+func (e *envRecorder) RunInDirToFile(_, _ string, _ []string, env []string, _ string) (string, error) {
+	e.envs = append(e.envs, env)
+	return "", nil
+}
+
 func TestOperatorDirIsInTree(t *testing.T) {
 	m := NewManager(WithCalicoDirectory("/some/calico"))
 	require.Equal(t, "/some/calico/operator", m.dir)
+}
+
+// A publish without CONFIRM echoes its pushes and exits 0, so the release passes
+// having published nothing.
+func TestPublishLatchesThePush(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		opts    []Option
+		wantEnv string
+		notEnv  string
+	}{
+		{
+			name:    "confirms by default",
+			wantEnv: "CONFIRM=true",
+			notEnv:  "DRYRUN=true",
+		},
+		{
+			name:    "dry run",
+			opts:    []Option{IsDryRun()},
+			wantEnv: "DRYRUN=true",
+			notEnv:  "CONFIRM=true",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			r := &envRecorder{}
+			opts := append([]Option{
+				WithCalicoDirectory("/some/calico"),
+				WithVersion("v3.34.0-test"),
+			}, tc.opts...)
+			m := NewManager(opts...)
+			m.runner = r
+
+			require.NoError(t, m.Publish())
+			require.Len(t, r.envs, 1)
+			require.True(t, slices.Contains(r.envs[0], tc.wantEnv), "expected %s in publish env", tc.wantEnv)
+			require.False(t, slices.Contains(r.envs[0], tc.notEnv), "did not expect %s in publish env", tc.notEnv)
+		})
+	}
 }
 
 func TestProductRegistryParts(t *testing.T) {

--- a/release/pkg/manager/operator/options.go
+++ b/release/pkg/manager/operator/options.go
@@ -44,6 +44,13 @@ func WithValidate(validate bool) Option {
 	}
 }
 
+func IsDryRun() Option {
+	return func(o *OperatorManager) error {
+		o.dryRun = true
+		return nil
+	}
+}
+
 func WithArchitectures(architectures []string) Option {
 	return func(o *OperatorManager) error {
 		o.architectures = architectures


### PR DESCRIPTION
The operator image is missing from the 2026-09-10 master hashrelease, because its publish ran as a dry run: the make targets echoed every push and the job went green having published nothing. Every other image publishes through the shared image publish path, which sets the push latch; the operator takes its own pass and never set it, so a real release would have hit this too. This sets the latch there as well, defaulting to a real push with a dry run available as an option.

**Release note:**
```release-note
None
```

**AI assistance:** Claude Code, for the hashrelease job log investigation and for the fix and its test.
