### PR TITLE
Invoke the nested webhooks command in the static manifests

### DIFF
--- a/charts/calico/templates/calico-webhooks.yaml
+++ b/charts/calico/templates/calico-webhooks.yaml
@@ -80,6 +80,7 @@ spec:
           imagePullPolicy: {{.Values.imagePullPolicy}}
           args:
             - component
+            - webhooks
             - webhook
             - --tls-cert-file=/certs/tls.crt
             - --tls-private-key-file=/certs/tls.key

--- a/charts/test/calico_chart_test.go
+++ b/charts/test/calico_chart_test.go
@@ -44,6 +44,35 @@ func TestCalicoNodeRunsHostWritingInitContainersAsRoot(t *testing.T) {
 	}
 }
 
+func TestCalicoWebhooksKeepsTheServerUnprivileged(t *testing.T) {
+	g := NewWithT(t)
+
+	var deployment appsv1.Deployment
+	renderCalicoResource(t, "templates/calico-webhooks.yaml", "Deployment", "calico-webhooks", &deployment)
+
+	container := containerByName(t, deployment.Spec.Template.Spec.Containers, "calico-webhooks")
+	g.Expect(container.SecurityContext.RunAsUser).To(Equal(ptr.To[int64](10001)))
+	g.Expect(container.SecurityContext.RunAsNonRoot).To(Equal(ptr.To(true)))
+}
+
+// The TLS flags live on the nested webhook command, so "component webhook" alone reaches
+// the parent group and the server exits with "unknown flag: --tls-cert-file".
+func TestCalicoWebhooksInvokesTheNestedWebhookCommand(t *testing.T) {
+	g := NewWithT(t)
+
+	var deployment appsv1.Deployment
+	renderCalicoResource(t, "templates/calico-webhooks.yaml", "Deployment", "calico-webhooks", &deployment)
+
+	container := containerByName(t, deployment.Spec.Template.Spec.Containers, "calico-webhooks")
+	g.Expect(container.Args).To(Equal([]string{
+		"component",
+		"webhooks",
+		"webhook",
+		"--tls-cert-file=/certs/tls.crt",
+		"--tls-private-key-file=/certs/tls.key",
+	}))
+}
+
 func renderCalicoResource(t *testing.T, templatePath, kind, name string, into any) {
 	t.Helper()
 	g := NewWithT(t)

--- a/manifests/calico-v3-crds.yaml
+++ b/manifests/calico-v3-crds.yaml
@@ -13381,6 +13381,7 @@ spec:
           imagePullPolicy: IfNotPresent
           args:
             - component
+            - webhooks
             - webhook
             - --tls-cert-file=/certs/tls.crt
             - --tls-private-key-file=/certs/tls.key


### PR DESCRIPTION
The v3.33 static manifests run calico-webhooks with a subcommand the consolidated calico binary does not have, so the pod crashloops on `unknown flag: --tls-cert-file`. Because the tiered-rbac webhook ships with `failurePolicy: Fail`, that then rejects every tiered policy write, and a manifest-installed cluster comes up with a non-functional policy plane. Master was fixed in #13665, but #13816 backported only the CNI half of it, so this brings over the webhook half plus the two chart render tests that cover it.

Found during the v3.33 test cycle, Zephyr OS-R233 / CR-17.

Related: [CORE-13638](https://tigera.atlassian.net/browse/CORE-13638)

**Release note:**
```release-note
Fixes calico-webhooks crashlooping on a non-operator manifest install, which left all tiered policy writes rejected.
```

**AI assistance:** Claude Code

By opening this PR you take responsibility for every line in it, and you agree to explain the change yourself during review rather than routing review comments back through an agent. See [AI_POLICY.md](../AI_POLICY.md).


[CORE-13638]: https://tigera.atlassian.net/browse/CORE-13638?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ