### PR TITLE
Restore the aggregated APIService in place on migration abort

### DIFF
--- a/kube-controllers/pkg/controllers/migration/apiservice_test.go
+++ b/kube-controllers/pkg/controllers/migration/apiservice_test.go
@@ -1,0 +1,158 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package migration
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8stesting "k8s.io/client-go/testing"
+	apiregv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
+	fakeapiregclient "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/fake"
+
+	migrationv1 "github.com/projectcalico/calico/kube-controllers/pkg/apis/migration/v1"
+)
+
+// apiServicesGVR addresses APIServices in the fake clientset's object tracker.
+var apiServicesGVR = apiregv1.SchemeGroupVersion.WithResource("apiservices")
+
+// newAutomanagedAPIServiceObj returns the CRD-backed APIService that
+// kube-aggregator's autoregister controller maintains for v3.projectcalico.org
+// while the v3 CRDs are installed.
+func newAutomanagedAPIServiceObj() *apiregv1.APIService {
+	return &apiregv1.APIService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   apiServiceName,
+			Labels: map[string]string{automanagedLabel: "true"},
+		},
+		Spec: apiregv1.APIServiceSpec{
+			Group:                "projectcalico.org",
+			Version:              "v3",
+			GroupPriorityMinimum: 1000,
+			VersionPriority:      100,
+		},
+	}
+}
+
+// autoregisteringAPIRegClient models kube-aggregator's autoregister controller:
+// deleting v3.projectcalico.org puts an automanaged, CRD-backed APIService
+// straight back. The counter reports how often that happened.
+func autoregisteringAPIRegClient(objects ...runtime.Object) (*fakeapiregclient.Clientset, *atomic.Int32) {
+	c := fakeapiregclient.NewSimpleClientset(objects...)
+	recreations := &atomic.Int32{}
+
+	c.PrependReactor("delete", "apiservices", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		del, ok := action.(k8stesting.DeleteAction)
+		if !ok || del.GetName() != apiServiceName {
+			return false, nil, nil
+		}
+		if _, err := c.Tracker().Get(apiServicesGVR, "", del.GetName()); err != nil {
+			return true, nil, err
+		}
+		if err := c.Tracker().Delete(apiServicesGVR, "", del.GetName()); err != nil {
+			return true, nil, err
+		}
+		recreations.Add(1)
+		return true, nil, c.Tracker().Add(newAutomanagedAPIServiceObj())
+	})
+
+	return c, recreations
+}
+
+// TestAbort_RestoresAPIServiceAgainstAutoregister covers CORE-13612. The abort
+// has to hand v3.projectcalico.org back to the aggregated API server even
+// though the v3 CRDs are still installed, so autoregister keeps re-creating a
+// CRD-backed one.
+func TestAbort_RestoresAPIServiceAgainstAutoregister(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+
+	bc := &mockBackendClient{clusterInfo: lockedV1ClusterInfo()}
+	m, _, _ := newErrorTestController(t, bc, migratingCR(t))
+
+	// The forward path already replaced the aggregated APIService with the
+	// automanaged one, which is the state the abort has to undo.
+	apiReg, recreations := autoregisteringAPIRegClient(newAutomanagedAPIServiceObj())
+	m.apiregClient = apiReg.ApiregistrationV1()
+
+	dm := &migrationv1.DatastoreMigration{}
+	g.Expect(m.rtClient.Get(ctx, dmKey, dm)).To(Succeed())
+	g.Expect(m.rtClient.Delete(ctx, dm)).To(Succeed())
+
+	m.queue.Add(defaultMigrationName)
+	g.Expect(m.processNextWorkItem()).To(BeTrue())
+	g.Expect(m.queue.NumRequeues(defaultMigrationName)).To(Equal(0), "abort should have succeeded")
+
+	apiSvc, err := apiReg.ApiregistrationV1().APIServices().Get(ctx, apiServiceName, metav1.GetOptions{})
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(apiSvc.Labels).NotTo(HaveKey(automanagedLabel), "the restored APIService must not stay CRD-backed")
+	g.Expect(apiSvc.Spec.Service).To(Equal(&apiregv1.ServiceReference{Namespace: "calico-system", Name: "calico-api"}))
+	g.Expect(recreations.Load()).To(BeZero(), "the restore must not delete the APIService — autoregister puts a CRD-backed one straight back")
+}
+
+// TestRestoreAPIService pins the branches that must keep working alongside the
+// in-place overwrite.
+func TestRestoreAPIService(t *testing.T) {
+	ctx := context.Background()
+	logCtx := logrus.WithField("test", t.Name())
+
+	t.Run("leaves an already-aggregated APIService alone", func(t *testing.T) {
+		g := NewWithT(t)
+
+		live := newAggregatedAPIServiceObj()
+		live.Spec.GroupPriorityMinimum = 4242
+		apiReg, _ := autoregisteringAPIRegClient(live)
+		m := &migrationController{ctx: ctx, apiregClient: apiReg.ApiregistrationV1()}
+
+		g.Expect(m.restoreAPIService(logCtx, migratingCR(t))).To(Succeed())
+
+		apiSvc, err := apiReg.ApiregistrationV1().APIServices().Get(ctx, apiServiceName, metav1.GetOptions{})
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(apiSvc.Spec.GroupPriorityMinimum).To(Equal(int32(4242)), "whoever re-registered the APIService should win over the saved copy")
+	})
+
+	t.Run("creates the saved APIService when none exists", func(t *testing.T) {
+		g := NewWithT(t)
+
+		apiReg, _ := autoregisteringAPIRegClient()
+		m := &migrationController{ctx: ctx, apiregClient: apiReg.ApiregistrationV1()}
+
+		g.Expect(m.restoreAPIService(logCtx, migratingCR(t))).To(Succeed())
+
+		apiSvc, err := apiReg.ApiregistrationV1().APIServices().Get(ctx, apiServiceName, metav1.GetOptions{})
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(apiSvc.Spec.Service).NotTo(BeNil())
+	})
+
+	t.Run("leaves the CRD-backed APIService in place with nothing saved", func(t *testing.T) {
+		g := NewWithT(t)
+
+		apiReg, _ := autoregisteringAPIRegClient(newAutomanagedAPIServiceObj())
+		m := &migrationController{ctx: ctx, apiregClient: apiReg.ApiregistrationV1()}
+
+		dm := migratingCR(t)
+		dm.Annotations = nil
+		g.Expect(m.restoreAPIService(logCtx, dm)).To(Succeed())
+
+		apiSvc, err := apiReg.ApiregistrationV1().APIServices().Get(ctx, apiServiceName, metav1.GetOptions{})
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(apiSvc.Labels).To(HaveKeyWithValue(automanagedLabel, "true"))
+	})
+}

--- a/kube-controllers/pkg/controllers/migration/controller.go
+++ b/kube-controllers/pkg/controllers/migration/controller.go
@@ -39,6 +39,7 @@ import (
 	"k8s.io/client-go/dynamic/dynamicinformer"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/retry"
 	"k8s.io/client-go/util/workqueue"
 	apiregv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 	apiregv1client "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1"
@@ -78,6 +79,10 @@ const (
 
 	// apiServiceName is the name of the aggregated APIService for v3.projectcalico.org.
 	apiServiceName = "v3.projectcalico.org"
+
+	// automanagedLabel marks an APIService that kube-aggregator's autoregister
+	// controller owns and will re-create for as long as its CRDs are installed.
+	automanagedLabel = "kube-aggregator.kubernetes.io/automanaged"
 
 	// clusterInfoName is the well-known name of the ClusterInformation resource.
 	clusterInfoName = "default"
@@ -593,7 +598,7 @@ func (m *migrationController) runPendingPrechecks(logCtx *logrus.Entry, dm *migr
 		} else {
 			return false, fmt.Errorf("checking APIService: %w", err)
 		}
-	} else if apiSvc.Labels != nil && apiSvc.Labels["kube-aggregator.kubernetes.io/automanaged"] == "true" {
+	} else if isAutomanagedAPIService(apiSvc) {
 		logCtx.Info("APIService v3.projectcalico.org is CRD-backed (v3 CRDs already installed)")
 	}
 
@@ -1160,7 +1165,7 @@ func (m *migrationController) saveAndDeleteAPIService(logCtx *logrus.Entry, dm *
 
 	// Check if it's already a CRD-backed (automanaged) APIService. If so,
 	// the aggregated one was already deleted and K8s auto-created this one.
-	if apiSvc.Labels != nil && apiSvc.Labels["kube-aggregator.kubernetes.io/automanaged"] == "true" {
+	if isAutomanagedAPIService(apiSvc) {
 		logCtx.Debug("APIService is already CRD-backed, nothing to save/delete")
 		return nil
 	}
@@ -1202,24 +1207,15 @@ func (m *migrationController) saveAndDeleteAPIService(logCtx *logrus.Entry, dm *
 	return nil
 }
 
-// restoreAPIService recreates the aggregated APIService from the saved annotation.
+// restoreAPIService puts the saved aggregated APIService spec back on
+// v3.projectcalico.org.
 func (m *migrationController) restoreAPIService(logCtx *logrus.Entry, dm *migrationv1.DatastoreMigration) error {
-	// Check if an aggregated APIService already exists (e.g., operator recreated it).
 	existing, err := m.apiregClient.APIServices().Get(m.ctx, apiServiceName, metav1.GetOptions{})
-	if err == nil {
-		if existing.Labels == nil || existing.Labels["kube-aggregator.kubernetes.io/automanaged"] != "true" {
-			logCtx.Info("Aggregated APIService already exists, skipping restore")
-			return nil
-		}
-		// The existing one is automanaged (CRD-backed). Delete it so we can
-		// recreate the aggregated one.
-		logCtx.Info("Deleting automanaged APIService to restore aggregated one")
-		if err := m.apiregClient.APIServices().Delete(m.ctx, apiServiceName, metav1.DeleteOptions{}); err != nil {
-			if !kerrors.IsNotFound(err) {
-				return fmt.Errorf("deleting automanaged APIService: %w", err)
-			}
-		}
-	} else if !kerrors.IsNotFound(err) {
+	switch {
+	case err == nil && !isAutomanagedAPIService(existing):
+		logCtx.Info("Aggregated APIService already exists, skipping restore")
+		return nil
+	case err != nil && !kerrors.IsNotFound(err):
 		return fmt.Errorf("checking existing APIService: %w", err)
 	}
 
@@ -1232,21 +1228,43 @@ func (m *migrationController) restoreAPIService(logCtx *logrus.Entry, dm *migrat
 		return nil
 	}
 
-	apiSvc := &apiregv1.APIService{}
-	if err := json.Unmarshal([]byte(savedData), apiSvc); err != nil {
+	saved := &apiregv1.APIService{}
+	if err := json.Unmarshal([]byte(savedData), saved); err != nil {
 		return fmt.Errorf("deserializing saved APIService: %w", err)
 	}
 
-	_, err = m.apiregClient.APIServices().Create(m.ctx, apiSvc, metav1.CreateOptions{})
-	if err != nil {
-		if kerrors.IsAlreadyExists(err) {
-			logCtx.Info("APIService already recreated (possibly by operator)")
-			return nil
-		}
-		return fmt.Errorf("creating restored APIService: %w", err)
+	// Overwrite the automanaged APIService in place rather than deleting and
+	// re-creating it. Autoregister re-creates a deleted automanaged APIService
+	// while the v3 CRDs are installed, but leaves one without the label alone.
+	racing := func(err error) bool {
+		return kerrors.IsConflict(err) || kerrors.IsAlreadyExists(err)
 	}
+	if err := retry.OnError(retry.DefaultRetry, racing, func() error {
+		current, err := m.apiregClient.APIServices().Get(m.ctx, apiServiceName, metav1.GetOptions{})
+		if err != nil {
+			if !kerrors.IsNotFound(err) {
+				return err
+			}
+			_, err = m.apiregClient.APIServices().Create(m.ctx, saved, metav1.CreateOptions{})
+			return err
+		}
+
+		current.Spec = saved.Spec
+		delete(current.Labels, automanagedLabel)
+		_, err = m.apiregClient.APIServices().Update(m.ctx, current, metav1.UpdateOptions{})
+		return err
+	}); err != nil {
+		return fmt.Errorf("restoring aggregated APIService: %w", err)
+	}
+
 	logCtx.Info("Restored aggregated APIService v3.projectcalico.org")
 	return nil
+}
+
+// isAutomanagedAPIService reports whether kube-aggregator's autoregister
+// controller owns this APIService, meaning it is backed by CRDs.
+func isAutomanagedAPIService(apiSvc *apiregv1.APIService) bool {
+	return apiSvc.Labels[automanagedLabel] == "true"
 }
 
 // lockV1Datastore sets DatastoreReady=false on the v1 ClusterInformation, so


### PR DESCRIPTION
Aborting an in-flight DatastoreMigration left the aggregated `v3.projectcalico.org` APIService unrestored, so Calico served from the v3 CRD store the abort had just emptied while the intact v1 data sat behind it. The abort deleted the CRD-backed APIService and tried to recreate the saved aggregated one, but kube-aggregator recreates it immediately while the v3 CRDs are still installed, so the create always lost the race and the resulting AlreadyExists was treated as success. The restore now overwrites the existing APIService in place and drops the automanaged label, which is what stops kube-aggregator managing it.

The FV suite used a fake apiregistration client that never recreates on delete, which is why this went unnoticed; the new test models kube-aggregator's recreation and fails without the fix.

Found during the v3.33 test cycle, Zephyr OS-R233 / CR-2.

Related: [CORE-13612](https://tigera.atlassian.net/browse/CORE-13612)

**Release note:**
```release-note
Fixes aborting a datastore migration leaving Calico serving from an empty datastore instead of restoring the aggregated API server.
```

**AI assistance:** Claude Code

By opening this PR you take responsibility for every line in it, and you agree to explain the change yourself during review rather than routing review comments back through an agent. See [AI_POLICY.md](../AI_POLICY.md).


[CORE-13612]: https://tigera.atlassian.net/browse/CORE-13612?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ