### PR TITLE
[v3.33] Select IP pools by address family instead of by name

### DIFF
--- a/e2e/pkg/describe/describe.go
+++ b/e2e/pkg/describe/describe.go
@@ -135,6 +135,21 @@ func RequiresBGPMesh() any {
 	return framework.WithLabel("RequiresBGPMesh")
 }
 
+// RequiresOperator marks tests that need tigera-operator running to reconcile a CR
+// they create. Manifest-installed clusters (INSTALLER=manual/packaged, i.e. a
+// MANIFEST_FILE like calico.yaml) have no operator, so such a test blocks until its
+// wait times out rather than skipping.
+func RequiresOperator() any {
+	return framework.WithLabel("RequiresOperator")
+}
+
+// RequiresCalicoIPAM marks tests that need Calico to be the IPAM plugin. Clusters
+// running a provider's CNI and IPAM (AWS VPC, Azure, GKE host-local) keep no
+// Calico IPAM state for these specs to read.
+func RequiresCalicoIPAM() any {
+	return framework.WithLabel("RequiresCalicoIPAM")
+}
+
 // WithFeature marks tests as verifying a specific feature.
 func WithFeature(feature string) any {
 	if !features[feature] {

--- a/e2e/pkg/tests/ipam/calico_ipam_test.go
+++ b/e2e/pkg/tests/ipam/calico_ipam_test.go
@@ -1,0 +1,121 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+
+package ipam
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Clusters installed with a named pool, on dual stack, or on a provider's IPAM
+// have no pool by these names, so a lookup by name fails rather than finding the
+// cluster's pool.
+func TestNoHardcodedDefaultPoolNames(t *testing.T) {
+	forEachSuiteFile(t, func(t *testing.T, fset *token.FileSet, f *ast.File) {
+		ast.Inspect(f, func(n ast.Node) bool {
+			lit, ok := n.(*ast.BasicLit)
+			if !ok || lit.Kind != token.STRING {
+				return true
+			}
+			if strings.Contains(lit.Value, "default-ipv4-ippool") || strings.Contains(lit.Value, "default-ipv6-ippool") {
+				t.Errorf("%s: IP pool names are not guaranteed; list the pools and select by address family instead", fset.Position(lit.Pos()))
+			}
+			return true
+		})
+	})
+}
+
+// A suite that reads Calico IPAM state has to carry the label, so the lanes
+// running a provider's IPAM can exclude it.
+func TestSuitesReadingCalicoIPAMCarryTheLabel(t *testing.T) {
+	forEachSuiteFile(t, func(t *testing.T, fset *token.FileSet, f *ast.File) {
+		for _, s := range calicoIPAMSuites(f) {
+			if s.labelled || !callsCalicoIPAMCheck(s.body) {
+				continue
+			}
+			t.Errorf("%s: suite reads Calico IPAM state, so it needs describe.RequiresCalicoIPAM", fset.Position(s.body.Pos()))
+		}
+	})
+}
+
+func forEachSuiteFile(t *testing.T, check func(*testing.T, *token.FileSet, *ast.File)) {
+	root, err := filepath.Abs("..")
+	if err != nil {
+		t.Fatalf("resolve tests root: %v", err)
+	}
+	fset := token.NewFileSet()
+	err = filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		f, err := parser.ParseFile(fset, path, nil, 0)
+		if err != nil {
+			return err
+		}
+		check(t, fset, f)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk tests: %v", err)
+	}
+}
+
+type calicoIPAMSuite struct {
+	body     ast.Node
+	labelled bool
+}
+
+// calicoIPAMSuites returns every CalicoDescribe body in the file, along with
+// whether it declares the Calico IPAM label.
+func calicoIPAMSuites(f *ast.File) []calicoIPAMSuite {
+	var found []calicoIPAMSuite
+	ast.Inspect(f, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok || !isSelector(call.Fun, "describe", "CalicoDescribe") {
+			return true
+		}
+		s := calicoIPAMSuite{}
+		for _, arg := range call.Args {
+			if inner, ok := arg.(*ast.CallExpr); ok && isSelector(inner.Fun, "describe", "RequiresCalicoIPAM") {
+				s.labelled = true
+			}
+			if fn, ok := arg.(*ast.FuncLit); ok {
+				s.body = fn
+			}
+		}
+		if s.body != nil {
+			found = append(found, s)
+		}
+		return true
+	})
+	return found
+}
+
+func callsCalicoIPAMCheck(body ast.Node) bool {
+	calls := false
+	ast.Inspect(body, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if ok && isSelector(call.Fun, "utils", "UsesCalicoIPAM") {
+			calls = true
+		}
+		return !calls
+	})
+	return calls
+}
+
+func isSelector(e ast.Expr, pkg, name string) bool {
+	sel, ok := e.(*ast.SelectorExpr)
+	if !ok {
+		return false
+	}
+	ident, ok := sel.X.(*ast.Ident)
+	return ok && ident.Name == pkg && sel.Sel.Name == name
+}

--- a/e2e/pkg/tests/ipam/ipam_gc.go
+++ b/e2e/pkg/tests/ipam/ipam_gc.go
@@ -42,6 +42,7 @@ import (
 var _ = describe.CalicoDescribe(
 	describe.WithTeam(describe.Core),
 	describe.WithFeature("IPAM"),
+	describe.RequiresCalicoIPAM(),
 	describe.WithSerial(), // Modifies global state, so run serially.
 	describe.WithCategory(describe.Networking),
 	"IPAM GC",

--- a/e2e/pkg/tests/ipam/ipam_strict_affinity.go
+++ b/e2e/pkg/tests/ipam/ipam_strict_affinity.go
@@ -49,6 +49,7 @@ const (
 var _ = describe.CalicoDescribe(
 	describe.WithTeam(describe.Core),
 	describe.WithFeature("IPAM"),
+	describe.RequiresCalicoIPAM(),
 	describe.WithSerial(), // Modifies global IPAMConfiguration state.
 	describe.WithCategory(describe.Networking),
 	"IPAM StrictAffinity",

--- a/e2e/pkg/tests/kubevirt/live_migration.go
+++ b/e2e/pkg/tests/kubevirt/live_migration.go
@@ -24,7 +24,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	//nolint:staticcheck // Ignore ST1001: should not use dot imports
 	. "github.com/onsi/gomega"
-	v3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
 	"github.com/sirupsen/logrus"
 	"k8s.io/kubernetes/test/e2e/framework"
 	kubevirtv1 "kubevirt.io/api/core/v1"
@@ -187,19 +186,20 @@ var _ = describe.CalicoDescribe(
 				defer cancel()
 				ns := f.Namespace.Name
 
-				// Precondition: natOutgoing must be false on the IPPool backing VM
+				// Precondition: natOutgoing must be false on the IPv4 pools backing VM
 				// workloads. If true, natOutgoing rewrites the VM's source IP to the
 				// node's IP at egress NAT and breaks the TOR's reverse-path matching
 				// after migration. The pipeline that runs this test is expected to
-				// configure the IPPool with natOutgoing=false at provisioning time;
-				// we only verify here so the failure mode is obvious.
-				const vmIPPoolName = "default-ipv4-ippool"
-				By(fmt.Sprintf("Verifying natOutgoing=false on IPPool %s", vmIPPoolName))
-				pool := &v3.IPPool{}
-				Expect(cli.Get(ctx, ctrlclient.ObjectKey{Name: vmIPPoolName}, pool)).
-					To(Succeed(), "IPPool %q must exist", vmIPPoolName)
-				Expect(pool.Spec.NATOutgoing).To(BeFalse(),
-					"IPPool %q must have natOutgoing=false (set by cluster provisioning)", vmIPPoolName)
+				// configure the pool with natOutgoing=false at provisioning time; we
+				// only verify here so the failure mode is obvious.
+				By("Verifying natOutgoing=false on the cluster's IPv4 IP pools")
+				pools, err := utils.IPPoolsForFamily(ctx, cli, false)
+				Expect(err).NotTo(HaveOccurred(), "list IP pools")
+				Expect(pools).NotTo(BeEmpty(), "cluster has no IPv4 IP pool for VM workloads")
+				for _, pool := range pools {
+					Expect(pool.Spec.NATOutgoing).To(BeFalse(),
+						"IPPool %q must have natOutgoing=false (set by cluster provisioning)", pool.Name)
+				}
 
 				By("Setting up eBGP peering between TOR and cluster nodes")
 				torPeer := setupKubeVirtEBGPPeering(f, tor)

--- a/e2e/pkg/utils/ippool.go
+++ b/e2e/pkg/utils/ippool.go
@@ -1,0 +1,40 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"context"
+	"strings"
+
+	v3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// IPPoolsForFamily returns the cluster's IP pools of one address family. A
+// cluster installed with a named pool, or on a provider's IPAM, has no pool
+// called default-ipv4-ippool, so select by family rather than by name.
+func IPPoolsForFamily(ctx context.Context, cli ctrlclient.Client, ipv6 bool) ([]v3.IPPool, error) {
+	pools := &v3.IPPoolList{}
+	if err := cli.List(ctx, pools); err != nil {
+		return nil, err
+	}
+	var matching []v3.IPPool
+	for _, pool := range pools.Items {
+		if strings.Contains(pool.Spec.CIDR, ":") == ipv6 {
+			matching = append(matching, pool)
+		}
+	}
+	return matching, nil
+}


### PR DESCRIPTION
Cherry-pick of https://github.com/projectcalico/calico/pull/13596 onto release-v3.33.

The IP pool specs looked up `default-ipv4-ippool` by name, which does not exist on a cluster running a provider's CNI, so they now select by address family and carry a label saying they need Calico IPAM.

`e2e/testsets` and `e2e/config/iptables` do not exist here, so those files are dropped, as is the duplicate BGP label definition this branch already has.

Related: [CORE-13391](https://tigera.atlassian.net/browse/CORE-13391)


[CORE-13391]: https://tigera.atlassian.net/browse/CORE-13391?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ