### PR TITLE
e2e: use the gcloud credential helper for gcr pulls

### DIFF
--- a/.semaphore/end-to-end/scripts/global_prologue.sh
+++ b/.semaphore/end-to-end/scripts/global_prologue.sh
@@ -165,6 +165,11 @@ chmod +x "${BZ_GLOBAL_BIN}/bz"
 mkdir -p "$HOME/.docker"
 cp ~/secrets/docker_cfg.json "$HOME/.docker/config.json"
 
+# gcr.io is Artifact-Registry-backed; the static token in docker_cfg.json is
+# short-lived, so a long job can no longer pull by the time the epilogue runs.
+# The helper mints a token per pull (must follow the docker_cfg copy above).
+gcloud auth --quiet configure-docker gcr.io || echo "[WARN] gcloud configure-docker failed"
+
 mkdir -p "${BZ_LOGS_DIR}"
 
 cd "$HOME" || exit


### PR DESCRIPTION
The e2e prologue copies a static docker_cfg.json to ~/.docker/config.json. The gcr credentials in it are short-lived, so once a job exceeds that time, nothing can pull from gcr any more. This means that lens-report:stable can't upload results to Lens.

Configure the credential helper after the copy, as .semaphore/release/hashrelease_enterprise.yml already does.

<!-- Describe your changes, including the type of change (bug fix, feature, etc.),
why it should be merged, testing done, and links to related issues. -->

<!-- For any user-visible change, replace TBD with a one-line description. -->
**Release note:**
```release-note
TBD
```

<!-- Replace TBD: say what AI tools helped write this change, or "None". -->
**AI assistance:** None