### PR TITLE
[v3.33] Require every e2e suite to declare a feature

### DIFF
--- a/e2e/pkg/describe/describe.go
+++ b/e2e/pkg/describe/describe.go
@@ -76,6 +76,8 @@ var features = map[string]bool{
 	"Datapath":        true,
 	"Istio":           true,
 	"KubeVirt":        true,
+	"Wireguard":       true,
+	"Flow-Logs":       true,
 }
 
 // RequiresRealKubeVirt marks tests that need a real KubeVirt installation with

--- a/e2e/pkg/describe/labels_test.go
+++ b/e2e/pkg/describe/labels_test.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+
+package describe
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Every suite has to declare a feature, or its cases land in no per-feature view
+// of the CI dashboard and nobody notices them failing.
+func TestEverySuiteDeclaresAFeature(t *testing.T) {
+	root, err := filepath.Abs("../tests")
+	if err != nil {
+		t.Fatalf("resolve tests root: %v", err)
+	}
+
+	fset := token.NewFileSet()
+	var undeclared []string
+	err = filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		f, err := parser.ParseFile(fset, path, nil, 0)
+		if err != nil {
+			return err
+		}
+		ast.Inspect(f, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok || !isDescribeCall(call, "CalicoDescribe") {
+				return true
+			}
+			for _, arg := range call.Args {
+				if inner, ok := arg.(*ast.CallExpr); ok && isDescribeCall(inner, "WithFeature") {
+					return true
+				}
+			}
+			pos := fset.Position(call.Pos())
+			undeclared = append(undeclared, pos.String())
+			return true
+		})
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk tests: %v", err)
+	}
+
+	for _, pos := range undeclared {
+		t.Errorf("%s: suite has no describe.WithFeature label", pos)
+	}
+}
+
+// isDescribeCall reports whether the call is describe.<name>(...) or, inside this
+// package, a bare <name>(...).
+func isDescribeCall(call *ast.CallExpr, name string) bool {
+	switch fn := call.Fun.(type) {
+	case *ast.SelectorExpr:
+		pkg, ok := fn.X.(*ast.Ident)
+		return ok && pkg.Name == "describe" && fn.Sel.Name == name
+	case *ast.Ident:
+		return fn.Name == name
+	}
+	return false
+}

--- a/e2e/pkg/tests/policy/staged_policy.go
+++ b/e2e/pkg/tests/policy/staged_policy.go
@@ -40,6 +40,7 @@ import (
 var _ = describe.CalicoDescribe(
 	describe.WithTeam(describe.Core),
 	describe.WithCategory(describe.Policy),
+	describe.WithFeature("Flow-Logs"),
 	describe.RequiresGoldmane(),
 	"staged network policy",
 	func() {
@@ -63,10 +64,11 @@ var _ = describe.CalicoDescribe(
 			Expect(err).NotTo(HaveOccurred())
 			checker = conncheck.NewConnectionTester(f)
 
-			// These tests rely on Whisker - if Whisker is not installed, short-circuit the tests.
 			installed, err := utils.WhiskerInstalled(cli)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(installed).To(BeTrue(), "Whisker is not installed in the cluster")
+			if !installed {
+				framework.Failf("Whisker is not installed in this cluster, so the lane should exclude the RequiresGoldmane label")
+			}
 
 			whiskerHTTPSClient, err = buildWhiskerHTTPSClient(context.TODO(), cli)
 			Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
Cherry-pick of https://github.com/projectcalico/calico/pull/13585 onto release-v3.33.

A suite that declares no feature, or one outside the known set, now fails a unit test rather than running unlabelled, and the Whisker specs pick up the `RequiresGoldmane` guard this branch is missing.

`e2e/testsets` does not exist on release-v3.33, so the generated testset records in the original are dropped.

Related: [CORE-13385](https://tigera.atlassian.net/browse/CORE-13385)


[CORE-13385]: https://tigera.atlassian.net/browse/CORE-13385?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ