### PR TITLE
Check the operator's component list against the images this repo builds

### DIFF
--- a/.semaphore/semaphore-scheduled-builds.yml
+++ b/.semaphore/semaphore-scheduled-builds.yml
@@ -290,6 +290,21 @@ blocks:
         - name: Check images availability
           commands:
             - make check-images-availability
+  - name: Check operator images
+    # An image built here but absent from the operator's component list is published
+    # and then never deployed. BUILD_IMAGES lives in the component Makefiles, so they
+    # are triggers too.
+    run:
+      when: "true"
+    dependencies: []
+    task:
+      prologue:
+        commands:
+          - cd release
+      jobs:
+        - name: Check operator images
+          commands:
+            - ../.semaphore/run-and-monitor check-operator-images.log make check-operator-images
   - name: Check SemaphoreCI files
     run:
       when: >-

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -290,6 +290,49 @@ blocks:
         - name: Check images availability
           commands:
             - make check-images-availability
+  - name: Check operator images
+    # An image built here but absent from the operator's component list is published
+    # and then never deployed. BUILD_IMAGES lives in the component Makefiles, so they
+    # are triggers too.
+    run:
+      when: >-
+        change_in(['/**/Makefile',
+        '/.semaphore/semaphore.yml.d/01-preamble.yml',
+        '/.semaphore/semaphore.yml.d/02-global_job_config.yml',
+        '/.semaphore/semaphore.yml.d/03-promotions.yml',
+        '/.semaphore/semaphore.yml.d/09-blocks.yml',
+        '/.semaphore/semaphore.yml.d/99-after_pipeline.yml',
+        '/.semaphore/semaphore.yml.d/blocks/10-check-operator-images.yml',
+        '/api/pkg/lib/numorstring/*.go',
+        '/hack/test/certs/',
+        '/lib.Makefile',
+        '/lib/logrusr/*.go',
+        '/lib/std/log/*.go',
+        '/metadata.mk',
+        '/operator/api/v1/*.go',
+        '/operator/pkg/components/*.go',
+        '/operator/version/*.go',
+        '/release/**'],
+        {pipeline_file: 'ignore', exclude: ['/**/*.md',
+        '/**/.gitignore',
+        '/**/AUTHORS*',
+        '/**/CONTRIBUTING*',
+        '/**/DEVELOPER_GUIDE*',
+        '/**/LICENSE*',
+        '/**/README*',
+        '/**/SECURITY.md',
+        '/api/**/*_test.go',
+        '/lib/**/*_test.go',
+        '/operator/**/*_test.go']})
+    dependencies: []
+    task:
+      prologue:
+        commands:
+          - cd release
+      jobs:
+        - name: Check operator images
+          commands:
+            - ../.semaphore/run-and-monitor check-operator-images.log make check-operator-images
   - name: Check SemaphoreCI files
     run:
       when: >-
@@ -7628,11 +7671,15 @@ blocks:
         '/.semaphore/semaphore.yml.d/09-blocks.yml',
         '/.semaphore/semaphore.yml.d/99-after_pipeline.yml',
         '/.semaphore/semaphore.yml.d/blocks/90-release.yml',
+        '/api/pkg/lib/numorstring/*.go',
         '/hack/test/certs/',
         '/lib.Makefile',
         '/lib/logrusr/*.go',
         '/lib/std/log/*.go',
         '/metadata.mk',
+        '/operator/api/v1/*.go',
+        '/operator/pkg/components/*.go',
+        '/operator/version/*.go',
         '/release/**'],
         {pipeline_file: 'ignore', exclude: ['/**/*.md',
         '/**/.gitignore',
@@ -7642,7 +7689,9 @@ blocks:
         '/**/LICENSE*',
         '/**/README*',
         '/**/SECURITY.md',
-        '/lib/**/*_test.go']})
+        '/api/**/*_test.go',
+        '/lib/**/*_test.go',
+        '/operator/**/*_test.go']})
     execution_time_limit:
       minutes: 30
     dependencies:

--- a/.semaphore/semaphore.yml.d/blocks/10-check-operator-images.yml
+++ b/.semaphore/semaphore.yml.d/blocks/10-check-operator-images.yml
@@ -1,0 +1,15 @@
+- name: Check operator images
+  # An image built here but absent from the operator's component list is published
+  # and then never deployed. BUILD_IMAGES lives in the component Makefiles, so they
+  # are triggers too.
+  run:
+    when: "${CHANGE_IN(release,non-go:/**/Makefile)}"
+  dependencies: []
+  task:
+    prologue:
+      commands:
+        - cd release
+    jobs:
+      - name: Check operator images
+        commands:
+          - ../.semaphore/run-and-monitor check-operator-images.log make check-operator-images

--- a/operator/build/Dockerfile
+++ b/operator/build/Dockerfile
@@ -40,6 +40,7 @@ LABEL release="1"
 LABEL summary="Tigera Operator manages the lifecycle of a Calico or Calico Enterprise installation on Kubernetes or OpenShift"
 LABEL vendor="Tigera"
 LABEL version=${GIT_VERSION}
+LABEL org.opencontainers.image.version="${GIT_VERSION}"
 
 COPY --from=source / /
 

--- a/release/Makefile
+++ b/release/Makefile
@@ -48,6 +48,17 @@ fv st:
 	@true
 
 ###############################################################################
+# Checks
+###############################################################################
+# bin/release tracks only release/ sources, so rebuild it to pick up the operator's
+# component list. Clearing MAKEFLAGS keeps an outer -C's -w directory lines out of
+# the parsed image list.
+.PHONY: check-operator-images
+check-operator-images:
+	@$(MAKE) --no-print-directory --always-make bin/release
+	@MAKEFLAGS= bin/release images check-operator
+
+###############################################################################
 # CI/CD
 ###############################################################################
 .PHONY: ci

--- a/release/cmd/images.go
+++ b/release/cmd/images.go
@@ -17,10 +17,12 @@ package main
 import (
 	"context"
 
+	"github.com/sirupsen/logrus"
 	cli "github.com/urfave/cli/v3"
 
 	"github.com/projectcalico/calico/release/internal/command"
 	"github.com/projectcalico/calico/release/internal/images"
+	"github.com/projectcalico/calico/release/internal/operatorimages"
 	"github.com/projectcalico/calico/release/internal/outputs"
 	"github.com/projectcalico/calico/release/internal/registry"
 	"github.com/projectcalico/calico/release/internal/utils"
@@ -37,6 +39,7 @@ var imagesSubCommands = func(cfg *Config) []*cli.Command {
 	return []*cli.Command{
 		imagesBuildCommand(cfg),
 		imagesPublishCommand(cfg),
+		imagesCheckOperatorCommand(cfg),
 	}
 }
 
@@ -155,6 +158,33 @@ func imagesPublishCommand(cfg *Config) *cli.Command {
 
 // releaseImageList runs make in every release directory, so a test replaces it.
 var releaseImageList = utils.BuildReleaseImageList
+
+var imagesCheckOperatorAction = func(cfg *Config) func(ctx context.Context, c *cli.Command) error {
+	return func(_ context.Context, _ *cli.Command) error {
+		configureLogging("images-check-operator.log")
+
+		// The operator publishes to registries of its own, so it is named apart from the
+		// release directories rather than discovered with them.
+		dirs := append(utils.ImageDiscoveryDirs(), utils.OperatorDir)
+		built, err := releaseImageList(cfg.RepoRootDir, dirs...)
+		if err != nil {
+			return err
+		}
+		if err := operatorimages.Check(built); err != nil {
+			return err
+		}
+		logrus.WithField("images", len(built)).Info("The operator deploys every image built here")
+		return nil
+	}
+}
+
+func imagesCheckOperatorCommand(cfg *Config) *cli.Command {
+	return &cli.Command{
+		Name:   "check-operator",
+		Usage:  "Check that the operator deploys every image this repo builds",
+		Action: imagesCheckOperatorAction(cfg),
+	}
+}
 
 // scanRequest builds the scan request. Release decides which bucket the
 // scanner files results under, so a hashrelease is not a release.

--- a/release/cmd/images_test.go
+++ b/release/cmd/images_test.go
@@ -428,3 +428,27 @@ func TestScanRequestSeparatesHashreleases(t *testing.T) {
 		})
 	}
 }
+
+// The operator directory is named apart from the release directories, so the check has to
+// ask for it explicitly or the operator's own image goes unexamined.
+func TestImagesCheckOperatorCoversTheOperatorDir(t *testing.T) {
+	// The action opens a log file in the working directory.
+	t.Chdir(t.TempDir())
+
+	original := releaseImageList
+	var gotDirs []string
+	releaseImageList = func(_ string, dirs ...string) ([]string, error) {
+		gotDirs = dirs
+		return []string{"node", "operator"}, nil
+	}
+	defer func() { releaseImageList = original }()
+
+	if err := imagesCheckOperatorAction(&Config{})(context.Background(), &cli.Command{}); err != nil {
+		t.Fatalf("check-operator: %v", err)
+	}
+	for _, want := range append(utils.ImageDiscoveryDirs(), utils.OperatorDir) {
+		if !slices.Contains(gotDirs, want) {
+			t.Errorf("check dirs omit %s", want)
+		}
+	}
+}

--- a/release/deps.txt
+++ b/release/deps.txt
@@ -19,16 +19,35 @@ github.com/ProtonMail/go-crypto v1.0.0
 github.com/cespare/xxhash/v2 v2.3.0
 github.com/cloudflare/circl v1.6.3
 github.com/cncf/xds/go v0.0.0-20260202195803-dba9d589def2
+github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 github.com/docker/cli v29.6.2+incompatible
 github.com/docker/docker v26.1.5+incompatible
 github.com/docker/docker-credential-helpers v0.9.8
+github.com/envoyproxy/gateway v1.8.3
 github.com/envoyproxy/go-control-plane v0.14.1-0.20260409050421-3f47accd6e14
 github.com/envoyproxy/go-control-plane/envoy v1.37.1-0.20260409050421-3f47accd6e14
 github.com/envoyproxy/protoc-gen-validate v1.3.3
+github.com/evanphx/json-patch v5.9.11+incompatible
 github.com/felixge/httpsnoop v1.1.0
+github.com/fxamacker/cbor/v2 v2.9.2
 github.com/go-jose/go-jose/v4 v4.1.4
 github.com/go-logr/logr v1.4.4
 github.com/go-logr/stdr v1.2.2
+github.com/go-openapi/jsonpointer v1.0.0
+github.com/go-openapi/jsonreference v1.0.0
+github.com/go-openapi/swag v0.27.1
+github.com/go-openapi/swag/cmdutils v0.27.1
+github.com/go-openapi/swag/conv v0.27.3
+github.com/go-openapi/swag/fileutils v0.27.3
+github.com/go-openapi/swag/jsonutils v0.27.3
+github.com/go-openapi/swag/loading v0.27.3
+github.com/go-openapi/swag/mangling v0.27.3
+github.com/go-openapi/swag/netutils v0.27.1
+github.com/go-openapi/swag/pools v0.27.3
+github.com/go-openapi/swag/stringutils v0.27.3
+github.com/go-openapi/swag/typeutils v0.27.3
+github.com/go-openapi/swag/yamlutils v0.27.3
+github.com/google/gnostic-models v0.7.1
 github.com/google/go-containerregistry v0.21.7
 github.com/google/go-github/v53 v53.2.0
 github.com/google/go-querystring v1.1.0
@@ -37,7 +56,10 @@ github.com/google/uuid v1.6.0
 github.com/googleapis/enterprise-certificate-proxy v0.3.14
 github.com/googleapis/gax-go/v2 v2.21.0
 github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674
+github.com/json-iterator/go v1.1.12
 github.com/klauspost/compress v1.20.0
+github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd
+github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee
 github.com/opencontainers/go-digest v1.0.0
 github.com/opencontainers/image-spec v1.1.1
 github.com/projectcalico/calico
@@ -47,6 +69,7 @@ github.com/snowzach/rotatefilehook v0.0.0-20220211133110-53752135082d
 github.com/spiffe/go-spiffe/v2 v2.8.1
 github.com/urfave/cli v1.22.16
 github.com/urfave/cli/v3 v3.10.0
+github.com/x448/float16 v0.8.4
 go.opentelemetry.io/auto/sdk v1.2.1
 go.opentelemetry.io/contrib/detectors/gcp v1.44.0
 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.69.0
@@ -56,6 +79,7 @@ go.opentelemetry.io/otel/metric v1.44.0
 go.opentelemetry.io/otel/sdk v1.44.0
 go.opentelemetry.io/otel/sdk/metric v1.44.0
 go.opentelemetry.io/otel/trace v1.44.0
+go.yaml.in/yaml/v2 v2.4.4
 go.yaml.in/yaml/v3 v3.0.4
 golang.org/x/crypto v0.56.0
 golang.org/x/net v0.58.0
@@ -70,11 +94,29 @@ google.golang.org/genproto/googleapis/api v0.0.0-20260706201446-f0a921348800
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260706201446-f0a921348800
 google.golang.org/grpc v1.83.1
 google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af
+gopkg.in/inf.v0 v0.9.1
 gopkg.in/natefinch/lumberjack.v2 v2.2.1
 gopkg.in/yaml.v3 v3.0.1
+k8s.io/api v0.37.0
+k8s.io/apiextensions-apiserver v0.37.0
+k8s.io/apimachinery v0.37.0
+k8s.io/klog v0.2.0
+k8s.io/klog/v2 v2.140.0
+k8s.io/kube-openapi v0.0.0-20260721132016-d427ff9ee9ad
+k8s.io/utils v0.0.0-20260707023825-cf1189d6abe3
+sigs.k8s.io/controller-runtime v0.24.1
+sigs.k8s.io/gateway-api v1.5.1
+sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730
+sigs.k8s.io/randfill v1.0.0
+sigs.k8s.io/structured-merge-diff/v6 v6.4.2
+sigs.k8s.io/yaml v1.6.0
 
+local:api/pkg/lib/numorstring
 local:lib/logrusr
 local:lib/std/log
+local:operator/api/v1
+local:operator/pkg/components
+local:operator/version
 local:release/cmd
 local:release/internal/branch
 local:release/internal/ci
@@ -83,6 +125,7 @@ local:release/internal/defaults
 local:release/internal/hashreleaseserver
 local:release/internal/images
 local:release/internal/imagescanner
+local:release/internal/operatorimages
 local:release/internal/outputs
 local:release/internal/pinnedversion
 local:release/internal/registry

--- a/release/internal/operatorimages/operatorimages.go
+++ b/release/internal/operatorimages/operatorimages.go
@@ -1,0 +1,65 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package operatorimages checks the images this repo builds against the ones the operator deploys.
+package operatorimages
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/projectcalico/calico/operator/pkg/components"
+)
+
+// notDeployed maps an image this repo publishes to the reason the operator does not deploy it.
+var notDeployed = map[string]string{}
+
+// Check fails when an image this repo builds is absent from the operator's component list. The
+// reverse is not checked: the operator also names images built outside this repo.
+func Check(built []string) error {
+	undeployed := missing(built, deployed())
+	if len(undeployed) == 0 {
+		return nil
+	}
+	return fmt.Errorf("the operator does not deploy images built here: %s; add each to a component list in operator/pkg/components, or to notDeployed with its reason",
+		strings.Join(undeployed, ", "))
+}
+
+// deployed returns the image names the operator's component list carries, plus the operator's
+// own image, which the list leaves out because the operator does not deploy itself.
+func deployed() []string {
+	comps := append(slices.Clone(components.CalicoImages), components.ComponentOperatorInit)
+	out := make([]string, 0, len(comps))
+	for _, c := range comps {
+		out = append(out, c.Image)
+	}
+	return out
+}
+
+// missing returns the built images no component names, less the exceptions.
+func missing(built, deployed []string) []string {
+	var out []string
+	for _, img := range built {
+		if _, ok := notDeployed[img]; ok {
+			continue
+		}
+		if slices.Contains(deployed, img) || slices.Contains(out, img) {
+			continue
+		}
+		out = append(out, img)
+	}
+	slices.Sort(out)
+	return out
+}

--- a/release/internal/operatorimages/operatorimages_test.go
+++ b/release/internal/operatorimages/operatorimages_test.go
@@ -1,0 +1,65 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package operatorimages
+
+import (
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestCheckAcceptsEveryDeployedImage(t *testing.T) {
+	if err := Check(deployed()); err != nil {
+		t.Fatalf("Check(deployed()): %v", err)
+	}
+}
+
+func TestCheckNamesTheUndeployedImages(t *testing.T) {
+	err := Check([]string{"node", "new-thing", "another-thing"})
+	if err == nil {
+		t.Fatal("Check: want an error for images the operator does not deploy")
+	}
+	for _, img := range []string{"new-thing", "another-thing"} {
+		if !strings.Contains(err.Error(), img) {
+			t.Errorf("Check error %q does not name %s", err, img)
+		}
+	}
+}
+
+func TestCheckSkipsExceptions(t *testing.T) {
+	notDeployed = map[string]string{"new-thing": "not deployed by the operator"}
+	t.Cleanup(func() {
+		notDeployed = map[string]string{}
+	})
+	if err := Check([]string{"node", "new-thing"}); err != nil {
+		t.Fatalf("Check: %v", err)
+	}
+}
+
+func TestMissingReportsEachImageOnce(t *testing.T) {
+	got := missing([]string{"new-thing", "node", "new-thing"}, []string{"node"})
+	if !slices.Equal(got, []string{"new-thing"}) {
+		t.Errorf("missing = %v, want [new-thing]", got)
+	}
+}
+
+func TestDeployedIncludesTheOperatorItself(t *testing.T) {
+	got := deployed()
+	for _, img := range []string{"calico", "node", "operator"} {
+		if !slices.Contains(got, img) {
+			t.Errorf("deployed() does not name %s", img)
+		}
+	}
+}

--- a/release/pkg/manager/calico/manager.go
+++ b/release/pkg/manager/calico/manager.go
@@ -971,6 +971,20 @@ func (r *CalicoManager) assertImageVersions() error {
 			return fmt.Errorf("unknown image: %s, update assertion to include validating image", img)
 		}
 	}
+	return r.assertOperatorImageVersion()
+}
+
+// assertOperatorImageVersion checks the operator image reports the version it was published at.
+// The operator publishes to registries of its own, so it is absent from the release images.
+func (r *CalicoManager) assertOperatorImageVersion() error {
+	img := fmt.Sprintf("%s/%s:%s", r.operatorRegistry, r.operatorImage, r.operatorVersion)
+	out, err := r.runner.Run("docker", []string{"inspect", `--format='{{ index .Config.Labels "org.opencontainers.image.version" }}'`, img}, nil)
+	if err != nil {
+		return fmt.Errorf("failed to get version from operator image %s: %w", img, err)
+	}
+	if !strings.Contains(out, r.operatorVersion) {
+		return fmt.Errorf("version does not match for image %s", img)
+	}
 	return nil
 }
 

--- a/release/pkg/manager/calico/manager_test.go
+++ b/release/pkg/manager/calico/manager_test.go
@@ -973,3 +973,34 @@ func TestBuildE2EBinariesUsesARCHES(t *testing.T) {
 			"e2e build-all should not set VALIDARCHES (lib.Makefile ignores it): %s", e)
 	}
 }
+
+func TestAssertOperatorImageVersion(t *testing.T) {
+	const version = "v1.42.0"
+	for _, tt := range []struct {
+		name    string
+		label   string
+		wantErr bool
+	}{
+		{name: "image reports the published version", label: version},
+		{name: "image reports another version", label: "v1.41.0", wantErr: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			f := newFakeRunner().on("docker inspect", tt.label, nil)
+			r := &CalicoManager{
+				runner:           f,
+				operatorRegistry: "quay.io/tigera",
+				operatorImage:    "operator",
+				operatorVersion:  version,
+			}
+
+			err := r.assertOperatorImageVersion()
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			require.Len(t, f.calls, 1)
+			require.Contains(t, f.calls[0], "quay.io/tigera/operator:"+version)
+		})
+	}
+}


### PR DESCRIPTION
## Description

- The operator's component list used to be generated from the images this repo produces; with the component versions on ldflags it is hand-written, so a new image can be built and published without anything noticing the operator never deploys it.
- `make -C release check-operator-images` asks each release directory for its `BUILD_IMAGES`, adds the operator's own directory, and fails on anything the operator's component list does not name. It runs locally as well as in a new CI block, triggered by the release tool's inputs and by every component Makefile.
- The check is one-directional on purpose: the operator also names images this repo does not build (busybox, flannel, the upstream Istio init images), so checking equality would want exceptions on both sides. Nothing needs an exception today.
- Second commit, same area: the release tool's image-version assertion skipped the operator, because it walks the release images and the operator publishes to registries of its own. It gets a check of its own, against a version label the operator image did not carry.

Tested with the release unit tests, and by running the check against a tree with one component dropped from the operator's list, where it fails with that image named.

Related: [CORE-13630](https://tigera.atlassian.net/browse/CORE-13630)

**Release note:**
```release-note
None
```

**AI assistance:** Claude Code wrote the check and the tests from my design.


[CORE-13630]: https://tigera.atlassian.net/browse/CORE-13630?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ