### PR TITLE
felix: add unit coverage for nftables performance features [CORE-13293]

### DIFF
--- a/felix/labelindex/dedup_overlap_repro_test.go
+++ b/felix/labelindex/dedup_overlap_repro_test.go
@@ -146,7 +146,7 @@ func TestOverlapSuppressorRemoveAncestorFirstLeavesNoStale(t *testing.T) {
 			name: "two levels, ancestor removed before descendant",
 			steps: []step{
 				{"add", "10.0.0.0/16"},
-				{"add", "10.0.1.0/24"}, // suppressed by the ancestor
+				{"add", "10.0.1.0/24"},    // suppressed by the ancestor
 				{"remove", "10.0.0.0/16"}, // re-advertises 10.0.1.0/24
 				{"remove", "10.0.1.0/24"}, // the transient re-advertise must be removed
 			},

--- a/felix/labelindex/dedup_overlap_repro_test.go
+++ b/felix/labelindex/dedup_overlap_repro_test.go
@@ -103,3 +103,134 @@ func TestOverlapSuppressorRemoveMiddleCoveredByAncestor(t *testing.T) {
 	Expect(rem).To(BeNil(), "middle CIDR was suppressed by the ancestor, so its removal must not be emitted")
 	Expect(adds).To(BeEmpty(), "the ancestor still covers the leaf, so nothing is re-exposed")
 }
+
+// programmedSet tracks the net set of emitted (dataplane-programmed) CIDRs as Add/Remove results are
+// applied, so a test can assert what the dataplane would hold after a sequence of operations. Add
+// returns (cidrToProgram, cidrsToWithdraw); Remove returns (cidrToWithdraw, cidrsToReadvertise).
+type programmedSet map[string]bool
+
+func (p programmedSet) applyAdd(add ip.CIDR, withdraw []ip.CIDR) {
+	if add != nil {
+		p[add.String()] = true
+	}
+	for _, w := range withdraw {
+		delete(p, w.String())
+	}
+}
+
+func (p programmedSet) applyRemove(withdraw ip.CIDR, readvertise []ip.CIDR) {
+	if withdraw != nil {
+		delete(p, withdraw.String())
+	}
+	for _, r := range readvertise {
+		p[r.String()] = true
+	}
+}
+
+// TestOverlapSuppressorRemoveAncestorFirstLeavesNoStale exercises (a): when the ancestor is removed
+// before the descendants it masks, Remove re-advertises those descendants (ClosestDescendants) even
+// though they are themselves about to be removed. The transient re-advertise must be cleaned up so
+// that removing every CIDR leaves no stale member behind.
+func TestOverlapSuppressorRemoveAncestorFirstLeavesNoStale(t *testing.T) {
+	RegisterTestingT(t)
+
+	type step struct {
+		op   string // "add" or "remove"
+		cidr string
+	}
+	tests := []struct {
+		name  string
+		steps []step
+	}{
+		{
+			name: "two levels, ancestor removed before descendant",
+			steps: []step{
+				{"add", "10.0.0.0/16"},
+				{"add", "10.0.1.0/24"}, // suppressed by the ancestor
+				{"remove", "10.0.0.0/16"}, // re-advertises 10.0.1.0/24
+				{"remove", "10.0.1.0/24"}, // the transient re-advertise must be removed
+			},
+		},
+		{
+			name: "three levels, removed top-down",
+			steps: []step{
+				{"add", "10.0.0.0/16"},
+				{"add", "10.0.1.0/24"},
+				{"add", "10.0.1.5/32"},
+				{"remove", "10.0.0.0/16"},
+				{"remove", "10.0.1.0/24"},
+				{"remove", "10.0.1.5/32"},
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			RegisterTestingT(t)
+
+			s := labelindex.NewMemberOverlapSuppressor()
+			prog := programmedSet{}
+			readvertised := false
+			for _, st := range tc.steps {
+				cidr := ip.MustParseCIDROrIP(st.cidr)
+				switch st.op {
+				case "add":
+					add, withdraw := s.Add(dedupTestSet, cidr)
+					prog.applyAdd(add, withdraw)
+				case "remove":
+					withdraw, readd := s.Remove(dedupTestSet, cidr)
+					if len(readd) > 0 {
+						readvertised = true
+					}
+					prog.applyRemove(withdraw, readd)
+				}
+			}
+			Expect(readvertised).To(BeTrue(),
+				"removing an ancestor before its descendants must transiently re-advertise the masked descendant")
+			Expect(prog).To(BeEmpty(),
+				"after removing every CIDR, the transient re-advertise must leave no stale member")
+		})
+	}
+}
+
+// TestOverlapSuppressorIPv6 exercises (d): the suppressor discriminates address family by a string
+// check for ":" in the CIDR, keeping v4 and v6 in separate tries. IPv6 CIDRs must nest and suppress
+// exactly like IPv4, and a v4 entry must never mask a v6 entry (or vice versa) in the same set.
+func TestOverlapSuppressorIPv6(t *testing.T) {
+	RegisterTestingT(t)
+
+	t.Run("IPv6 nesting is suppressed and re-exposed like IPv4", func(t *testing.T) {
+		RegisterTestingT(t)
+
+		s := labelindex.NewMemberOverlapSuppressor()
+		broad := ip.MustParseCIDROrIP("fd00::/16")
+		nested := ip.MustParseCIDROrIP("fd00:1::/32")
+
+		add, withdraw := s.Add(dedupTestSet, broad)
+		Expect(add).To(Equal(broad), "broad IPv6 CIDR should be programmed")
+		Expect(withdraw).To(BeEmpty())
+
+		add, withdraw = s.Add(dedupTestSet, nested)
+		Expect(add).To(BeNil(), "nested IPv6 CIDR is covered by the ancestor, so must be suppressed")
+		Expect(withdraw).To(BeEmpty())
+
+		rem, readd := s.Remove(dedupTestSet, broad)
+		Expect(rem).To(Equal(broad), "IPv6 ancestor was programmed, so its removal must be emitted")
+		Expect(readd).To(ConsistOf(nested), "removing the IPv6 ancestor must re-expose its descendant")
+	})
+
+	t.Run("v4 and v6 entries in one set do not mask each other", func(t *testing.T) {
+		RegisterTestingT(t)
+
+		s := labelindex.NewMemberOverlapSuppressor()
+		v4 := ip.MustParseCIDROrIP("0.0.0.0/0")
+		v6 := ip.MustParseCIDROrIP("::/0")
+
+		add, _ := s.Add(dedupTestSet, v4)
+		Expect(add).To(Equal(v4), "IPv4 default route must be programmed")
+
+		add, withdraw := s.Add(dedupTestSet, v6)
+		Expect(add).To(Equal(v6),
+			"IPv6 default route lives in a separate trie (':' discriminates family), so it must not be suppressed by the IPv4 entry")
+		Expect(withdraw).To(BeEmpty(), "adding the IPv6 entry must not withdraw the IPv4 entry")
+	})
+}

--- a/felix/labelindex/named_port_index_test.go
+++ b/felix/labelindex/named_port_index_test.go
@@ -1500,3 +1500,121 @@ func (t *testRecorder) OnMemberRemoved(ipSetID string, member ipsetmember.IPSetM
 		delete(t.ipsets, ipSetID)
 	}
 }
+
+// (b) A pod (WorkloadEndpoint) and a network set can contribute the identical /32 to one IP set. The
+// two arrive through different machinery but collapse to a single member via ipSetData.memberToRefCount
+// on the 0<->1 transition, so the member is emitted exactly once and survives until the last source
+// is gone. This is verified in both suppress modes because the collapse happens above the suppressor.
+var _ = Describe("SelectorAndNamedPortIndex duplicate CIDR from two sources", func() {
+	const dupCIDR = "10.0.0.5/32"
+	podKey := model.WorkloadEndpointKey{
+		Hostname: "host1", OrchestratorID: "k8s", WorkloadID: "ns/pod1", EndpointID: "eth0",
+	}
+	nsKey := model.NetworkSetKey{Name: "ns-dup"}
+
+	for _, suppress := range []bool{false, true} {
+		suppress := suppress
+		It(fmt.Sprintf("emits the shared /32 once and refcounts the two sources (suppressOverlaps=%v)", suppress), func() {
+			uut := NewSelectorAndNamedPortIndex(suppress)
+			var adds, removes int
+			live := map[ipsetmember.IPSetMember]bool{}
+			uut.OnMemberAdded = func(_ string, m ipsetmember.IPSetMember) { adds++; live[m] = true }
+			uut.OnMemberRemoved = func(_ string, m ipsetmember.IPSetMember) { removes++; delete(live, m) }
+
+			uut.OnUpdate(api.Update{KVPair: model.KVPair{
+				Key: podKey,
+				Value: &model.WorkloadEndpoint{
+					Labels:   uniquelabels.Make(map[string]string{"dup": "y"}),
+					IPv4Nets: []calinet.IPNet{calinet.MustParseNetwork(dupCIDR)},
+				},
+			}})
+			uut.OnUpdate(api.Update{KVPair: model.KVPair{
+				Key: nsKey,
+				Value: &model.NetworkSet{
+					Nets:   []calinet.IPNet{calinet.MustParseNetwork(dupCIDR)},
+					Labels: uniquelabels.Make(map[string]string{"dup": "y"}),
+				},
+			}})
+			s, err := selector.Parse("dup == 'y'")
+			Expect(err).NotTo(HaveOccurred())
+			uut.UpdateIPSet("dup-set", s, ipsetmember.ProtocolNone, "")
+
+			Expect(live).To(HaveLen(1), "the shared /32 must be programmed exactly once")
+			Expect(adds).To(Equal(1), "two sources for the identical CIDR must collapse to a single add")
+
+			// Drop the pod; the network set still contributes the CIDR, so the member must stay.
+			uut.OnUpdate(api.Update{KVPair: model.KVPair{Key: podKey, Value: nil}})
+			Expect(live).To(HaveLen(1), "member must survive while the other source still contributes it")
+			Expect(removes).To(Equal(0), "removing one of two sources must not withdraw the member")
+
+			// Drop the network set; the last source is now gone.
+			uut.OnUpdate(api.Update{KVPair: model.KVPair{Key: nsKey, Value: nil}})
+			Expect(live).To(BeEmpty(), "member must be withdrawn once the last source is gone")
+			Expect(removes).To(Equal(1))
+		})
+	}
+})
+
+// (c) UpdateIPSet handles a changed selector for an existing IP set ID by emitting a removal for every
+// member in Go map-iteration order over memberToRefCount, then rescanning. That order is the one place
+// member removal is nondeterministic and is the case least suited to manual reproduction. With
+// overlapping members and the suppressor enabled, the set must converge to the new selector's result
+// with no stale entry, regardless of iteration order.
+var _ = Describe("SelectorAndNamedPortIndex selector-changed reprogram path", func() {
+	feed := func() (*SelectorAndNamedPortIndex, *testRecorder) {
+		uut := NewSelectorAndNamedPortIndex(true)
+		rec := newRecorder()
+		uut.OnMemberAdded = rec.OnMemberAdded
+		uut.OnMemberRemoved = rec.OnMemberRemoved
+		// Group 1: three nested/overlapping CIDRs (12.0.0.0/8 covers /16 covers /32).
+		uut.OnUpdate(api.Update{KVPair: model.KVPair{
+			Key: model.NetworkSetKey{Name: "grp1"},
+			Value: &model.NetworkSet{
+				Nets: []calinet.IPNet{
+					calinet.MustParseNetwork("12.1.2.142/32"),
+					calinet.MustParseNetwork("12.1.0.0/16"),
+					calinet.MustParseNetwork("12.0.0.0/8"),
+				},
+				Labels: uniquelabels.Make(map[string]string{"grp": "1"}),
+			},
+		}})
+		// Group 2: a single non-overlapping CIDR.
+		uut.OnUpdate(api.Update{KVPair: model.KVPair{
+			Key: model.NetworkSetKey{Name: "grp2"},
+			Value: &model.NetworkSet{
+				Nets:   []calinet.IPNet{calinet.MustParseNetwork("13.0.0.0/8")},
+				Labels: uniquelabels.Make(map[string]string{"grp": "2"}),
+			},
+		}})
+		return uut, rec
+	}
+	members := func(rec *testRecorder) []string {
+		var out []string
+		for m := range rec.ipsets["reprog"] {
+			out = append(out, m.ToProtobufFormat())
+		}
+		return out
+	}
+
+	It("converges to the new selector's members with no stale entry, across map-iteration orders", func() {
+		s1, err := selector.Parse("grp == '1'")
+		Expect(err).NotTo(HaveOccurred())
+		s2, err := selector.Parse("grp == '2'")
+		Expect(err).NotTo(HaveOccurred())
+
+		// memberToRefCount iteration order varies between runs, so a leak that only manifests under
+		// some orders shows up over enough iterations.
+		for i := 0; i < 50; i++ {
+			uut, rec := feed()
+
+			uut.UpdateIPSet("reprog", s1, ipsetmember.ProtocolNone, "")
+			Expect(members(rec)).To(ConsistOf("12.0.0.0/8"),
+				"suppressed group 1 must collapse to the covering CIDR")
+
+			// Same ID, different selector: the reprogram path.
+			Expect(func() { uut.UpdateIPSet("reprog", s2, ipsetmember.ProtocolNone, "") }).NotTo(Panic())
+			Expect(members(rec)).To(ConsistOf("13.0.0.0/8"),
+				"after the selector change the set must hold only group 2 with no stale group-1 CIDR (iteration %d)", i)
+		}
+	})
+})

--- a/felix/nftables/maps_test.go
+++ b/felix/nftables/maps_test.go
@@ -328,6 +328,68 @@ var _ = Describe("Maps with empty data plane", func() {
 		Expect(upd.MembersToDel).To(HaveLen(1))
 		s.FinishMapUpdates(upd)
 	})
+
+	// NF-3: a policy chain can be the jump target of several map members at once (refcount > 1).
+	// It must stay referenced until its LAST member is removed - decrefing it to zero on the first
+	// removal would delete a chain the surviving members still jump to, breaking dispatch.
+	It("keeps a shared jump chain referenced until its last map member is removed", func() {
+		m := nftables.MapMetadata{Name: "m1", Type: nftables.MapTypeInterfaceMatch}
+
+		// Two interfaces jump to the SAME chain.
+		s.AddOrReplaceMap(m, map[string][]string{
+			"caliA": {"jump shared"},
+			"caliB": {"jump shared"},
+		})
+		Expect(chainRefs).To(Equal(map[string]int{"shared": 2}), "both members must reference the shared chain")
+		s.FinishMapUpdates(s.MapUpdates())
+
+		// Remove one interface; the shared chain must remain (refcount 2 -> 1).
+		s.AddOrReplaceMap(m, map[string][]string{"caliB": {"jump shared"}})
+		Expect(chainRefs).To(Equal(map[string]int{"shared": 1}),
+			"shared chain must stay referenced while another member still jumps to it")
+		upd := s.MapUpdates()
+		Expect(upd.MembersToAdd).To(HaveLen(0))
+		Expect(upd.MembersToDel).To(HaveLen(1))
+		s.FinishMapUpdates(upd)
+
+		// Remove the last interface; now the chain is fully dereferenced (1 -> 0, key removed).
+		s.AddOrReplaceMap(m, map[string][]string{})
+		Expect(chainRefs).To(BeEmpty(), "shared chain must be dereferenced once its last map member is gone")
+	})
+
+	// NF-3: several AddOrReplaceMap calls can land between applies (churn). MapUpdates must emit only
+	// the NET delta against the programmed state - a member added then removed before an apply must
+	// leave no trace, and chain refcounts must stay balanced across the churn.
+	It("coalesces churn on a map into the net delta and keeps chain refcounts balanced", func() {
+		m := nftables.MapMetadata{Name: "m1", Type: nftables.MapTypeInterfaceMatch}
+
+		// Program an initial member and settle.
+		s.AddOrReplaceMap(m, map[string][]string{"caliA": {"jump chainA"}})
+		s.FinishMapUpdates(s.MapUpdates())
+		Expect(chainRefs).To(Equal(map[string]int{"chainA": 1}))
+
+		// Churn before any apply: add caliB, then rechain caliA and drop caliB again.
+		s.AddOrReplaceMap(m, map[string][]string{
+			"caliA": {"jump chainA"},
+			"caliB": {"jump chainB"},
+		})
+		s.AddOrReplaceMap(m, map[string][]string{"caliA": {"jump chainA2"}})
+
+		// Net vs the programmed {caliA->chainA}: caliA rechained (one del + one add); caliB was added
+		// and removed within the churn, so it must not appear in the delta at all.
+		upd := s.MapUpdates()
+		Expect(upd.MembersToAdd).To(HaveLen(1), "only the rechained caliA member should be added")
+		Expect(upd.MembersToDel).To(HaveLen(1), "only the old caliA member should be deleted; caliB coalesced away")
+
+		// Refcounts must reflect the final desired state, with no leak from the transient caliB->chainB.
+		Expect(chainRefs).To(Equal(map[string]int{"chainA2": 1}),
+			"chainA decref'd, chainA2 incref'd, and the transient chainB fully released")
+		s.FinishMapUpdates(upd)
+		Expect(s.MapUpdates()).To(Equal(&nftables.MapUpdates{
+			MapToAddedMembers:   map[string]set.Set[nftables.MapMember]{},
+			MapToDeletedMembers: map[string]set.Set[nftables.MapMember]{},
+		}))
+	})
 })
 
 func loadMapsDataplaneState(f *fakeNFT, s *nftables.Maps) error {

--- a/felix/nftables/table_test.go
+++ b/felix/nftables/table_test.go
@@ -1422,6 +1422,54 @@ var _ = Describe("Table with flowtable offload enabled", func() {
 		Expect(f.Fake().Dump()).To(ContainSubstring("devices = { cali1234, eth0, vxlan.calico }"))
 	})
 
+	// NF-5: as pods churn, the endpoint manager pushes a changing workload-interface set via
+	// SetWorkloadInterfaces. The flowtable device list must track that desired set - dropping an
+	// interface that leaves it (distinct from the kernel-prune path) and picking up new ones - while
+	// the overlay device stays put.
+	It("tracks workload-interface churn in the flowtable device set", func() {
+		var ff *fakeNFT
+		newDataplane := func(fam knftables.Family, name string, options ...knftables.Option) (knftables.Interface, error) {
+			ff = NewFake(fam, name)
+			return ff, nil
+		}
+		tbl := nftables.NewTable(
+			"calico", 4, rulesdefs.RuleHashPrefix,
+			environment.NewFeatureDetector(nil),
+			nftables.TableOptions{
+				NewDataplane:     newDataplane,
+				LookPathOverride: testutils.LookPathNoLegacy,
+				OpRecorder:       logrusr.NewSummarizer("test loop"),
+				ListInterfacesOverride: func() ([]string, error) {
+					// All candidate veths exist in the kernel, so removals here come from the desired
+					// set changing rather than from a device disappearing.
+					return []string{"cali1234", "cali5678", "cali9abc", "vxlan.calico", "lo"}, nil
+				},
+			},
+			true,
+		)
+		tbl.SetOverlayDevices([]string{"vxlan.calico"})
+
+		// knftables' fake ignores a re-"add flowtable" for an existing flowtable (real nft treats it
+		// as create-or-update), so Dump() is stuck at the first write. Assert on what we asked nft to
+		// do across the transactions instead.
+
+		// Two workload interfaces up.
+		tbl.SetWorkloadInterfaces([]string{"cali1234", "cali5678"})
+		Expect(tbl.Apply()).To(BeNumerically("<", 100*time.Millisecond))
+		Expect(flowtableDevicesProgrammed(ff)).To(ContainElement("devices = { cali1234, cali5678, vxlan.calico }"))
+
+		// Churn: cali1234 leaves the set, cali9abc joins. The newly programmed device line must drop
+		// cali1234 and pick up cali9abc.
+		tbl.SetWorkloadInterfaces([]string{"cali5678", "cali9abc"})
+		Expect(tbl.Apply()).To(BeNumerically("<", 100*time.Millisecond))
+		Expect(flowtableDevicesProgrammed(ff)).To(ContainElement("devices = { cali5678, cali9abc, vxlan.calico }"))
+
+		// All workloads gone: only the overlay device remains in the programmed list.
+		tbl.SetWorkloadInterfaces(nil)
+		Expect(tbl.Apply()).To(BeNumerically("<", 100*time.Millisecond))
+		Expect(flowtableDevicesProgrammed(ff)).To(ContainElement("devices = { vxlan.calico }"))
+	})
+
 	// A full resync must re-assert the flowtable even with no devices, otherwise the always-present
 	// FORWARD rule would reference a flowtable that the resync failed to recreate.
 	It("should re-assert the flowtable on a resync with no devices", func() {


### PR DESCRIPTION
Adds table-driven unit tests for behaviours exercised by the nftables performance testcycle (CORE-13293) that had no direct unit coverage. Test-only — no production code changes.

**What's added**
- `felix/labelindex/dedup_overlap_repro_test.go` — overlap suppressor: removing an ancestor before its descendants re-advertises the masked descendants transiently and leaves no stale member; IPv6 nesting plus v4/v6 trie isolation (family discriminated by the `:` check).
- `felix/labelindex/named_port_index_test.go` — `SelectorAndNamedPortIndex`: a pod and a network set contributing the identical `/32` collapse to a single member via `memberToRefCount`; the `UpdateIPSet` "selector changed for existing ID" reprogram path converges regardless of Go map-iteration order (looped 50×).
- `felix/nftables/maps_test.go` — a jump chain shared by several map members stays referenced until its last member is removed (refcount > 1 partial removal); map churn coalesces to the net delta with balanced chain refcounts.
- `felix/nftables/table_test.go` — the flowtable device set tracks workload-interface churn (desired-set change, distinct from the kernel-prune path).

**Testing done**
`go test ./felix/labelindex/ ./felix/nftables/` — all pass. The same behaviours were also validated end-to-end on a Calico v3.33 hashrelease cluster in nftables mode as part of the CORE-13293 testcycle.

**AI assistance:** these tests were written with AI assistance (Claude Code). The author has reviewed the changes and can explain them.

**Release note:**
```release-note
None
```
