### PR TITLE
Clear programClusterRoutes when clusterRoutingMode is removed

### DIFF
--- a/operator/pkg/controller/installation/core_controller.go
+++ b/operator/pkg/controller/installation/core_controller.go
@@ -887,6 +887,9 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 		return reconcile.Result{}, err
 	}
 
+	// The mode we last applied.  Read before the status write below overwrites it.
+	appliedClusterRoutingMode := clusterRoutingModeFromStatus(instance)
+
 	// Publish the effective config before anything below can return early, since every other
 	// controller reads it instead of the spec and stalls until it lands.
 	computed := defaulted.Spec.DeepCopy()
@@ -1068,7 +1071,7 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 		}
 
 		// Configure cluster routing mode.
-		u3, err := setClusterRoutingOnFelixConfiguration(defaulted, fc, reqLogger)
+		u3, err := setClusterRoutingOnFelixConfiguration(defaulted, appliedClusterRoutingMode, fc, reqLogger)
 		if err != nil {
 			return false, err
 		}
@@ -1089,7 +1092,7 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 	// Set any non-default BGPConfiguration values that we need.
 	_, err = utils.PatchBGPConfiguration(ctx, r.client, func(bgpConfig *v3.BGPConfiguration) (bool, error) {
 		// Configure cluster routing mode.
-		u, err := setClusterRoutingOnBGPConfiguration(defaulted, bgpConfig, reqLogger)
+		u, err := setClusterRoutingOnBGPConfiguration(defaulted, appliedClusterRoutingMode, bgpConfig, reqLogger)
 		if err != nil {
 			return false, err
 		}
@@ -1780,15 +1783,34 @@ func allNodesRunTargetVersion(install *operatorv1.Installation, needNsMigration,
 	return install.Status.Variant == install.Spec.Variant && install.Status.CalicoVersion == targetVersion
 }
 
+// clearClusterRoutes takes back a value we wrote, so Calico's defaults decide again.  One we never
+// wrote is the user's.
+func clearClusterRoutes(
+	applied *operatorv1.ClusterRoutingMode,
+	programClusterRoutes **string,
+	resource string,
+	reqLogger logr.Logger,
+) bool {
+	if applied == nil || *programClusterRoutes == nil {
+		return false
+	}
+
+	reqLogger.Info("Clearing programClusterRoutes, clusterRoutingMode is no longer set",
+		"resource", resource, "was", **programClusterRoutes)
+	*programClusterRoutes = nil
+	return true
+}
+
 // setClusterRoutingOnFelixConfiguration sets programClusterRoutes in the FelixConfiguration resource
 // based on the value of clusterRoutingMode in the install config.
 func setClusterRoutingOnFelixConfiguration(
 	install *operatorv1.Installation,
+	applied *operatorv1.ClusterRoutingMode,
 	fc *v3.FelixConfiguration,
 	reqLogger logr.Logger,
 ) (bool, error) {
 	if install.Spec.CalicoNetwork == nil || install.Spec.CalicoNetwork.ClusterRoutingMode == nil {
-		return false, nil
+		return clearClusterRoutes(applied, &fc.Spec.ProgramClusterRoutes, "FelixConfiguration", reqLogger), nil
 	}
 
 	updated := false
@@ -1807,11 +1829,12 @@ func setClusterRoutingOnFelixConfiguration(
 // based on the value of clusterRoutingMode in the install config.
 func setClusterRoutingOnBGPConfiguration(
 	install *operatorv1.Installation,
+	applied *operatorv1.ClusterRoutingMode,
 	bgpConfig *v3.BGPConfiguration,
 	reqLogger logr.Logger,
 ) (bool, error) {
 	if install.Spec.CalicoNetwork == nil || install.Spec.CalicoNetwork.ClusterRoutingMode == nil {
-		return false, nil
+		return clearClusterRoutes(applied, &bgpConfig.Spec.ProgramClusterRoutes, "BGPConfiguration", reqLogger), nil
 	}
 
 	updated := false
@@ -1885,6 +1908,15 @@ func clusterRoutingMode(install *operatorv1.Installation) operatorv1.ClusterRout
 		return operatorv1.ClusterRoutingModeFelixIPIPOnly
 	}
 	return *install.Spec.CalicoNetwork.ClusterRoutingMode
+}
+
+// clusterRoutingModeFromStatus returns the mode we last applied: our only record that
+// programClusterRoutes is ours, not the user's.
+func clusterRoutingModeFromStatus(install *operatorv1.Installation) *operatorv1.ClusterRoutingMode {
+	if install.Status.Computed == nil || install.Status.Computed.CalicoNetwork == nil {
+		return nil
+	}
+	return install.Status.Computed.CalicoNetwork.ClusterRoutingMode
 }
 
 // setBPFUpdatesOnFelixConfiguration will take the passed in fc and update any BPF properties needed

--- a/operator/pkg/controller/installation/core_controller_test.go
+++ b/operator/pkg/controller/installation/core_controller_test.go
@@ -1365,6 +1365,56 @@ var _ = Describe("Testing core-controller installation", func() {
 			Expect(*bgpConfig.Spec.ProgramClusterRoutes).To(Equal("EnabledNoEncapOnly"))
 		})
 
+		It("should clear programClusterRoutes when ClusterRoutingMode is removed", func() {
+			bird := operator.ClusterRoutingModeBIRD
+			cr.Spec.CalicoNetwork = &operator.CalicoNetworkSpec{ClusterRoutingMode: &bird}
+			Expect(c.Create(ctx, cr)).NotTo(HaveOccurred())
+			_, err := r.Reconcile(ctx, reconcile.Request{})
+			Expect(err).ShouldNot(HaveOccurred())
+
+			fc := &v3.FelixConfiguration{}
+			Expect(c.Get(ctx, types.NamespacedName{Name: "default"}, fc)).NotTo(HaveOccurred())
+			Expect(fc.Spec.ProgramClusterRoutes).NotTo(BeNil())
+
+			// Remove the mode again; the operator has to take its own writes back out.
+			Expect(c.Get(ctx, types.NamespacedName{Name: "default"}, cr)).NotTo(HaveOccurred())
+			cr.Spec.CalicoNetwork.ClusterRoutingMode = nil
+			Expect(c.Update(ctx, cr)).NotTo(HaveOccurred())
+			_, err = r.Reconcile(ctx, reconcile.Request{})
+			Expect(err).ShouldNot(HaveOccurred())
+
+			fc = &v3.FelixConfiguration{}
+			Expect(c.Get(ctx, types.NamespacedName{Name: "default"}, fc)).NotTo(HaveOccurred())
+			Expect(fc.Spec.ProgramClusterRoutes).To(BeNil())
+
+			bgpConfig := &v3.BGPConfiguration{}
+			Expect(c.Get(ctx, types.NamespacedName{Name: "default"}, bgpConfig)).NotTo(HaveOccurred())
+			Expect(bgpConfig.Spec.ProgramClusterRoutes).To(BeNil())
+		})
+
+		It("should leave a user's own programClusterRoutes alone when ClusterRoutingMode was never set", func() {
+			cr.Spec.CalicoNetwork = &operator.CalicoNetworkSpec{}
+			Expect(c.Create(ctx, cr)).NotTo(HaveOccurred())
+			_, err := r.Reconcile(ctx, reconcile.Request{})
+			Expect(err).ShouldNot(HaveOccurred())
+
+			// The user configures Felix directly, which is the supported route while the
+			// Installation field is unset.
+			fc := &v3.FelixConfiguration{}
+			Expect(c.Get(ctx, types.NamespacedName{Name: "default"}, fc)).NotTo(HaveOccurred())
+			userValue := "Enabled"
+			fc.Spec.ProgramClusterRoutes = &userValue
+			Expect(c.Update(ctx, fc)).NotTo(HaveOccurred())
+
+			_, err = r.Reconcile(ctx, reconcile.Request{})
+			Expect(err).ShouldNot(HaveOccurred())
+
+			fc = &v3.FelixConfiguration{}
+			Expect(c.Get(ctx, types.NamespacedName{Name: "default"}, fc)).NotTo(HaveOccurred())
+			Expect(fc.Spec.ProgramClusterRoutes).NotTo(BeNil())
+			Expect(*fc.Spec.ProgramClusterRoutes).To(Equal(userValue))
+		})
+
 		It("should create the default BGPConfig and FelixConfig with ClusterRoutingMode set", func() {
 			bgpConfig := &v3.BGPConfiguration{}
 			err := c.Get(ctx, types.NamespacedName{Name: "default"}, bgpConfig)


### PR DESCRIPTION
## Problem

Setting `Installation.spec.calicoNetwork.clusterRoutingMode` and then removing it leaves the cluster running whatever that mode last wrote, while the `Installation` looks exactly like one that never touched the field. Nothing is written, nothing is logged, and `status.computed` is empty.

The state it can strand is the **deprecated** BIRD-programs-IPIP configuration. A user who sets `BIRD` to opt out of the v3.33 default and then removes the field expecting the default back stays on the deprecated arm, with no indication anywhere.

```
kubectl patch installation default --type=merge \
  -p '{"spec":{"calicoNetwork":{"clusterRoutingMode":"BIRD"}}}'
#  -> FelixConfiguration=Disabled  BGPConfiguration=Enabled      (correct)

kubectl patch installation default --type=json \
  -p '[{"op":"remove","path":"/spec/calicoNetwork/clusterRoutingMode"}]'
#  -> both still set, status.computed empty, operator log silent for 76s
```

## Why the early return is there

`setClusterRoutingOnFelixConfiguration` and `setClusterRoutingOnBGPConfiguration` return early when the mode is nil. That is correct for a field that was never set: writing there would pin the operator's idea of today's Calico defaults into the datastore, which is exactly what `clusterRoutingMode()` documents as the reason for the gate. What it cannot do is tell never-set from set-then-unset.

## Change

Use `status.computed` as the record of what the operator last applied. It is persisted on the CR so it survives restarts, and it still holds the previous reconcile's value at the point the setters run. A mode there plus no mode in the spec is the set-to-unset transition.

On that transition, clear `programClusterRoutes` and let Calico's own defaults decide again — which is what the existing comment asks for. The gate is preserved: an unset field still never *writes* a value.

A value the operator never wrote belongs to the user and is left alone, so configuring `programClusterRoutes` directly on FelixConfiguration keeps working while the Installation field is unset.

## Tests

Two specs in `core_controller_test.go`, both driving real reconciles against the fake client:

* set, then remove → both `programClusterRoutes` cleared
* never set, user writes `programClusterRoutes` directly → left alone

Mutation-tested: reverting either setter to `return false, nil` fails the first spec. The existing "should not patch FelixConfig and BGPConfig when ClusterRouteMode not set" spec is unchanged and still passes, which is the regression guard for the documented no-write-on-unset behaviour.

Suite: 311 passed / 22 failed. The 22 are all `cel_validation_test.go` `[BeforeEach]` envtest setup failures; a control run on unmodified `upstream/master` in the same worktree fails the identical 22 (309 passed / 22 failed), so they are pre-existing and environmental.

Found during the v3.33 test cycle, Zephyr OS-R232 / RT-3.

CORE-13588

## AI assistance

This PR was written in part with the assistance of generative AI.

### Release Note

```release-note
Fix the operator leaving a stale programClusterRoutes value behind when clusterRoutingMode is removed from the Installation, which could strand a cluster on the deprecated BIRD-programs-IPIP configuration.
```
