### PR TITLE
Make every bpf-gpl header self-contained

### DIFF
--- a/felix/CLAUDE.md
+++ b/felix/CLAUDE.md
@@ -32,28 +32,8 @@ A test's ID is the concatenation of all its nested `Context`/`Describe` headings
 
 ### BPF-Specific Tests
 
-#### Where the BPF code lives
-
-- `bpf-gpl/` — eBPF programs, GPL v2.0/Apache dual licensed for Linux kernel compatibility.
-- `bpf-apache/` — Apache-licensed BPF code.
-- `make clone-libbpf` — run before your first BPF build; fetches libbpf.
-- BPF tooling versions (`LIBBPF_VERSION`, `BPFTOOL_IMAGE`) are pinned in [`metadata.mk`](../metadata.mk).
-
-#### Building BPF Programs
-
-After modifying C code in `bpf-gpl/`, verify it compiles for all targets (IPv4, IPv6, all hook types):
-
-```bash
-make build-bpf
-```
-
-Run `make clean` first if you hit stale object issues. Use `make -C felix build` to verify both BPF C and Go code compile together.
-
-Every header in `bpf-gpl/` must be self-contained (include what it uses, so include order never matters). After adding or changing includes, run the check, which compiles each header on its own under every build variant:
-
-```bash
-make check-bpf-headers
-```
+The BPF C programs live in `bpf-gpl/`; building them, checking headers and the
+include conventions are covered in [`bpf-gpl/CLAUDE.md`](./bpf-gpl/CLAUDE.md).
 
 #### BPF Unit Tests
 

--- a/felix/CLAUDE.md
+++ b/felix/CLAUDE.md
@@ -49,6 +49,12 @@ make build-bpf
 
 Run `make clean` first if you hit stale object issues. Use `make -C felix build` to verify both BPF C and Go code compile together.
 
+Every header in `bpf-gpl/` must be self-contained (include what it uses, so include order never matters). After adding or changing includes, run the check, which compiles each header on its own under every build variant:
+
+```bash
+make check-bpf-headers
+```
+
 #### BPF Unit Tests
 
 BPF unit tests run the BPF dataplane programs in a privileged container:

--- a/felix/Makefile
+++ b/felix/Makefile
@@ -49,6 +49,10 @@ GENERATED_DOCS_FILES=docs/config-params.json docs/config-params.md
 FV_SRC_FILES:=$(shell find fv -type f -name '*.go' -print)
 EXTRA_DOCKER_ARGS+=-v $(CURDIR)/../pod2daemon:/go/src/github.com/projectcalico/calico/pod2daemon:rw
 
+# Extra static-checks prerequisites; must be set before the include because
+# lib.Makefile's static-checks rule expands it when it is parsed.
+LOCAL_CHECKS = check-bpf-headers
+
 ###############################################################################
 # Download and include ../lib.Makefile
 #   Additions to EXTRA_DOCKER_ARGS need to happen before the include since
@@ -210,9 +214,6 @@ build-bpf: $(LIBBPF_A) $(PROD_BPF_PROGS) $(BPF_GPL_UT_O_FILES)
 .PHONY: check-bpf-headers
 check-bpf-headers: $(LIBBPF_FILE_CREATED)
 	$(DOCKER_GO_BUILD) make -C bpf-gpl ARCH=$(ARCH) check-headers
-
-# Run as part of static-checks (see lib.Makefile).
-LOCAL_CHECKS := check-bpf-headers
 
 $(PROD_BPF_PROGS) &: $(BPF_APACHE_O_FILES) $(BPF_GPL_O_FILES)
 	rm -rf bin/bpf

--- a/felix/Makefile
+++ b/felix/Makefile
@@ -208,8 +208,11 @@ build-bpf: $(LIBBPF_A) $(PROD_BPF_PROGS) $(BPF_GPL_UT_O_FILES)
 # Checks that every bpf-gpl header compiles on its own, i.e. that no header
 # relies on its includer's include order.
 .PHONY: check-bpf-headers
-check-bpf-headers: $(LIBBPF_A)
+check-bpf-headers: $(LIBBPF_FILE_CREATED)
 	$(DOCKER_GO_BUILD) make -C bpf-gpl ARCH=$(ARCH) check-headers
+
+# Run as part of static-checks (see lib.Makefile).
+LOCAL_CHECKS := check-bpf-headers
 
 $(PROD_BPF_PROGS) &: $(BPF_APACHE_O_FILES) $(BPF_GPL_O_FILES)
 	rm -rf bin/bpf

--- a/felix/Makefile
+++ b/felix/Makefile
@@ -205,6 +205,12 @@ PROD_BPF_PROGS=$(PROD_BPF_APACHE_PROGS) $(PROD_BPF_GPL_PROGS)
 .PHONY: build-bpf clean-bpf
 build-bpf: $(LIBBPF_A) $(PROD_BPF_PROGS) $(BPF_GPL_UT_O_FILES)
 
+# Checks that every bpf-gpl header compiles on its own, i.e. that no header
+# relies on its includer's include order.
+.PHONY: check-bpf-headers
+check-bpf-headers: $(LIBBPF_A)
+	$(DOCKER_GO_BUILD) make -C bpf-gpl ARCH=$(ARCH) check-headers
+
 $(PROD_BPF_PROGS) &: $(BPF_APACHE_O_FILES) $(BPF_GPL_O_FILES)
 	rm -rf bin/bpf
 	mkdir -p bin/bpf

--- a/felix/bpf-gpl/CLAUDE.md
+++ b/felix/bpf-gpl/CLAUDE.md
@@ -65,9 +65,6 @@ that is not self-contained.
   `globals.h` and `ip_addr.h` sit below it: userspace (`felix/bpf/libbpf`)
   includes them via cgo, so they must not pull in `bpf.h` or the BPF helpers.
   `check-headers` compiles them with the host compiler to keep that true.
-- **The cgroup (`connect_balancer*.c`) programs must not include `types.h`.**
-  Its kernel headers need `sys/socket.h`, which those programs have to
-  suppress; see `sock_type.h` and the guarded include in `nat_lookup.h`.
 - **A header that defines a map must be listed in `IP_MAP_HEADERS`,
   `COMMON_MAP_HEADERS` or `XDP_MAP_HEADERS` in the `Makefile`.** Felix creates
   maps by looking them up by name in the generated map-stub objects; a map

--- a/felix/bpf-gpl/CLAUDE.md
+++ b/felix/bpf-gpl/CLAUDE.md
@@ -39,8 +39,9 @@ that is not self-contained.
 - **Every header is self-contained.** Include what you use, so that include
   order never matters and no header relies on its includer.
 - **Guard every header** with `#ifndef __CALI_<FILENAME>_H__` /
-  `#define __CALI_<FILENAME>_H__` (e.g. `nat_types.h` → `__CALI_NAT_TYPES_H__`).
-  The name is derived from the file name so guards are unique by construction.
+  `#define __CALI_<FILENAME>_H__` (e.g. `nat_types.h` → `__CALI_NAT_TYPES_H__`;
+  a `cali_` file prefix is dropped, so `cali_bpf.h` → `__CALI_BPF_H__`). The name
+  is derived from the file name so guards are unique by construction.
 - **Order includes** as system headers (`<linux/...>`, `<std...>`), a blank
   line, then project headers, each group sorted alphabetically. Where a header
   picks its IPv4 or IPv6 twin, that `#ifdef IPVER6` block comes last:
@@ -49,7 +50,7 @@ that is not self-contained.
   #include <linux/if_ether.h>
   #include <linux/in.h>
 
-  #include "bpf.h"
+  #include "cali_bpf.h"
   #include "log.h"
   #include "nat_types.h"
   #ifdef IPVER6
@@ -61,9 +62,10 @@ that is not self-contained.
 
 - **`.c` files define `CALI_LOG` before any include.** `log.h` only defines
   it when unset, so the override must come first.
-- **`bpf.h` is the root of the include graph.** Only `bpf_inline.h`,
-  `globals.h` and `ip_addr.h` sit below it: userspace (`felix/bpf/libbpf`)
-  includes them via cgo, so they must not pull in `bpf.h` or the BPF helpers.
+- **`cali_bpf.h` is the root of the include graph.** (It is not named `bpf.h`
+  so it can never be confused with libbpf's.) Only `bpf_inline.h`, `globals.h`
+  and `ip_addr.h` sit below it: userspace (`felix/bpf/libbpf`) includes them via
+  cgo, so they must not pull in `cali_bpf.h` or the BPF helpers.
   `check-headers` compiles them with the host compiler to keep that true.
 - **A header that defines a map must be listed in `IP_MAP_HEADERS`,
   `COMMON_MAP_HEADERS` or `XDP_MAP_HEADERS` in the `Makefile`.** Felix creates

--- a/felix/bpf-gpl/CLAUDE.md
+++ b/felix/bpf-gpl/CLAUDE.md
@@ -1,0 +1,77 @@
+# BPF C Programs (`felix/bpf-gpl`)
+
+Operational guidance for the eBPF dataplane programs. For the design of the
+programs themselves see [`felix/DESIGN.md`](../DESIGN.md) and the `bpf-*.md`
+sub-designs under [`felix/design/`](../design/).
+
+## Layout and licensing
+
+- `bpf-gpl/` — the dataplane programs. Dual licensed GPL v2.0/Apache for Linux
+  kernel compatibility; every file carries the `Apache-2.0 OR GPL-2.0-or-later`
+  SPDX header. Nothing enforces this automatically — add it yourself.
+- `bpf-apache/` — Apache-only BPF code.
+- `ut/` — C entry points for the BPF unit tests in `felix/bpf/ut`.
+- Tooling versions (`LIBBPF_VERSION`, `BPFTOOL_IMAGE`) are pinned in
+  [`metadata.mk`](../../metadata.mk). Run `make -C felix clone-libbpf` before
+  your first build.
+
+## Building and checking
+
+All commands run from `felix/`, in the go-build container:
+
+```bash
+make build-bpf                                          # every variant: IPv4/IPv6, all hook types
+make check-bpf-headers                                  # include guards + header self-containment (~5s)
+make FOCUS="TestPrecompiledBinariesAreLoadable" ut-bpf  # every object passes the local kernel's verifier
+```
+
+Run `make clean` first if you hit stale object issues. `make build` compiles
+BPF C and Go together. The BPF unit and FV test invocations are in
+[`felix/CLAUDE.md`](../CLAUDE.md).
+
+`check-bpf-headers` runs from `make static-checks`, so CI fails on a header
+that is not self-contained.
+
+## Headers and includes
+
+`./check-headers` enforces the first two rules; follow the rest by hand.
+
+- **Every header is self-contained.** Include what you use, so that include
+  order never matters and no header relies on its includer.
+- **Guard every header** with `#ifndef __CALI_<FILENAME>_H__` /
+  `#define __CALI_<FILENAME>_H__` (e.g. `nat_types.h` → `__CALI_NAT_TYPES_H__`).
+  The name is derived from the file name so guards are unique by construction.
+- **Order includes** as system headers (`<linux/...>`, `<std...>`), a blank
+  line, then project headers, each group sorted alphabetically. Where a header
+  picks its IPv4 or IPv6 twin, that `#ifdef IPVER6` block comes last:
+
+  ```c
+  #include <linux/if_ether.h>
+  #include <linux/in.h>
+
+  #include "bpf.h"
+  #include "log.h"
+  #include "nat_types.h"
+  #ifdef IPVER6
+  #include "nat6.h"
+  #else
+  #include "nat4.h"
+  #endif
+  ```
+
+- **`.c` files define `CALI_LOG` before any include.** `log.h` only defines
+  it when unset, so the override must come first.
+- **`bpf.h` is the root of the include graph.** Only `bpf_inline.h`,
+  `globals.h` and `ip_addr.h` sit below it: userspace (`felix/bpf/libbpf`)
+  includes them via cgo, so they must not pull in `bpf.h` or the BPF helpers.
+  `check-headers` compiles them with the host compiler to keep that true.
+- **The cgroup (`connect_balancer*.c`) programs must not include `types.h`.**
+  Its kernel headers need `sys/socket.h`, which those programs have to
+  suppress; see `sock_type.h` and the guarded include in `nat_lookup.h`.
+- **A header that defines a map must be listed in `IP_MAP_HEADERS`,
+  `COMMON_MAP_HEADERS` or `XDP_MAP_HEADERS` in the `Makefile`.** Felix creates
+  maps by looking them up by name in the generated map-stub objects; a map
+  missing from the stubs loses its BTF.
+- `check-headers` has a table of which build variants each header is meant for
+  (`only`); a header that is XDP-only, cgroup-only or IPv4/IPv6-only needs an
+  entry there.

--- a/felix/bpf-gpl/Makefile
+++ b/felix/bpf-gpl/Makefile
@@ -146,6 +146,7 @@ map-objs: $(MAP_OBJS)
 
 # Check that every header compiles on its own under each build variant it is
 # meant for, i.e. that no header relies on its includer's include order.
+.PHONY: check-headers
 check-headers:
 	./check-headers $(CC) $(CFLAGS)
 

--- a/felix/bpf-gpl/Makefile
+++ b/felix/bpf-gpl/Makefile
@@ -79,7 +79,7 @@ UT_OBJS+=ut/tcp_rst_v6.o
 
 XDP_MAP_HEADERS := jump.h
 COMMON_MAP_HEADERS := counters.h ifstate.h ringbuf.h profiling.h rule_counters.h qos.h ctlb_map.h $(XDP_MAP_HEADERS)
-IP_MAP_HEADERS := arp.h conntrack_cleanup.h conntrack_types.h failsafe.h nat_types.h policy.h routes.h sendrecv.h
+IP_MAP_HEADERS := allowsources.h arp.h conntrack_cleanup.h conntrack_types.h failsafe.h nat_types.h policy.h routes.h sendrecv.h
 IPV4_MAP_HEADERS := $(IP_MAP_HEADERS) ip_v4_fragment.h
 IPV6_MAP_HEADERS := $(IP_MAP_HEADERS)
 
@@ -143,6 +143,11 @@ C_FILES:=tc_preamble.c tc.c connect_balancer.c connect_balancer_v46.c connect_ba
 all: $(OBJS)
 ut-objs: $(UT_OBJS)
 map-objs: $(MAP_OBJS)
+
+# Check that every header compiles on its own under each build variant it is
+# meant for, i.e. that no header relies on its includer's include order.
+check-headers:
+	./check-headers $(CC) $(CFLAGS)
 
 libbpf: $(LIBBPF_FILE_CREATED)
 # A plain clone, not hack/fetch-repo: this directory ships as the GPL source

--- a/felix/bpf-gpl/Makefile
+++ b/felix/bpf-gpl/Makefile
@@ -90,7 +90,7 @@ MAP_CFLAGS := $(subst -emit-llvm,,$(CFLAGS))
 
 # Generate _map_stub.c
 define generate_stub
-	echo '#include "bpf.h"' > $@; \
+	echo '#include "cali_bpf.h"' > $@; \
 	for header in $^; do \
 		echo "#include \"$${header}\"" >> $@; \
 	done; \
@@ -259,7 +259,7 @@ conntrack_cleanup_v6.d: conntrack_cleanup.c
 
 # LLVM 21 added TrapUnreachable=true to the BPF backend (llvm/llvm-project#131731).
 # This causes llc to emit a trap instruction (call to __bpf_trap kfunc) after
-# every __builtin_unreachable().  Our bpf_exit() helper (bpf.h) uses inline asm
+# every __builtin_unreachable().  Our bpf_exit() helper (cali_bpf.h) uses inline asm
 # to emit a BPF "exit" instruction followed by __builtin_unreachable() to tell
 # the compiler the path is dead.  With TrapUnreachable, llc inserts a trap
 # instruction after the exit; the kernel BPF verifier sees it as unreachable

--- a/felix/bpf-gpl/allowsources.h
+++ b/felix/bpf-gpl/allowsources.h
@@ -1,8 +1,8 @@
 #ifndef __CALI_ALLOWSOURCES_H__
 #define __CALI_ALLOWSOURCES_H__
 
-#include <linux/in.h>
 #include "bpf.h"
+#include "ip_addr.h"
 
 #define IPV4_ADDR_BITS 32
 #define IPV6_ADDR_BITS 128
@@ -40,4 +40,4 @@ static CALI_BPF_INLINE bool cali_allowsource_lookup(ipv46_addr_t *addr, __u32 if
     return cali_sprefix_lookup_elem(&k);
 }
 
-# endif /* __CALI_ALLOWSOURCES_H__ */
+#endif /* __CALI_ALLOWSOURCES_H__ */

--- a/felix/bpf-gpl/allowsources.h
+++ b/felix/bpf-gpl/allowsources.h
@@ -1,3 +1,7 @@
+// Project Calico BPF dataplane programs.
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
+
 #ifndef __CALI_ALLOWSOURCES_H__
 #define __CALI_ALLOWSOURCES_H__
 

--- a/felix/bpf-gpl/allowsources.h
+++ b/felix/bpf-gpl/allowsources.h
@@ -5,7 +5,7 @@
 #ifndef __CALI_ALLOWSOURCES_H__
 #define __CALI_ALLOWSOURCES_H__
 
-#include "bpf.h"
+#include "cali_bpf.h"
 #include "ip_addr.h"
 
 #define IPV4_ADDR_BITS 32

--- a/felix/bpf-gpl/arp.h
+++ b/felix/bpf-gpl/arp.h
@@ -5,7 +5,7 @@
 #ifndef __CALI_ARP_H__
 #define __CALI_ARP_H__
 
-#include "bpf.h"
+#include "cali_bpf.h"
 #include "ip_addr.h"
 
 struct arp_key {

--- a/felix/bpf-gpl/arp.h
+++ b/felix/bpf-gpl/arp.h
@@ -5,6 +5,7 @@
 #ifndef __CALI_ARP_H__
 #define __CALI_ARP_H__
 
+#include "bpf.h"
 #include "ip_addr.h"
 
 struct arp_key {

--- a/felix/bpf-gpl/bpf.h
+++ b/felix/bpf-gpl/bpf.h
@@ -5,23 +5,27 @@
 #ifndef __CALI_BPF_H__
 #define __CALI_BPF_H__
 
-#include <linux/types.h>
-#include <linux/bpf.h>
-#include <bpf_helpers.h>   /* For bpf_xxx helper functions. */
-#include <bpf_endian.h>    /* For bpf_ntohX etc. */
-#include <bpf_core_read.h>
-#include <stddef.h>
-#include <linux/ip.h>
+/* stdbool.h and stddef.h have no deps so they are safe to include; stdint.h
+ * pulls in parts of the std lib that aren't compatible with BPF. */
 #include <stdbool.h>
+#include <stddef.h>
 
-/* CALI_BPF_INLINE must be defined before we include any of our headers. They
- * assume it exists!
+#include <linux/bpf.h>
+#include <linux/ip.h>
+#include <linux/pkt_cls.h>
+#include <linux/types.h>
+
+#include <bpf_core_read.h>
+#include <bpf_endian.h>    /* For bpf_ntohX etc. */
+#include <bpf_helpers.h>   /* For bpf_xxx helper functions. */
+
+#include "bpf_inline.h"
+
+/* bpf.h is the root of the BPF include graph: every other header includes it.
+ * Only globals.h and ip_addr.h sit below it, because userspace
+ * (felix/bpf/libbpf) shares them.  Every header includes what it uses, so
+ * include order never matters; ./check-headers enforces that.
  */
-#define CALI_BPF_INLINE inline __attribute__((always_inline))
-
-#define __unused __attribute__((unused))
-
-#include "globals.h"
 
 #define BPF_REDIR_EGRESS 0
 #define BPF_REDIR_INGRESS 1
@@ -294,6 +298,9 @@ static CALI_BPF_INLINE void ip_dec_ttl(struct iphdr *ip)
 #define ip_ttl_exceeded(ip) (CALI_F_TO_HOST && !CALI_F_IPIP && (ip)->ttl <= 1)
 #endif
 
+/* Accessors for the configured globals (see globals.h).  Programs that are
+ * not configured by Felix (XDP, cgroup) see constant placeholder values.
+ */
 #if CALI_F_XDP
 
 extern const volatile struct cali_xdp_preamble_globals __globals;

--- a/felix/bpf-gpl/bpf.h
+++ b/felix/bpf-gpl/bpf.h
@@ -21,8 +21,10 @@
 
 #include "bpf_inline.h"
 
+#define __unused __attribute__((unused))
+
 /* bpf.h is the root of the BPF include graph: every other header includes it.
- * Only globals.h and ip_addr.h sit below it, because userspace
+ * Only bpf_inline.h, globals.h and ip_addr.h sit below it, because userspace
  * (felix/bpf/libbpf) shares them.  Every header includes what it uses, so
  * include order never matters; ./check-headers enforces that.
  */

--- a/felix/bpf-gpl/bpf_inline.h
+++ b/felix/bpf-gpl/bpf_inline.h
@@ -1,0 +1,15 @@
+// Project Calico BPF dataplane programs.
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
+
+#ifndef __CALI_BPF_INLINE_H__
+#define __CALI_BPF_INLINE_H__
+
+/* Kept apart from bpf.h so that the headers shared with userspace (globals.h,
+ * ip_addr.h) can use it without pulling in the BPF helper definitions.
+ */
+#define CALI_BPF_INLINE inline __attribute__((always_inline))
+
+#define __unused __attribute__((unused))
+
+#endif /* __CALI_BPF_INLINE_H__ */

--- a/felix/bpf-gpl/bpf_inline.h
+++ b/felix/bpf-gpl/bpf_inline.h
@@ -10,6 +10,4 @@
  */
 #define CALI_BPF_INLINE inline __attribute__((always_inline))
 
-#define __unused __attribute__((unused))
-
 #endif /* __CALI_BPF_INLINE_H__ */

--- a/felix/bpf-gpl/cali_bpf.h
+++ b/felix/bpf-gpl/cali_bpf.h
@@ -23,7 +23,8 @@
 
 #define __unused __attribute__((unused))
 
-/* bpf.h is the root of the BPF include graph: every other header includes it.
+/* cali_bpf.h is the root of the BPF include graph: every other header includes
+ * it.  It is not called bpf.h so that it can never be confused with libbpf's.
  * Only bpf_inline.h, globals.h and ip_addr.h sit below it, because userspace
  * (felix/bpf/libbpf) shares them.  Every header includes what it uses, so
  * include order never matters; ./check-headers enforces that.

--- a/felix/bpf-gpl/check-headers
+++ b/felix/bpf-gpl/check-headers
@@ -10,6 +10,9 @@
 # something first.
 #
 # Usage: ./check-headers <compiler> [cflags...]
+#
+# The (header, variant) pairs are compiled in parallel: this script lists them
+# and xargs re-invokes it with --one for each pair.
 
 set -u
 
@@ -17,9 +20,6 @@ if [ $# -lt 1 ]; then
   echo "usage: $0 <compiler> [cflags...]" >&2
   exit 2
 fi
-
-tmpdir=$(mktemp -d)
-trap 'rm -rf "${tmpdir}"' EXIT
 
 common="-DCALI_DROP_WORKLOAD_TO_HOST=false -DCALI_FIB_LOOKUP_ENABLED=true"
 declare -A variants=(
@@ -48,35 +48,39 @@ declare -A only=(
   [nat6.h]="$tc6" [icmp6.h]="$tc6" [parsing6.h]="$tc6 xdp6" [tcp6.h]="$tc6"
 )
 
-fail=0
-for h in *.h; do
-  for v in "${!variants[@]}"; do
-    if [ -n "${only[$h]:-}" ] && ! [[ " ${only[$h]} " == *" $v "* ]]; then
-      continue
-    fi
-    src="${tmpdir}/${h%.h}_${v}.c"
-    echo "#include \"$h\"" > "${src}"
-    if ! out=$("$@" -I . ${common} ${variants[$v]} -c "${src}" -o "${tmpdir}/out.o" 2>&1); then
-      fail=1
-      echo "FAIL: $h is not self-contained under variant $v:"
-      echo "${out}" | grep -E 'error:' | head -5 | sed 's/^/    /'
-    fi
-  done
-done
-
-# Headers shared with userspace (felix/bpf/libbpf) must also compile with the
-# host compiler, without the BPF helper definitions.
-for h in globals.h ip_addr.h bpf_inline.h; do
-  src="${tmpdir}/${h%.h}_userspace.c"
+# --one <header> <variant> <compiler> [cflags...]: compile a single pair.
+if [ "$1" = "--one" ]; then
+  h=$2; v=$3; shift 3
+  src=$(mktemp --suffix=.c)
+  trap 'rm -f "${src}" "${src%.c}.o"' EXIT
   echo "#include \"$h\"" > "${src}"
-  if ! out=$("${HOST_CC:-cc}" -Wall -Werror -I . -I ./libbpf/include/uapi -c "${src}" -o "${tmpdir}/out.o" 2>&1); then
-    fail=1
+  if [ "$v" = "userspace" ]; then
+    out=$("${HOST_CC:-cc}" -Wall -Werror -I . -I ./libbpf/include/uapi -c "${src}" -o "${src%.c}.o" 2>&1) && exit 0
     echo "FAIL: $h does not compile for userspace:"
-    echo "${out}" | grep -E 'error:' | head -5 | sed 's/^/    /'
+  else
+    out=$("$@" -I . ${common} ${variants[$v]} -c "${src}" -o "${src%.c}.o" 2>&1) && exit 0
+    echo "FAIL: $h is not self-contained under variant $v:"
   fi
-done
-
-if [ "${fail}" = 0 ]; then
-  echo "All headers are self-contained."
+  echo "${out}" | grep -E 'error:' | head -5 | sed 's/^/    /'
+  exit 1
 fi
-exit ${fail}
+
+{
+  for h in *.h; do
+    for v in "${!variants[@]}"; do
+      if [ -n "${only[$h]:-}" ] && ! [[ " ${only[$h]} " == *" $v "* ]]; then
+        continue
+      fi
+      echo "$h $v"
+    done
+  done
+  # Headers shared with userspace (felix/bpf/libbpf) must also compile with the
+  # host compiler, without the BPF helper definitions.
+  for h in globals.h ip_addr.h bpf_inline.h; do
+    echo "$h userspace"
+  done
+} | xargs -P "$(nproc)" -I{} bash -c 'exec "$0" --one {} "$@"' "$0" "$@"
+if [ "${PIPESTATUS[1]}" != 0 ]; then
+  exit 1
+fi
+echo "All headers are self-contained."

--- a/felix/bpf-gpl/check-headers
+++ b/felix/bpf-gpl/check-headers
@@ -4,10 +4,13 @@
 # Copyright (c) 2026 Tigera, Inc. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 
-# Checks that every header is self-contained: a translation unit that includes
-# only that header must compile under each build variant the header is meant
-# for.  A failure means the header relies on its includer having included
-# something first.
+# Checks that every header:
+#
+# - has an include guard named __CALI_<FILENAME>_H__, so guards are unique
+#   and cannot silently hide one header behind another; and
+# - is self-contained: a translation unit that includes only that header must
+#   compile under each build variant the header is meant for.  A failure means
+#   the header relies on its includer having included something first.
 #
 # Usage: ./check-headers <compiler> [cflags...]
 #
@@ -62,6 +65,18 @@ if [ "$1" = "--one" ]; then
     echo "FAIL: $h is not self-contained under variant $v:"
   fi
   echo "${out}" | grep -E 'error:' | head -5 | sed 's/^/    /'
+  exit 1
+fi
+
+fail=0
+for h in *.h ut/*.h; do
+  guard="__CALI_$(basename "${h%.h}" | tr '[:lower:]' '[:upper:]')_H__"
+  if ! grep -qx "#ifndef ${guard}" "$h" || ! grep -qx "#define ${guard}" "$h"; then
+    echo "FAIL: $h must have include guard: #ifndef ${guard} / #define ${guard}"
+    fail=1
+  fi
+done
+if [ "${fail}" != 0 ]; then
   exit 1
 fi
 

--- a/felix/bpf-gpl/check-headers
+++ b/felix/bpf-gpl/check-headers
@@ -24,24 +24,28 @@ if [ $# -lt 1 ]; then
   exit 2
 fi
 
-common="-DCALI_DROP_WORKLOAD_TO_HOST=false -DCALI_FIB_LOOKUP_ENABLED=true"
+# CALI_COMPILE_FLAGS values match what calculate-flags derives for the real
+# objects (CALI_TC_HOST_EP=1, CALI_TC_INGRESS=2, CALI_CGROUP=8, CALI_XDP_PROG=64,
+# CALI_CT_CLEANUP=512, CALI_TC_PREAMBLE=2048).  The ut flags mirror UT_CFLAGS
+# in the Makefile.
+debug="-DCALI_LOG_LEVEL=CALI_LOG_LEVEL_DEBUG"
 declare -A variants=(
-  [tc4]="-DBPF_CORE_SUPPORTED -DCALI_LOG_LEVEL=CALI_LOG_LEVEL_DEBUG -DCALI_COMPILE_FLAGS=0"
-  [tc6]="-DBPF_CORE_SUPPORTED -DCALI_LOG_LEVEL=CALI_LOG_LEVEL_DEBUG -DCALI_COMPILE_FLAGS=0 -DIPVER6"
-  [tc4legacy]="-DCALI_LOG_LEVEL=CALI_LOG_LEVEL_OFF -DCALI_COMPILE_FLAGS=0"
-  [tc4hep]="-DBPF_CORE_SUPPORTED -DCALI_LOG_LEVEL=CALI_LOG_LEVEL_DEBUG -DCALI_COMPILE_FLAGS=3"
-  [xdp]="-DBPF_CORE_SUPPORTED -DCALI_LOG_LEVEL=CALI_LOG_LEVEL_DEBUG -DCALI_COMPILE_FLAGS=64"
-  [xdp6]="-DBPF_CORE_SUPPORTED -DCALI_LOG_LEVEL=CALI_LOG_LEVEL_DEBUG -DCALI_COMPILE_FLAGS=64 -DIPVER6"
-  [cgroup]="-DBPF_CORE_SUPPORTED -DCALI_LOG_LEVEL=CALI_LOG_LEVEL_DEBUG -DCALI_COMPILE_FLAGS=8"
-  [ctclean]="-DBPF_CORE_SUPPORTED -DCALI_LOG_LEVEL=CALI_LOG_LEVEL_DEBUG -DCALI_COMPILE_FLAGS=512"
-  [preamble]="-DBPF_CORE_SUPPORTED -DCALI_LOG_LEVEL=CALI_LOG_LEVEL_DEBUG -DCALI_COMPILE_FLAGS=2048"
-  [ut]="-DBPF_CORE_SUPPORTED -DCALI_LOG_LEVEL=CALI_LOG_LEVEL_DEBUG -DCALI_COMPILE_FLAGS=0 -DUNITTEST"
+  [tc4]="${debug} -DCALI_COMPILE_FLAGS=0"
+  [tc6]="${debug} -DCALI_COMPILE_FLAGS=0 -DIPVER6"
+  [tc4nolog]="-DCALI_LOG_LEVEL=CALI_LOG_LEVEL_OFF -DCALI_COMPILE_FLAGS=0"
+  [tc4hep]="${debug} -DCALI_COMPILE_FLAGS=3"
+  [xdp]="${debug} -DCALI_COMPILE_FLAGS=67"
+  [xdp6]="${debug} -DCALI_COMPILE_FLAGS=67 -DIPVER6"
+  [cgroup]="${debug} -DCALI_COMPILE_FLAGS=8"
+  [ctclean]="${debug} -DCALI_COMPILE_FLAGS=512"
+  [preamble]="${debug} -DCALI_COMPILE_FLAGS=2048"
+  [ut]="${debug} -D__BPFTOOL_LOADER__ -DUNITTEST -DCALI_LOG_PFX=UNITTEST"
 )
 
 # Which variants a header is meant for.  Headers not listed must compile under
 # every variant.  "tc" headers use the skb-based context (not XDP, not cgroup).
-tc="tc4 tc6 tc4legacy tc4hep ctclean preamble ut"
-tc4="tc4 tc4legacy tc4hep ctclean preamble ut"
+tc="tc4 tc6 tc4nolog tc4hep ctclean preamble ut"
+tc4="tc4 tc4nolog tc4hep ctclean preamble ut"
 tc6="tc6"
 declare -A only=(
   [ctlb.h]="cgroup" [connect.h]="cgroup"
@@ -55,13 +59,13 @@ declare -A only=(
 if [ "$1" = "--one" ]; then
   h=$2; v=$3; shift 3
   src=$(mktemp --suffix=.c)
-  trap 'rm -f "${src}" "${src%.c}.o"' EXIT
+  trap 'rm -f "${src}"' EXIT
   echo "#include \"$h\"" > "${src}"
   if [ "$v" = "userspace" ]; then
-    out=$("${HOST_CC:-cc}" -Wall -Werror -I . -I ./libbpf/include/uapi -c "${src}" -o "${src%.c}.o" 2>&1) && exit 0
+    out=$("${HOST_CC:-cc}" -Wall -Werror -I . -I ./libbpf/include/uapi -fsyntax-only "${src}" 2>&1) && exit 0
     echo "FAIL: $h does not compile for userspace:"
   else
-    out=$("$@" -I . ${common} ${variants[$v]} -c "${src}" -o "${src%.c}.o" 2>&1) && exit 0
+    out=$("$@" -I . ${variants[$v]} -fsyntax-only "${src}" 2>&1) && exit 0
     echo "FAIL: $h is not self-contained under variant $v:"
   fi
   echo "${out}" | grep -E 'error:' | head -5 | sed 's/^/    /'
@@ -76,11 +80,26 @@ for h in *.h ut/*.h; do
     fail=1
   fi
 done
+# A stale or mistyped "only" entry would silently skip every variant.
+for h in "${!only[@]}"; do
+  if [ ! -f "$h" ]; then
+    echo "FAIL: only[$h] names a header that does not exist"
+    fail=1
+  fi
+  for v in ${only[$h]}; do
+    if [ -z "${variants[$v]:-}" ]; then
+      echo "FAIL: only[$h] names unknown variant $v"
+      fail=1
+    fi
+  done
+done
 if [ "${fail}" != 0 ]; then
   exit 1
 fi
 
-{
+# ut/ut.h is the test harness, not a library header: it calls the entry point
+# that each ut/*.c defines, so it cannot compile on its own.
+if ! {
   for h in *.h; do
     for v in "${!variants[@]}"; do
       if [ -n "${only[$h]:-}" ] && ! [[ " ${only[$h]} " == *" $v "* ]]; then
@@ -94,8 +113,7 @@ fi
   for h in globals.h ip_addr.h bpf_inline.h; do
     echo "$h userspace"
   done
-} | xargs -P "$(nproc)" -I{} bash -c 'exec "$0" --one {} "$@"' "$0" "$@"
-if [ "${PIPESTATUS[1]}" != 0 ]; then
+} | xargs -P "$(nproc)" -I{} bash -c 'exec "$0" --one {} "$@"' "$0" "$@"; then
   exit 1
 fi
 echo "All headers are self-contained."

--- a/felix/bpf-gpl/check-headers
+++ b/felix/bpf-gpl/check-headers
@@ -48,7 +48,8 @@ tc="tc4 tc6 tc4nolog tc4hep ctclean preamble ut"
 tc4="tc4 tc4nolog tc4hep ctclean preamble ut"
 tc6="tc6"
 declare -A only=(
-  [ctlb.h]="cgroup" [connect.h]="cgroup"
+  [ctlb.h]="cgroup" [connect.h]="cgroup" [sock_type.h]="cgroup"
+  [ut/ut.h]="ut"
   [conntrack.h]="$tc" [fib.h]="$tc" [fib_co_re.h]="$tc" [fib_common.h]="$tc" [maglev.h]="$tc"
   [nat.h]="$tc" [icmp.h]="$tc" [qos.h]="$tc" [rpf.h]="$tc" [events.h]="$tc" [tc.h]="$tc"
   [nat4.h]="$tc4" [icmp4.h]="$tc4" [parsing4.h]="$tc4 xdp" [tcp4.h]="$tc4" [ip_v4_fragment.h]="$tc4"
@@ -61,11 +62,15 @@ if [ "$1" = "--one" ]; then
   src=$(mktemp --suffix=.c)
   trap 'rm -f "${src}"' EXIT
   echo "#include \"$h\"" > "${src}"
+  if [ "$h" = "ut/ut.h" ]; then
+    # The UT harness calls the entry point that each ut/*.c defines.
+    echo "static CALI_BPF_INLINE int calico_unittest_entry(struct __sk_buff *skb) { return 0; }" >> "${src}"
+  fi
   if [ "$v" = "userspace" ]; then
     out=$("${HOST_CC:-cc}" -Wall -Werror -I . -I ./libbpf/include/uapi -fsyntax-only "${src}" 2>&1) && exit 0
     echo "FAIL: $h does not compile for userspace:"
   else
-    out=$("$@" -I . ${variants[$v]} -fsyntax-only "${src}" 2>&1) && exit 0
+    out=$("$1" -I . "${@:2}" ${variants[$v]} -fsyntax-only "${src}" 2>&1) && exit 0
     echo "FAIL: $h is not self-contained under variant $v:"
   fi
   echo "${out}" | grep -E 'error:' | head -5 | sed 's/^/    /'
@@ -97,10 +102,8 @@ if [ "${fail}" != 0 ]; then
   exit 1
 fi
 
-# ut/ut.h is the test harness, not a library header: it calls the entry point
-# that each ut/*.c defines, so it cannot compile on its own.
 if ! {
-  for h in *.h; do
+  for h in *.h ut/*.h; do
     for v in "${!variants[@]}"; do
       if [ -n "${only[$h]:-}" ] && ! [[ " ${only[$h]} " == *" $v "* ]]; then
         continue

--- a/felix/bpf-gpl/check-headers
+++ b/felix/bpf-gpl/check-headers
@@ -1,0 +1,82 @@
+#!/bin/bash
+
+# Project Calico BPF dataplane build scripts.
+# Copyright (c) 2026 Tigera, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
+
+# Checks that every header is self-contained: a translation unit that includes
+# only that header must compile under each build variant the header is meant
+# for.  A failure means the header relies on its includer having included
+# something first.
+#
+# Usage: ./check-headers <compiler> [cflags...]
+
+set -u
+
+if [ $# -lt 1 ]; then
+  echo "usage: $0 <compiler> [cflags...]" >&2
+  exit 2
+fi
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "${tmpdir}"' EXIT
+
+common="-DCALI_DROP_WORKLOAD_TO_HOST=false -DCALI_FIB_LOOKUP_ENABLED=true"
+declare -A variants=(
+  [tc4]="-DBPF_CORE_SUPPORTED -DCALI_LOG_LEVEL=CALI_LOG_LEVEL_DEBUG -DCALI_COMPILE_FLAGS=0"
+  [tc6]="-DBPF_CORE_SUPPORTED -DCALI_LOG_LEVEL=CALI_LOG_LEVEL_DEBUG -DCALI_COMPILE_FLAGS=0 -DIPVER6"
+  [tc4legacy]="-DCALI_LOG_LEVEL=CALI_LOG_LEVEL_OFF -DCALI_COMPILE_FLAGS=0"
+  [tc4hep]="-DBPF_CORE_SUPPORTED -DCALI_LOG_LEVEL=CALI_LOG_LEVEL_DEBUG -DCALI_COMPILE_FLAGS=3"
+  [xdp]="-DBPF_CORE_SUPPORTED -DCALI_LOG_LEVEL=CALI_LOG_LEVEL_DEBUG -DCALI_COMPILE_FLAGS=64"
+  [xdp6]="-DBPF_CORE_SUPPORTED -DCALI_LOG_LEVEL=CALI_LOG_LEVEL_DEBUG -DCALI_COMPILE_FLAGS=64 -DIPVER6"
+  [cgroup]="-DBPF_CORE_SUPPORTED -DCALI_LOG_LEVEL=CALI_LOG_LEVEL_DEBUG -DCALI_COMPILE_FLAGS=8"
+  [ctclean]="-DBPF_CORE_SUPPORTED -DCALI_LOG_LEVEL=CALI_LOG_LEVEL_DEBUG -DCALI_COMPILE_FLAGS=512"
+  [preamble]="-DBPF_CORE_SUPPORTED -DCALI_LOG_LEVEL=CALI_LOG_LEVEL_DEBUG -DCALI_COMPILE_FLAGS=2048"
+  [ut]="-DBPF_CORE_SUPPORTED -DCALI_LOG_LEVEL=CALI_LOG_LEVEL_DEBUG -DCALI_COMPILE_FLAGS=0 -DUNITTEST"
+)
+
+# Which variants a header is meant for.  Headers not listed must compile under
+# every variant.  "tc" headers use the skb-based context (not XDP, not cgroup).
+tc="tc4 tc6 tc4legacy tc4hep ctclean preamble ut"
+tc4="tc4 tc4legacy tc4hep ctclean preamble ut"
+tc6="tc6"
+declare -A only=(
+  [ctlb.h]="cgroup" [connect.h]="cgroup"
+  [conntrack.h]="$tc" [fib.h]="$tc" [fib_co_re.h]="$tc" [fib_common.h]="$tc" [maglev.h]="$tc"
+  [nat.h]="$tc" [icmp.h]="$tc" [qos.h]="$tc" [rpf.h]="$tc" [events.h]="$tc" [tc.h]="$tc"
+  [nat4.h]="$tc4" [icmp4.h]="$tc4" [parsing4.h]="$tc4 xdp" [tcp4.h]="$tc4" [ip_v4_fragment.h]="$tc4"
+  [nat6.h]="$tc6" [icmp6.h]="$tc6" [parsing6.h]="$tc6 xdp6" [tcp6.h]="$tc6"
+)
+
+fail=0
+for h in *.h; do
+  for v in "${!variants[@]}"; do
+    if [ -n "${only[$h]:-}" ] && ! [[ " ${only[$h]} " == *" $v "* ]]; then
+      continue
+    fi
+    src="${tmpdir}/${h%.h}_${v}.c"
+    echo "#include \"$h\"" > "${src}"
+    if ! out=$("$@" -I . ${common} ${variants[$v]} -c "${src}" -o "${tmpdir}/out.o" 2>&1); then
+      fail=1
+      echo "FAIL: $h is not self-contained under variant $v:"
+      echo "${out}" | grep -E 'error:' | head -5 | sed 's/^/    /'
+    fi
+  done
+done
+
+# Headers shared with userspace (felix/bpf/libbpf) must also compile with the
+# host compiler, without the BPF helper definitions.
+for h in globals.h ip_addr.h bpf_inline.h; do
+  src="${tmpdir}/${h%.h}_userspace.c"
+  echo "#include \"$h\"" > "${src}"
+  if ! out=$("${HOST_CC:-cc}" -Wall -Werror -I . -I ./libbpf/include/uapi -c "${src}" -o "${tmpdir}/out.o" 2>&1); then
+    fail=1
+    echo "FAIL: $h does not compile for userspace:"
+    echo "${out}" | grep -E 'error:' | head -5 | sed 's/^/    /'
+  fi
+done
+
+if [ "${fail}" = 0 ]; then
+  echo "All headers are self-contained."
+fi
+exit ${fail}

--- a/felix/bpf-gpl/check-headers
+++ b/felix/bpf-gpl/check-headers
@@ -6,7 +6,8 @@
 
 # Checks that every header:
 #
-# - has an include guard named __CALI_<FILENAME>_H__, so guards are unique
+# - has an include guard named __CALI_<FILENAME>_H__ (any cali_ prefix on the
+#   file name dropped), so guards are unique
 #   and cannot silently hide one header behind another; and
 # - is self-contained: a translation unit that includes only that header must
 #   compile under each build variant the header is meant for.  A failure means
@@ -79,7 +80,8 @@ fi
 
 fail=0
 for h in *.h ut/*.h; do
-  guard="__CALI_$(basename "${h%.h}" | tr '[:lower:]' '[:upper:]')_H__"
+  name=$(basename "${h%.h}"); name=${name#cali_}
+  guard="__CALI_$(echo "${name}" | tr '[:lower:]' '[:upper:]')_H__"
   if ! grep -qx "#ifndef ${guard}" "$h" || ! grep -qx "#define ${guard}" "$h"; then
     echo "FAIL: $h must have include guard: #ifndef ${guard} / #define ${guard}"
     fail=1

--- a/felix/bpf-gpl/connect.h
+++ b/felix/bpf-gpl/connect.h
@@ -8,7 +8,7 @@
 #include <linux/bpf.h>
 #include <linux/in.h>
 
-#include "bpf.h"
+#include "cali_bpf.h"
 #include "ctlb.h"
 #include "ip_addr.h"
 #include "log.h"

--- a/felix/bpf-gpl/connect.h
+++ b/felix/bpf-gpl/connect.h
@@ -6,9 +6,16 @@
 #define __CONNECT_H__
 
 #include <linux/bpf.h>
+#include <linux/in.h>
 
 #include "bpf.h"
+#include "ctlb.h"
+#include "ip_addr.h"
+#include "log.h"
 #include "nat_lookup.h"
+#include "nat_types.h"
+#include "sendrecv.h"
+#include "sock_type.h"
 
 static CALI_BPF_INLINE int do_nat_common(struct bpf_sock_addr *ctx, __u8 proto, ipv46_addr_t *dst, bool connect)
 {
@@ -86,7 +93,7 @@ out:
 	return err;
 }
 
-static CALI_BPF_INLINE int connect(struct bpf_sock_addr *ctx, ipv46_addr_t *dst)
+static CALI_BPF_INLINE int do_connect(struct bpf_sock_addr *ctx, ipv46_addr_t *dst)
 {
 	int ret = 1; /* OK value */
 

--- a/felix/bpf-gpl/connect.h
+++ b/felix/bpf-gpl/connect.h
@@ -2,8 +2,8 @@
 // Copyright (c) 2020-2022 Tigera, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 
-#ifndef __CONNECT_H__
-#define __CONNECT_H__
+#ifndef __CALI_CONNECT_H__
+#define __CALI_CONNECT_H__
 
 #include <linux/bpf.h>
 #include <linux/in.h>
@@ -132,4 +132,4 @@ out:
 	return ret;
 }
 
-#endif /* __CONNECT_H__ */
+#endif /* __CALI_CONNECT_H__ */

--- a/felix/bpf-gpl/connect_balancer.c
+++ b/felix/bpf-gpl/connect_balancer.c
@@ -2,33 +2,26 @@
 // Copyright (c) 2020-2022 Tigera, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 
-#include <linux/bpf.h>
-
-// socket_type.h contains the definition of SOCK_XXX constants that we need
-// but it's supposed to be imported via socket.h, which we can't import due
-// to lack of std lib support for BPF.  Bypass its check for now.
-#define _SYS_SOCKET_H
-#include <bits/socket_type.h>
-
-#include <stdbool.h>
-
-#include "globals.h"
-#include "ctlb.h"
-#include "bpf.h"
-
+/* Log prefix for this program.  log.h only defines CALI_LOG if it is not
+ * already set, so this must come before any include. */
 #define CALI_LOG(fmt, ...) bpf_log("CTLB------------: " fmt, ## __VA_ARGS__)
 
-#include "log.h"
+#include <linux/bpf.h>
 
-#include "sendrecv.h"
+#include "bpf.h"
 #include "connect.h"
+#include "ctlb.h"
+#include "globals.h"
+#include "log.h"
+#include "sendrecv.h"
+#include "sock_type.h"
 
 SEC("cgroup/connect4")
 int calico_connect_v4(struct bpf_sock_addr *ctx)
 {
 	CALI_DEBUG("calico_connect_v4");
 
-	return connect(ctx, &ctx->user_ip4);
+	return do_connect(ctx, &ctx->user_ip4);
 }
 
 SEC("cgroup/sendmsg4")

--- a/felix/bpf-gpl/connect_balancer.c
+++ b/felix/bpf-gpl/connect_balancer.c
@@ -8,7 +8,7 @@
 
 #include <linux/bpf.h>
 
-#include "bpf.h"
+#include "cali_bpf.h"
 #include "connect.h"
 #include "ctlb.h"
 #include "globals.h"

--- a/felix/bpf-gpl/connect_balancer_v46.c
+++ b/felix/bpf-gpl/connect_balancer_v46.c
@@ -8,7 +8,7 @@
 
 #include <linux/bpf.h>
 
-#include "bpf.h"
+#include "cali_bpf.h"
 #include "connect.h"
 #include "ctlb.h"
 #include "ctlb_map.h"

--- a/felix/bpf-gpl/connect_balancer_v46.c
+++ b/felix/bpf-gpl/connect_balancer_v46.c
@@ -2,27 +2,20 @@
 // Copyright (c) 2020-2022 Tigera, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 
-#include <linux/bpf.h>
-
-// socket_type.h contains the definition of SOCK_XXX constants that we need
-// but it's supposed to be imported via socket.h, which we can't import due
-// to lack of std lib support for BPF.  Bypass its check for now.
-#define _SYS_SOCKET_H
-#include <bits/socket_type.h>
-
-#include <stdbool.h>
-
-#include "bpf.h"
-#include "globals.h"
-#include "ctlb.h"
-#include "ctlb_map.h"
-
+/* Log prefix for this program.  log.h only defines CALI_LOG if it is not
+ * already set, so this must come before any include. */
 #define CALI_LOG(fmt, ...) bpf_log("CTLB-V46--------: " fmt, ## __VA_ARGS__)
 
-#include "log.h"
+#include <linux/bpf.h>
 
-#include "sendrecv.h"
+#include "bpf.h"
 #include "connect.h"
+#include "ctlb.h"
+#include "ctlb_map.h"
+#include "globals.h"
+#include "log.h"
+#include "sendrecv.h"
+#include "sock_type.h"
 
 static CALI_BPF_INLINE bool is_ipv4_as_ipv6(__u32 *addr) {
 	return addr[0] == 0 && addr[1] == 0 && addr[2] == bpf_htonl(0x0000ffff);
@@ -46,7 +39,7 @@ int calico_connect_v46(struct bpf_sock_addr *ctx)
 v4:
 	ipv4 = ctx->user_ip6[3];
 
- 	if ((ret = connect(ctx, &ipv4)) != 1) {
+ 	if ((ret = do_connect(ctx, &ipv4)) != 1) {
 		goto out;
 	}
 

--- a/felix/bpf-gpl/connect_balancer_v6.c
+++ b/felix/bpf-gpl/connect_balancer_v6.c
@@ -2,26 +2,19 @@
 // Copyright (c) 2020-2022 Tigera, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 
-#include <linux/bpf.h>
-
-// socket_type.h contains the definition of SOCK_XXX constants that we need
-// but it's supposed to be imported via socket.h, which we can't import due
-// to lack of std lib support for BPF.  Bypass its check for now.
-#define _SYS_SOCKET_H
-#include <bits/socket_type.h>
-
-#include <stdbool.h>
-
-#include "bpf.h"
-#include "globals.h"
-#include "ctlb.h"
-
+/* Log prefix for this program.  log.h only defines CALI_LOG if it is not
+ * already set, so this must come before any include. */
 #define CALI_LOG(fmt, ...) bpf_log("CTLB-V6---------: " fmt, ## __VA_ARGS__)
 
-#include "log.h"
+#include <linux/bpf.h>
 
-#include "sendrecv.h"
+#include "bpf.h"
 #include "connect.h"
+#include "ctlb.h"
+#include "globals.h"
+#include "log.h"
+#include "sendrecv.h"
+#include "sock_type.h"
 
 #undef debug_ip
 
@@ -36,7 +29,7 @@ int calico_connect_v6(struct bpf_sock_addr *ctx)
 	ipv46_addr_t dst = {};
 	be32_4_ip_to_ipv6_addr_t(&dst, ctx->user_ip6);
 
-	int ret = connect(ctx, &dst);
+	int ret = do_connect(ctx, &dst);
 	ipv6_addr_t_to_be32_4_ip(ctx->user_ip6, &dst);
 
 	return ret;

--- a/felix/bpf-gpl/connect_balancer_v6.c
+++ b/felix/bpf-gpl/connect_balancer_v6.c
@@ -8,7 +8,7 @@
 
 #include <linux/bpf.h>
 
-#include "bpf.h"
+#include "cali_bpf.h"
 #include "connect.h"
 #include "ctlb.h"
 #include "globals.h"

--- a/felix/bpf-gpl/conntrack.h
+++ b/felix/bpf-gpl/conntrack.h
@@ -5,13 +5,28 @@
 #ifndef __CALI_CONNTRACK_H__
 #define __CALI_CONNTRACK_H__
 
+#include <linux/icmp.h>
 #include <linux/in.h>
-#include "nat.h"
+#include <linux/ip.h>
+#include <linux/ipv6.h>
+#include <linux/tcp.h>
+#include <linux/udp.h>
+
+#include "allowsources.h"
 #include "bpf.h"
+#include "conntrack_types.h"
+#include "counters.h"
+#include "globals.h"
 #include "icmp.h"
-#include "types.h"
-#include "rpf.h"
+#include "ip_addr.h"
+#include "log.h"
+#include "nat.h"
 #include "qos.h"
+#include "reasons.h"
+#include "routes.h"
+#include "rpf.h"
+#include "skb.h"
+#include "types.h"
 
 #ifdef IPVER6
 #define IPPROTO_ICMP_46	IPPROTO_ICMPV6

--- a/felix/bpf-gpl/conntrack.h
+++ b/felix/bpf-gpl/conntrack.h
@@ -13,7 +13,7 @@
 #include <linux/udp.h>
 
 #include "allowsources.h"
-#include "bpf.h"
+#include "cali_bpf.h"
 #include "conntrack_types.h"
 #include "counters.h"
 #include "globals.h"

--- a/felix/bpf-gpl/conntrack_cleanup.c
+++ b/felix/bpf-gpl/conntrack_cleanup.c
@@ -6,7 +6,7 @@
  * already set, so this must come before any include. */
 #define CALI_LOG(fmt, ...) bpf_log("CT-CLEANER------: " fmt, ## __VA_ARGS__)
 
-#include "bpf.h"
+#include "cali_bpf.h"
 #include "conntrack.h"
 #include "conntrack_cleanup.h"
 #include "conntrack_types.h"

--- a/felix/bpf-gpl/conntrack_cleanup.c
+++ b/felix/bpf-gpl/conntrack_cleanup.c
@@ -2,16 +2,17 @@
 // Copyright (c) 2024 Tigera, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 
-#include <linux/types.h>
-#include <linux/bpf.h>
-#include <linux/pkt_cls.h>
-
-#include <stdbool.h>
-
+/* Log prefix for this program.  log.h only defines CALI_LOG if it is not
+ * already set, so this must come before any include. */
 #define CALI_LOG(fmt, ...) bpf_log("CT-CLEANER------: " fmt, ## __VA_ARGS__)
-#include "log.h"
 
+#include "bpf.h"
+#include "conntrack.h"
 #include "conntrack_cleanup.h"
+#include "conntrack_types.h"
+#include "globals.h"
+#include "log.h"
+#include "qos.h"
 
 const volatile struct cali_ct_cleanup_globals __globals;
 

--- a/felix/bpf-gpl/conntrack_cleanup.h
+++ b/felix/bpf-gpl/conntrack_cleanup.h
@@ -2,8 +2,8 @@
 // Copyright (c) 2024 Tigera, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 
-#ifndef __CALI_CT_CLEAN_H__
-#define __CALI_CT_CLEAN_H__
+#ifndef __CALI_CONNTRACK_CLEANUP_H__
+#define __CALI_CONNTRACK_CLEANUP_H__
 
 #include "bpf.h"
 #include "conntrack_types.h"
@@ -38,4 +38,4 @@ CALI_MAP_NAMED(CCQ_MAP, cali_ccq, 2,
 		BPF_F_NO_PREALLOC
 );
 
-#endif // __CALI_CT_CLEAN_H__
+#endif /* __CALI_CONNTRACK_CLEANUP_H__ */

--- a/felix/bpf-gpl/conntrack_cleanup.h
+++ b/felix/bpf-gpl/conntrack_cleanup.h
@@ -6,9 +6,6 @@
 #define __CALI_CT_CLEAN_H__
 
 #include "bpf.h"
-#include "types.h"
-#include "counters.h"
-#include "conntrack.h"
 #include "conntrack_types.h"
 
 #ifdef IPVER6

--- a/felix/bpf-gpl/conntrack_cleanup.h
+++ b/felix/bpf-gpl/conntrack_cleanup.h
@@ -5,7 +5,7 @@
 #ifndef __CALI_CONNTRACK_CLEANUP_H__
 #define __CALI_CONNTRACK_CLEANUP_H__
 
-#include "bpf.h"
+#include "cali_bpf.h"
 #include "conntrack_types.h"
 
 #ifdef IPVER6

--- a/felix/bpf-gpl/conntrack_types.h
+++ b/felix/bpf-gpl/conntrack_types.h
@@ -7,7 +7,7 @@
 
 #include <linux/tcp.h>
 
-#include "bpf.h"
+#include "cali_bpf.h"
 #include "ip_addr.h"
 
 // Connection tracking.

--- a/felix/bpf-gpl/conntrack_types.h
+++ b/felix/bpf-gpl/conntrack_types.h
@@ -5,6 +5,11 @@
 #ifndef __CALI_CONNTRACK_TYPES_H__
 #define __CALI_CONNTRACK_TYPES_H__
 
+#include <linux/tcp.h>
+
+#include "bpf.h"
+#include "ip_addr.h"
+
 // Connection tracking.
 
 struct calico_ct_key {

--- a/felix/bpf-gpl/counters.h
+++ b/felix/bpf-gpl/counters.h
@@ -5,7 +5,7 @@
 #ifndef __CALI_COUNTERS_H__
 #define __CALI_COUNTERS_H__
 
-#include "bpf.h"
+#include "cali_bpf.h"
 #include "types.h"
 
 #define MAX_COUNTERS_SIZE 27

--- a/felix/bpf-gpl/ctlb.h
+++ b/felix/bpf-gpl/ctlb.h
@@ -1,5 +1,5 @@
-#ifndef _CTLB_H_
-#define _CTLB_H_
+#ifndef __CALI_CTLB_H__
+#define __CALI_CTLB_H__
 
 #include "globals.h"
 
@@ -7,4 +7,4 @@ const volatile struct cali_ctlb_globals __globals;
 #define CTLB_UDP_NOT_SEEN_TIMEO __globals.udp_not_seen_timeo
 #define CTLB_EXCLUDE_UDP __globals.exclude_udp
 
-#endif /* _CTLB_H_ */
+#endif /* __CALI_CTLB_H__ */

--- a/felix/bpf-gpl/ctlb.h
+++ b/felix/bpf-gpl/ctlb.h
@@ -1,3 +1,7 @@
+// Project Calico BPF dataplane programs.
+// Copyright (c) 2022-2023 Tigera, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
+
 #ifndef __CALI_CTLB_H__
 #define __CALI_CTLB_H__
 

--- a/felix/bpf-gpl/ctlb.h
+++ b/felix/bpf-gpl/ctlb.h
@@ -1,6 +1,8 @@
 #ifndef _CTLB_H_
 #define _CTLB_H_
 
+#include "globals.h"
+
 const volatile struct cali_ctlb_globals __globals;
 #define CTLB_UDP_NOT_SEEN_TIMEO __globals.udp_not_seen_timeo
 #define CTLB_EXCLUDE_UDP __globals.exclude_udp

--- a/felix/bpf-gpl/ctlb_map.h
+++ b/felix/bpf-gpl/ctlb_map.h
@@ -2,8 +2,8 @@
 // Copyright (c) 2020-2025 Tigera, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 
-#ifndef __CALI_CTLB_MAPS_H__
-#define __CALI_CTLB_MAPS_H__
+#ifndef __CALI_CTLB_MAP_H__
+#define __CALI_CTLB_MAP_H__
 
 #include <linux/bpf.h>
 

--- a/felix/bpf-gpl/ctlb_map.h
+++ b/felix/bpf-gpl/ctlb_map.h
@@ -6,7 +6,7 @@
 #define __CALI_CTLB_MAPS_H__
 
 #include <linux/bpf.h>
-#include <stdbool.h>
+
 #include "bpf.h"
 
 struct {

--- a/felix/bpf-gpl/ctlb_map.h
+++ b/felix/bpf-gpl/ctlb_map.h
@@ -7,7 +7,7 @@
 
 #include <linux/bpf.h>
 
-#include "bpf.h"
+#include "cali_bpf.h"
 
 struct {
 	__uint(type, BPF_MAP_TYPE_PROG_ARRAY);

--- a/felix/bpf-gpl/events.h
+++ b/felix/bpf-gpl/events.h
@@ -2,8 +2,8 @@
 // Copyright (c) 2021-2026 Tigera, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 
-#ifndef __CALI_EVETNS_H__
-#define __CALI_EVETNS_H__
+#ifndef __CALI_EVENTS_H__
+#define __CALI_EVENTS_H__
 
 #include "bpf.h"
 #include "events_type.h"
@@ -30,4 +30,4 @@ static CALI_BPF_INLINE void event_flow_log(struct cali_tc_ctx *ctx)
 	}
 }
 
-#endif /* __CALI_EVETNS_H__ */
+#endif /* __CALI_EVENTS_H__ */

--- a/felix/bpf-gpl/events.h
+++ b/felix/bpf-gpl/events.h
@@ -5,7 +5,7 @@
 #ifndef __CALI_EVENTS_H__
 #define __CALI_EVENTS_H__
 
-#include "bpf.h"
+#include "cali_bpf.h"
 #include "events_type.h"
 #include "log.h"
 #include "ringbuf.h"

--- a/felix/bpf-gpl/events.h
+++ b/felix/bpf-gpl/events.h
@@ -6,11 +6,10 @@
 #define __CALI_EVETNS_H__
 
 #include "bpf.h"
-#include "types.h"
-#include "ringbuf.h"
-#include "jump.h"
 #include "events_type.h"
 #include "log.h"
+#include "ringbuf.h"
+#include "types.h"
 
 static CALI_BPF_INLINE void event_flow_log(struct cali_tc_ctx *ctx)
 {

--- a/felix/bpf-gpl/events_type.h
+++ b/felix/bpf-gpl/events_type.h
@@ -5,6 +5,8 @@
 #ifndef __CALI_EVENTS_TYPE_H__
 #define __CALI_EVENTS_TYPE_H__
 
+#include <linux/types.h>
+
 #define EVENT_LOST_EVENTS          0
 
 #define EVENT_PROTO_STATS       1

--- a/felix/bpf-gpl/failsafe.h
+++ b/felix/bpf-gpl/failsafe.h
@@ -6,7 +6,7 @@
 #define __CALI_BPF_FAILSAFE_H__
 
 #include "bpf.h"
-#include "types.h"
+#include "ip_addr.h"
 
 struct failsafe_key {
 	__u32 prefixlen;

--- a/felix/bpf-gpl/failsafe.h
+++ b/felix/bpf-gpl/failsafe.h
@@ -5,7 +5,7 @@
 #ifndef __CALI_FAILSAFE_H__
 #define __CALI_FAILSAFE_H__
 
-#include "bpf.h"
+#include "cali_bpf.h"
 #include "ip_addr.h"
 
 struct failsafe_key {

--- a/felix/bpf-gpl/failsafe.h
+++ b/felix/bpf-gpl/failsafe.h
@@ -2,8 +2,8 @@
 // Copyright (c) 2021 Tigera, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 
-#ifndef __CALI_BPF_FAILSAFE_H__
-#define __CALI_BPF_FAILSAFE_H__
+#ifndef __CALI_FAILSAFE_H__
+#define __CALI_FAILSAFE_H__
 
 #include "bpf.h"
 #include "ip_addr.h"
@@ -67,4 +67,4 @@ static CALI_BPF_INLINE bool is_failsafe_out(__u8 ip_proto, __u16 dport, ipv46_ad
 	return false;
 }
 
-#endif /* __CALI_BPF_FAILSAFE_H__ */
+#endif /* __CALI_FAILSAFE_H__ */

--- a/felix/bpf-gpl/fib_co_re.h
+++ b/felix/bpf-gpl/fib_co_re.h
@@ -10,7 +10,7 @@
 #include <linux/in.h>
 
 #include "arp.h"
-#include "bpf.h"
+#include "cali_bpf.h"
 #include "conntrack.h"
 #include "conntrack_types.h"
 #include "counters.h"

--- a/felix/bpf-gpl/fib_co_re.h
+++ b/felix/bpf-gpl/fib_co_re.h
@@ -5,11 +5,27 @@
 #ifndef __CALI_FIB_CO_RE_H__
 #define __CALI_FIB_CO_RE_H__
 
+#include <linux/if_ether.h>
+#include <linux/if_packet.h>
+#include <linux/in.h>
+
+#include "arp.h"
+#include "bpf.h"
+#include "conntrack.h"
+#include "conntrack_types.h"
+#include "counters.h"
+#include "fib_common.h"
+#include "globals.h"
+#include "ip_addr.h"
+#include "log.h"
 #include "profiling.h"
+#include "reasons.h"
+#include "routes.h"
+#include "skb.h"
+#include "types.h"
 #ifndef IPVER6
 #include "ip_v4_fragment.h"
 #endif
-#include <linux/if_packet.h>
 
 static CALI_BPF_INLINE int make_room_for_l2_header(struct cali_tc_ctx *ctx)
 {

--- a/felix/bpf-gpl/fib_common.h
+++ b/felix/bpf-gpl/fib_common.h
@@ -5,7 +5,7 @@
 #ifndef __CALI_FIB_COMMON_H__
 #define __CALI_FIB_COMMON_H__
 
-#include "bpf.h"
+#include "cali_bpf.h"
 #include "conntrack_types.h"
 #include "ifstate.h"
 #include "log.h"

--- a/felix/bpf-gpl/fib_common.h
+++ b/felix/bpf-gpl/fib_common.h
@@ -5,9 +5,11 @@
 #ifndef __CALI_FIB_COMMON_H__
 #define __CALI_FIB_COMMON_H__
 
-#include "types.h"
-#include "skb.h"
+#include "bpf.h"
+#include "conntrack_types.h"
 #include "ifstate.h"
+#include "log.h"
+#include "types.h"
 
 #if CALI_FIB_ENABLED
 #define fwd_fib(fwd)			((fwd)->fib)

--- a/felix/bpf-gpl/globals.h
+++ b/felix/bpf-gpl/globals.h
@@ -5,6 +5,9 @@
 #ifndef __CALI_GLOBALS_H__
 #define __CALI_GLOBALS_H__
 
+#include <linux/types.h>
+#include <stdbool.h>
+
 #include "ip_addr.h"
 
 #define DECLARE_TC_GLOBAL_DATA(name, ip_t) \

--- a/felix/bpf-gpl/icmp.h
+++ b/felix/bpf-gpl/icmp.h
@@ -5,6 +5,9 @@
 #ifndef __CALI_ICMP_H__
 #define __CALI_ICMP_H__
 
+#include "bpf.h"
+#include "types.h"
+
 #ifdef IPVER6
 #include "icmp6.h"
 

--- a/felix/bpf-gpl/icmp.h
+++ b/felix/bpf-gpl/icmp.h
@@ -5,7 +5,7 @@
 #ifndef __CALI_ICMP_H__
 #define __CALI_ICMP_H__
 
-#include "bpf.h"
+#include "cali_bpf.h"
 #include "types.h"
 
 #ifdef IPVER6

--- a/felix/bpf-gpl/icmp4.h
+++ b/felix/bpf-gpl/icmp4.h
@@ -12,7 +12,7 @@
 #include <linux/tcp.h>
 #include <linux/udp.h>
 
-#include "bpf.h"
+#include "cali_bpf.h"
 #include "counters.h"
 #include "globals.h"
 #include "log.h"

--- a/felix/bpf-gpl/icmp4.h
+++ b/felix/bpf-gpl/icmp4.h
@@ -5,13 +5,21 @@
 #ifndef __CALI_ICMP4_H__
 #define __CALI_ICMP4_H__
 
-#include <linux/if_ether.h>
-#include <linux/ip.h>
 #include <linux/icmp.h>
+#include <linux/if_ether.h>
+#include <linux/in.h>
+#include <linux/ip.h>
+#include <linux/tcp.h>
+#include <linux/udp.h>
 
 #include "bpf.h"
+#include "counters.h"
+#include "globals.h"
 #include "log.h"
+#include "reasons.h"
+#include "routes.h"
 #include "skb.h"
+#include "types.h"
 
 static CALI_BPF_INLINE int icmp_v4_reply(struct cali_tc_ctx *ctx,
 					__u8 type, __u8 code, __be32 un)

--- a/felix/bpf-gpl/icmp6.h
+++ b/felix/bpf-gpl/icmp6.h
@@ -10,7 +10,7 @@
 #include <linux/in.h>
 #include <linux/ipv6.h>
 
-#include "bpf.h"
+#include "cali_bpf.h"
 #include "counters.h"
 #include "globals.h"
 #include "ip_addr.h"

--- a/felix/bpf-gpl/icmp6.h
+++ b/felix/bpf-gpl/icmp6.h
@@ -5,6 +5,21 @@
 #ifndef __CALI_ICMP6_H__
 #define __CALI_ICMP6_H__
 
+#include <linux/icmpv6.h>
+#include <linux/if_ether.h>
+#include <linux/in.h>
+#include <linux/ipv6.h>
+
+#include "bpf.h"
+#include "counters.h"
+#include "globals.h"
+#include "ip_addr.h"
+#include "log.h"
+#include "reasons.h"
+#include "routes.h"
+#include "skb.h"
+#include "types.h"
+
 static CALI_BPF_INLINE int icmp_v6_reply(struct cali_tc_ctx *ctx,
 					__u8 type, __u8 code, __be32 un)
 {

--- a/felix/bpf-gpl/ifstate.h
+++ b/felix/bpf-gpl/ifstate.h
@@ -5,6 +5,8 @@
 #ifndef __CALI_IFSTATE_H__
 #define __CALI_IFSTATE_H__
 
+#include "bpf.h"
+
 struct ifstate_val {
 	__u32 flags;
 	char  name[16];

--- a/felix/bpf-gpl/ifstate.h
+++ b/felix/bpf-gpl/ifstate.h
@@ -5,7 +5,7 @@
 #ifndef __CALI_IFSTATE_H__
 #define __CALI_IFSTATE_H__
 
-#include "bpf.h"
+#include "cali_bpf.h"
 
 struct ifstate_val {
 	__u32 flags;

--- a/felix/bpf-gpl/ip_addr.h
+++ b/felix/bpf-gpl/ip_addr.h
@@ -5,6 +5,12 @@
 #ifndef __CALI_IP_ADDR_H__
 #define __CALI_IP_ADDR_H__
 
+#include <linux/in6.h>
+#include <linux/types.h>
+#include <stdbool.h>
+
+#include "bpf_inline.h"
+
 typedef struct {
 	__be32 a;
 	__be32 b;
@@ -15,8 +21,6 @@ typedef struct {
 typedef __be32 ipv4_addr_t;
 
 #ifdef IPVER6
-
-#include <linux/in6.h>
 
 static CALI_BPF_INLINE bool ipv6_addr_t_eq(ipv6_addr_t x, ipv6_addr_t y)
 {

--- a/felix/bpf-gpl/ip_v4_fragment.h
+++ b/felix/bpf-gpl/ip_v4_fragment.h
@@ -8,7 +8,7 @@
 #include <linux/ip.h>
 #include <time.h> /* CLOCK_MONOTONIC */
 
-#include "bpf.h"
+#include "cali_bpf.h"
 #include "globals.h"
 #include "ip_addr.h"
 #include "log.h"

--- a/felix/bpf-gpl/ip_v4_fragment.h
+++ b/felix/bpf-gpl/ip_v4_fragment.h
@@ -5,9 +5,11 @@
 #ifndef __CALI_IP_V4_FRAGMENT_H__
 #define __CALI_IP_V4_FRAGMENT_H__
 
-#include <time.h>
+#include <linux/ip.h>
+#include <time.h> /* CLOCK_MONOTONIC */
 
 #include "bpf.h"
+#include "globals.h"
 #include "ip_addr.h"
 #include "log.h"
 #include "parsing.h"

--- a/felix/bpf-gpl/jenkins_hash.h
+++ b/felix/bpf-gpl/jenkins_hash.h
@@ -23,7 +23,7 @@
 #ifndef __CALI_JENKINS_HASH_H__
 #define __CALI_JENKINS_HASH_H__
 
-#include "bpf.h"
+#include "cali_bpf.h"
 
 #define hashsize(n) ((__u32)1<<(n))
 #define rot(x,k) (((x)<<(k)) | ((x)>>(32-(k))))

--- a/felix/bpf-gpl/jenkins_hash.h
+++ b/felix/bpf-gpl/jenkins_hash.h
@@ -1,5 +1,4 @@
-
-/* 
+/*
  * Copyright (C) 2006. Bob Jenkins (bob_jenkins@burtleburtle.net)
  *
  * https://burtleburtle.net/bob/hash/
@@ -21,6 +20,8 @@
  * -Alex
 */
 
+#ifndef __CALI_JENKINS_HASH_H__
+#define __CALI_JENKINS_HASH_H__
 
 #include "bpf.h"
 
@@ -161,3 +162,5 @@ static CALI_BPF_INLINE __u32 hashword(
 	/*------------------------------------------------------ report the result */
 	return c;
 }
+
+#endif /* __CALI_JENKINS_HASH_H__ */

--- a/felix/bpf-gpl/jump.h
+++ b/felix/bpf-gpl/jump.h
@@ -5,6 +5,9 @@
 #ifndef __CALI_BPF_JUMP_H__
 #define __CALI_BPF_JUMP_H__
 
+#include "bpf.h"
+#include "globals.h"
+#include "log.h"
 #include "types.h"
 
 #define STATE_SIZE 512

--- a/felix/bpf-gpl/jump.h
+++ b/felix/bpf-gpl/jump.h
@@ -5,7 +5,7 @@
 #ifndef __CALI_JUMP_H__
 #define __CALI_JUMP_H__
 
-#include "bpf.h"
+#include "cali_bpf.h"
 #include "globals.h"
 #include "log.h"
 #include "types.h"

--- a/felix/bpf-gpl/jump.h
+++ b/felix/bpf-gpl/jump.h
@@ -2,8 +2,8 @@
 // Copyright (c) 2020-2022 Tigera, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 
-#ifndef __CALI_BPF_JUMP_H__
-#define __CALI_BPF_JUMP_H__
+#ifndef __CALI_JUMP_H__
+#define __CALI_JUMP_H__
 
 #include "bpf.h"
 #include "globals.h"
@@ -148,4 +148,4 @@ CALI_MAP_V1(cali_jump_prog_map, BPF_MAP_TYPE_PROG_ARRAY, __u32, __u32, 240000, 0
 	__CALI_JUMP_TO_POLICY(ctx, PROG_INDEX_ALLOWED, PROG_INDEX_DROP, PROG_INDEX_POLICY)
 #endif
 
-#endif /* __CALI_BPF_JUMP_H__ */
+#endif /* __CALI_JUMP_H__ */

--- a/felix/bpf-gpl/log.h
+++ b/felix/bpf-gpl/log.h
@@ -6,6 +6,7 @@
 #define __CALI_LOG_H__
 
 #include "bpf.h"
+#include "globals.h"
 
 #define CALI_LOG_LEVEL_OFF 0
 #define CALI_LOG_LEVEL_INFO 5

--- a/felix/bpf-gpl/log.h
+++ b/felix/bpf-gpl/log.h
@@ -5,7 +5,7 @@
 #ifndef __CALI_LOG_H__
 #define __CALI_LOG_H__
 
-#include "bpf.h"
+#include "cali_bpf.h"
 #include "globals.h"
 
 #define CALI_LOG_LEVEL_OFF 0

--- a/felix/bpf-gpl/maglev.h
+++ b/felix/bpf-gpl/maglev.h
@@ -5,7 +5,12 @@
 #ifndef __CALI_MAGLEV_H__
 #define __CALI_MAGLEV_H__
 
+#include "bpf.h"
+#include "ip_addr.h"
 #include "jenkins_hash.h"
+#include "log.h"
+#include "nat_types.h"
+#include "types.h"
 
 static CALI_BPF_INLINE struct calico_nat_dest* maglev_select_backend(struct cali_tc_ctx *ctx)
 {

--- a/felix/bpf-gpl/maglev.h
+++ b/felix/bpf-gpl/maglev.h
@@ -5,7 +5,7 @@
 #ifndef __CALI_MAGLEV_H__
 #define __CALI_MAGLEV_H__
 
-#include "bpf.h"
+#include "cali_bpf.h"
 #include "ip_addr.h"
 #include "jenkins_hash.h"
 #include "log.h"

--- a/felix/bpf-gpl/metadata.h
+++ b/felix/bpf-gpl/metadata.h
@@ -5,7 +5,7 @@
 #ifndef __CALI_METADATA_H__
 #define __CALI_METADATA_H__
 
-#include "bpf.h"
+#include "cali_bpf.h"
 #include "log.h"
 #include "skb.h"
 #include "types.h"

--- a/felix/bpf-gpl/metadata.h
+++ b/felix/bpf-gpl/metadata.h
@@ -5,6 +5,11 @@
 #ifndef __CALI_METADATA_H__
 #define __CALI_METADATA_H__
 
+#include "bpf.h"
+#include "log.h"
+#include "skb.h"
+#include "types.h"
+
 /* A struct to share information between TC and XDP programs.
  * The struct must be 4 byte aligned, based on
  * samples/bpf/xdp2skb_meta_kern.c code in the Kernel source. */

--- a/felix/bpf-gpl/nat.h
+++ b/felix/bpf-gpl/nat.h
@@ -9,7 +9,7 @@
 #include <linux/in.h>
 
 #include "arp.h"
-#include "bpf.h"
+#include "cali_bpf.h"
 #include "counters.h"
 #include "globals.h"
 #include "ip_addr.h"

--- a/felix/bpf-gpl/nat.h
+++ b/felix/bpf-gpl/nat.h
@@ -5,12 +5,20 @@
 #ifndef __CALI_NAT_H__
 #define __CALI_NAT_H__
 
-#ifndef CALI_VXLAN_VNI
-#define CALI_VXLAN_VNI 0xca11c0
-#endif
+#include <linux/if_ether.h>
+#include <linux/in.h>
 
-#define vxlan_udp_csum_ok(udp) ((udp)->check == 0)
-
+#include "arp.h"
+#include "bpf.h"
+#include "counters.h"
+#include "globals.h"
+#include "ip_addr.h"
+#include "log.h"
+#include "nat_types.h"
+#include "reasons.h"
+#include "routes.h"
+#include "skb.h"
+#include "types.h"
 #ifdef IPVER6
 #include "nat6.h"
 #else

--- a/felix/bpf-gpl/nat4.h
+++ b/felix/bpf-gpl/nat4.h
@@ -5,15 +5,19 @@
 #ifndef __CALI_NAT4_H__
 #define __CALI_NAT4_H__
 
-#include <stddef.h>
-
 #include <linux/if_ether.h>
+#include <linux/in.h>
+#include <linux/ip.h>
 #include <linux/udp.h>
 
 #include "bpf.h"
-#include "skb.h"
-#include "routes.h"
+#include "counters.h"
+#include "globals.h"
+#include "log.h"
 #include "nat_types.h"
+#include "reasons.h"
+#include "skb.h"
+#include "types.h"
 
 /* Number of bytes we add to a packet when we do encap. */
 #define VXLAN_ENCAP_SIZE	(sizeof(struct ethhdr) + sizeof(struct iphdr) + \

--- a/felix/bpf-gpl/nat4.h
+++ b/felix/bpf-gpl/nat4.h
@@ -10,7 +10,7 @@
 #include <linux/ip.h>
 #include <linux/udp.h>
 
-#include "bpf.h"
+#include "cali_bpf.h"
 #include "counters.h"
 #include "globals.h"
 #include "log.h"

--- a/felix/bpf-gpl/nat6.h
+++ b/felix/bpf-gpl/nat6.h
@@ -5,15 +5,21 @@
 #ifndef __CALI_NAT6_H__
 #define __CALI_NAT6_H__
 
-#include <stddef.h>
-
 #include <linux/if_ether.h>
+#include <linux/in.h>
+#include <linux/ip.h>
+#include <linux/ipv6.h>
 #include <linux/udp.h>
 
 #include "bpf.h"
-#include "skb.h"
-#include "routes.h"
+#include "counters.h"
+#include "globals.h"
+#include "ip_addr.h"
+#include "log.h"
 #include "nat_types.h"
+#include "reasons.h"
+#include "skb.h"
+#include "types.h"
 
 /* Number of bytes we add to a packet when we do encap. */
 #define VXLAN_ENCAP_SIZE	(sizeof(struct ethhdr) + sizeof(struct iphdr) + \

--- a/felix/bpf-gpl/nat6.h
+++ b/felix/bpf-gpl/nat6.h
@@ -11,7 +11,7 @@
 #include <linux/ipv6.h>
 #include <linux/udp.h>
 
-#include "bpf.h"
+#include "cali_bpf.h"
 #include "counters.h"
 #include "globals.h"
 #include "ip_addr.h"

--- a/felix/bpf-gpl/nat_lookup.h
+++ b/felix/bpf-gpl/nat_lookup.h
@@ -5,14 +5,18 @@
 #ifndef __CALI_NAT_LOOKUP_H__
 #define __CALI_NAT_LOOKUP_H__
 
-#include <stddef.h>
-
-#include <linux/if_ether.h>
-#include <linux/udp.h>
+#include <linux/in.h>
 
 #include "bpf.h"
-#include "routes.h"
+#include "ip_addr.h"
+#include "log.h"
 #include "nat_types.h"
+#include "routes.h"
+#if !(CALI_F_XDP) && !(CALI_F_CGROUP)
+/* The cgroup programs must not pull in types.h: its kernel headers need
+ * sys/socket.h, which connect_balancer.c has to suppress. */
+#include "types.h"
+#endif
 
 static CALI_BPF_INLINE struct calico_nat_dest* calico_nat_lookup(ipv46_addr_t *ip_src,
 								 ipv46_addr_t *ip_dst,

--- a/felix/bpf-gpl/nat_lookup.h
+++ b/felix/bpf-gpl/nat_lookup.h
@@ -7,7 +7,7 @@
 
 #include <linux/in.h>
 
-#include "bpf.h"
+#include "cali_bpf.h"
 #include "ip_addr.h"
 #include "log.h"
 #include "nat_types.h"

--- a/felix/bpf-gpl/nat_lookup.h
+++ b/felix/bpf-gpl/nat_lookup.h
@@ -13,8 +13,7 @@
 #include "nat_types.h"
 #include "routes.h"
 #if !(CALI_F_XDP) && !(CALI_F_CGROUP)
-/* The cgroup programs must not pull in types.h: its kernel headers need
- * sys/socket.h, which connect_balancer.c has to suppress. */
+/* Only the skb-based programs pass a cali_tc_ctx (see below). */
 #include "types.h"
 #endif
 

--- a/felix/bpf-gpl/nat_types.h
+++ b/felix/bpf-gpl/nat_types.h
@@ -6,6 +6,7 @@
 #define __CALI_NAT_TYPES_H__
 
 #include "bpf.h"
+#include "ip_addr.h"
 
 typedef enum calico_nat_lookup_result {
 	NAT_LOOKUP_ALLOW,
@@ -118,6 +119,12 @@ struct vxlanhdr {
 	__be32 flags;
 	__be32 vni;
 };
+
+#ifndef CALI_VXLAN_VNI
+#define CALI_VXLAN_VNI 0xca11c0
+#endif
+
+#define vxlan_udp_csum_ok(udp) ((udp)->check == 0)
 
 struct cali_maglev_key {
 	__u32 sid;

--- a/felix/bpf-gpl/nat_types.h
+++ b/felix/bpf-gpl/nat_types.h
@@ -5,7 +5,7 @@
 #ifndef __CALI_NAT_TYPES_H__
 #define __CALI_NAT_TYPES_H__
 
-#include "bpf.h"
+#include "cali_bpf.h"
 #include "ip_addr.h"
 
 typedef enum calico_nat_lookup_result {

--- a/felix/bpf-gpl/parsing.h
+++ b/felix/bpf-gpl/parsing.h
@@ -7,7 +7,7 @@
 
 #include <linux/in.h>
 
-#include "bpf.h"
+#include "cali_bpf.h"
 #include "counters.h"
 #include "globals.h"
 #include "log.h"

--- a/felix/bpf-gpl/parsing.h
+++ b/felix/bpf-gpl/parsing.h
@@ -5,19 +5,18 @@
 #ifndef __CALI_PARSING_H__
 #define __CALI_PARSING_H__
 
+#include <linux/in.h>
+
+#include "bpf.h"
 #include "counters.h"
+#include "globals.h"
+#include "log.h"
+#include "nat_types.h"
+#include "parsing_types.h"
+#include "reasons.h"
 #include "routes.h"
 #include "skb.h"
 #include "types.h"
-
-#define PARSING_OK 0
-#define PARSING_OK_V6 1
-#define PARSING_ALLOW_WITHOUT_ENFORCING_POLICY 2
-#define PARSING_FRAG_STORED 3
-#define PARSING_ERROR -1
-
-static CALI_BPF_INLINE int bpf_load_bytes(struct cali_tc_ctx *ctx, __u32 offset, void *buf, __u32 len);
-
 #ifdef IPVER6
 #include "parsing6.h"
 #else
@@ -45,23 +44,6 @@ static CALI_BPF_INLINE void tc_state_fill_from_iphdr(struct cali_tc_ctx *ctx)
 	return tc_state_fill_from_iphdr_v4(ctx);
 }
 #endif
-
-static CALI_BPF_INLINE int bpf_load_bytes(struct cali_tc_ctx *ctx, __u32 offset, void *buf, __u32 len)
-{
-	int ret;
-
-#if CALI_F_XDP
-	if (bpf_core_enum_value_exists(enum bpf_func_id, BPF_FUNC_xdp_load_bytes)) {
-		ret = bpf_xdp_load_bytes(ctx->xdp, offset, buf, len);
-	} else {
-		return -22 /* EINVAL */;
-	}
-#else /* CALI_F_XDP */
-	ret = bpf_skb_load_bytes(ctx->skb, offset, buf, len);
-#endif /* CALI_F_XDP */
-
-	return ret;
-}
 
 /* Continue parsing packet based on the IP protocol and fill in relevant fields
  * in the state (struct cali_tc_state). */

--- a/felix/bpf-gpl/parsing4.h
+++ b/felix/bpf-gpl/parsing4.h
@@ -7,7 +7,7 @@
 
 #include <linux/if_ether.h>
 
-#include "bpf.h"
+#include "cali_bpf.h"
 #include "counters.h"
 #include "log.h"
 #include "parsing_types.h"

--- a/felix/bpf-gpl/parsing4.h
+++ b/felix/bpf-gpl/parsing4.h
@@ -5,8 +5,15 @@
 #ifndef __CALI_PARSING4_H__
 #define __CALI_PARSING4_H__
 
+#include <linux/if_ether.h>
+
 #include "bpf.h"
 #include "counters.h"
+#include "log.h"
+#include "parsing_types.h"
+#include "reasons.h"
+#include "skb.h"
+#include "types.h"
 
 static CALI_BPF_INLINE int parse_packet_ip_v4(struct cali_tc_ctx *ctx)
 {

--- a/felix/bpf-gpl/parsing6.h
+++ b/felix/bpf-gpl/parsing6.h
@@ -8,7 +8,7 @@
 #include <linux/if_ether.h>
 #include <linux/in.h>
 
-#include "bpf.h"
+#include "cali_bpf.h"
 #include "counters.h"
 #include "ip_addr.h"
 #include "log.h"

--- a/felix/bpf-gpl/parsing6.h
+++ b/felix/bpf-gpl/parsing6.h
@@ -5,8 +5,17 @@
 #ifndef __CALI_PARSING6_H__
 #define __CALI_PARSING6_H__
 
+#include <linux/if_ether.h>
+#include <linux/in.h>
+
 #include "bpf.h"
 #include "counters.h"
+#include "ip_addr.h"
+#include "log.h"
+#include "parsing_types.h"
+#include "reasons.h"
+#include "skb.h"
+#include "types.h"
 
 static CALI_BPF_INLINE int parse_packet_ip_v6(struct cali_tc_ctx *ctx) {
 	__u16 protocol = 0;

--- a/felix/bpf-gpl/parsing_types.h
+++ b/felix/bpf-gpl/parsing_types.h
@@ -1,0 +1,17 @@
+// Project Calico BPF dataplane programs.
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
+
+#ifndef __CALI_PARSING_TYPES_H__
+#define __CALI_PARSING_TYPES_H__
+
+/* Results of parse_packet_ip(), shared by parsing.h and the per-IP-version
+ * implementations in parsing4.h and parsing6.h.
+ */
+#define PARSING_OK 0
+#define PARSING_OK_V6 1
+#define PARSING_ALLOW_WITHOUT_ENFORCING_POLICY 2
+#define PARSING_FRAG_STORED 3
+#define PARSING_ERROR -1
+
+#endif /* __CALI_PARSING_TYPES_H__ */

--- a/felix/bpf-gpl/policy.h
+++ b/felix/bpf-gpl/policy.h
@@ -5,7 +5,7 @@
 #ifndef __CALI_POLICY_H__
 #define __CALI_POLICY_H__
 
-#include "bpf.h"
+#include "cali_bpf.h"
 #include "ip_addr.h"
 
 // Base of range for reserved IP set IDs for Calico Enterprise.

--- a/felix/bpf-gpl/policy.h
+++ b/felix/bpf-gpl/policy.h
@@ -5,6 +5,9 @@
 #ifndef __CALI_POLICY_H__
 #define __CALI_POLICY_H__
 
+#include "bpf.h"
+#include "ip_addr.h"
+
 // Base of range for reserved IP set IDs for Calico Enterprise.
 #define RESERVED_IP_SET_BASE (((__u64)1)<<32)
 

--- a/felix/bpf-gpl/policy_default.c
+++ b/felix/bpf-gpl/policy_default.c
@@ -10,7 +10,7 @@
  * before Felix replaces the policy program with its generated version.
  */
 
-#include "bpf.h"
+#include "cali_bpf.h"
 #include "jump.h"
 #include "log.h"
 #include "policy.h"

--- a/felix/bpf-gpl/policy_default.c
+++ b/felix/bpf-gpl/policy_default.c
@@ -10,13 +10,11 @@
  * before Felix replaces the policy program with its generated version.
  */
 
-#include <stdbool.h>
-
 #include "bpf.h"
-#include "log.h"
-#include "types.h"
 #include "jump.h"
+#include "log.h"
 #include "policy.h"
+#include "types.h"
 
 /* If we want to just compile the code without defining any policies and to
  * avoid compiling out code paths that are not reachable if traffic is denied,

--- a/felix/bpf-gpl/profiling.h
+++ b/felix/bpf-gpl/profiling.h
@@ -5,7 +5,7 @@
 #ifndef __CALI_PROFILING_H__
 #define __CALI_PROFILING_H__
 
-#include "bpf.h"
+#include "cali_bpf.h"
 
 struct prof_key {
 	__u32 ifindex;

--- a/felix/bpf-gpl/profiling.h
+++ b/felix/bpf-gpl/profiling.h
@@ -2,8 +2,8 @@
 // Copyright (c) 2024 Tigera, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 
-#ifndef __CALI_BPF_PROFILING_H__
-#define __CALI_BPF_PROFILING_H__
+#ifndef __CALI_PROFILING_H__
+#define __CALI_PROFILING_H__
 
 #include "bpf.h"
 
@@ -46,4 +46,4 @@ static CALI_BPF_INLINE void prof_record_sample(__u32 ifindex, __u32 kind, __u64 
 	}
 }
 
-#endif /* __CALI_BPF_PROFILING_H__ */
+#endif /* __CALI_PROFILING_H__ */

--- a/felix/bpf-gpl/profiling.h
+++ b/felix/bpf-gpl/profiling.h
@@ -5,6 +5,8 @@
 #ifndef __CALI_BPF_PROFILING_H__
 #define __CALI_BPF_PROFILING_H__
 
+#include "bpf.h"
+
 struct prof_key {
 	__u32 ifindex;
 	__u32 kind;

--- a/felix/bpf-gpl/qos.h
+++ b/felix/bpf-gpl/qos.h
@@ -5,7 +5,7 @@
 #ifndef __CALI_QOS_H__
 #define __CALI_QOS_H__
 
-#include "bpf.h"
+#include "cali_bpf.h"
 #include "counters.h"
 #include "globals.h"
 #include "ifstate.h"

--- a/felix/bpf-gpl/qos.h
+++ b/felix/bpf-gpl/qos.h
@@ -6,9 +6,13 @@
 #define __CALI_QOS_H__
 
 #include "bpf.h"
-#include "skb.h"
 #include "counters.h"
+#include "globals.h"
 #include "ifstate.h"
+#include "log.h"
+#include "reasons.h"
+#include "skb.h"
+#include "types.h"
 
 struct calico_qos_key {
 	__u32 ifindex;

--- a/felix/bpf-gpl/ringbuf.h
+++ b/felix/bpf-gpl/ringbuf.h
@@ -5,7 +5,7 @@
 #ifndef __CALI_RINGBUF_H__
 #define __CALI_RINGBUF_H__
 
-#include "bpf.h"
+#include "cali_bpf.h"
 #include "events_type.h"
 
 // Ring buffer map macro — ring buffers have no key/value types and no

--- a/felix/bpf-gpl/routes.h
+++ b/felix/bpf-gpl/routes.h
@@ -7,7 +7,7 @@
 
 #include <linux/in.h>
 
-#include "bpf.h"
+#include "cali_bpf.h"
 #include "ip_addr.h"
 
 // Map: Routes

--- a/felix/bpf-gpl/routes.h
+++ b/felix/bpf-gpl/routes.h
@@ -6,7 +6,9 @@
 #define __CALI_ROUTES_H__
 
 #include <linux/in.h>
+
 #include "bpf.h"
+#include "ip_addr.h"
 
 // Map: Routes
 

--- a/felix/bpf-gpl/rpf.h
+++ b/felix/bpf-gpl/rpf.h
@@ -8,7 +8,7 @@
 #include <linux/in.h>
 
 #include "allowsources.h"
-#include "bpf.h"
+#include "cali_bpf.h"
 #include "conntrack_types.h"
 #include "globals.h"
 #include "ip_addr.h"

--- a/felix/bpf-gpl/rpf.h
+++ b/felix/bpf-gpl/rpf.h
@@ -5,11 +5,16 @@
 #ifndef __CALI_RPF_H__
 #define __CALI_RPF_H__
 
-#include "bpf.h"
-#include "types.h"
-#include "skb.h"
-#include "routes.h"
+#include <linux/in.h>
+
 #include "allowsources.h"
+#include "bpf.h"
+#include "conntrack_types.h"
+#include "globals.h"
+#include "ip_addr.h"
+#include "log.h"
+#include "routes.h"
+#include "types.h"
 
 #define RPF_RES_FAIL		0
 #define RPF_RES_STRICT		1

--- a/felix/bpf-gpl/rule_counters.h
+++ b/felix/bpf-gpl/rule_counters.h
@@ -5,7 +5,7 @@
 #ifndef __CALI_RULE_COUNTERS_H__
 #define __CALI_RULE_COUNTERS_H__
 
-#include "bpf.h"
+#include "cali_bpf.h"
 #include "log.h"
 #include "types.h"
 

--- a/felix/bpf-gpl/sendrecv.h
+++ b/felix/bpf-gpl/sendrecv.h
@@ -2,8 +2,8 @@
 // Copyright (c) 2020-2021 Tigera, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 
-#ifndef __SENDRECV_H__
-#define __SENDRECV_H__
+#ifndef __CALI_SENDRECV_H__
+#define __CALI_SENDRECV_H__
 
 #include "bpf.h"
 #include "ip_addr.h"
@@ -62,4 +62,4 @@ static CALI_BPF_INLINE __u32 host_to_ctx_port(__u16 port)
 	return bpf_htonl(((__u32)port) << 16);
 }
 
-#endif /* __SENDRECV_H__ */
+#endif /* __CALI_SENDRECV_H__ */

--- a/felix/bpf-gpl/sendrecv.h
+++ b/felix/bpf-gpl/sendrecv.h
@@ -5,7 +5,7 @@
 #ifndef __CALI_SENDRECV_H__
 #define __CALI_SENDRECV_H__
 
-#include "bpf.h"
+#include "cali_bpf.h"
 #include "ip_addr.h"
 
 struct sendrec_key {

--- a/felix/bpf-gpl/sendrecv.h
+++ b/felix/bpf-gpl/sendrecv.h
@@ -5,6 +5,9 @@
 #ifndef __SENDRECV_H__
 #define __SENDRECV_H__
 
+#include "bpf.h"
+#include "ip_addr.h"
+
 struct sendrec_key {
 	__u64 cookie;
 	ipv46_addr_t ip;

--- a/felix/bpf-gpl/skb.h
+++ b/felix/bpf-gpl/skb.h
@@ -2,8 +2,8 @@
 // Copyright (c) 2020-2022 Tigera, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 
-#ifndef __SKB_H__
-#define __SKB_H__
+#ifndef __CALI_SKB_H__
+#define __CALI_SKB_H__
 
 #include <linux/if_ether.h>
 #include <linux/in.h>
@@ -278,4 +278,4 @@ static CALI_BPF_INLINE void skb_log(struct cali_tc_ctx *ctx, bool accepted)
 	}
 }
 
-#endif /* __SKB_H__ */
+#endif /* __CALI_SKB_H__ */

--- a/felix/bpf-gpl/skb.h
+++ b/felix/bpf-gpl/skb.h
@@ -12,7 +12,7 @@
 #include <linux/tcp.h>
 #include <linux/udp.h>
 
-#include "bpf.h"
+#include "cali_bpf.h"
 #include "globals.h"
 #include "log.h"
 #include "types.h"

--- a/felix/bpf-gpl/skb.h
+++ b/felix/bpf-gpl/skb.h
@@ -6,13 +6,16 @@
 #define __SKB_H__
 
 #include <linux/if_ether.h>
+#include <linux/in.h>
 #include <linux/ip.h>
-#include <linux/udp.h>
+#include <linux/ipv6.h>
 #include <linux/tcp.h>
+#include <linux/udp.h>
 
 #include "bpf.h"
-#include "types.h"
+#include "globals.h"
 #include "log.h"
+#include "types.h"
 
 /* skb_start_ptr is equivalent to (void*)((__u64)skb->data); the read is done
  * in a way that is acceptable to the verifier and it is done as a volatile read
@@ -171,6 +174,26 @@ static CALI_BPF_INLINE int skb_refresh_validate_ptrs(struct cali_tc_ctx *ctx, lo
 	ctx->ip_header =  ctx->data_start + skb_iphdr_offset(ctx);
 
 	return 0;
+}
+
+/* bpf_load_bytes copies len bytes of packet data at offset into buf, using the
+ * loader helper appropriate to the program type.
+ */
+static CALI_BPF_INLINE int bpf_load_bytes(struct cali_tc_ctx *ctx, __u32 offset, void *buf, __u32 len)
+{
+	int ret;
+
+#if CALI_F_XDP
+	if (bpf_core_enum_value_exists(enum bpf_func_id, BPF_FUNC_xdp_load_bytes)) {
+		ret = bpf_xdp_load_bytes(ctx->xdp, offset, buf, len);
+	} else {
+		return -22 /* EINVAL */;
+	}
+#else /* CALI_F_XDP */
+	ret = bpf_skb_load_bytes(ctx->skb, offset, buf, len);
+#endif /* CALI_F_XDP */
+
+	return ret;
 }
 
 #define skb_ptr_after(skb, ptr) ((void *)((ptr) + 1))

--- a/felix/bpf-gpl/sock_type.h
+++ b/felix/bpf-gpl/sock_type.h
@@ -5,14 +5,11 @@
 #ifndef __CALI_SOCK_TYPE_H__
 #define __CALI_SOCK_TYPE_H__
 
-/* SOCK_STREAM/SOCK_DGRAM for the cgroup socket programs.  They live in
- * bits/socket_type.h, which refuses to be included except via sys/socket.h,
- * and sys/socket.h needs libc types that BPF builds lack.  Pretend
- * sys/socket.h is already included.
+/* Socket types for the cgroup socket programs.  The libc definitions live in
+ * sys/socket.h, which BPF builds cannot include, so define the (ABI-fixed)
+ * values here.
  */
-#ifndef _SYS_SOCKET_H
-#define _SYS_SOCKET_H
-#endif
-#include <bits/socket_type.h>
+#define SOCK_STREAM 1
+#define SOCK_DGRAM  2
 
 #endif /* __CALI_SOCK_TYPE_H__ */

--- a/felix/bpf-gpl/sock_type.h
+++ b/felix/bpf-gpl/sock_type.h
@@ -1,0 +1,18 @@
+// Project Calico BPF dataplane programs.
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
+
+#ifndef __CALI_SOCK_TYPE_H__
+#define __CALI_SOCK_TYPE_H__
+
+/* SOCK_STREAM/SOCK_DGRAM for the cgroup socket programs.  They live in
+ * bits/socket_type.h, which refuses to be included except via sys/socket.h,
+ * and sys/socket.h needs libc types that BPF builds lack.  Pretend
+ * sys/socket.h is already included.
+ */
+#ifndef _SYS_SOCKET_H
+#define _SYS_SOCKET_H
+#endif
+#include <bits/socket_type.h>
+
+#endif /* __CALI_SOCK_TYPE_H__ */

--- a/felix/bpf-gpl/tc.c
+++ b/felix/bpf-gpl/tc.c
@@ -27,7 +27,7 @@
 #include <linux/udp.h>
 
 #include "arp.h"
-#include "bpf.h"
+#include "cali_bpf.h"
 #include "conntrack.h"
 #include "conntrack_types.h"
 #include "counters.h"

--- a/felix/bpf-gpl/tc.c
+++ b/felix/bpf-gpl/tc.c
@@ -2,25 +2,9 @@
 // Copyright (c) 2020-2026 Tigera, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 
-#include <linux/types.h>
-#include <linux/bpf.h>
-#include <linux/pkt_cls.h>
-#include <linux/ip.h>
-#include <linux/tcp.h>
-#include <linux/in.h>
-#include <linux/udp.h>
-#include <linux/if_ether.h>
-#include <iproute2/bpf_elf.h>
-
-// stdbool.h has no deps so it's OK to include; stdint.h pulls in parts
-// of the std lib that aren't compatible with BPF.
-#include <stdbool.h>
-
-
-#include "bpf.h"
-
+/* Log prefix for this program.  log.h only defines CALI_LOG if it is not
+ * already set, so this must come before any include. */
 #define CALI_IFACE_LOG(fmt, ...) bpf_log("%s" fmt, ctx->globals->data.iface_name, ## __VA_ARGS__)
-
 #define CALI_LOG(fmt, ...) do { \
 	if (((CALI_COMPILE_FLAGS) & CALI_TC_HOST_EP) && ((CALI_COMPILE_FLAGS) & CALI_TC_INGRESS)) { \
 		CALI_IFACE_LOG("-I: " fmt, ## __VA_ARGS__);	\
@@ -33,38 +17,51 @@
 	}							\
 } while (0)
 
-#include "types.h"
-#include "counters.h"
-#include "skb.h"
-#include "policy.h"
+#include <linux/icmp.h>
+#include <linux/icmpv6.h>
+#include <linux/if_ether.h>
+#include <linux/in.h>
+#include <linux/ip.h>
+#include <linux/ipv6.h>
+#include <linux/tcp.h>
+#include <linux/udp.h>
+
+#include "arp.h"
+#include "bpf.h"
 #include "conntrack.h"
+#include "conntrack_types.h"
+#include "counters.h"
+#include "events.h"
+#include "failsafe.h"
+#include "fib.h"
+#include "globals.h"
+#include "icmp.h"
+#include "ip_addr.h"
+#include "jump.h"
+#include "log.h"
+#include "maglev.h"
+#include "metadata.h"
 #include "nat.h"
 #include "nat_lookup.h"
-#include "routes.h"
-#include "jump.h"
-#include "reasons.h"
-#include "icmp.h"
-#include "arp.h"
-#include "sendrecv.h"
-#include "events.h"
-#include "fib.h"
-#include "rpf.h"
+#include "nat_types.h"
 #include "parsing.h"
-#include "failsafe.h"
-#include "metadata.h"
-#include "bpf_helpers.h"
-#include "rule_counters.h"
+#include "parsing_types.h"
+#include "policy.h"
 #include "qos.h"
-#include "maglev.h"
-
-#ifndef IPVER6
+#include "reasons.h"
+#include "routes.h"
+#include "rpf.h"
+#include "rule_counters.h"
+#include "sendrecv.h"
+#include "skb.h"
+#include "tc.h"
+#include "types.h"
+#ifdef IPVER6
+#include "tcp6.h"
+#else
 #include "ip_v4_fragment.h"
 #include "tcp4.h"
-#else
-#include "tcp6.h"
 #endif
-
-#include "tc.h"
 
 #define HAS_HOST_CONFLICT_PROG CALI_F_TO_HEP
 

--- a/felix/bpf-gpl/tc.h
+++ b/felix/bpf-gpl/tc.h
@@ -2,8 +2,8 @@
 // Copyright (c) 2020-2022 Tigera, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 
-#ifndef __CALI_BPF_TC_H__
-#define __CALI_BPF_TC_H__
+#ifndef __CALI_TC_H__
+#define __CALI_TC_H__
 
 #include "bpf.h"
 #include "types.h"
@@ -17,4 +17,4 @@ static CALI_BPF_INLINE void calico_tc_process_ct_lookup(struct cali_tc_ctx *ctx)
 
 int parse_packet(struct __sk_buff *skb, struct cali_tc_ctx *ctx);
 
-#endif /* __CALI_BPF_TC_H__ */
+#endif /* __CALI_TC_H__ */

--- a/felix/bpf-gpl/tc.h
+++ b/felix/bpf-gpl/tc.h
@@ -5,6 +5,7 @@
 #ifndef __CALI_BPF_TC_H__
 #define __CALI_BPF_TC_H__
 
+#include "bpf.h"
 #include "types.h"
 
 static CALI_BPF_INLINE int calico_tc(struct __sk_buff *skb);

--- a/felix/bpf-gpl/tc.h
+++ b/felix/bpf-gpl/tc.h
@@ -5,7 +5,7 @@
 #ifndef __CALI_TC_H__
 #define __CALI_TC_H__
 
-#include "bpf.h"
+#include "cali_bpf.h"
 #include "types.h"
 
 static CALI_BPF_INLINE int calico_tc(struct __sk_buff *skb);

--- a/felix/bpf-gpl/tc_preamble.c
+++ b/felix/bpf-gpl/tc_preamble.c
@@ -4,7 +4,7 @@
 
 #include <linux/if_ether.h>
 
-#include "bpf.h"
+#include "cali_bpf.h"
 #include "globals.h"
 #include "jump.h"
 #include "log.h"

--- a/felix/bpf-gpl/tc_preamble.c
+++ b/felix/bpf-gpl/tc_preamble.c
@@ -2,16 +2,13 @@
 // Copyright (c) 2023 Tigera, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 
-// stdbool.h has no deps so it's OK to include; stdint.h pulls in parts
-// of the std lib that aren't compatible with BPF.
-#include <stdbool.h>
 #include <linux/if_ether.h>
 
 #include "bpf.h"
-#include "types.h"
 #include "globals.h"
 #include "jump.h"
 #include "log.h"
+#include "types.h"
 
 const volatile struct cali_tc_preamble_globals __globals;
 

--- a/felix/bpf-gpl/tcp4.h
+++ b/felix/bpf-gpl/tcp4.h
@@ -10,7 +10,7 @@
 #include <linux/ip.h>
 #include <linux/tcp.h>
 
-#include "bpf.h"
+#include "cali_bpf.h"
 #include "counters.h"
 #include "log.h"
 #include "reasons.h"

--- a/felix/bpf-gpl/tcp4.h
+++ b/felix/bpf-gpl/tcp4.h
@@ -6,11 +6,16 @@
 #define __CALI_TCP4_H__
 
 #include <linux/if_ether.h>
+#include <linux/in.h>
 #include <linux/ip.h>
+#include <linux/tcp.h>
 
 #include "bpf.h"
+#include "counters.h"
 #include "log.h"
+#include "reasons.h"
 #include "skb.h"
+#include "types.h"
 
 static CALI_BPF_INLINE int tcp_v4_rst(struct cali_tc_ctx *ctx) {
 	if (skb_refresh_validate_ptrs(ctx, TCP_SIZE)) {

--- a/felix/bpf-gpl/tcp6.h
+++ b/felix/bpf-gpl/tcp6.h
@@ -6,11 +6,17 @@
 #define __CALI_TCP6_H__
 
 #include <linux/if_ether.h>
-#include <linux/ip.h>
+#include <linux/in.h>
+#include <linux/ipv6.h>
+#include <linux/tcp.h>
 
 #include "bpf.h"
+#include "counters.h"
+#include "ip_addr.h"
 #include "log.h"
+#include "reasons.h"
 #include "skb.h"
+#include "types.h"
 
 static CALI_BPF_INLINE int tcp_v6_rst(struct cali_tc_ctx *ctx) {
 	if (skb_refresh_validate_ptrs(ctx, TCP_SIZE)) {

--- a/felix/bpf-gpl/tcp6.h
+++ b/felix/bpf-gpl/tcp6.h
@@ -10,7 +10,7 @@
 #include <linux/ipv6.h>
 #include <linux/tcp.h>
 
-#include "bpf.h"
+#include "cali_bpf.h"
 #include "counters.h"
 #include "ip_addr.h"
 #include "log.h"

--- a/felix/bpf-gpl/types.h
+++ b/felix/bpf-gpl/types.h
@@ -20,7 +20,7 @@
 #include <linux/ip.h>
 #endif
 
-#include "bpf.h"
+#include "cali_bpf.h"
 #include "conntrack_types.h"
 #include "events_type.h"
 #include "globals.h"

--- a/felix/bpf-gpl/types.h
+++ b/felix/bpf-gpl/types.h
@@ -2,8 +2,8 @@
 // Copyright (c) 2020-2025 Tigera, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 
-#ifndef __CALI_BPF_TYPES_H__
-#define __CALI_BPF_TYPES_H__
+#ifndef __CALI_TYPES_H__
+#define __CALI_TYPES_H__
 
 #include <linux/bpf.h>
 #include <linux/if_ether.h>
@@ -327,4 +327,4 @@ static CALI_BPF_INLINE int l4_hdr_len(struct cali_tc_ctx *ctx)
 #define IP_SET(var, val) ((var) = (val))
 
 
-#endif /* __CALI_BPF_TYPES_H__ */
+#endif /* __CALI_TYPES_H__ */

--- a/felix/bpf-gpl/types.h
+++ b/felix/bpf-gpl/types.h
@@ -5,24 +5,27 @@
 #ifndef __CALI_BPF_TYPES_H__
 #define __CALI_BPF_TYPES_H__
 
-#include <linux/types.h>
 #include <linux/bpf.h>
-#include <linux/pkt_cls.h>
-#ifdef IPVER6
-#include <linux/ipv6.h>
-#include <linux/icmpv6.h>
-#else
-#include <linux/ip.h>
-#include <linux/icmp.h>
-#endif
-#include <linux/tcp.h>
+#include <linux/if_ether.h>
 #include <linux/in.h>
+#include <linux/pkt_cls.h>
+#include <linux/tcp.h>
+#include <linux/types.h>
 #include <linux/udp.h>
+#ifdef IPVER6
+#include <linux/icmpv6.h>
+#include <linux/ipv6.h>
+#else
+#include <linux/icmp.h>
+#include <linux/ip.h>
+#endif
+
 #include "bpf.h"
-#include "arp.h"
 #include "conntrack_types.h"
-#include "nat_types.h"
 #include "events_type.h"
+#include "globals.h"
+#include "ip_addr.h"
+#include "nat_types.h"
 #include "reasons.h"
 
 #define IPV4_UDP_SIZE		(sizeof(struct iphdr) + sizeof(struct udphdr))

--- a/felix/bpf-gpl/ut/icmp6_port_unreachable.c
+++ b/felix/bpf-gpl/ut/icmp6_port_unreachable.c
@@ -3,10 +3,16 @@
 // SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 
 #include "ut.h"
+
 #include "bpf.h"
-#include "nat.h"
+#include "globals.h"
 #include "icmp.h"
+#include "jump.h"
+#include "log.h"
+#include "nat.h"
 #include "parsing.h"
+#include "parsing_types.h"
+#include "types.h"
 
 const volatile struct cali_tc_preamble_globals __globals;
 

--- a/felix/bpf-gpl/ut/icmp6_port_unreachable.c
+++ b/felix/bpf-gpl/ut/icmp6_port_unreachable.c
@@ -4,7 +4,7 @@
 
 #include "ut.h"
 
-#include "bpf.h"
+#include "cali_bpf.h"
 #include "globals.h"
 #include "icmp.h"
 #include "jump.h"

--- a/felix/bpf-gpl/ut/icmp_port_unreachable.c
+++ b/felix/bpf-gpl/ut/icmp_port_unreachable.c
@@ -3,9 +3,14 @@
 // SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 
 #include "ut.h"
+
 #include "bpf.h"
-#include "nat.h"
+#include "globals.h"
 #include "icmp.h"
+#include "jump.h"
+#include "log.h"
+#include "nat.h"
+#include "types.h"
 
 const volatile struct cali_tc_preamble_globals __globals;
 

--- a/felix/bpf-gpl/ut/icmp_port_unreachable.c
+++ b/felix/bpf-gpl/ut/icmp_port_unreachable.c
@@ -4,7 +4,7 @@
 
 #include "ut.h"
 
-#include "bpf.h"
+#include "cali_bpf.h"
 #include "globals.h"
 #include "icmp.h"
 #include "jump.h"

--- a/felix/bpf-gpl/ut/icmp_too_big.c
+++ b/felix/bpf-gpl/ut/icmp_too_big.c
@@ -3,11 +3,16 @@
 // SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 
 #include "ut.h"
+
 #include "bpf.h"
-#include "nat.h"
+#include "globals.h"
 #include "icmp.h"
-#include "parsing.h"
 #include "jump.h"
+#include "log.h"
+#include "nat.h"
+#include "parsing.h"
+#include "parsing_types.h"
+#include "types.h"
 
 const volatile struct cali_tc_preamble_globals __globals;
 

--- a/felix/bpf-gpl/ut/icmp_too_big.c
+++ b/felix/bpf-gpl/ut/icmp_too_big.c
@@ -4,7 +4,7 @@
 
 #include "ut.h"
 
-#include "bpf.h"
+#include "cali_bpf.h"
 #include "globals.h"
 #include "icmp.h"
 #include "jump.h"

--- a/felix/bpf-gpl/ut/icmp_ttl_exceeded.c
+++ b/felix/bpf-gpl/ut/icmp_ttl_exceeded.c
@@ -3,9 +3,14 @@
 // SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 
 #include "ut.h"
+
 #include "bpf.h"
-#include "nat.h"
+#include "globals.h"
 #include "icmp.h"
+#include "jump.h"
+#include "log.h"
+#include "nat.h"
+#include "types.h"
 
 const volatile struct cali_tc_preamble_globals __globals;
 

--- a/felix/bpf-gpl/ut/icmp_ttl_exceeded.c
+++ b/felix/bpf-gpl/ut/icmp_ttl_exceeded.c
@@ -4,7 +4,7 @@
 
 #include "ut.h"
 
-#include "bpf.h"
+#include "cali_bpf.h"
 #include "globals.h"
 #include "icmp.h"
 #include "jump.h"

--- a/felix/bpf-gpl/ut/ip_dec_ttl.c
+++ b/felix/bpf-gpl/ut/ip_dec_ttl.c
@@ -4,7 +4,7 @@
 
 #include "ut.h"
 
-#include "bpf.h"
+#include "cali_bpf.h"
 #include "counters.h"
 #include "globals.h"
 #include "jump.h"

--- a/felix/bpf-gpl/ut/ip_dec_ttl.c
+++ b/felix/bpf-gpl/ut/ip_dec_ttl.c
@@ -3,8 +3,15 @@
 // SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 
 #include "ut.h"
+
 #include "bpf.h"
+#include "counters.h"
+#include "globals.h"
+#include "jump.h"
+#include "log.h"
+#include "reasons.h"
 #include "skb.h"
+#include "types.h"
 
 const volatile struct cali_tc_preamble_globals __globals;
 

--- a/felix/bpf-gpl/ut/ip_parse_test.c
+++ b/felix/bpf-gpl/ut/ip_parse_test.c
@@ -4,7 +4,7 @@
 
 #include "ut.h"
 
-#include "bpf.h"
+#include "cali_bpf.h"
 #include "globals.h"
 #include "jump.h"
 #include "log.h"

--- a/felix/bpf-gpl/ut/ip_parse_test.c
+++ b/felix/bpf-gpl/ut/ip_parse_test.c
@@ -3,9 +3,15 @@
 // SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 
 #include "ut.h"
-#include "parsing.h"
+
+#include "bpf.h"
+#include "globals.h"
 #include "jump.h"
+#include "log.h"
 #include "nat.h"
+#include "parsing.h"
+#include "parsing_types.h"
+#include "types.h"
 
 const volatile struct cali_tc_preamble_globals __globals;
 

--- a/felix/bpf-gpl/ut/ipv4_opts_test.c
+++ b/felix/bpf-gpl/ut/ipv4_opts_test.c
@@ -4,7 +4,7 @@
 
 #include "ut.h"
 
-#include "bpf.h"
+#include "cali_bpf.h"
 #include "counters.h"
 #include "globals.h"
 #include "jump.h"

--- a/felix/bpf-gpl/ut/ipv4_opts_test.c
+++ b/felix/bpf-gpl/ut/ipv4_opts_test.c
@@ -3,9 +3,17 @@
 // SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 
 #include "ut.h"
-#include "parsing.h"
+
+#include "bpf.h"
+#include "counters.h"
+#include "globals.h"
 #include "jump.h"
+#include "log.h"
 #include "nat.h"
+#include "parsing.h"
+#include "parsing_types.h"
+#include "reasons.h"
+#include "types.h"
 
 const volatile struct cali_tc_preamble_globals __globals;
 

--- a/felix/bpf-gpl/ut/nat_decap_test.c
+++ b/felix/bpf-gpl/ut/nat_decap_test.c
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 
 #include "ut.h"
+
 #include "bpf.h"
 #include "nat.h"
 

--- a/felix/bpf-gpl/ut/nat_decap_test.c
+++ b/felix/bpf-gpl/ut/nat_decap_test.c
@@ -4,7 +4,7 @@
 
 #include "ut.h"
 
-#include "bpf.h"
+#include "cali_bpf.h"
 #include "nat.h"
 
 static CALI_BPF_INLINE int calico_unittest_entry (struct __sk_buff *skb)

--- a/felix/bpf-gpl/ut/nat_encap_test.c
+++ b/felix/bpf-gpl/ut/nat_encap_test.c
@@ -4,7 +4,7 @@
 
 #include "ut.h"
 
-#include "bpf.h"
+#include "cali_bpf.h"
 #include "globals.h"
 #include "jump.h"
 #include "log.h"

--- a/felix/bpf-gpl/ut/nat_encap_test.c
+++ b/felix/bpf-gpl/ut/nat_encap_test.c
@@ -3,8 +3,13 @@
 // SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 
 #include "ut.h"
+
 #include "bpf.h"
+#include "globals.h"
+#include "jump.h"
+#include "log.h"
 #include "nat.h"
+#include "types.h"
 
 const volatile struct cali_tc_preamble_globals __globals;
 

--- a/felix/bpf-gpl/ut/ringbuf_events.c
+++ b/felix/bpf-gpl/ut/ringbuf_events.c
@@ -2,13 +2,17 @@
 // Copyright (c) 2020-2026 Tigera, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 
-#include "ut.h"
-#include "bpf.h"
-#include "ringbuf.h"
-#include "skb.h"
-
 #include <linux/ip.h>
 #include <linux/udp.h>
+
+#include "ut.h"
+
+#include "bpf.h"
+#include "events_type.h"
+#include "log.h"
+#include "ringbuf.h"
+#include "skb.h"
+#include "types.h"
 
 struct tuple {
 	struct event_header hdr;

--- a/felix/bpf-gpl/ut/ringbuf_events.c
+++ b/felix/bpf-gpl/ut/ringbuf_events.c
@@ -7,7 +7,7 @@
 
 #include "ut.h"
 
-#include "bpf.h"
+#include "cali_bpf.h"
 #include "events_type.h"
 #include "log.h"
 #include "ringbuf.h"

--- a/felix/bpf-gpl/ut/tcp_rst.c
+++ b/felix/bpf-gpl/ut/tcp_rst.c
@@ -4,7 +4,7 @@
 
 #include "ut.h"
 
-#include "bpf.h"
+#include "cali_bpf.h"
 #include "globals.h"
 #include "jump.h"
 #include "log.h"

--- a/felix/bpf-gpl/ut/tcp_rst.c
+++ b/felix/bpf-gpl/ut/tcp_rst.c
@@ -3,15 +3,20 @@
 // SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 
 #include "ut.h"
+
 #include "bpf.h"
-#include "nat.h"
-#ifndef IPVER6
-#include "tcp4.h"
-#else
-#include "tcp6.h"
-#endif
-#include "parsing.h"
+#include "globals.h"
 #include "jump.h"
+#include "log.h"
+#include "nat.h"
+#include "parsing.h"
+#include "parsing_types.h"
+#include "types.h"
+#ifdef IPVER6
+#include "tcp6.h"
+#else
+#include "tcp4.h"
+#endif
 
 const volatile struct cali_tc_preamble_globals __globals;
 

--- a/felix/bpf-gpl/ut/ut.h
+++ b/felix/bpf-gpl/ut/ut.h
@@ -5,7 +5,7 @@
 #ifndef __CALI_UT_H__
 #define __CALI_UT_H__
 
-#include "bpf.h"
+#include "cali_bpf.h"
 #include "globals.h"
 
 /* Harness for the mini-UT programs: each test file includes this header and

--- a/felix/bpf-gpl/ut/ut.h
+++ b/felix/bpf-gpl/ut/ut.h
@@ -1,30 +1,16 @@
 // Project Calico BPF dataplane programs.
-// Copyright (c) 2020-2021 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2026 Tigera, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 
-#include <linux/types.h>
-#include <linux/bpf.h>
-#include <linux/pkt_cls.h>
-#ifdef IPVER6
-#include <linux/ipv6.h>
-#include <linux/icmpv6.h>
-#else
-#include <linux/ip.h>
-#include <linux/icmp.h>
-#endif
-#include <linux/tcp.h>
-#include <linux/in.h>
-#include <linux/udp.h>
-#include <linux/if_ether.h>
-#include <iproute2/bpf_elf.h>
-
-#include <stdbool.h>
+#ifndef __CALI_UT_H__
+#define __CALI_UT_H__
 
 #include "bpf.h"
-#include "types.h"
-#include "counters.h"
-#include "jump.h"
+#include "globals.h"
 
+/* Harness for the mini-UT programs: each test file includes this header and
+ * defines calico_unittest_entry(), which the "tc" program below calls.
+ */
 const volatile struct cali_tc_preamble_globals __globals;
 
 static CALI_BPF_INLINE int calico_unittest_entry (struct __sk_buff *skb);
@@ -33,3 +19,5 @@ __attribute__((section("tc"))) int unittest(struct __sk_buff *skb)
 {
 	return calico_unittest_entry(skb);
 }
+
+#endif /* __CALI_UT_H__ */

--- a/felix/bpf-gpl/xdp.c
+++ b/felix/bpf-gpl/xdp.c
@@ -2,34 +2,31 @@
 // Copyright (c) 2021-2022 Tigera, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 
+/* Log prefix for this program.  log.h only defines CALI_LOG if it is not
+ * already set, so this must come before any include. */
+#define CALI_LOG(fmt, ...) bpf_log("%s-X: " fmt, ctx->xdp_globals->iface_name, ## __VA_ARGS__)
+
 #include <linux/if_ether.h>
+#include <linux/in.h>
 #include <linux/ip.h>
 #include <linux/ipv6.h>
-#include <linux/in.h>
-#include <linux/icmp.h>
 #include <linux/tcp.h>
 #include <linux/udp.h>
 
-// stdbool.h has no deps so it's OK to include; stdint.h pulls in parts
-// of the std lib that aren't compatible with BPF.
-#include <stdbool.h>
-
 #include "bpf.h"
-
-#define CALI_LOG(fmt, ...) bpf_log("%s-X: " fmt, ctx->xdp_globals->iface_name, ## __VA_ARGS__)
-
-#include "log.h"
-#include "types.h"
 #include "counters.h"
-#include "skb.h"
-#include "routes.h"
-#include "reasons.h"
-#include "parsing.h"
 #include "failsafe.h"
-#include "jump.h"
-#include "policy.h"
-#include "metadata.h"
 #include "globals.h"
+#include "jump.h"
+#include "log.h"
+#include "metadata.h"
+#include "parsing.h"
+#include "parsing_types.h"
+#include "policy.h"
+#include "reasons.h"
+#include "routes.h"
+#include "skb.h"
+#include "types.h"
 
 /* calico_xdp is the main function used in all of the xdp programs */
 SEC("xdp")

--- a/felix/bpf-gpl/xdp.c
+++ b/felix/bpf-gpl/xdp.c
@@ -13,7 +13,7 @@
 #include <linux/tcp.h>
 #include <linux/udp.h>
 
-#include "bpf.h"
+#include "cali_bpf.h"
 #include "counters.h"
 #include "failsafe.h"
 #include "globals.h"

--- a/felix/bpf-gpl/xdp_preamble.c
+++ b/felix/bpf-gpl/xdp_preamble.c
@@ -4,7 +4,7 @@
 
 #include <linux/if_ether.h>
 
-#include "bpf.h"
+#include "cali_bpf.h"
 #include "globals.h"
 #include "jump.h"
 #include "log.h"

--- a/felix/bpf-gpl/xdp_preamble.c
+++ b/felix/bpf-gpl/xdp_preamble.c
@@ -2,17 +2,14 @@
 // Copyright (c) 2023 Tigera, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 
-// stdbool.h has no deps so it's OK to include; stdint.h pulls in parts
-// of the std lib that aren't compatible with BPF.
-#include <stdbool.h>
 #include <linux/if_ether.h>
 
-#include "skb.h"
 #include "bpf.h"
-#include "types.h"
 #include "globals.h"
 #include "jump.h"
 #include "log.h"
+#include "skb.h"
+#include "types.h"
 
 const volatile struct cali_xdp_preamble_globals __globals;
 

--- a/felix/design/bpf-conntrack-flowstate.md
+++ b/felix/design/bpf-conntrack-flowstate.md
@@ -269,7 +269,7 @@ unambiguously a mid-flow packet. BPF and `*tables` cooperate to let
 it through:
 
 - On host ingress, a BPF program that sees a mid-flow TCP miss sets
-  `CALI_SKB_MARK_FALLTHROUGH` on the packet (`bpf.h` enum
+  `CALI_SKB_MARK_FALLTHROUGH` on the packet (`cali_bpf.h` enum
   `calico_skb_mark`) and returns `TC_ACT_UNSPEC`, letting the packet
   continue into netfilter.
 - Felix installs a rule
@@ -381,7 +381,7 @@ comment: "Mark traffic towards the host - it is TRACKed"
 
 The mark is `tcdefs.MarkSeenSkipFIB`, which equals
 `CALI_SKB_MARK_SKIP_FIB` on the BPF side
-(see `felix/bpf-gpl/bpf.h` `enum calico_skb_mark`). Because this
+(see `felix/bpf-gpl/cali_bpf.h` `enum calico_skb_mark`). Because this
 happens in raw-PREROUTING, it runs _before_ any DNAT chain, so the
 destination is still the host IP at match time.
 

--- a/felix/design/bpf-encap-fragments-icmp.md
+++ b/felix/design/bpf-encap-fragments-icmp.md
@@ -262,7 +262,7 @@ where an error is actually needed.
 
 ### Cases
 
-- **TTL exceeded.** `ip_ttl_exceeded` in `bpf.h` tests for TTL==1
+- **TTL exceeded.** `ip_ttl_exceeded` in `cali_bpf.h` tests for TTL==1
   (IPv4) / hop-limit==1 (IPv6) on a host-egress path. If that
   holds and the packet would have been forwarded, the program
   generates an ICMP Time Exceeded and drops the packet instead.

--- a/felix/design/bpf-host-networking.md
+++ b/felix/design/bpf-host-networking.md
@@ -52,7 +52,7 @@ namespace:
 - `bpfout.cali` (C-side identifier: `natout_idx`)
 
 See `felix/dataplane/linux/dataplanedefs/dataplane_defs.go` for the
-Go-side constants, and `felix/bpf-gpl/bpf.h` for the
+Go-side constants, and `felix/bpf-gpl/globals.h` / `bpf.h` for the
 C-side configurables. (The reference design document refers to these
 as `bpfnatin`/`bpfnatout`; the implementation names are slightly
 different.)

--- a/felix/design/bpf-host-networking.md
+++ b/felix/design/bpf-host-networking.md
@@ -52,7 +52,7 @@ namespace:
 - `bpfout.cali` (C-side identifier: `natout_idx`)
 
 See `felix/dataplane/linux/dataplanedefs/dataplane_defs.go` for the
-Go-side constants, and `felix/bpf-gpl/globals.h` / `bpf.h` for the
+Go-side constants, and `felix/bpf-gpl/bpf.h` for the
 C-side configurables. (The reference design document refers to these
 as `bpfnatin`/`bpfnatout`; the implementation names are slightly
 different.)

--- a/felix/design/bpf-host-networking.md
+++ b/felix/design/bpf-host-networking.md
@@ -52,7 +52,7 @@ namespace:
 - `bpfout.cali` (C-side identifier: `natout_idx`)
 
 See `felix/dataplane/linux/dataplanedefs/dataplane_defs.go` for the
-Go-side constants, and `felix/bpf-gpl/globals.h` / `bpf.h` for the
+Go-side constants, and `felix/bpf-gpl/globals.h` / `cali_bpf.h` for the
 C-side configurables. (The reference design document refers to these
 as `bpfnatin`/`bpfnatout`; the implementation names are slightly
 different.)

--- a/felix/design/bpf-observability.md
+++ b/felix/design/bpf-observability.md
@@ -162,7 +162,7 @@ should not assume changes propagate to the other.
 ### Enablement
 
 Flow logs are gated globally by the `FLOWLOGS_ENABLED` flag
-(`felix/bpf-gpl/bpf.h` / `globals.h`, bit
+(`felix/bpf-gpl/cali_bpf.h` / `globals.h`, bit
 `CALI_GLOBALS_FLOWLOGS_ENABLED`). Set per-attach-type through
 the `FlowLogsEnabled` field on the AttachPoint. When the flag
 is off, the emission paths in the BPF programs are compiled to

--- a/felix/design/bpf-overview.md
+++ b/felix/design/bpf-overview.md
@@ -175,7 +175,7 @@ it forwards directly and the host stack never sees the packet.
 ### Marks: the out-of-band channel between BPF and netfilter
 
 BPF and `*tables` communicate via the top bits of the skb mark. The
-full table is in `felix/bpf-gpl/bpf.h` (`enum calico_skb_mark`); the
+full table is in `felix/bpf-gpl/cali_bpf.h` (`enum calico_skb_mark`); the
 marks a reviewer encounters most often are:
 
 | Mark                          | Set by            | Meaning                                                            |
@@ -275,7 +275,7 @@ packet" condition); if it could and isn't, that's a red flag.
   already in cache; reading and writing them is negligible.
 - **Gate optional work on compile-time flags.** When a feature is
   off for this attach type, a `CALI_F_*` / `HAS_*` guard in
-  `bpf.h` eliminates the code at verification time. A runtime
+  `cali_bpf.h` eliminates the code at verification time. A runtime
   global flag costs a load per packet — cheap but not free.
 - **Own a sub-program for slow work.** When a feature does need
   real computation (Maglev hashing, fragment reassembly, ICMP

--- a/felix/design/bpf-services.md
+++ b/felix/design/bpf-services.md
@@ -161,7 +161,7 @@ runs:
 >   WireGuard, or no encap. It carries external traffic that has
 >   hit a NodePort on a node whose selected backend is on a
 >   different node. It uses a fixed VNI of **`0xca11c0`**
->   (`CALI_VXLAN_VNI` in `felix/bpf-gpl/nat.h`) — reserving that
+>   (`CALI_VXLAN_VNI` in `felix/bpf-gpl/nat_types.h`) — reserving that
 >   value so receivers can tell NodePort-forwarding packets from
 >   overlay packets on the same device.
 > - **Pod-to-pod overlay VXLAN** is what pod→pod traffic uses when

--- a/felix/design/bpf-services.md
+++ b/felix/design/bpf-services.md
@@ -264,7 +264,7 @@ flow — return packets must still match the CT entry.
   layout need to respect both.
 - A change to DSR gating must still compile-time-assert
   `CALI_F_DSR` only with `CALI_F_FROM_WEP` or `CALI_F_HEP`
-  (see the `COMPILE_TIME_ASSERT` in `felix/bpf-gpl/bpf.h`). DSR
+  (see the `COMPILE_TIME_ASSERT` in `felix/bpf-gpl/cali_bpf.h`). DSR
   makes no sense on WEP ingress.
 
 
@@ -323,7 +323,7 @@ destination and then tail-calls into policy as any other caller
 would.
 
 Only HEP-ingress programs on the main interface need Maglev; the
-macro `HAS_MAGLEV` in `felix/bpf-gpl/bpf.h` expands to
+macro `HAS_MAGLEV` in `felix/bpf-gpl/cali_bpf.h` expands to
 `(CALI_F_FROM_HEP && CALI_F_MAIN)`, and `GetApplicableSubProgs` in
 `hook/map.go` only loads the Maglev sub-program for attach types
 where this is true.

--- a/felix/design/bpf-xdp.md
+++ b/felix/design/bpf-xdp.md
@@ -59,7 +59,7 @@ forwarding decisions. The handoff is via packet metadata:
 - On the TC ingress hook, the program calls
   `xdp2tc_get_metadata(skb)` and, on
   `CALI_META_ACCEPTED_BY_XDP`, sets
-  `skb->mark = CALI_SKB_MARK_BYPASS_XDP` (`bpf.h`) and skips the
+  `skb->mark = CALI_SKB_MARK_BYPASS_XDP` (`cali_bpf.h`) and skips the
   policy step.
 
 The same jump-map / preamble machinery from [bpf-tc-programs.md → TC program layout](./bpf-tc-programs.md) applies. XDP has its


### PR DESCRIPTION
Every header in `felix/bpf-gpl` now compiles on its own, so include order no longer matters, and a new check keeps it that way.

**Problem.** 31 of the 46 headers did not compile standalone. `bpf.h` pulled in `globals.h` (which needed `bpf.h`'s own macros), `types.h` dragged in `arp.h` for nothing, and the per-IP-version headers (`nat4/6.h`, `parsing4/6.h`, `icmp4/6.h`) only compiled when textually included mid-way through their umbrella header, after shared defines. Adding an include in the "wrong" place silently worked or failed depending on what came before it.

**Change.**
- `bpf.h` is renamed `cali_bpf.h` so it can never be confused with libbpf's `bpf.h`, which sits on the same include path (that confusion is exactly what let the `ut/ut.h` check pass vacuously in an earlier revision). It is the root: no Calico includes beyond a tiny `bpf_inline.h`. `globals.h` and `ip_addr.h` stay below it and userspace-safe, since `felix/bpf/libbpf` includes them via cgo. `felix/DESIGN.md`'s `applyTo` glob, `calculate-flags` and `bpf_inline.h` follow the rename — a stale glob would silently skip the `bpf-tc-programs` sub-design for any PR touching `cali_bpf.h`.
- Every header includes what it uses. Include blocks are sorted, system headers first. The `.c` files put their `CALI_LOG` override above all includes, with a comment saying why. `ip_addr.h` is the one exception: `<linux/in6.h>` stays inside its `#ifdef IPVER6`, because it and glibc's `netinet/in.h` co-exist in only one include order and `ip_addr.h` is compiled by cgo.
- Shared definitions leave the umbrella headers: `CALI_VXLAN_VNI` to `nat_types.h`, `PARSING_*` to `parsing_types.h`, `bpf_load_bytes` to `skb.h`. `sock_type.h` defines `SOCK_STREAM`/`SOCK_DGRAM` directly, replacing the `_SYS_SOCKET_H` poke that pulled in `bits/socket_type.h` and, as a side effect, broke `<linux/if.h>` in the cgroup programs. The `connect()` helper becomes `do_connect()` so it cannot clash with libc's declaration.
- `allowsources.h` is added to `IP_MAP_HEADERS`. It previously reached the IPv4/IPv6 map stubs only transitively via `conntrack_cleanup.h -> conntrack.h -> rpf.h`, a chain this PR breaks; Felix creates maps by name prefix from those stubs, so listing it explicitly keeps the `cali_v{4,6}_sprefix` maps in the stubs.
- `bpf-gpl/check-headers` requires every header to be guarded by `__CALI_<FILENAME>_H__` (guards unique by construction; twelve stragglers renamed) and compiles each header alone under every variant the real build uses, plus a host-compiler pass for the userspace-shared headers. The variants are derived by running `calculate-flags` over the object lists rather than restated in the script, so a new program with a new flag combination is covered without touching the check; only the objects the `Makefile` compiles with literal flags (the UT harness, `xdp_preamble`, the `notrace` preambles, `tcx_test`, the map stubs) are listed explicitly. That is 5497 (header, variant) pairs over the 26 distinct `CALI_COMPILE_FLAGS` values the build actually uses. The check also requires the `only` table to name real headers and variants, and each variant group to be non-empty. It runs in parallel (~22s) via `make -C felix check-bpf-headers` and from `make static-checks`.

**Testing.**
- Built all 126 program objects at the merge base and on this branch in the go-build container and compared `llvm-objdump -d`: the disassembly is identical for every object, 1,839,641 lines either side. The `.o` files themselves differ only in debug/BTF metadata, which carries the include paths and line numbers.
- The union of maps across the map stubs is unchanged. The only object-level difference is that maps a program never referenced no longer appear in its object (e.g. the ARP map drops out of the XDP, preamble and default-policy objects).
- `make FOCUS="TestPrecompiledBinariesAreLoadable|TestIpDecTTL|TestNatEncap|TestRingBuf" ut-bpf` passes (121 subtests).
- `go build` of `felix/bpf/libbpf` and `felix/bpf/maps` (the cgo consumers of `globals.h`/`ip_addr.h`) passes.
- The widened check was mutation-tested: a breakage behind `#if CALI_F_DSR` in `ip_addr.h` is caught, and was not caught by the narrower variant table it replaces.

- The BPF C build/check commands and the include conventions now live in `felix/bpf-gpl/CLAUDE.md`.

**AI assistance:** Claude Code did the include analysis, edits and object-diff verification; reviewed and driven by me.
