### PR TITLE
[v3.31] felix/fv: wait for Felix to be ready before asserting on status files

### DIFF
--- a/felix/fv/pod_setup_wait_test.go
+++ b/felix/fv/pod_setup_wait_test.go
@@ -74,13 +74,18 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ Pod setup status wait", []a
 			}
 		}
 
-		It("should receive DataplaneInSync message from the dataplane", func() {
+		startFelixAndWaitForInSync := func() {
 			tc.Felixes[0].TriggerDelayedStart()
+			tc.Felixes[0].WaitForReady()
 			Eventually(dataplaneInSyncReceivedC, "10s").Should(BeClosed(), "receipt of DataplaneInSync message not seen in logs")
+		}
+
+		It("should receive DataplaneInSync message from the dataplane", func() {
+			startFelixAndWaitForInSync()
 		})
 
 		It("should create endpoint-status files in a directory named endpoint-status with the specified directory prefix", func() {
-			tc.Felixes[0].TriggerDelayedStart()
+			startFelixAndWaitForInSync()
 			var filenames [2]string
 			var statCmds [2]func() error
 			for i := range dummyWorkloads {
@@ -114,8 +119,7 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ Pod setup status wait", []a
 			tc.Felixes[0].Exec("touch", name)
 
 			By("Waiting for Felix's status file reporter to come in-sync")
-			tc.Felixes[0].TriggerDelayedStart()
-			Eventually(dataplaneInSyncReceivedC, "10s").Should(BeClosed(), "receipt of DataplaneInSync message not seen in logs")
+			startFelixAndWaitForInSync()
 
 			By("checking if the stale file has been cleaned up")
 			fileExists := func() bool {
@@ -123,7 +127,7 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ Pod setup status wait", []a
 				_, err := tc.Felixes[0].ExecOutput("stat", name)
 				return err == nil
 			}
-			Eventually(fileExists).Should(BeFalse(), "Stale file was not cleaned up by Felix")
+			Eventually(fileExists, "10s", "500ms").Should(BeFalse(), "Stale file was not cleaned up by Felix")
 		})
 
 		It("should re-use pre-existing files after a restart", func() {
@@ -144,11 +148,10 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ Pod setup status wait", []a
 			By("creating a file with the determined name before Felix starts")
 			expectedFilename := filepath.Join("/tmp/endpoint-status", filename)
 			tc.Felixes[0].Exec("mkdir", "/tmp/endpoint-status")
-			tc.Felixes[0].Exec("touch", filename)
+			tc.Felixes[0].Exec("touch", expectedFilename)
 
 			By("waiting for Felix's status file reporter to become in-sync")
-			tc.Felixes[0].TriggerDelayedStart()
-			Eventually(dataplaneInSyncReceivedC, "10s").Should(BeClosed(), "receipt of DataplaneInSync message not seen in logs")
+			startFelixAndWaitForInSync()
 
 			output, err := tc.Felixes[0].ExecOutput("cat", expectedFilename)
 			Expect(err).NotTo(HaveOccurred(), "stat call failed while trying to create a file")


### PR DESCRIPTION
**Cherry-pick history**
- Pick onto **release-v3.31**: projectcalico/calico#13815

Waits for Felix to be ready before the assertions in the `Pod setup status wait` FV suite, so their 10s deadlines no longer have to cover Felix start-up too — which is what times out on a loaded CI runner. CORE-13626

### Conflict resolved by hand

This branch's copy of the file is older than master's: `//go:build fvtests`, Ginkgo v1 imports, a `nodeCount` const, `StartNNodeTopology`, an explicit `AfterEach`, and `Start()` without an `infra` argument. Those regions are untouched by the pick and applied without trouble.

The one conflict was in `should create endpoint-status files`, which on this branch calls `TriggerDelayedStart()` with no in-sync wait at all, where master already had one. Resolved to match master's end state, so that test now calls the shared helper and gains both the readiness wait and an in-sync wait it previously lacked. That is deliberate: with no in-sync wait, its `statCmds` 10s deadline had to cover the whole of Felix start-up, which makes it the most exposed test on this branch rather than the least.

The resulting file is byte-identical to the equivalent pick on the matching enterprise branch, which is the same file vintage.

Verified on this branch: `go vet -tags fvtests -composites=false ./felix/fv/` is clean. `WaitForReady` exists here, so the helper resolves. No FV run yet.

**Release note:**
```release-note
None
```

**AI assistance:** Claude Code (Opus 5) performed the cherry-pick, resolved the conflict, and wrote this description.

By opening this PR you take responsibility for every line in it, and you agree to explain the change yourself during review rather than routing review comments back through an agent. See [AI_POLICY.md](../AI_POLICY.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<details>
<summary><b>Cherry-Pick PR details</b></summary>

- **Original PR ID**: 13815
- **Original Commit SHA**: 372fa68b70
- **Source Repo**: `projectcalico/calico`
- **Target Repo**: `projectcalico/calico`
- **Target Branch**: `release-v3.31`
</details>
