### PR TITLE
Collapse the duplicate external node labels into one

### DIFF
--- a/e2e/pkg/describe/describe.go
+++ b/e2e/pkg/describe/describe.go
@@ -200,10 +200,6 @@ func WithExternalNode() any {
 	return framework.WithLabel("ExternalNode")
 }
 
-func RequiresExternalNode() any {
-	return framework.WithLabel("RequiresExternalNode")
-}
-
 // RequiresAzureIPAM marks tests that require a cluster with Azure IPAM.
 func RequiresAzureIPAM() any {
 	return framework.WithLabel("AzureIPAM")

--- a/e2e/pkg/utils/externalnode/client_test.go
+++ b/e2e/pkg/utils/externalnode/client_test.go
@@ -73,7 +73,7 @@ func TestTestsNeedingTheExternalNodeCarryTheLabel(t *testing.T) {
 		t.Fatal("no e2e test calls externalnode.MustNewClient, so this guard checks nothing")
 	}
 	for _, path := range paths {
-		if !fileContains(t, path, "ExternalNode") {
+		if !fileContains(t, path, "describe.WithExternalNode(") {
 			t.Errorf("%s: needs the external node but carries no describe.WithExternalNode label", path)
 		}
 	}


### PR DESCRIPTION
RequiresExternalNode was declared alongside ExternalNode and never used by any spec, so a lane excluding one label would still have selected anything that picked up the other. Deleting it leaves ExternalNode, which the lane configs already exclude in 45 places.

The guard that checks external-node specs carry a label was matching the bare string ExternalNode, which the conncheck helper name satisfies on its own, so it now matches the label helper call.

```release-note
None
```
