### PR TITLE
Run kube-controllers on the host network during a datastore migration

### DIFF
--- a/operator/pkg/controller/installation/core_controller.go
+++ b/operator/pkg/controller/installation/core_controller.go
@@ -1405,6 +1405,7 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 		Namespace:              common.CalicoNamespace,
 		BindingNamespaces:      []string{common.CalicoNamespace},
 		Image:                  r.ext.KubeControllersImage(),
+		MigrationActive:        migrationExists,
 	}
 	components = append(components, kubecontrollers.NewCalicoKubeControllers(&kubeControllersCfg))
 

--- a/operator/pkg/render/kubecontrollers/kube-controllers.go
+++ b/operator/pkg/render/kubecontrollers/kube-controllers.go
@@ -78,6 +78,11 @@ type KubeControllersConfiguration struct {
 	// For details on why this is needed see 'Node and Installation finalizer' in the core_controller.
 	Terminating bool
 
+	// MigrationActive host-networks the deployment for the duration of a
+	// DatastoreMigration. The migration locks the datastore, which stops CNI, so a
+	// pod-networked replacement could never be scheduled to finish the job.
+	MigrationActive bool
+
 	// Secrets - provided by the caller. Used to generate secrets in the destination
 	// namespace to be returned by the rendered. Expected that the calling code
 	// take care to pass the same secret on each reconcile where possible.
@@ -525,6 +530,11 @@ func (c *kubeControllersComponent) controllersDeployment() *appsv1.Deployment {
 		InitContainers:     initContainers,
 		Containers:         []corev1.Container{container},
 		Volumes:            c.kubeControllersVolumes(),
+	}
+
+	if c.cfg.MigrationActive {
+		podSpec.HostNetwork = true
+		podSpec.DNSPolicy = corev1.DNSClusterFirstWithHostNet
 	}
 
 	var replicas int32 = 1

--- a/operator/pkg/render/kubecontrollers/kube-controllers_test.go
+++ b/operator/pkg/render/kubecontrollers/kube-controllers_test.go
@@ -313,6 +313,23 @@ var _ = Describe("kube-controllers rendering tests", func() {
 		Expect(d.Spec.Template.Spec.Tolerations).To(ConsistOf(rmeta.TolerateCriticalAddonsAndControlPlane))
 	})
 
+	It("should host-network the deployment while a migration is active", func() {
+		cfg.MigrationActive = true
+		component := kubecontrollers.NewCalicoKubeControllers(&cfg)
+		resources, _ := component.Objects()
+		d := rtest.GetResource(resources, kubecontrollers.KubeController, common.CalicoNamespace, "apps", "v1", "Deployment").(*appsv1.Deployment)
+		Expect(d.Spec.Template.Spec.HostNetwork).To(BeTrue())
+		Expect(d.Spec.Template.Spec.DNSPolicy).To(Equal(corev1.DNSClusterFirstWithHostNet))
+	})
+
+	It("should not host-network the deployment when no migration is active", func() {
+		component := kubecontrollers.NewCalicoKubeControllers(&cfg)
+		resources, _ := component.Objects()
+		d := rtest.GetResource(resources, kubecontrollers.KubeController, common.CalicoNamespace, "apps", "v1", "Deployment").(*appsv1.Deployment)
+		Expect(d.Spec.Template.Spec.HostNetwork).To(BeFalse())
+		Expect(d.Spec.Template.Spec.DNSPolicy).To(BeEmpty())
+	})
+
 	It("should render resourcerequirements", func() {
 		rr := &corev1.ResourceRequirements{
 			Requests: corev1.ResourceList{


### PR DESCRIPTION
Losing the calico-kube-controllers pod while a DatastoreMigration is in progress wedges the migration permanently: the CNI plugin refuses requests while the migration holds the v1 datastore lock, and the controller that would release that lock runs inside the pod that can no longer be scheduled. Recovery needs a manual patch.

Host networking during the migration window breaks the cycle, since a host-networked pod never calls CNI, and the controller's existing resume path then picks the migration back up on its own. It is scoped to the window so the deployment keeps its network policy the rest of the time, and flipped off only once the CR is gone, because the abort runs from a finalizer and needs host networking too.

Found during the v3.33 test cycle, Zephyr OS-R233 / CR-19.

Related: [CORE-13631](https://tigera.atlassian.net/browse/CORE-13631)

**Release note:**
```release-note
Fixes a datastore migration wedging permanently if the calico-kube-controllers pod is lost while the migration is in progress.
```

**AI assistance:** Claude Code

By opening this PR you take responsibility for every line in it, and you agree to explain the change yourself during review rather than routing review comments back through an agent. See [AI_POLICY.md](../AI_POLICY.md).


[CORE-13631]: https://tigera.atlassian.net/browse/CORE-13631?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ