### PR TITLE
app-policy: aggregate the per-flow log spam from Dikastes policy eval

### DIFF
--- a/app-policy/checker/bench_egress_test.go
+++ b/app-policy/checker/bench_egress_test.go
@@ -155,7 +155,7 @@ func egressFlow(destIP string, destPort int32) *MockFlow {
 }
 
 func benchEvaluateEgressAllowList(b *testing.B, caseFor egressCaseFunc) {
-	_, restoreLogging := withBenchLogging(log.WarnLevel)
+	restoreLogging := withBenchLogging(log.WarnLevel)
 	defer restoreLogging()
 
 	store, ep, target := buildEgressAllowListStore()

--- a/app-policy/checker/bench_test.go
+++ b/app-policy/checker/bench_test.go
@@ -24,27 +24,28 @@ package checker
 //	go test ./app-policy/checker/ -run '^$' -bench BenchmarkEvaluateBaselinePolicyScale \
 //	    -benchmem -benchtime 100x -cpu 1
 //
-// The MissingSets variant deletes some referenced IP sets from the store, which makes
-// each evaluation log "IPSet not found" warnings — the signature seen in production
-// logs when the policy store is out of sync. The warnings/op metric ties the two
-// together: if production logs show those warnings spaced T apart, the implied
-// per-evaluation wall time is T x warnings/op, which can be compared against the
-// measured ns/op to judge whether a node is evaluation-bound or pacing on something
-// else. Note that the benchmark discards log output, so a real deployment pays the
-// log write on top of the formatting cost measured here.
+// The MissingSets variants delete some referenced IP sets from the store, so every
+// evaluation looks up sets that are not there — the condition behind the "IPSet not
+// found" logs seen in production when the policy store is out of sync. Those lookups
+// are aggregated into one line per interval, so the variants measure what that leaves
+// on the hot path: MissingSets pays the aggregator's per-lookup bookkeeping, LogsOff
+// has the level gate closed so it pays nothing at all, and Unaggregated writes a line
+// per lookup, as this call site did before it was aggregated. The misses/op metric is
+// the number of missing-set lookups one evaluation makes, checked against the analytic
+// count before the timed loop. Note that the benchmark discards log output, so a real
+// deployment pays the log write on top of the formatting cost measured here.
 
 import (
 	"fmt"
 	"io"
 	"math/rand"
 	"net"
-	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
 
 	v3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 
 	"github.com/projectcalico/calico/app-policy/policystore"
 	"github.com/projectcalico/calico/felix/calc"
@@ -52,6 +53,7 @@ import (
 	"github.com/projectcalico/calico/felix/rules"
 	"github.com/projectcalico/calico/felix/types"
 	"github.com/projectcalico/calico/lib/logrusr"
+	log "github.com/projectcalico/calico/lib/std/log"
 )
 
 // baselinePolicyScaleParams describes a policy store dominated by "baseline" policies:
@@ -107,35 +109,74 @@ const (
 var benchTraceSink []*calc.RuleID
 
 func BenchmarkEvaluateBaselinePolicyScale(b *testing.B) {
+	missingSetsParams := func() baselinePolicyScaleParams {
+		p := defaultBaselinePolicyScaleParams()
+		p.numMissingIPSets = 8
+		return p
+	}
+
 	b.Run("AllSetsPresent", func(b *testing.B) {
-		benchEvaluateBaselinePolicyScale(b, defaultBaselinePolicyScaleParams(), log.WarnLevel, false)
+		benchEvaluateBaselinePolicyScale(b, benchRun{
+			params: defaultBaselinePolicyScaleParams(), logLevel: logrus.WarnLevel,
+		})
 	})
 	b.Run("MissingSets", func(b *testing.B) {
-		p := defaultBaselinePolicyScaleParams()
-		p.numMissingIPSets = 8
-		benchEvaluateBaselinePolicyScale(b, p, log.WarnLevel, false)
+		benchEvaluateBaselinePolicyScale(b, benchRun{
+			params: missingSetsParams(), logLevel: logrus.WarnLevel,
+		})
 	})
-	// As MissingSets but with warnings disabled, to isolate the cost of formatting the
-	// "IPSet not found" warnings.
+	// As MissingSets but with warnings disabled, so the aggregator drops each miss at its
+	// level gate: what separates this from MissingSets is the aggregator's bookkeeping.
 	b.Run("MissingSetsLogsOff", func(b *testing.B) {
-		p := defaultBaselinePolicyScaleParams()
-		p.numMissingIPSets = 8
-		benchEvaluateBaselinePolicyScale(b, p, log.ErrorLevel, false)
+		benchEvaluateBaselinePolicyScale(b, benchRun{
+			params: missingSetsParams(), logLevel: logrus.ErrorLevel,
+		})
+	})
+	// As MissingSets but writing a line per miss, which is what this call site did before
+	// it was aggregated: what separates this from MissingSets is what aggregation saves.
+	b.Run("MissingSetsUnaggregated", func(b *testing.B) {
+		benchEvaluateBaselinePolicyScale(b, benchRun{
+			params: missingSetsParams(), logLevel: logrus.WarnLevel, unaggregated: true,
+		})
 	})
 	// Fixed per-Evaluate overhead: the first rule of the first policy matches, so the
 	// walk short-circuits immediately.
 	b.Run("MatchEarly", func(b *testing.B) {
-		benchEvaluateBaselinePolicyScale(b, defaultBaselinePolicyScaleParams(), log.WarnLevel, true)
+		benchEvaluateBaselinePolicyScale(b, benchRun{
+			params: defaultBaselinePolicyScaleParams(), logLevel: logrus.WarnLevel, matchEarly: true,
+		})
 	})
 }
 
-func benchEvaluateBaselinePolicyScale(b *testing.B, p baselinePolicyScaleParams, level log.Level, matchEarly bool) {
-	logger := log.StandardLogger()
-	counter, restoreLogging := withBenchLogging(level)
-	defer restoreLogging()
+// benchRun is one variant: the store to evaluate against, and how the logging the
+// evaluation provokes is set up.
+type benchRun struct {
+	params baselinePolicyScaleParams
 
-	store, ep, expectedWarns := buildBaselinePolicyStore(p)
-	if matchEarly {
+	// Level the log backend is set to. The missing-set line is reported at Warn, so
+	// anything above that closes its level gate.
+	logLevel logrus.Level
+
+	// unaggregated makes the missing-set logger write one line per occurrence rather than
+	// one per interval, reproducing what this call site cost before it was aggregated.
+	unaggregated bool
+
+	matchEarly bool
+}
+
+func benchEvaluateBaselinePolicyScale(b *testing.B, run benchRun) {
+	p := run.params
+
+	logger := logrus.StandardLogger()
+	restoreLogging := withBenchLogging(run.logLevel)
+	oldMissingIPSets := missingIPSets
+	defer func() {
+		restoreLogging()
+		missingIPSets = oldMissingIPSets
+	}()
+
+	store, ep, expectedMisses := buildBaselinePolicyStore(p)
+	if run.matchEarly {
 		addMatchEarlyPolicy(store, ep)
 	}
 	flow := &MockFlow{
@@ -146,10 +187,18 @@ func benchEvaluateBaselinePolicyScale(b *testing.B, p baselinePolicyScaleParams,
 		Protocol:   6, // TCP
 	}
 
-	// Pre-flight outside the timed loop: prove the walk is the intended one and that
-	// the warning count matches the analytic count, so that warnings/op is exact.
-	trace, _ := Evaluate(EnforcedOnly, rules.RuleDirIngress, store, ep, flow)
-	if matchEarly {
+	// Pre-flight outside the timed loop: prove the walk is the intended one and that the
+	// number of missing-set lookups matches the analytic count, so misses/op is exact.
+	// Counting them means seeing every one, so for this single evaluation the aggregator
+	// is given a zero interval, which writes a line per occurrence.
+	counter := &ipsetMissCounter{Logger: log.Default()}
+	missingIPSets = newMissingIPSetsLogger(counter)
+
+	trace, err := Evaluate(EnforcedOnly, rules.RuleDirIngress, store, ep, flow)
+	if err != nil {
+		b.Fatalf("pre-flight Evaluate failed: %v", err)
+	}
+	if run.matchEarly {
 		if len(trace) != 1 || trace[0].Action != rules.RuleActionAllow || trace[0].Index != 0 {
 			b.Fatalf("expected an immediate allow from the match-early policy, got %v", trace)
 		}
@@ -158,11 +207,17 @@ func benchEvaluateBaselinePolicyScale(b *testing.B, p baselinePolicyScaleParams,
 			b.Fatalf("expected a full walk ending in the tier default deny, got %v", trace)
 		}
 	}
-	if logger.IsLevelEnabled(log.WarnLevel) && counter.count.Load() != int64(expectedWarns) {
-		b.Fatalf("expected %d 'IPSet not found' warnings per Evaluate, got %d",
-			expectedWarns, counter.count.Load())
+	if logger.IsLevelEnabled(logrus.WarnLevel) && counter.count.Load() != int64(expectedMisses) {
+		b.Fatalf("expected %d missing IP set lookups per Evaluate, got %d",
+			expectedMisses, counter.count.Load())
 	}
-	counter.count.Store(0)
+
+	// The timed loop runs the real logger, at the production interval — unless this is the
+	// variant measuring what that interval saves.
+	missingIPSets = oldMissingIPSets
+	if run.unaggregated {
+		missingIPSets = newMissingIPSetsLogger(nil)
+	}
 
 	b.ReportAllocs()
 	b.ResetTimer()
@@ -170,18 +225,29 @@ func benchEvaluateBaselinePolicyScale(b *testing.B, p baselinePolicyScaleParams,
 		benchTraceSink, _ = Evaluate(EnforcedOnly, rules.RuleDirIngress, store, ep, flow)
 	}
 	b.StopTimer()
-	b.ReportMetric(float64(counter.count.Load())/float64(b.N), "warnings/op")
+	b.ReportMetric(float64(expectedMisses), "misses/op")
 	rulesWalked := p.numPolicies * p.rulesPerPolicy
-	if matchEarly {
+	if run.matchEarly {
 		rulesWalked = 1
 	}
 	b.ReportMetric(float64(rulesWalked), "rules/op")
 }
 
+// newMissingIPSetsLogger builds a stand-in for the checker's missing-IP-set logger that
+// writes a line per occurrence rather than one per interval, to the given Logger or to
+// the registered default when it is nil.
+func newMissingIPSetsLogger(target log.Logger) *log.AggregatingLogger {
+	opts := []log.AggregatingLoggerOpt{log.OptInterval(0)}
+	if target != nil {
+		opts = append(opts, log.OptLogger(target))
+	}
+	return log.NewAggregatingLogger("IPSet not found", "ipsets", opts...)
+}
+
 // buildBaselinePolicyStore builds a policy store at the given scale, plus an endpoint
 // whose single "perimeter" tier applies every policy. It returns the number of rule
-// references to deleted (missing) IP sets, which is exactly the number of "IPSet not
-// found" warnings one Evaluate of a non-matching flow emits.
+// references to deleted (missing) IP sets, which is exactly the number of missing-set
+// lookups one Evaluate of a non-matching flow makes.
 func buildBaselinePolicyStore(p baselinePolicyScaleParams) (*policystore.PolicyStore, *proto.WorkloadEndpoint, int) {
 	rng := rand.New(rand.NewSource(p.seed))
 	store := policystore.NewPolicyStore()
@@ -231,14 +297,14 @@ func buildBaselinePolicyStore(p baselinePolicyScaleParams) (*policystore.PolicyS
 	rng.Shuffle(len(referencedIDs), func(a, b int) {
 		referencedIDs[a], referencedIDs[b] = referencedIDs[b], referencedIDs[a]
 	})
-	expectedWarns := 0
+	expectedMisses := 0
 	for _, id := range referencedIDs[:p.numMissingIPSets] {
 		delete(store.IPSetByID, id)
-		expectedWarns += refCount[id]
+		expectedMisses += refCount[id]
 	}
 
 	ep := &proto.WorkloadEndpoint{Tiers: []*proto.TierInfo{tier}}
-	return store, ep, expectedWarns
+	return store, ep, expectedMisses
 }
 
 // makeScaleIPSets populates the store with NET-type IP sets (the dominant type in the
@@ -305,53 +371,54 @@ func addMatchEarlyPolicy(store *policystore.PolicyStore, ep *proto.WorkloadEndpo
 	ep.Tiers[0].IngressPolicies = append([]*proto.PolicyID{policyID}, ep.Tiers[0].IngressPolicies...)
 }
 
-// ipsetMissCounter is a logrus hook that counts "IPSet not found" warnings, so the
-// benchmark can report warnings per evaluation.
+// ipsetMissCounter counts the "IPSet not found" lines written through it and passes
+// everything on to the Logger it wraps, so the benchmark can count missing-set lookups
+// while they still cost what they cost in production. Embedding the Logger is also what
+// keeps the level gate honest: Enabled comes from the wrapped backend.
 type ipsetMissCounter struct {
+	log.Logger
 	count atomic.Int64
 }
 
-func (c *ipsetMissCounter) Levels() []log.Level { return []log.Level{log.WarnLevel} }
-
-func (c *ipsetMissCounter) Fire(e *log.Entry) error {
-	// The message carries the set ID, so match on the prefix.
-	if strings.HasPrefix(e.Message, "IPSet not found") {
+func (c *ipsetMissCounter) Warn(msg string, args ...any) {
+	if msg == "IPSet not found" {
 		c.count.Add(1)
 	}
-	return nil
+	c.Logger.Warn(msg, args...)
 }
 
 // withBenchLogging sets the log level, discards output so the terminal is not part of the
-// measurement, installs the "IPSet not found" counter, and unthrottles the evaluation path's
-// rate-limited loggers. It returns the counter and a function restoring everything.
-func withBenchLogging(level log.Level) (*ipsetMissCounter, func()) {
-	logger := log.StandardLogger()
+// measurement, registers the logrus backend behind the lib/std/log facade, and unthrottles the
+// evaluation path's rate-limited loggers. It returns a function restoring all of it.
+//
+// The facade discards everything until a backend is registered, so without that the benchmark
+// would measure a path no deployment runs, and the miss count would come out at zero.
+func withBenchLogging(level logrus.Level) func() {
+	logger := logrus.StandardLogger()
 	oldLevel, oldOut := logger.GetLevel(), logger.Out
-	counter := &ipsetMissCounter{}
-	hooks := make(log.LevelHooks)
-	hooks.Add(counter)
-	oldHooks := logger.ReplaceHooks(hooks)
+	oldDefault := log.Default()
 	restoreLoggers := withUnthrottledEvalPathLogs()
 
 	logger.SetLevel(level)
 	// The formatting cost stays in the measurement; a real deployment pays the write too.
 	logger.SetOutput(io.Discard)
+	log.SetDefaultLogger(logrusr.New(logger))
 
-	return counter, func() {
+	return func() {
 		logger.SetLevel(oldLevel)
 		logger.SetOutput(oldOut)
-		logger.ReplaceHooks(oldHooks)
+		log.SetDefaultLogger(oldDefault)
 		restoreLoggers()
 	}
 }
 
 // withUnthrottledEvalPathLogs replaces the evaluation path's rate-limited loggers with ones
-// that never suppress, and returns a function restoring them. The warnings/op metric counts
-// every occurrence, which is the point of it — production gets the throttled loggers, and the
+// that never suppress, and returns a function restoring them. The benchmark counts every
+// occurrence, which is the point of it — production gets the throttled loggers, and the
 // emitted line's "logsSkipped" field carries the count this benchmark reports directly.
 func withUnthrottledEvalPathLogs() func() {
 	saved := []**logrusr.RateLimitedLogger{
-		&rlogIPSetMissing, &rlogBadPrincipal, &rlogBadProtocol, &rlogBadProtocolName,
+		&rlogBadProtocol, &rlogBadProtocolName,
 		&rlogBadCIDR, &rlogBadSelector, &rlogBadRulePath,
 	}
 	originals := make([]*logrusr.RateLimitedLogger, len(saved))

--- a/app-policy/checker/check.go
+++ b/app-policy/checker/check.go
@@ -67,19 +67,18 @@ const (
 // Every log site on the per-request evaluation path needs its own rate limiter.
 //
 // A rule set that applies tens of thousands of rules to one endpoint turns any per-rule log
-// into a storm: the conditions below are all "shouldn't happen, but does" — a dangling IP set
-// reference while the store catches up, a malformed CIDR or selector that got past validation,
-// a flow that is not IP at all — and each one repeats for every rule in the set, on every
-// request. Rate limiting is per logger instance, so sharing one across sites would let the
-// noisiest message starve the rest; sites that report the same condition do share one.
+// into a storm: the conditions below are all "shouldn't happen, but does" — a malformed CIDR
+// or selector that got past validation, a flow that is not IP at all — and each one repeats
+// for every rule in the set, on every request. Rate limiting is per logger instance, so
+// sharing one across sites would let the noisiest message starve the rest; sites that report
+// the same condition do share one. The sites that key on a value that varies aggregate instead;
+// see missingIPSets and unparseablePrincipals in requestcache.go.
 //
 // These sites must not use the WithField/WithError builders: those allocate a fields map, a
 // logrus.Entry and a wrapper *before* the rate limiter gets to drop the message, which is the
 // per-rule allocation this path has been optimised to avoid. Pass the value to Warnf instead.
 var (
-	rlogIPSetMissing = newEvalPathLogger()
-	rlogBadPrincipal = newEvalPathLogger()
-	rlogBadProtocol  = newEvalPathLogger()
+	rlogBadProtocol = newEvalPathLogger()
 	// The adapter warns when Envoy names a protocol it cannot map. requestCache memoizes
 	// the resolved protocol, so this fires once per request rather than once per rule.
 	rlogBadProtocolName = newEvalPathLogger()

--- a/app-policy/checker/match_test.go
+++ b/app-policy/checker/match_test.go
@@ -16,18 +16,22 @@ package checker
 
 import (
 	"fmt"
+	"io"
 	"math"
 	"strings"
 	"testing"
+	"time"
 
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	auth "github.com/envoyproxy/go-control-plane/envoy/service/auth/v3"
 	. "github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
 
 	"github.com/projectcalico/calico/app-policy/checker/mocks"
 	"github.com/projectcalico/calico/app-policy/policystore"
 	"github.com/projectcalico/calico/felix/proto"
 	"github.com/projectcalico/calico/felix/types"
+	"github.com/projectcalico/calico/lib/logrusr"
 	libnet "github.com/projectcalico/calico/libcalico-go/lib/net"
 )
 
@@ -1533,4 +1537,57 @@ func TestMatchUnsupportedL4Protocol(t *testing.T) {
 			Expect(match("testns", &proto.Rule{}, req)).To(BeFalse())
 		})
 	}
+}
+
+// Repeated failures on the evaluation path are rate limited: one line, then a count of what
+// was suppressed. Without this a single malformed CIDR logs once per rule, for every request.
+// The other eval-path loggers in check.go share this limiter's configuration.
+func TestEvalPathWarningsAreRateLimited(t *testing.T) {
+	RegisterTestingT(t)
+
+	logger := logrus.StandardLogger()
+	oldLevel, oldOut := logger.GetLevel(), logger.Out
+	counter := &entryCounter{}
+	hooks := make(logrus.LevelHooks)
+	hooks.Add(counter)
+	oldHooks := logger.ReplaceHooks(hooks)
+	savedLogger := rlogBadCIDR
+	defer func() {
+		logger.SetLevel(oldLevel)
+		logger.SetOutput(oldOut)
+		logger.ReplaceHooks(oldHooks)
+		rlogBadCIDR = savedLogger
+	}()
+	logger.SetLevel(logrus.WarnLevel)
+	logger.SetOutput(io.Discard)
+	// A long interval with no burst allowance: the first message is written, the rest are
+	// counted.
+	rlogBadCIDR = logrusr.NewRateLimitedLogger(logrusr.OptInterval(time.Hour))
+
+	ip := libnet.ParseIP("192.168.5.6")
+	for range 100 {
+		Expect(matchNet("test", []string{"192.168.0.0.0/16"}, ip.Network().IP)).To(BeFalse())
+	}
+
+	Expect(counter.entries).To(HaveLen(1), "expected one emitted warning for 100 bad CIDRs")
+	Expect(counter.entries[0].Message).To(ContainSubstring("192.168.0.0.0/16"))
+	Expect(counter.entries[0].Data).NotTo(HaveKey("logsSkipped"))
+
+	// The suppressed count surfaces on the next line that is allowed through, so the storm is
+	// still visible in the log.
+	rlogBadCIDR.Force().Warnf("unable to parse CIDR %s", "192.168.0.0.0/16")
+	Expect(counter.entries).To(HaveLen(2))
+	Expect(counter.entries[1].Data).To(HaveKeyWithValue("logsSkipped", 99))
+}
+
+// entryCounter collects the log entries written during a test.
+type entryCounter struct {
+	entries []*logrus.Entry
+}
+
+func (c *entryCounter) Levels() []logrus.Level { return logrus.AllLevels }
+
+func (c *entryCounter) Fire(e *logrus.Entry) error {
+	c.entries = append(c.entries, e)
+	return nil
 }

--- a/app-policy/checker/requestcache.go
+++ b/app-policy/checker/requestcache.go
@@ -20,14 +20,20 @@ import (
 	"regexp"
 	"sync"
 
-	log "github.com/sirupsen/logrus"
-
 	"github.com/projectcalico/calico/app-policy/policystore"
 	"github.com/projectcalico/calico/felix/proto"
 	"github.com/projectcalico/calico/felix/types"
+	log "github.com/projectcalico/calico/lib/std/log"
 )
 
 const SPIFFEIDPattern = "^spiffe://[^/]+/ns/([^/]+)/sa/([^/]+)$"
+
+// Levels the two aggregated conditions report at. Named so the tests build their stand-in
+// loggers from the same values rather than restating them, which would let the two drift.
+const (
+	missingIPSetsLevel         = log.LevelWarn
+	unparseablePrincipalsLevel = log.LevelError
+)
 
 var (
 	protocolMap = map[string]int{
@@ -38,6 +44,20 @@ var (
 
 	spiffeIdRegExp     *regexp.Regexp
 	spiffeIdRegExpOnce = sync.Once{}
+
+	// A principal we cannot parse would otherwise log once for every flow it sources. Aggregating on
+	// the principal loses nothing: parseSpiffeID's only failure names the principal and the pattern
+	// it did not match, and that pattern is a constant.
+	unparseablePrincipals = log.NewAggregatingLogger("failed to parse principal", "principals",
+		log.OptLevel(unparseablePrincipalsLevel))
+
+	// A missing IP set is looked up once per rule that references it, for every flow the policy
+	// applies to, so one bad reference logs at flow rate. Aggregate rather than plain rate-limit so
+	// that the one line per window names every set that went missing, not just whichever one
+	// happened to trip the timer - with several missing at once that is the difference between
+	// seeing one stale reference and seeing that a whole sync is behind.
+	missingIPSets = log.NewAggregatingLogger("IPSet not found", "ipsets",
+		log.OptLevel(missingIPSetsLevel))
 )
 
 type requestCache struct {
@@ -203,7 +223,7 @@ func ipProtoPortKey(ipStr string, protocol, port int) string {
 func (r *requestCache) getIPSet(id string) policystore.IPSet {
 	s, ok := r.store.IPSetByID[id]
 	if !ok {
-		rlogIPSetMissing.Warnf("IPSet not found: %s", id)
+		missingIPSets.Record(id)
 		return nil
 	}
 	return s
@@ -226,7 +246,7 @@ func (r *requestCache) initNamespace(name string) *namespace {
 func (r *requestCache) initPeer(principal string, labels map[string]string) *peer {
 	peer, err := parseSpiffeID(principal)
 	if err != nil {
-		rlogBadPrincipal.Errorf("failed to parse principal: %v", err)
+		unparseablePrincipals.Record(principal)
 		return nil
 	}
 	peer.Labels = make(map[string]string)

--- a/app-policy/checker/requestcache_test.go
+++ b/app-policy/checker/requestcache_test.go
@@ -15,19 +15,200 @@
 package checker
 
 import (
-	"io"
+	"context"
+	"slices"
+	"sync"
 	"testing"
 	"time"
 
 	authz "github.com/envoyproxy/go-control-plane/envoy/service/auth/v3"
 	. "github.com/onsi/gomega"
-	log "github.com/sirupsen/logrus"
 
 	"github.com/projectcalico/calico/app-policy/policystore"
 	"github.com/projectcalico/calico/felix/proto"
 	"github.com/projectcalico/calico/felix/types"
-	"github.com/projectcalico/calico/lib/logrusr"
+	log "github.com/projectcalico/calico/lib/std/log"
 )
+
+// TestGetIPSetAggregatesMisses covers the wiring rather than the aggregator itself (which has its
+// own tests in lib/std/log): a store miss must still return nil, and the repeated misses a single
+// flow provokes must collapse to one line naming the sets that went missing, not one line each.
+func TestGetIPSetAggregatesMisses(t *testing.T) {
+	RegisterTestingT(t)
+
+	capture, restore := captureCheckerLogs()
+	defer restore()
+
+	req := &authz.CheckRequest{Attributes: &authz.AttributeContext{
+		Source:      &authz.AttributeContext_Peer{Principal: ""},
+		Destination: &authz.AttributeContext_Peer{Principal: ""},
+	}}
+	rc := NewRequestCache(policystore.NewPolicyStore(), NewCheckRequestToFlowAdapter(req))
+
+	// The store is empty, so every lookup misses. Aggregation changes only the logging: the value
+	// getIPSet returns is what it always was.
+	for range 100 {
+		Expect(rc.getIPSet("missing-a")).To(BeNil())
+		Expect(rc.getIPSet("missing-b")).To(BeNil())
+	}
+
+	// The first miss is reported as it happens, carrying only itself.
+	lines := capture.snapshot()
+	Expect(lines).To(HaveLen(1))
+	Expect(lines[0].msg).To(Equal("IPSet not found"))
+	Expect(lines[0].level).To(Equal(missingIPSetsLevel))
+	Expect(argValue(lines[0], "ipsets")).To(Equal(log.AggregatedValues{"missing-a"}))
+
+	// The other 199 fold into the window behind it, which closes on its own and names both sets that
+	// went missing. Without aggregation these 200 misses were 200 lines.
+	Eventually(capture.snapshot, "5s", "10ms").Should(HaveLen(2))
+	lines = capture.snapshot()
+	Expect(argValue(lines[1], "ipsets")).To(Equal(log.AggregatedValues{"missing-a", "missing-b"}))
+	Expect(argValue(lines[1], "totalEvents")).To(Equal(199))
+}
+
+// TestAggregatedConditionLevels pins the severities themselves. captureCheckerLogs builds its
+// stand-ins from these same constants, so the other tests follow production wherever it goes;
+// this one is what makes moving it a deliberate edit rather than a silent one.
+func TestAggregatedConditionLevels(t *testing.T) {
+	RegisterTestingT(t)
+
+	Expect(missingIPSetsLevel).To(Equal(log.LevelWarn))
+	Expect(unparseablePrincipalsLevel).To(Equal(log.LevelError))
+}
+
+// TestGetIPSetHit confirms the hit path is untouched: a set that is present is returned as-is and
+// logs nothing.
+func TestGetIPSetHit(t *testing.T) {
+	RegisterTestingT(t)
+
+	capture, restore := captureCheckerLogs()
+	defer restore()
+
+	store := policystore.NewPolicyStore()
+	store.IPSetByID["present"] = policystore.NewIPSet(proto.IPSetUpdate_IP)
+
+	req := &authz.CheckRequest{Attributes: &authz.AttributeContext{
+		Source:      &authz.AttributeContext_Peer{Principal: ""},
+		Destination: &authz.AttributeContext_Peer{Principal: ""},
+	}}
+	rc := NewRequestCache(store, NewCheckRequestToFlowAdapter(req))
+
+	Expect(rc.getIPSet("present")).NotTo(BeNil())
+	Expect(capture.snapshot()).To(BeEmpty())
+}
+
+// captureCheckerLogs points this package's aggregating loggers at one capturing logger, and returns
+// that capture alongside the func that puts the originals back. They are package-level because an
+// aggregation window is shared process-wide, so a test driving the real ones would leak both their
+// window state and their output into every other test in the package.
+//
+// The interval is cut to a fraction of the production five minutes so that a test can watch a window
+// close without waiting on one.
+func captureCheckerLogs() (*captureLogger, func()) {
+	capture := &captureLogger{}
+	savedIPSets, savedPrincipals := missingIPSets, unparseablePrincipals
+	// Built from the production levels, not from restated literals: without OptLevel both would
+	// default to Warn, and the principal site would be exercised a level below the one it reports
+	// at. Taking the constants means a change to either severity reaches these tests.
+	missingIPSets = log.NewAggregatingLogger("IPSet not found", "ipsets",
+		log.OptLogger(capture), log.OptInterval(captureInterval), log.OptLevel(missingIPSetsLevel))
+	unparseablePrincipals = log.NewAggregatingLogger("failed to parse principal", "principals",
+		log.OptLogger(capture), log.OptInterval(captureInterval), log.OptLevel(unparseablePrincipalsLevel))
+	return capture, func() {
+		missingIPSets, unparseablePrincipals = savedIPSets, savedPrincipals
+	}
+}
+
+// captureInterval is long enough that a test's whole burst lands in one window, short enough that
+// waiting for that window to close costs nothing worth measuring.
+const captureInterval = 100 * time.Millisecond
+
+// captureLogger is a log.Logger recording what it was asked to write, so a test can assert on it.
+// Windows close on a timer, so lines arrive on a goroutine of their own; the mutex is what lets a
+// test read them while that is happening.
+type captureLogger struct {
+	mu    sync.Mutex
+	lines []capturedLine
+}
+
+type capturedLine struct {
+	msg   string
+	args  []any
+	level log.Level
+}
+
+func (c *captureLogger) Debug(msg string, args ...any) { c.record(log.LevelDebug, msg, args) }
+func (c *captureLogger) Info(msg string, args ...any)  { c.record(log.LevelInfo, msg, args) }
+func (c *captureLogger) Warn(msg string, args ...any)  { c.record(log.LevelWarn, msg, args) }
+func (c *captureLogger) Error(msg string, args ...any) { c.record(log.LevelError, msg, args) }
+
+func (c *captureLogger) With(args ...any) log.Logger { return c }
+
+func (c *captureLogger) Enabled(context.Context, log.Level) bool { return true }
+
+func (c *captureLogger) record(level log.Level, msg string, args []any) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.lines = append(c.lines, capturedLine{msg: msg, args: args, level: level})
+}
+
+// snapshot returns the lines written so far. Gomega polls it, so it must copy rather than hand out
+// the slice the writer is appending to.
+func (c *captureLogger) snapshot() []capturedLine {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return slices.Clone(c.lines)
+}
+
+// argValue returns the value a captured line carries under key, out of the alternating key/value
+// arguments the facade takes.
+func argValue(line capturedLine, key string) any {
+	for i := 0; i+1 < len(line.args); i += 2 {
+		if line.args[i] == key {
+			return line.args[i+1]
+		}
+	}
+	return nil
+}
+
+// TestInitPeerAggregatesParseFailures covers the other converted site. A peer whose principal will
+// not parse provokes the same failure on every flow it sources, so those must collapse to one line
+// naming the principals rather than one line per flow. Aggregating on the principal is what makes
+// dropping the error harmless - parseSpiffeID's only failure is a function of the principal.
+func TestInitPeerAggregatesParseFailures(t *testing.T) {
+	RegisterTestingT(t)
+
+	capture, restore := captureCheckerLogs()
+	defer restore()
+
+	req := &authz.CheckRequest{Attributes: &authz.AttributeContext{
+		Source:      &authz.AttributeContext_Peer{Principal: ""},
+		Destination: &authz.AttributeContext_Peer{Principal: ""},
+	}}
+	rc := NewRequestCache(policystore.NewPolicyStore(), NewCheckRequestToFlowAdapter(req))
+
+	// Neither principal is a SPIFFE ID, so every call fails to parse and returns nil.
+	for range 100 {
+		Expect(rc.initPeer("not-a-spiffe-id", nil)).To(BeNil())
+		Expect(rc.initPeer("spiffe://missing-the-rest", nil)).To(BeNil())
+	}
+
+	// The first failure is reported as it happens, naming the principal rather than an error string.
+	lines := capture.snapshot()
+	Expect(lines).To(HaveLen(1))
+	Expect(lines[0].msg).To(Equal("failed to parse principal"))
+	Expect(lines[0].level).To(Equal(unparseablePrincipalsLevel))
+	Expect(argValue(lines[0], "principals")).To(Equal(log.AggregatedValues{"not-a-spiffe-id"}))
+
+	// The remaining 199 fold into the window behind it, which closes on its own naming both bad
+	// principals.
+	Eventually(capture.snapshot, "5s", "10ms").Should(HaveLen(2))
+	lines = capture.snapshot()
+	Expect(argValue(lines[1], "principals")).To(
+		Equal(log.AggregatedValues{"not-a-spiffe-id", "spiffe://missing-the-rest"}))
+	Expect(argValue(lines[1], "totalEvents")).To(Equal(199))
+}
 
 // Successful parse should return name and namespace.
 func TestParseSpiffeIdOk(t *testing.T) {
@@ -271,60 +452,6 @@ func TestUnparseablePrincipalIsMemoized(t *testing.T) {
 	// and re-logs the failure.
 	Expect(uut.identities[sourceSide].resolved).To(BeTrue())
 	Expect(matchServiceAccounts(nil, uut.getSrcPeer())).To(BeTrue())
-}
-
-// Repeated failures on the evaluation path are rate limited: one line, then a count of what
-// was suppressed. Without this a single dangling IP set reference logs once per rule, for
-// every request.
-func TestEvalPathWarningsAreRateLimited(t *testing.T) {
-	RegisterTestingT(t)
-
-	logger := log.StandardLogger()
-	oldLevel, oldOut := logger.GetLevel(), logger.Out
-	counter := &entryCounter{}
-	hooks := make(log.LevelHooks)
-	hooks.Add(counter)
-	oldHooks := logger.ReplaceHooks(hooks)
-	savedLogger := rlogIPSetMissing
-	defer func() {
-		logger.SetLevel(oldLevel)
-		logger.SetOutput(oldOut)
-		logger.ReplaceHooks(oldHooks)
-		rlogIPSetMissing = savedLogger
-	}()
-	logger.SetLevel(log.WarnLevel)
-	logger.SetOutput(io.Discard)
-	// A long interval with no burst allowance: the first message is written, the rest are
-	// counted.
-	rlogIPSetMissing = logrusr.NewRateLimitedLogger(logrusr.OptInterval(time.Hour))
-
-	uut := NewRequestCache(policystore.NewPolicyStore(), NewCheckRequestToFlowAdapter(
-		&authz.CheckRequest{Attributes: &authz.AttributeContext{}}))
-	for range 100 {
-		Expect(uut.getIPSet("missing-set")).To(BeNil())
-	}
-
-	Expect(counter.entries).To(HaveLen(1), "expected one emitted warning for 100 misses")
-	Expect(counter.entries[0].Message).To(ContainSubstring("missing-set"))
-	Expect(counter.entries[0].Data).NotTo(HaveKey("logsSkipped"))
-
-	// The suppressed count surfaces on the next line that is allowed through, so the storm is
-	// still visible in the log.
-	rlogIPSetMissing.Force().Warnf("IPSet not found: %s", "missing-set")
-	Expect(counter.entries).To(HaveLen(2))
-	Expect(counter.entries[1].Data).To(HaveKeyWithValue("logsSkipped", 99))
-}
-
-// entryCounter collects the log entries written during a test.
-type entryCounter struct {
-	entries []*log.Entry
-}
-
-func (c *entryCounter) Levels() []log.Level { return log.AllLevels }
-
-func (c *entryCounter) Fire(e *log.Entry) error {
-	c.entries = append(c.entries, e)
-	return nil
 }
 
 // ipProtoPortKey has to produce exactly the member format Felix emits for an IP+port

--- a/app-policy/pkg/dikastes/dikastes.go
+++ b/app-policy/pkg/dikastes/dikastes.go
@@ -37,6 +37,8 @@ import (
 	"github.com/projectcalico/calico/app-policy/proto"
 	"github.com/projectcalico/calico/app-policy/syncher"
 	"github.com/projectcalico/calico/app-policy/uds"
+	"github.com/projectcalico/calico/lib/logrusr"
+	"github.com/projectcalico/calico/lib/std/log"
 )
 
 const (
@@ -47,6 +49,12 @@ const (
 // RunServer starts the dikastes authorization server. It listens on the given Unix domain
 // socket path, syncs policy from the given dial target, and blocks until a signal is received.
 func RunServer(listenPath, dialTarget string) {
+	// Point the lib/std/log facade at the logrus standard logger, which main has configured, so
+	// code written against the facade lands in the same output at the same level. The facade
+	// defaults to discarding everything until a backend is registered, so without this any facade
+	// logging in the code this server runs - policy evaluation included - would silently go nowhere.
+	log.SetDefaultLogger(logrusr.New(logrus.StandardLogger()))
+
 	_, err := os.Stat(listenPath)
 	if !os.IsNotExist(err) {
 		if err := os.Remove(listenPath); err != nil {

--- a/felix/daemon/daemon.go
+++ b/felix/daemon/daemon.go
@@ -44,6 +44,7 @@ import (
 	"github.com/projectcalico/calico/felix/statusrep"
 	"github.com/projectcalico/calico/felix/usagerep"
 	"github.com/projectcalico/calico/lib/logrusr"
+	stdlog "github.com/projectcalico/calico/lib/std/log"
 	"github.com/projectcalico/calico/libcalico-go/lib/apiconfig"
 	"github.com/projectcalico/calico/libcalico-go/lib/apis/internalapi"
 	"github.com/projectcalico/calico/libcalico-go/lib/backend"
@@ -115,6 +116,13 @@ func Run(configFile string, gitVersion string, buildDate string, gitRevision str
 	// Special-case handling for environment variable-configured logging:
 	// Initialise early so we can trace out config parsing.
 	logrusr.ConfigureEarlyLoggingFromEnv("felix")
+
+	// Point the lib/std/log facade at the same logrus logger, so code written against the
+	// facade lands in Felix's log output rather than being dropped.  The facade discards
+	// everything until a backend is registered, and Felix reaches such code through the
+	// collector, which evaluates policy using app-policy/checker.  The adapter holds the
+	// standard logger itself, so the levels ConfigureLogging sets below apply to it too.
+	stdlog.SetDefaultLogger(logrusr.New(log.StandardLogger()))
 
 	ctx := context.Background()
 

--- a/lib/logrusr/destination_test.go
+++ b/lib/logrusr/destination_test.go
@@ -30,6 +30,7 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	. "github.com/projectcalico/calico/lib/logrusr"
+	stdlog "github.com/projectcalico/calico/lib/std/log"
 )
 
 // countingCounter is a trivial Counter used by the destination tests.
@@ -91,6 +92,68 @@ func TestCallerReporting_WithField(t *testing.T) {
 	if !strings.Contains(buf.String(), "destination_test.go") {
 		t.Errorf("expected destination_test.go in output: %s", buf.String())
 	}
+}
+
+// TestCallerReporting_WrittenFromALoggingGoroutine covers a line written from a
+// goroutine the logging code itself started, where the stack holds no caller at
+// all: an AggregatingLogger holds occurrences and writes them out when the
+// window closes on a timer. Walking off the end of that stack finds the runtime
+// frame the goroutine was started at, which names an assembly file and tells a
+// reader nothing. Name the logging code that wrote the line instead.
+func TestCallerReporting_WrittenFromALoggingGoroutine(t *testing.T) {
+	var out syncBuffer
+	saved := log.StandardLogger().Out
+	log.StandardLogger().Out = &out
+	t.Cleanup(func() { log.StandardLogger().Out = saved })
+
+	savedDefault := stdlog.Default()
+	t.Cleanup(func() { stdlog.SetDefaultLogger(savedDefault) })
+	stdlog.SetDefaultLogger(New(log.StandardLogger()))
+
+	a := stdlog.NewAggregatingLogger("Test log", "values", stdlog.OptInterval(50*time.Millisecond))
+	a.Record("v:first")  // Written inline, from this goroutine.
+	a.Record("v:second") // Folds into a window that closes on a timer.
+
+	var closed string
+	for range 200 {
+		if lines := out.lines(); len(lines) == 2 {
+			closed = lines[1]
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if closed == "" {
+		t.Fatalf("the window never closed: %s", out.String())
+	}
+	if !strings.Contains(closed, "aggregating.go") {
+		t.Errorf("expected aggregating.go in the closed window's line: %s", closed)
+	}
+	if strings.Contains(closed, "asm_") || strings.Contains(closed, FileNameUnknown) {
+		t.Errorf("expected a logging frame, not the goroutine's entry point: %s", closed)
+	}
+}
+
+// syncBuffer is a log destination a test can read while another goroutine is
+// still writing to it.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *syncBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *syncBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+func (b *syncBuffer) lines() []string {
+	return strings.Split(strings.TrimSuffix(b.String(), "\n"), "\n")
 }
 
 func TestCallerReporting_RateLimitedLogger(t *testing.T) {

--- a/lib/logrusr/formatter.go
+++ b/lib/logrusr/formatter.go
@@ -49,6 +49,7 @@ const (
 	logrusPackage  = "github.com/sirupsen/logrus."
 	logrusrPackage = "github.com/projectcalico/calico/lib/logrusr."
 	stdlogPackage  = "github.com/projectcalico/calico/lib/std/log."
+	runtimePackage = "runtime."
 	maxCallerDepth = 32
 )
 
@@ -349,6 +350,13 @@ func GetFileInfo(entry *log.Entry) (string, int) {
 // lookupCaller walks the stack and returns the first frame whose
 // function is not in logrus, lib/logrusr or lib/std/log — i.e. the
 // user code that actually issued the log call.
+//
+// A line can also be written from a goroutine the logging code owns, with
+// no user code below it: a logger that batches or aggregates and writes
+// what it held when a timer fires.  There the walk finds only logging
+// frames and then the runtime frame the goroutine was started at, which
+// names an assembly file and tells a reader nothing.  Fall back to the
+// outermost logging frame instead — the logging code that wrote the line.
 func lookupCaller() (string, int) {
 	pcsPtr := pcsPool.Get().(*[]uintptr)
 	defer pcsPool.Put(pcsPtr)
@@ -360,17 +368,26 @@ func lookupCaller() (string, int) {
 		return FileNameUnknown, 0
 	}
 	frames := runtime.CallersFrames(pcs[:n])
+	var lastLogging *runtime.Frame
 	for {
 		frame, more := frames.Next()
 		fn := frame.Function
-		if !strings.HasPrefix(fn, logrusPackage) &&
-			!strings.HasPrefix(fn, logrusrPackage) &&
-			!strings.HasPrefix(fn, stdlogPackage) {
+		switch {
+		case strings.HasPrefix(fn, logrusPackage),
+			strings.HasPrefix(fn, logrusrPackage),
+			strings.HasPrefix(fn, stdlogPackage):
+			lastLogging = &frame
+		case strings.HasPrefix(fn, runtimePackage):
+			// Where a goroutine was started, never who logged.
+		default:
 			return path.Base(frame.File), frame.Line
 		}
 		if !more {
 			break
 		}
+	}
+	if lastLogging != nil {
+		return path.Base(lastLogging.File), lastLogging.Line
 	}
 	return FileNameUnknown, 0
 }

--- a/lib/std/log/aggregating.go
+++ b/lib/std/log/aggregating.go
@@ -1,0 +1,288 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package log
+
+import (
+	"context"
+	"maps"
+	"slices"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	fieldTotalEvents   = "totalEvents"
+	fieldUnnamedEvents = "unnamedEvents"
+	fieldMaxNamed      = "maxNamed"
+
+	defaultAggregationInterval = 5 * time.Minute
+	defaultAggregationLevel    = LevelWarn
+	defaultMaxNamed            = 100
+)
+
+// NewAggregatingLogger returns an AggregatingLogger that writes msg at most once per interval,
+// listing under field the distinct values that provoked it since the last line.
+//
+// Reach for it on a hot path where the same "should not happen" condition recurs keyed on some
+// value - an ID, a name, an address. Logging each occurrence floods the output; logging only the
+// first loses the fact that it is still happening; logging one arbitrary occurrence per interval
+// cannot tell one bad value from a hundred. AggregatingLogger names every distinct value it saw in
+// the interval on a single line, so the flood is suppressed without losing what caused it.
+//
+// Typical use is a package-level variable, since the aggregation window is shared process-wide:
+//
+//	var missingIPSets = log.NewAggregatingLogger("IPSet not found", "ipsets")
+//
+//	func lookup(id string) *ipSet {
+//	  s, ok := store[id]
+//	  if !ok {
+//	    missingIPSets.Record(id)
+//	    return nil
+//	  }
+//	  return s
+//	}
+//
+// The options are optional; see the Opt* functions for the defaults. A given condition is reported
+// at one severity, so the level is set here rather than per call - use OptLevel to report at
+// anything other than Warn.
+func NewAggregatingLogger(msg, field string, opts ...AggregatingLoggerOpt) *AggregatingLogger {
+	a := &AggregatingLogger{
+		msg:       msg,
+		field:     field,
+		level:     defaultAggregationLevel,
+		interval:  defaultAggregationInterval,
+		maxNamed:  defaultMaxNamed,
+		named:     map[string]struct{}{},
+		afterFunc: func(d time.Duration, f func()) { time.AfterFunc(d, f) },
+	}
+	for _, opt := range opts {
+		opt(a)
+	}
+	return a
+}
+
+type AggregatingLoggerOpt func(*AggregatingLogger)
+
+// OptLevel sets the level the aggregated line is written at, and so also the level below which
+// Record does nothing at all. Defaults to LevelWarn.
+func OptLevel(l Level) AggregatingLoggerOpt {
+	return func(a *AggregatingLogger) {
+		a.level = l
+	}
+}
+
+// OptInterval sets the minimum gap between two emitted lines. Defaults to five minutes.
+func OptInterval(d time.Duration) AggregatingLoggerOpt {
+	return func(a *AggregatingLogger) {
+		a.interval = d
+	}
+}
+
+// OptMaxNamed caps how many distinct values one line will name, which also caps how many the logger
+// holds between lines. Defaults to 100. Occurrences of further values are counted rather than named
+// - see AggregatingLogger.Record.
+func OptMaxNamed(n int) AggregatingLoggerOpt {
+	return func(a *AggregatingLogger) {
+		a.maxNamed = n
+	}
+}
+
+// OptLogger writes to the given Logger rather than to whichever Logger is installed as the default
+// when a line is emitted. Mostly useful in tests; production callers should leave it unset so their
+// output follows the process-wide backend.
+func OptLogger(l Logger) AggregatingLoggerOpt {
+	return func(a *AggregatingLogger) {
+		a.logger = l
+	}
+}
+
+// AggregatingLogger collapses a flood of one recurring log line into a single line per interval
+// naming the distinct values behind it. Construct one with NewAggregatingLogger. Safe for
+// concurrent use.
+type AggregatingLogger struct {
+	msg   string // the message every emitted line carries
+	field string // key the list of distinct values is written under
+
+	level    Level // level every emitted line is written at
+	interval time.Duration
+	maxNamed int
+
+	// Logger to write to, or nil to use whichever Logger is default at the time a line is emitted.
+	logger Logger
+
+	// How a window's close is scheduled. time.AfterFunc in production; tests replace it to fire the
+	// close where a real timer would, without a sleep.
+	afterFunc func(time.Duration, func())
+
+	// Lock over the window state below. Never held while writing a log.
+	mu         sync.Mutex
+	named      map[string]struct{} // distinct values to name next line, at most maxNamed of them
+	unnamed    int                 // occurrences of values maxNamed kept out of named
+	total      int                 // occurrences this window, named and unnamed alike
+	nextEmit   time.Time
+	started    bool   // whether a line has ever been emitted; until then the next Record emits
+	closeArmed bool   // whether this window's close is already scheduled
+	gen        uint64 // counts windows, so a close that a Record beat to the drain can tell
+}
+
+// Record notes one occurrence of the condition for value. It writes the aggregated line if this
+// occurrence is the first ever, or the first since the interval elapsed; otherwise the occurrence
+// folds into the current window silently and costs only a mutex and a map lookup.
+//
+// A window is written out when the interval elapses, whether or not anything else has happened by
+// then, so a burst that stops as abruptly as it started is still reported one interval later. It is
+// not held until the condition next recurs, which for a transient fault could be hours away, or
+// never - and which would report a flood that is long over as though it were happening now.
+//
+// Once maxNamed distinct values are held, occurrences of further values are counted into the
+// unnamedEvents field rather than named. That count is a number of occurrences, not of distinct
+// values: how many distinct values sit behind them cannot be known without retaining them, which is
+// what the cap exists to prevent.
+func (a *AggregatingLogger) Record(value string) {
+	logger := a.target()
+	if !logger.Enabled(context.Background(), a.level) {
+		// Nothing would be written, so skip the bookkeeping too.
+		return
+	}
+	if w := a.sample(value, time.Now()); w != nil {
+		a.emit(logger, w)
+	}
+}
+
+// target resolves the Logger to write to. When none was given it reads the default on every use
+// rather than capturing it once: an AggregatingLogger is typically a package-level variable, so it
+// is constructed during package initialisation, long before main installs the real backend. Holding
+// the Logger found at construction would pin the no-op default and silently drop every line.
+func (a *AggregatingLogger) target() Logger {
+	if a.logger != nil {
+		return a.logger
+	}
+	return Default()
+}
+
+// sample folds one occurrence of value into the current window, and returns the drained window when
+// this occurrence trips the interval gate. Otherwise it returns nil, meaning nothing to write yet,
+// and schedules the close that will write the window out when the interval elapses. Taking now as a
+// parameter is what keeps the tests off the wall clock.
+func (a *AggregatingLogger) sample(value string, now time.Time) *aggregateWindow {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	a.total++
+	if _, ok := a.named[value]; !ok {
+		if len(a.named) < a.maxNamed {
+			a.named[value] = struct{}{}
+		} else {
+			a.unnamed++
+		}
+	}
+
+	if a.started && now.Before(a.nextEmit) {
+		a.armCloseLocked(now)
+		return nil
+	}
+	return a.drainLocked(now)
+}
+
+// armCloseLocked schedules the close of the window this occurrence has just joined, unless the
+// window's close is scheduled already. Without it a window would only be written by the next
+// occurrence to arrive after the interval, so the tail of a burst that stops would sit unreported
+// until the condition recurred.
+func (a *AggregatingLogger) armCloseLocked(now time.Time) {
+	if a.closeArmed {
+		return
+	}
+	a.closeArmed = true
+	// The deadline stands in for the clock at close time. Using it rather than whenever the callback
+	// happens to run keeps windows exactly one interval apart, however late the timer is.
+	deadline, gen := a.nextEmit, a.gen
+	a.afterFunc(deadline.Sub(now), func() { a.closeWindow(gen, deadline) })
+}
+
+// closeWindow writes out the window the timer was armed for. A Record may have drained that window
+// first, in which case the generation has moved on and this timer has nothing to do.
+func (a *AggregatingLogger) closeWindow(gen uint64, deadline time.Time) {
+	logger := a.target()
+
+	a.mu.Lock()
+	if a.gen != gen || a.total == 0 {
+		a.mu.Unlock()
+		return
+	}
+	w := a.drainLocked(deadline)
+	a.mu.Unlock()
+
+	a.emit(logger, w)
+}
+
+// drainLocked takes everything the current window holds, leaving an empty one behind that runs for
+// the next interval from now.
+func (a *AggregatingLogger) drainLocked(now time.Time) *aggregateWindow {
+	w := &aggregateWindow{
+		named:   AggregatedValues(slices.Sorted(maps.Keys(a.named))), // sorted so repeated lines are comparable
+		unnamed: a.unnamed,
+		total:   a.total,
+	}
+
+	clear(a.named)
+	a.unnamed = 0
+	a.total = 0
+	a.nextEmit = now.Add(a.interval)
+	a.started = true
+	a.closeArmed = false
+	a.gen++
+	return w
+}
+
+func (a *AggregatingLogger) emit(logger Logger, w *aggregateWindow) {
+	args := []any{a.field, w.named, fieldTotalEvents, w.total}
+	if w.unnamed > 0 {
+		// The value list is short of the whole story. Say how many occurrences went unnamed and what
+		// cap caused it, so a reader knows the list is partial.
+		args = append(args, fieldUnnamedEvents, w.unnamed, fieldMaxNamed, a.maxNamed)
+	}
+
+	// Logger exposes one method per level rather than a level argument, matching slog. Levels
+	// between the named ones round down, as slog handlers do.
+	switch {
+	case a.level >= LevelError:
+		logger.Error(a.msg, args...)
+	case a.level >= LevelWarn:
+		logger.Warn(a.msg, args...)
+	case a.level >= LevelInfo:
+		logger.Info(a.msg, args...)
+	default:
+		logger.Debug(a.msg, args...)
+	}
+}
+
+// aggregateWindow is one interval's worth of drained state, ready to be written as a single line.
+type aggregateWindow struct {
+	named   AggregatedValues // distinct values seen this window, sorted, at most maxNamed of them
+	unnamed int              // occurrences whose value the cap kept out of named
+	total   int              // occurrences this window, named and unnamed alike
+}
+
+// AggregatedValues is the list of distinct values an emitted line names. It is a type of its own so
+// that a text backend renders it as a bracketed comma-separated list - a Logger given a plain
+// []string writes it as a Go slice literal, which is the difference between reading a hundred IP set
+// IDs and reading a hundred IP set IDs wrapped in quotes, commas and a type name. A structured
+// backend still sees a list of strings.
+type AggregatedValues []string
+
+func (v AggregatedValues) String() string {
+	return "[" + strings.Join(v, ",") + "]"
+}

--- a/lib/std/log/aggregating_test.go
+++ b/lib/std/log/aggregating_test.go
@@ -1,0 +1,553 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// These tests sit inside the package so they can drive sample() with an explicit clock, which keeps
+// them off the wall clock and out of sleeps.
+package log
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"sync"
+	"testing"
+	"time"
+)
+
+// t0 anchors every test to a fixed instant, so results never depend on when the suite runs.
+var t0 = time.Unix(1_700_000_000, 0)
+
+const testInterval = 5 * time.Minute
+
+// TestAggregatingLoggerFloodOfOneValue covers the simplest flood shape: one value recurring over and
+// over on a hot path. The repeats must collapse to one window per interval, and that window must
+// still account for every occurrence it swallowed.
+func TestAggregatingLoggerFloodOfOneValue(t *testing.T) {
+	a := NewAggregatingLogger("IPSet not found", "ipsets", OptInterval(testInterval))
+
+	const occurrences = 100
+	var emitted []*aggregateWindow
+	for i := range occurrences {
+		// All inside one interval, so only the very first occurrence emits.
+		if w := a.sample("s:missing", t0.Add(time.Duration(i)*time.Millisecond)); w != nil {
+			emitted = append(emitted, w)
+		}
+	}
+
+	if len(emitted) != 1 {
+		t.Fatalf("expected 1 emitted window within the interval, got %d", len(emitted))
+	}
+	// The first occurrence emits immediately, with nothing accumulated behind it yet.
+	mustNameExactly(t, emitted[0], "s:missing")
+	mustTotal(t, emitted[0], 1)
+	mustUnnamed(t, emitted[0], 0)
+
+	// Once the interval elapses the next occurrence emits, reporting every repeat it suppressed.
+	w := a.sample("s:missing", t0.Add(testInterval+time.Second))
+	if w == nil {
+		t.Fatal("expected an emitted window once the interval had elapsed")
+	}
+	mustNameExactly(t, w, "s:missing")
+	mustUnnamed(t, w, 0)
+	// occurrences-1 suppressed (the first emitted in its own window), plus this emitting one.
+	mustTotal(t, w, occurrences)
+}
+
+// TestAggregatingLoggerNamesEveryDistinctValue covers the shape that motivates this type: not one
+// value repeated but many distinct ones, each hit at volume. Suppressing by time alone would name
+// only whichever value tripped the timer; this must name them all.
+func TestAggregatingLoggerNamesEveryDistinctValue(t *testing.T) {
+	a := NewAggregatingLogger("IPSet not found", "ipsets", OptInterval(testInterval))
+
+	// The first occurrence emits immediately, carrying only itself.
+	first := a.sample("s:missing-00", t0)
+	if first == nil {
+		t.Fatal("expected the first occurrence to emit")
+	}
+	mustNameExactly(t, first, "s:missing-00")
+
+	// A burst of further distinct values inside the interval: all folded in, none emitted.
+	const distinct = 50
+	var want []string
+	for i := 1; i < distinct; i++ {
+		value := fmt.Sprintf("s:missing-%02d", i)
+		want = append(want, value)
+		if w := a.sample(value, t0.Add(time.Duration(i)*time.Millisecond)); w != nil {
+			t.Fatalf("occurrence %d emitted inside the interval, expected it to be folded in", i)
+		}
+	}
+
+	// The next occurrence after the interval emits, naming every value accumulated in the window.
+	// s:missing-00 emitted in its own window and so is not carried into this one.
+	want = append(want, "s:missing-final")
+	slices.Sort(want)
+
+	w := a.sample("s:missing-final", t0.Add(testInterval+time.Second))
+	if w == nil {
+		t.Fatal("expected an emitted window once the interval had elapsed")
+	}
+	mustNameExactly(t, w, want...)
+	mustUnnamed(t, w, 0)
+	mustTotal(t, w, distinct)
+}
+
+// TestAggregatingLoggerClosesAWindowThatGoesQuiet covers the burst that stops. Draining only when
+// the next occurrence arrives would leave everything the burst accumulated unreported until the
+// condition recurred - hours later for a transient fault, or never - and would then report it as
+// though it were happening at that moment. The window must close on its own instead.
+func TestAggregatingLoggerClosesAWindowThatGoesQuiet(t *testing.T) {
+	capture := &captureLogger{level: LevelDebug}
+	timer := &fakeTimer{}
+	a := NewAggregatingLogger("IPSet not found", "ipsets", OptInterval(testInterval), OptLogger(capture))
+	a.afterFunc = timer.afterFunc
+
+	// The first occurrence emits on its own, as Record would write it.
+	w := a.sample("s:missing-00", t0)
+	if w == nil {
+		t.Fatal("expected the first occurrence to emit")
+	}
+	a.emit(capture, w)
+
+	// The rest of the burst folds in behind it, and then the condition clears: nothing arrives after
+	// this to drain what they left.
+	const distinct = 20
+	var want []string
+	for i := 1; i < distinct; i++ {
+		value := fmt.Sprintf("s:missing-%02d", i)
+		want = append(want, value)
+		if w := a.sample(value, t0.Add(time.Duration(i)*time.Millisecond)); w != nil {
+			t.Fatalf("occurrence %d emitted inside the interval, expected it to be folded in", i)
+		}
+	}
+	slices.Sort(want)
+
+	// One close per window, however many occurrences join it, and scheduled for the end of the
+	// window rather than an interval after whichever occurrence happened to schedule it.
+	if len(timer.armed) != 1 {
+		t.Fatalf("scheduled %d closes for one window, expected 1", len(timer.armed))
+	}
+	if got := timer.armed[0].after; got != testInterval-time.Millisecond {
+		t.Errorf("close scheduled in %v, expected %v", got, testInterval-time.Millisecond)
+	}
+
+	// The window closes on its own, naming everything held in it.
+	timer.armed[0].fire()
+	if len(capture.lines) != 2 {
+		t.Fatalf("wrote %d lines, expected the first occurrence and then the closed window",
+			len(capture.lines))
+	}
+	mustLoggedArgs(t, capture.last(), "ipsets", AggregatedValues(want), fieldTotalEvents, distinct-1)
+}
+
+// TestAggregatingLoggerCloseYieldsToARecordThatDrainedFirst covers the two ways a window can end
+// meeting each other. An occurrence arriving after the interval drains the window itself, so the
+// close scheduled for that window must do nothing rather than write a second, empty line - while the
+// window opened behind it still gets a close of its own.
+func TestAggregatingLoggerCloseYieldsToARecordThatDrainedFirst(t *testing.T) {
+	capture := &captureLogger{level: LevelDebug}
+	timer := &fakeTimer{}
+	a := NewAggregatingLogger("IPSet not found", "ipsets", OptInterval(testInterval), OptLogger(capture))
+	a.afterFunc = timer.afterFunc
+
+	if w := a.sample("s:seed", t0); w == nil {
+		t.Fatal("expected the first occurrence to emit")
+	}
+	if w := a.sample("s:held", t0.Add(time.Second)); w != nil {
+		t.Fatal("expected the second occurrence to fold into the window")
+	}
+
+	// An occurrence after the interval drains the window, taking what was held with it.
+	w := a.sample("s:drains-it", t0.Add(testInterval+time.Second))
+	if w == nil {
+		t.Fatal("expected the occurrence after the interval to emit")
+	}
+	mustNameExactly(t, w, "s:drains-it", "s:held")
+	a.emit(capture, w)
+
+	// So the close scheduled for that window has nothing left to write.
+	timer.armed[0].fire()
+	if len(capture.lines) != 1 {
+		t.Fatalf("wrote %d lines, expected the overtaken close to write nothing", len(capture.lines))
+	}
+
+	// The window the drain opened schedules its own close, and that one does write.
+	if w := a.sample("s:next", t0.Add(testInterval+2*time.Second)); w != nil {
+		t.Fatal("expected the next occurrence to fold into the new window")
+	}
+	if len(timer.armed) != 2 {
+		t.Fatalf("scheduled %d closes, expected one per window", len(timer.armed))
+	}
+	timer.armed[1].fire()
+	if len(capture.lines) != 2 {
+		t.Fatalf("wrote %d lines, expected the new window to close too", len(capture.lines))
+	}
+	mustLoggedArgs(t, capture.last(), "ipsets", AggregatedValues{"s:next"}, fieldTotalEvents, 1)
+}
+
+// fakeTimer stands in for time.AfterFunc, holding the window closes an AggregatingLogger schedules
+// so that a test can fire them where a real timer would, with no sleep and no wall clock.
+type fakeTimer struct {
+	armed []scheduledClose
+}
+
+type scheduledClose struct {
+	after time.Duration
+	fire  func()
+}
+
+func (f *fakeTimer) afterFunc(d time.Duration, fn func()) {
+	f.armed = append(f.armed, scheduledClose{after: d, fire: fn})
+}
+
+// TestAggregatingLoggerCapsNamedValues asserts the cap bounds both the emitted line and the memory
+// held behind it: past maxNamed distinct values, further ones are counted, not named.
+func TestAggregatingLoggerCapsNamedValues(t *testing.T) {
+	const maxNamed = 10
+	a := NewAggregatingLogger("IPSet not found", "ipsets",
+		OptInterval(testInterval), OptMaxNamed(maxNamed))
+
+	// Emit and reset the initial window so the next one starts empty.
+	if w := a.sample("s:seed", t0); w == nil {
+		t.Fatal("expected the first occurrence to emit")
+	}
+
+	// Feed far more distinct values than the cap, all inside the interval.
+	const distinct = 100
+	for i := range distinct {
+		a.sample(fmt.Sprintf("s:over-%03d", i), t0.Add(time.Duration(i+1)*time.Millisecond))
+	}
+
+	w := a.sample("s:trigger", t0.Add(testInterval+time.Second))
+	if w == nil {
+		t.Fatal("expected an emitted window once the interval had elapsed")
+	}
+	if len(w.named) != maxNamed {
+		t.Errorf("named %d values, expected the cap of %d", len(w.named), maxNamed)
+	}
+	// Everything that did not fit under the cap is counted instead: the distinct over-values plus
+	// the triggering one, less the maxNamed that were named.
+	mustUnnamed(t, w, distinct+1-maxNamed)
+	mustTotal(t, w, distinct+1)
+	// The accumulator itself never grew past the cap either.
+	if len(a.named) != 0 {
+		t.Errorf("accumulator holds %d values after draining, expected 0", len(a.named))
+	}
+}
+
+// TestAggregatingLoggerCountsOverflowOccurrences pins down what the overflow counter means, which is
+// the thing easiest to get wrong: it counts *occurrences* that could not be named, never distinct
+// values. One value hammering the hot path past the cap must not read as thousands of distinct
+// values - inferring a distinct count from these occurrences would overstate the problem by three
+// orders of magnitude, exactly when someone is trying to size it.
+func TestAggregatingLoggerCountsOverflowOccurrences(t *testing.T) {
+	const maxNamed = 3
+	capture := &captureLogger{level: LevelDebug}
+	a := NewAggregatingLogger("IPSet not found", "ipsets",
+		OptInterval(testInterval), OptMaxNamed(maxNamed), OptLogger(capture))
+
+	if w := a.sample("s:seed", t0); w == nil {
+		t.Fatal("expected the first occurrence to emit")
+	}
+
+	// Fill the cap.
+	for i := range maxNamed {
+		a.sample(fmt.Sprintf("s:in-cap-%d", i), t0.Add(time.Duration(i+1)*time.Millisecond))
+	}
+	// Then a single further value, recurring the way a hot path makes it recur.
+	const repeats = 1000
+	for i := range repeats {
+		a.sample("s:overflow", t0.Add(time.Duration(maxNamed+1+i)*time.Millisecond))
+	}
+
+	w := a.sample("s:overflow", t0.Add(testInterval+time.Second))
+	if w == nil {
+		t.Fatal("expected an emitted window once the interval had elapsed")
+	}
+	mustNameExactly(t, w, "s:in-cap-0", "s:in-cap-1", "s:in-cap-2")
+	// Four distinct values occurred; 1001 occurrences of the fourth went unnamed.
+	mustUnnamed(t, w, repeats+1)
+	mustTotal(t, w, maxNamed+repeats+1)
+
+	// And the emitted line says so in those terms. The arguments are asserted exhaustively: a line
+	// carrying anything that reads as a distinct-value count would be claiming 1004 where the truth
+	// is 4, and would do so precisely when a reader is trying to size the problem.
+	a.emit(capture, w)
+	mustLoggedArgs(t, capture.last(),
+		"ipsets", w.named,
+		fieldTotalEvents, maxNamed+repeats+1,
+		fieldUnnamedEvents, repeats+1,
+		fieldMaxNamed, maxNamed,
+	)
+}
+
+// TestAggregatingLoggerEmittedArgs covers the shape of the line itself: an uncapped window says only
+// what it saw, and a capped one adds the two values that flag the list as partial.
+func TestAggregatingLoggerEmittedArgs(t *testing.T) {
+	const maxNamed = 2
+	capture := &captureLogger{level: LevelDebug}
+	a := NewAggregatingLogger("IPSet not found", "ipsets",
+		OptInterval(testInterval), OptMaxNamed(maxNamed), OptLogger(capture))
+
+	// An uncapped window: the value list is complete, so nothing flags it as partial.
+	a.emit(capture, &aggregateWindow{named: AggregatedValues{"s:a", "s:b"}, total: 7})
+	if got := capture.last().msg; got != "IPSet not found" {
+		t.Errorf("message %q, expected %q", got, "IPSet not found")
+	}
+	mustLoggedArgs(t, capture.last(), "ipsets", AggregatedValues{"s:a", "s:b"}, fieldTotalEvents, 7)
+
+	// A capped window: same values plus the two that say the list is short of the whole story.
+	a.emit(capture, &aggregateWindow{named: AggregatedValues{"s:a", "s:b"}, unnamed: 40, total: 47})
+	mustLoggedArgs(t, capture.last(),
+		"ipsets", AggregatedValues{"s:a", "s:b"},
+		fieldTotalEvents, 47,
+		fieldUnnamedEvents, 40,
+		fieldMaxNamed, maxNamed,
+	)
+}
+
+// TestAggregatingLoggerReportsAtItsLevel asserts the level is the aggregator's, not a fixed Warn:
+// whatever OptLevel names is the method the line goes out on. The conditions worth aggregating span
+// Debug through Error - a missing entry is a warning, an uncompilable expression is an error - and
+// each wants reporting at its own severity.
+func TestAggregatingLoggerReportsAtItsLevel(t *testing.T) {
+	for _, tc := range []struct {
+		level      Level
+		wantMethod string
+	}{
+		{LevelError, "Error"},
+		{LevelWarn, "Warn"},
+		{LevelInfo, "Info"},
+		{LevelDebug, "Debug"},
+	} {
+		t.Run(tc.wantMethod, func(t *testing.T) {
+			capture := &captureLogger{level: LevelDebug}
+			a := NewAggregatingLogger("condition", "values",
+				OptLevel(tc.level), OptLogger(capture))
+
+			a.Record("v:one")
+
+			if len(capture.lines) != 1 {
+				t.Fatalf("wrote %d lines, expected 1", len(capture.lines))
+			}
+			if capture.last().method != tc.wantMethod {
+				t.Errorf("wrote via %s, expected %s", capture.last().method, tc.wantMethod)
+			}
+		})
+	}
+}
+
+// TestAggregatingLoggerDefaultsToWarn pins the default, since most callers will not name a level.
+func TestAggregatingLoggerDefaultsToWarn(t *testing.T) {
+	capture := &captureLogger{level: LevelDebug}
+	a := NewAggregatingLogger("condition", "values", OptLogger(capture))
+
+	a.Record("v:one")
+
+	if len(capture.lines) != 1 {
+		t.Fatalf("wrote %d lines, expected 1", len(capture.lines))
+	}
+	if capture.last().method != "Warn" {
+		t.Errorf("wrote via %s, expected Warn", capture.last().method)
+	}
+}
+
+// TestAggregatingLoggerSkipsWorkBelowItsLevel asserts the level guard, and that it tracks the
+// aggregator's own level rather than a fixed one: when the Logger is not writing at that level,
+// Record must cost nothing at all, not merely write nothing. Being cheap on a hot path is the whole
+// point of the type.
+func TestAggregatingLoggerSkipsWorkBelowItsLevel(t *testing.T) {
+	// An Info-level aggregator against a Logger writing only Warn and above: nothing it records
+	// would ever reach the output.
+	capture := &captureLogger{level: LevelWarn}
+	a := NewAggregatingLogger("condition", "values",
+		OptLevel(LevelInfo), OptInterval(testInterval), OptLogger(capture))
+
+	for range 100 {
+		a.Record("v:one")
+	}
+
+	if len(capture.lines) != 0 {
+		t.Errorf("wrote %d lines below its level, expected none", len(capture.lines))
+	}
+	if a.total != 0 || len(a.named) != 0 {
+		t.Errorf("accumulated total=%d named=%d below its level, expected no bookkeeping at all",
+			a.total, len(a.named))
+	}
+
+	// Turning the Logger up to Info resumes both.
+	capture.setLevel(LevelInfo)
+	a.Record("v:one")
+	if len(capture.lines) != 1 {
+		t.Errorf("wrote %d lines once the Logger reached Info, expected 1", len(capture.lines))
+	}
+}
+
+// TestAggregatingLoggerFollowsTheDefaultLogger covers the trap this type is most likely to fall
+// into. An AggregatingLogger is meant to be a package-level variable, so it is constructed during
+// package initialisation - before main installs the real backend, when Default() is still the no-op.
+// Resolving the Logger once at construction would pin that no-op and silently drop every line, which
+// is worse than the flood it replaces. It must read Default() at the point it writes.
+func TestAggregatingLoggerFollowsTheDefaultLogger(t *testing.T) {
+	saved := Default()
+	defer SetDefaultLogger(saved)
+
+	// Construct while the no-op default is installed, as a package-level variable would.
+	SetDefaultLogger(nil)
+	a := NewAggregatingLogger("condition", "values")
+
+	// Nothing is written, and the no-op reports nothing enabled, so nothing accumulates either.
+	a.Record("v:one")
+
+	// Now the backend registers, the way main does at process start.
+	capture := &captureLogger{level: LevelDebug}
+	SetDefaultLogger(capture)
+
+	a.Record("v:two")
+
+	if len(capture.lines) != 1 {
+		t.Fatalf("wrote %d lines after the backend registered, expected 1", len(capture.lines))
+	}
+	mustLoggedArgs(t, capture.last(), "values", AggregatedValues{"v:two"}, fieldTotalEvents, 1)
+}
+
+// TestAggregatingLoggerRecordUsesWallClock covers the one thing sample() cannot: that Record wires
+// itself to the real clock, so a second call inside the interval is suppressed.
+func TestAggregatingLoggerRecordUsesWallClock(t *testing.T) {
+	capture := &captureLogger{level: LevelDebug}
+	a := NewAggregatingLogger("condition", "values", OptInterval(time.Hour), OptLogger(capture))
+
+	a.Record("v:first")
+	a.Record("v:second")
+
+	if len(capture.lines) != 1 {
+		t.Fatalf("wrote %d lines within the interval, expected 1", len(capture.lines))
+	}
+	mustLoggedArgs(t, capture.last(), "values", AggregatedValues{"v:first"}, fieldTotalEvents, 1)
+}
+
+// TestAggregatingLoggerRecordSchedulesTheWindowClose covers the other half of that wiring: Record
+// schedules the close as well as folding the occurrence in, so what it folded in is written out
+// without a further Record to drain it.
+func TestAggregatingLoggerRecordSchedulesTheWindowClose(t *testing.T) {
+	capture := &captureLogger{level: LevelDebug}
+	timer := &fakeTimer{}
+	a := NewAggregatingLogger("condition", "values", OptInterval(time.Hour), OptLogger(capture))
+	a.afterFunc = timer.afterFunc
+
+	a.Record("v:first")  // Emits immediately.
+	a.Record("v:second") // Folds into the window behind it, and schedules that window's close.
+
+	if len(timer.armed) != 1 {
+		t.Fatalf("scheduled %d closes, expected 1", len(timer.armed))
+	}
+	timer.armed[0].fire()
+
+	if len(capture.lines) != 2 {
+		t.Fatalf("wrote %d lines, expected the first occurrence and then the closed window",
+			len(capture.lines))
+	}
+	mustLoggedArgs(t, capture.last(), "values", AggregatedValues{"v:second"}, fieldTotalEvents, 1)
+}
+
+// captureLogger is a Logger that records what it was asked to write, so a test can assert on it.
+type captureLogger struct {
+	mu    sync.Mutex
+	level Level
+	lines []loggedLine
+}
+
+type loggedLine struct {
+	method string // which of Debug/Info/Warn/Error carried the line
+	msg    string
+	args   []any
+}
+
+func (c *captureLogger) Debug(msg string, args ...any) { c.record("Debug", msg, args) }
+func (c *captureLogger) Info(msg string, args ...any)  { c.record("Info", msg, args) }
+func (c *captureLogger) Warn(msg string, args ...any)  { c.record("Warn", msg, args) }
+func (c *captureLogger) Error(msg string, args ...any) { c.record("Error", msg, args) }
+
+func (c *captureLogger) With(args ...any) Logger { return c }
+
+func (c *captureLogger) Enabled(_ context.Context, level Level) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return level >= c.level
+}
+
+func (c *captureLogger) record(method, msg string, args []any) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.lines = append(c.lines, loggedLine{method: method, msg: msg, args: args})
+}
+
+func (c *captureLogger) setLevel(l Level) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.level = l
+}
+
+func (c *captureLogger) last() loggedLine {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if len(c.lines) == 0 {
+		return loggedLine{}
+	}
+	return c.lines[len(c.lines)-1]
+}
+
+var _ Logger = (*captureLogger)(nil)
+
+// mustLoggedArgs asserts the line carried exactly the given key/value args, in order. Exhaustive by
+// design: an extra argument is as much a defect as a missing one.
+func mustLoggedArgs(t *testing.T, line loggedLine, want ...any) {
+	t.Helper()
+	if len(line.args) != len(want) {
+		t.Fatalf("line carried %d args %v, expected %d %v", len(line.args), line.args, len(want), want)
+	}
+	for i := range want {
+		got, expected := line.args[i], want[i]
+		if gotSlice, ok := got.(AggregatedValues); ok {
+			expectedSlice, ok := expected.(AggregatedValues)
+			if !ok || !slices.Equal(gotSlice, expectedSlice) {
+				t.Errorf("arg %d is %v, expected %v", i, got, expected)
+			}
+			continue
+		}
+		if got != expected {
+			t.Errorf("arg %d is %v, expected %v", i, got, expected)
+		}
+	}
+}
+
+func mustNameExactly(t *testing.T, w *aggregateWindow, want ...string) {
+	t.Helper()
+	if !slices.Equal(w.named, AggregatedValues(want)) {
+		t.Errorf("named %v, expected %v", w.named, want)
+	}
+}
+
+func mustTotal(t *testing.T, w *aggregateWindow, want int) {
+	t.Helper()
+	if w.total != want {
+		t.Errorf("total %d, expected %d", w.total, want)
+	}
+}
+
+func mustUnnamed(t *testing.T, w *aggregateWindow, want int) {
+	t.Helper()
+	if w.unnamed != want {
+		t.Errorf("unnamed %d, expected %d", w.unnamed, want)
+	}
+}


### PR DESCRIPTION
Dikastes evaluates policy per flow, and two log lines in that path fire once per flow whenever a single bad rule or a transient store gap exists:

- "IPSet not found", from `getIPSet`, which every rule carrying an IP set reference reaches for each of its Src/Dst/NotSrc/NotDst set IDs; and
- "failed to parse principal", from `initPeer`, for every flow a peer with an unparseable principal sources.

Both are rate-limited through `lib/logrusr` today. That suppresses the flood but keeps only whichever occurrence happened to trip the timer, which cannot distinguish one stale reference from a sync that is wholly behind - the thing a reader needs to know.

So this adds `AggregatingLogger` to `lib/std/log`. It holds one window per interval and emits a single line naming every distinct value seen in it, so the flood is suppressed without losing which values caused it. The suppressed path costs a mutex and a map lookup, and below the level the aggregator reports at it costs nothing, since nothing would be written. A cap (100 by default) bounds both the emitted line and the map behind it; occurrences past the cap are reported as `unnamedEvents`, counted rather than named, because how many distinct values sit behind them cannot be known without retaining them.

A window is written out when its interval elapses rather than when the next occurrence happens to arrive: the first occurrence to join a window schedules that window's close. Draining on the next occurrence alone would hold everything a burst accumulated until the condition next recurred - hours later for a transient fault, or never - and would then report a flood that was long over as though it were happening at that moment.

The level is the aggregator's own, set once at construction alongside the message it reports: a missing IP set is a warning, an unparseable principal is an error, and each reports at its own severity.

Both converted sites key on the value that varies, so neither needs a rate limiter any more. For the principal that also drops the error from the line, which loses nothing: `parseSpiffeID`'s only failure names the principal and the pattern it did not match, and that pattern is a constant. Both lines do change shape, so the release note calls that out for anyone with a saved query over either.

This makes `app-policy` the third component on the `lib/std/log` facade, so the logrus backend is registered in both binaries that reach the converted call sites: the dikastes server, and Felix, whose collector evaluates policy through `app-policy/checker`. Without that the facade's no-op default would discard these lines entirely - a silent regression worse than the flood, and one no unit test would catch, since the tests inject a logger. The aggregator resolves the default logger when it writes rather than when it is constructed, for the same reason: a package-level aggregator is built during package init, long before main registers a backend. `lib/logrusr`'s caller lookup also learns to name the logging code when a line is written from the window-close timer, where the stack holds no caller at all.

The Evaluate benchmark grows a `MissingSetsUnaggregated` variant, which measures what aggregation buys per evaluation at the production scale the benchmark models: roughly 50 allocs and 0.6 KB per evaluation with aggregation against roughly 480 allocs and 26 KB writing a line per miss. `TestEvalPathWarningsAreRateLimited`, which drove the missing-IP-set limiter, now drives the bad-CIDR limiter instead, whose configuration it shares.

This is a pick of the Enterprise change (tigera/calico-private#13119) into open source. The `lib/std/log` and `lib/logrusr` changes are verbatim. The checker package here already rate-limited both sites through `lib/logrusr` and shares its benchmark harness across the ingress and egress fixtures, so the checker-side changes were adapted to that rather than applied verbatim, following how the change was reconciled with the same harness on the Enterprise master branch. The principal message keeps this repo's wording ("failed to parse principal").

**Testing:** `go test` for `app-policy/checker`, `lib/std/log` and `lib/logrusr` passes; `golangci-lint run --new-from-rev upstream/master` over the changed packages reports no issues; the benchmark's pre-flight check confirms the per-evaluation miss count against the analytic count.

**Release note:**
```release-note
Dikastes and Felix now report the recurring policy-evaluation conditions "IPSet not found" and "failed to parse principal" as one aggregated log line per five-minute window, naming every IP set or principal seen in that window, in place of a rate-limited line per flow. The aggregated lines carry the IP set IDs and principals in list-valued "ipsets" and "principals" fields rather than in the message text, and no longer carry the rate limiter's "logsSkipped" count.
```

**AI assistance:** Claude Code. Claude Opus 5 helped write the original change in calico-private; Claude Fable 5.1 performed this pick and the adaptation to this repo's checker package.

By opening this PR you take responsibility for every line in it, and you agree to explain the change yourself during review rather than routing review comments back through an agent. See [AI_POLICY.md](../AI_POLICY.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
