### PR TITLE
Build the controller reconcilers through an exported constructor

### DIFF
--- a/operator/pkg/controller/apiserver/apiserver_controller.go
+++ b/operator/pkg/controller/apiserver/apiserver_controller.go
@@ -61,18 +61,40 @@ const ResourceName string = "apiserver"
 
 var log = logf.Log.WithName("controller_apiserver")
 
+// ReconcilerOptions is what the API server reconciler needs to run.
+type ReconcilerOptions struct {
+	Client              client.Client
+	Scheme              *runtime.Scheme
+	Status              status.StatusManager
+	TierWatchReady      *utils.ReadyFlag
+	MigrationWatchReady *utils.ReadyFlag
+	Options             options.ControllerOptions
+}
+
+// NewReconciler returns an API server reconciler a caller can drive without a manager.
+func NewReconciler(o ReconcilerOptions) *ReconcileAPIServer {
+	return &ReconcileAPIServer{
+		client:              o.Client,
+		scheme:              o.Scheme,
+		status:              o.Status,
+		tierWatchReady:      o.TierWatchReady,
+		migrationWatchReady: o.MigrationWatchReady,
+		opts:                o.Options,
+		ext:                 o.Options.Extensions.APIServer(),
+	}
+}
+
 // Add creates a new APIServer Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
 func Add(mgr manager.Manager, opts options.ControllerOptions) error {
-	r := &ReconcileAPIServer{
-		client:              mgr.GetClient(),
-		scheme:              mgr.GetScheme(),
-		status:              status.New(mgr.GetClient(), "apiserver", opts.KubernetesVersion),
-		tierWatchReady:      &utils.ReadyFlag{},
-		migrationWatchReady: &utils.ReadyFlag{},
-		opts:                opts,
-		ext:                 opts.Extensions.APIServer(),
-	}
+	r := NewReconciler(ReconcilerOptions{
+		Client:              mgr.GetClient(),
+		Scheme:              mgr.GetScheme(),
+		Status:              status.New(mgr.GetClient(), "apiserver", opts.KubernetesVersion),
+		TierWatchReady:      &utils.ReadyFlag{},
+		MigrationWatchReady: &utils.ReadyFlag{},
+		Options:             opts,
+	})
 	r.status.Run(opts.ShutdownContext)
 
 	c, err := ctrlruntime.NewController("apiserver-controller", mgr, ctrl.Options{Reconciler: r})

--- a/operator/pkg/controller/clusterconnection/clusterconnection_controller.go
+++ b/operator/pkg/controller/clusterconnection/clusterconnection_controller.go
@@ -68,7 +68,15 @@ func Add(mgr manager.Manager, opts options.ControllerOptions) error {
 	// Create the reconciler
 	tierWatchReady := &utils.ReadyFlag{}
 	clusterInfoWatchReady := &utils.ReadyFlag{}
-	reconciler := newReconciler(mgr.GetClient(), mgr.GetScheme(), statusManager, opts.DetectedProvider, tierWatchReady, clusterInfoWatchReady, opts)
+	reconciler := NewReconciler(ReconcilerOptions{
+		Client:                mgr.GetClient(),
+		Scheme:                mgr.GetScheme(),
+		Status:                statusManager,
+		Provider:              opts.DetectedProvider,
+		TierWatchReady:        tierWatchReady,
+		ClusterInfoWatchReady: clusterInfoWatchReady,
+		Options:               opts,
+	})
 
 	// Create a new controller
 	c, err := ctrlruntime.NewController(controllerName, mgr, ctrl.Options{Reconciler: reconciler})
@@ -128,27 +136,34 @@ func Add(mgr manager.Manager, opts options.ControllerOptions) error {
 	return nil
 }
 
-// newReconciler returns a new reconcile.Reconciler
-func newReconciler(
-	cli client.Client,
-	schema *runtime.Scheme,
-	statusMgr status.StatusManager,
-	p operatorv1.Provider,
-	tierWatchReady *utils.ReadyFlag,
-	clusterInfoWatchReady *utils.ReadyFlag,
-	opts options.ControllerOptions,
-) *ReconcileConnection {
-	c := &ReconcileConnection{
-		cli:                   cli,
-		scheme:                schema,
-		provider:              p,
-		status:                statusMgr,
-		tierWatchReady:        tierWatchReady,
-		clusterInfoWatchReady: clusterInfoWatchReady,
-		opts:                  opts,
-		ext:                   opts.Extensions.ClusterConnection(),
+// ReconcilerOptions is what the cluster connection reconciler needs to run.
+type ReconcilerOptions struct {
+	Client                client.Client
+	Scheme                *runtime.Scheme
+	Status                status.StatusManager
+	Provider              operatorv1.Provider
+	TierWatchReady        *utils.ReadyFlag
+	ClusterInfoWatchReady *utils.ReadyFlag
+	Options               options.ControllerOptions
+}
+
+// NewReconciler returns a cluster connection reconciler a caller can drive without a manager.
+func NewReconciler(o ReconcilerOptions) *ReconcileConnection {
+	if o.Options.ShutdownContext == nil {
+		o.Options.ShutdownContext = context.Background()
 	}
-	c.status.Run(opts.ShutdownContext)
+
+	c := &ReconcileConnection{
+		cli:                   o.Client,
+		scheme:                o.Scheme,
+		provider:              o.Provider,
+		status:                o.Status,
+		tierWatchReady:        o.TierWatchReady,
+		clusterInfoWatchReady: o.ClusterInfoWatchReady,
+		opts:                  o.Options,
+		ext:                   o.Options.Extensions.ClusterConnection(),
+	}
+	c.status.Run(o.Options.ShutdownContext)
 	return c
 }
 

--- a/operator/pkg/controller/clusterconnection/shim_test.go
+++ b/operator/pkg/controller/clusterconnection/shim_test.go
@@ -18,8 +18,6 @@
 package clusterconnection
 
 import (
-	"context"
-
 	"golang.org/x/net/http/httpproxy"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -40,10 +38,15 @@ func NewReconcilerWithShims(
 	clusterInfoWatchReady *utils.ReadyFlag,
 	opts options.ControllerOptions,
 ) reconcile.Reconciler {
-	if opts.ShutdownContext == nil {
-		opts.ShutdownContext = context.Background()
-	}
-	return newReconciler(cli, schema, status, provider, tierWatchReady, clusterInfoWatchReady, opts)
+	return NewReconciler(ReconcilerOptions{
+		Client:                cli,
+		Scheme:                schema,
+		Status:                status,
+		Provider:              provider,
+		TierWatchReady:        tierWatchReady,
+		ClusterInfoWatchReady: clusterInfoWatchReady,
+		Options:               opts,
+	})
 }
 
 // ResolvedPodProxies exposes what the reconciler read off the Guardian pods.

--- a/operator/pkg/controller/gatewayapi/gatewayapi_controller.go
+++ b/operator/pkg/controller/gatewayapi/gatewayapi_controller.go
@@ -64,22 +64,54 @@ const (
 
 var log = logf.Log.WithName("controller_gatewayapi")
 
+// ReconcilerOptions is what the Gateway API reconciler needs to run.
+type ReconcilerOptions struct {
+	Client         client.Client
+	Scheme         *runtime.Scheme
+	Status         status.StatusManager
+	TierWatchReady *utils.ReadyFlag
+	ClusterDomain  string
+	Variant        operatorv1.ProductVariant
+	Ext            extensions.GatewayAPIExtension
+}
+
+// NewReconciler returns a Gateway API reconciler a caller can drive without a manager.
+// Add replaces the lazy watches, which a manager-less caller has no controller to add.
+func NewReconciler(o ReconcilerOptions) *ReconcileGatewayAPI {
+	tierWatchReady := o.TierWatchReady
+	if tierWatchReady == nil {
+		tierWatchReady = &utils.ReadyFlag{}
+	}
+
+	return &ReconcileGatewayAPI{
+		client:              o.Client,
+		scheme:              o.Scheme,
+		status:              o.Status,
+		tierWatchReady:      tierWatchReady,
+		clusterDomain:       o.ClusterDomain,
+		variant:             o.Variant,
+		ext:                 o.Ext,
+		newComponentHandler: utils.NewComponentHandler,
+		watchEnvoyProxy:     func(operatorv1.NamespacedName) error { return nil },
+		watchEnvoyGateway:   func(operatorv1.NamespacedName) error { return nil },
+		watchGateways:       func() error { return nil },
+	}
+}
+
 // Add creates a new GatewayAPI Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
 //
 // Start Watches within the Add function for any resources that this controller creates or monitors. This will trigger
 // calls to Reconcile() when an instance of one of the watched resources is modified.
 func Add(mgr manager.Manager, opts options.ControllerOptions) error {
-	r := &ReconcileGatewayAPI{
-		client:              mgr.GetClient(),
-		scheme:              mgr.GetScheme(),
-		tierWatchReady:      &utils.ReadyFlag{},
-		status:              status.New(mgr.GetClient(), "gatewayapi", opts.KubernetesVersion),
-		clusterDomain:       opts.ClusterDomain,
-		variant:             opts.Variant,
-		ext:                 opts.Extensions.GatewayAPI(),
-		newComponentHandler: utils.NewComponentHandler,
-	}
+	r := NewReconciler(ReconcilerOptions{
+		Client:        mgr.GetClient(),
+		Scheme:        mgr.GetScheme(),
+		Status:        status.New(mgr.GetClient(), "gatewayapi", opts.KubernetesVersion),
+		ClusterDomain: opts.ClusterDomain,
+		Variant:       opts.Variant,
+		Ext:           opts.Extensions.GatewayAPI(),
+	})
 	r.status.Run(opts.ShutdownContext)
 
 	c, err := ctrlruntime.NewController("gatewayapi-controller", mgr, ctrl.Options{Reconciler: r})
@@ -602,7 +634,7 @@ func (r *ReconcileGatewayAPI) Reconcile(ctx context.Context, request reconcile.R
 	}
 
 	// Per-namespace resources, owned by the namespace's Gateways so the GC cleans them up.
-	if err = r.reconcileGatewayNamespaceResources(ctx, trustedBundle, pullSecrets, gwList.Items, ownedClass); err != nil {
+	if err = r.ReconcileGatewayNamespaceResources(ctx, trustedBundle, pullSecrets, gwList.Items, ownedClass); err != nil {
 		r.status.SetDegraded(operatorv1.ResourceUpdateError, "Error writing per-namespace Gateway resources", err, log)
 		return reconcile.Result{}, err
 	}
@@ -684,16 +716,10 @@ func (r *ReconcileGatewayAPI) maintainFinalizer(ctx context.Context, gatewayAPI 
 	return utils.MaintainInstallationFinalizer(ctx, r.client, gatewayAPI, render.GatewayAPIFinalizer, &gatewayAPIDeployment)
 }
 
-// reconcileGatewayNamespaceResources writes the per-namespace resources owned by the namespace's
-// Gateways, so the GC removes them once the last Gateway is gone (and the GatewayAPI CR's deletion
-// doesn't strand them). Reserved namespaces are skipped; the trust bundle and operator-secrets
-// RoleBinding are written for every variant, and the variant's extension adds whatever else the
-// namespace needs.
-// Each object is written once per owning Gateway, because the component handler takes a single
-// owner. MultipleOwnersLabel makes it merge that owner reference into the references already on the
-// object instead of replacing them, which is what keeps the namespace's other Gateways — and any
-// reference another feature added, such as the waypoint controller's Istio CR — in place.
-func (r *ReconcileGatewayAPI) reconcileGatewayNamespaceResources(ctx context.Context, bundle certificatemanagement.TrustedBundle, pullSecrets []*corev1.Secret, gateways []gapi.Gateway, ownedClass map[string]bool) error {
+// ReconcileGatewayNamespaceResources writes each namespace's resources once per owning Gateway,
+// skipping reserved namespaces. MultipleOwnersLabel makes the handler merge that owner into the
+// references already there rather than replace them.
+func (r *ReconcileGatewayAPI) ReconcileGatewayNamespaceResources(ctx context.Context, bundle certificatemanagement.TrustedBundle, pullSecrets []*corev1.Secret, gateways []gapi.Gateway, ownedClass map[string]bool) error {
 	gatewaysByNamespace := map[string][]*gapi.Gateway{}
 	for i := range gateways {
 		gw := &gateways[i]

--- a/operator/pkg/controller/gatewayapi/gatewayapi_controller_test.go
+++ b/operator/pkg/controller/gatewayapi/gatewayapi_controller_test.go
@@ -753,7 +753,7 @@ var _ = Describe("Gateway API controller tests", func() {
 		gateways := []gapi.Gateway{
 			{ObjectMeta: metav1.ObjectMeta{Namespace: "app-ns", Name: "gw1", UID: "u1"}, Spec: gapi.GatewaySpec{GatewayClassName: gatewayapi.GatewayClassName}},
 		}
-		Expect(r.reconcileGatewayNamespaceResources(ctx, bundle, nil, gateways, map[string]bool{gatewayapi.GatewayClassName: true})).NotTo(HaveOccurred())
+		Expect(r.ReconcileGatewayNamespaceResources(ctx, bundle, nil, gateways, map[string]bool{gatewayapi.GatewayClassName: true})).NotTo(HaveOccurred())
 
 		// The operator needs secret CRUD for the UI gateway TLS secret on
 		// both variants; the WAF SA/RoleBinding are Enterprise-only.
@@ -775,7 +775,7 @@ var _ = Describe("Gateway API controller tests", func() {
 			{ObjectMeta: metav1.ObjectMeta{Namespace: "other-ns", Name: "gw3", UID: "u3"}, Spec: gapi.GatewaySpec{GatewayClassName: "not-ours"}},
 			{ObjectMeta: metav1.ObjectMeta{Namespace: common.CalicoNamespace, Name: "gw4", UID: "u4"}, Spec: gapi.GatewaySpec{GatewayClassName: gatewayapi.GatewayClassName}},
 		}
-		Expect(r.reconcileGatewayNamespaceResources(ctx, bundle, nil, gateways, map[string]bool{gatewayapi.GatewayClassName: true})).NotTo(HaveOccurred())
+		Expect(r.ReconcileGatewayNamespaceResources(ctx, bundle, nil, gateways, map[string]bool{gatewayapi.GatewayClassName: true})).NotTo(HaveOccurred())
 
 		By("creating the bundle + operator-secrets RoleBinding in app-ns, owned by both Gateways")
 		ownerNames := func(o client.Object) []string {
@@ -813,7 +813,7 @@ var _ = Describe("Gateway API controller tests", func() {
 		gateways := []gapi.Gateway{
 			{ObjectMeta: metav1.ObjectMeta{Namespace: "app-ns", Name: "gw1", UID: "u1"}, Spec: gapi.GatewaySpec{GatewayClassName: gatewayapi.GatewayClassName}},
 		}
-		Expect(r.reconcileGatewayNamespaceResources(ctx, nil, nil, gateways, map[string]bool{gatewayapi.GatewayClassName: true})).NotTo(HaveOccurred())
+		Expect(r.ReconcileGatewayNamespaceResources(ctx, nil, nil, gateways, map[string]bool{gatewayapi.GatewayClassName: true})).NotTo(HaveOccurred())
 
 		By("keeping the Istio reference and adding our Gateway alongside it")
 		ownerKinds := func(o client.Object) []string {
@@ -848,7 +848,7 @@ var _ = Describe("Gateway API controller tests", func() {
 			{ObjectMeta: metav1.ObjectMeta{Namespace: "app-ns", Name: "gw1", UID: "u1"}, Spec: gapi.GatewaySpec{GatewayClassName: gatewayapi.GatewayClassName}},
 			{ObjectMeta: metav1.ObjectMeta{Namespace: "app-ns", Name: "flipped", UID: "u-flipped"}, Spec: gapi.GatewaySpec{GatewayClassName: "not-ours"}},
 		}
-		Expect(r.reconcileGatewayNamespaceResources(ctx, nil, nil, gateways, map[string]bool{gatewayapi.GatewayClassName: true})).NotTo(HaveOccurred())
+		Expect(r.ReconcileGatewayNamespaceResources(ctx, nil, nil, gateways, map[string]bool{gatewayapi.GatewayClassName: true})).NotTo(HaveOccurred())
 
 		updatedRB := &rbacv1.RoleBinding{}
 		Expect(c.Get(ctx, client.ObjectKey{Namespace: "app-ns", Name: "tigera-operator-secrets"}, updatedRB)).NotTo(HaveOccurred())

--- a/operator/pkg/controller/installation/core_controller.go
+++ b/operator/pkg/controller/installation/core_controller.go
@@ -265,24 +265,60 @@ func newReconciler(mgr manager.Manager, opts options.ControllerOptions) (*Reconc
 	// Create a Typha autoscaler.
 	typhaScaler := typhaautoscaler.New(mgr.GetClient(), common.TyphaDeploymentName, typhaautoscaler.NodeReplicaCounter, statusManager)
 
-	r := &ReconcileInstallation{
-		config:              mgr.GetConfig(),
-		client:              mgr.GetClient(),
-		scheme:              mgr.GetScheme(),
-		watches:             make(map[runtime.Object]struct{}),
-		status:              statusManager,
-		typhaAutoscaler:     typhaScaler,
-		namespaceMigration:  nm,
-		tierWatchReady:      &utils.ReadyFlag{},
-		migrationWatchReady: &utils.ReadyFlag{},
-		newComponentHandler: utils.NewComponentHandler,
-		opts:                opts,
-		ext:                 opts.Extensions.Installation(),
-	}
+	r := NewReconciler(ReconcilerOptions{
+		Config:             mgr.GetConfig(),
+		Client:             mgr.GetClient(),
+		Scheme:             mgr.GetScheme(),
+		Status:             statusManager,
+		TyphaAutoscaler:    typhaScaler,
+		NamespaceMigration: nm,
+		Options:            opts,
+	})
 	r.status.Run(opts.ShutdownContext)
 	r.typhaAutoscaler.Start(opts.ShutdownContext)
 
 	return r, nil
+}
+
+// ReconcilerOptions is what the Installation reconciler needs to run.
+type ReconcilerOptions struct {
+	Config              *rest.Config
+	Client              client.Client
+	Scheme              *runtime.Scheme
+	Status              status.StatusManager
+	TyphaAutoscaler     *typhaautoscaler.Autoscaler
+	NamespaceMigration  migration.NamespaceMigration
+	TierWatchReady      *utils.ReadyFlag
+	MigrationWatchReady *utils.ReadyFlag
+	Options             options.ControllerOptions
+}
+
+// NewReconciler returns an Installation reconciler a caller can drive without a manager.
+func NewReconciler(o ReconcilerOptions) *ReconcileInstallation {
+	tierWatchReady := o.TierWatchReady
+	if tierWatchReady == nil {
+		tierWatchReady = &utils.ReadyFlag{}
+	}
+
+	migrationWatchReady := o.MigrationWatchReady
+	if migrationWatchReady == nil {
+		migrationWatchReady = &utils.ReadyFlag{}
+	}
+
+	return &ReconcileInstallation{
+		config:              o.Config,
+		client:              o.Client,
+		scheme:              o.Scheme,
+		watches:             make(map[runtime.Object]struct{}),
+		status:              o.Status,
+		typhaAutoscaler:     o.TyphaAutoscaler,
+		namespaceMigration:  o.NamespaceMigration,
+		tierWatchReady:      tierWatchReady,
+		migrationWatchReady: migrationWatchReady,
+		newComponentHandler: utils.NewComponentHandler,
+		opts:                o.Options,
+		ext:                 o.Options.Extensions.Installation(),
+	}
 }
 
 // secondaryResources returns a list of the secondary resources that this controller

--- a/operator/pkg/controller/istio/istio_controller.go
+++ b/operator/pkg/controller/istio/istio_controller.go
@@ -97,16 +97,36 @@ func Add(mgr manager.Manager, opts options.ControllerOptions) error {
 
 // newReconciler returns a new reconcile.Reconciler
 func newReconciler(mgr manager.Manager, opts options.ControllerOptions) *ReconcileIstio {
-	r := &ReconcileIstio{
+	r := NewReconciler(ReconcilerOptions{
 		Client:   mgr.GetClient(),
-		scheme:   mgr.GetScheme(),
-		status:   status.New(mgr.GetClient(), "istio", opts.KubernetesVersion),
-		provider: opts.DetectedProvider,
-		ext:      opts.Extensions,
-	}
+		Scheme:   mgr.GetScheme(),
+		Status:   status.New(mgr.GetClient(), "istio", opts.KubernetesVersion),
+		Provider: opts.DetectedProvider,
+		Ext:      opts.Extensions,
+	})
 
 	r.status.Run(opts.ShutdownContext)
 	return r
+}
+
+// ReconcilerOptions is what the Istio reconciler needs to run.
+type ReconcilerOptions struct {
+	Client   client.Client
+	Scheme   *runtime.Scheme
+	Status   status.StatusManager
+	Provider operatorv1.Provider
+	Ext      extensions.Extensions
+}
+
+// NewReconciler returns an Istio reconciler a caller can drive without a manager.
+func NewReconciler(o ReconcilerOptions) *ReconcileIstio {
+	return &ReconcileIstio{
+		Client:   o.Client,
+		scheme:   o.Scheme,
+		status:   o.Status,
+		provider: o.Provider,
+		ext:      o.Ext,
+	}
 }
 
 // ReconcileIstio reconciles a Istio object

--- a/operator/pkg/controller/tiers/tiers_controller.go
+++ b/operator/pkg/controller/tiers/tiers_controller.go
@@ -49,15 +49,37 @@ import (
 
 var log = logf.Log.WithName("controller_tiers")
 
+// ReconcilerOptions is what the Tiers reconciler needs to run.
+type ReconcilerOptions struct {
+	Client             client.Client
+	Scheme             *runtime.Scheme
+	Status             status.StatusManager
+	TierWatchReady     *utils.ReadyFlag
+	PolicyWatchesReady *utils.ReadyFlag
+	Options            options.ControllerOptions
+}
+
+// NewReconciler returns a Tiers reconciler a caller can drive without a manager.
+func NewReconciler(o ReconcilerOptions) *ReconcileTiers {
+	return &ReconcileTiers{
+		client:             o.Client,
+		scheme:             o.Scheme,
+		status:             o.Status,
+		tierWatchReady:     o.TierWatchReady,
+		policyWatchesReady: o.PolicyWatchesReady,
+		opts:               o.Options,
+	}
+}
+
 // Add creates a new Tiers Controller and adds it to the Manager.
 // The Manager will set fields on the Controller and Start it when the Manager is Started.
 func Add(mgr manager.Manager, opts options.ControllerOptions) error {
-	r := &ReconcileTiers{
-		client: mgr.GetClient(),
-		scheme: mgr.GetScheme(),
-		status: status.New(mgr.GetClient(), "tiers", opts.KubernetesVersion),
-		opts:   opts,
-	}
+	r := NewReconciler(ReconcilerOptions{
+		Client:  mgr.GetClient(),
+		Scheme:  mgr.GetScheme(),
+		Status:  status.New(mgr.GetClient(), "tiers", opts.KubernetesVersion),
+		Options: opts,
+	})
 	r.status.Run(opts.ShutdownContext)
 
 	c, err := ctrlruntime.NewController("tiers-controller", mgr, controller.Options{Reconciler: r})


### PR DESCRIPTION
## Description

Six controllers build their reconciler through an exported constructor taking an options struct. Adding the controller to the manager is the only caller in this repo, and stays the one place that wires the fields.

The reason is on the variant side. A build serving another product variant keeps that variant's specs in its own packages, and those specs reconcile the core controllers. Nothing outside a controller package can construct its reconciler, so that coverage has to sit in the shared package and import the variant from there.

The controllers are apiserver, clusterconnection, gatewayapi, installation, istio and tiers. The Gateway API controller's per-namespace reconciliation step is exported for the same reason, and both it and the cluster connection reconciler default the watch-readiness flags a manager-less caller has no watches to set.

Related: [CORE-13562](https://tigera.atlassian.net/browse/CORE-13562)

**Release note:**
```release-note
None
```


[CORE-13562]: https://tigera.atlassian.net/browse/CORE-13562?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ