### PR TITLE
[DE-4549] refactor(release): move artifact distribution into its own package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -454,9 +454,6 @@ release: release/bin/release
 release-publish: release/bin/release bin/gh bin/ghr bin/helm
 	@release/bin/release release publish
 
-release-public: bin/gh release/bin/release
-	@release/bin/release release public
-
 # Create a release branch.
 create-release-branch: release/bin/release
 	@release/bin/release branch cut

--- a/release/cmd/flags.go
+++ b/release/cmd/flags.go
@@ -557,7 +557,8 @@ const (
 	envPublishGitRef        = "PUBLISH_GIT_REF"
 	envReleaseGitRef        = "RELEASE_GIT_REF"
 	envPublishGithubRelease = "PUBLISH_GITHUB_RELEASE"
-	envReleaseGithubRelease = "RELEASE_GITHUB"
+	envReleaseGithub        = "RELEASE_GITHUB"
+	envReleaseGithubRelease = "RELEASE_GITHUB_RELEASE"
 	envDraftGithubRelease   = "PUBLISH_GITHUB_RELEASE_DRAFT"
 	envReleaseGithubDraft   = "RELEASE_GITHUB_DRAFT"
 )
@@ -729,7 +730,7 @@ var (
 		Name:     "github-release",
 		Category: stepControlCategory,
 		Usage:    "Publish the GitHub release",
-		Sources:  cli.EnvVars(envPublishGithubRelease, envReleaseGithubRelease),
+		Sources:  cli.EnvVars(envPublishGithubRelease, envReleaseGithub, envReleaseGithubRelease),
 		Value:    true,
 		Action: func(_ context.Context, c *cli.Command, b bool) error {
 			if b && c.String(githubTokenFlag.Name) == "" {

--- a/release/cmd/flags.go
+++ b/release/cmd/flags.go
@@ -24,6 +24,7 @@ import (
 	cli "github.com/urfave/cli/v3"
 
 	"github.com/projectcalico/calico/release/internal/defaults"
+	"github.com/projectcalico/calico/release/internal/github"
 	"github.com/projectcalico/calico/release/internal/images"
 	"github.com/projectcalico/calico/release/internal/utils"
 	"github.com/projectcalico/calico/release/pkg/manager/operator"
@@ -462,7 +463,7 @@ var (
 	githubTokenFlag = &cli.StringFlag{
 		Name:    "github-token",
 		Usage:   "The GitHub token to use when interacting with the GitHub API",
-		Sources: cli.EnvVars("GITHUB_TOKEN", "GH_TOKEN"),
+		Sources: cli.EnvVars(github.TokenEnvVars...),
 		Action: func(_ context.Context, c *cli.Command, s string) error {
 			if s == "" {
 				if c.Bool(ciFlag.Name) {

--- a/release/cmd/flags.go
+++ b/release/cmd/flags.go
@@ -557,7 +557,9 @@ const (
 	envPublishGitRef        = "PUBLISH_GIT_REF"
 	envReleaseGitRef        = "RELEASE_GIT_REF"
 	envPublishGithubRelease = "PUBLISH_GITHUB_RELEASE"
-	envReleaseGithubRelease = "RELEASE_GITHUB_RELEASE"
+	envReleaseGithubRelease = "RELEASE_GITHUB"
+	envDraftGithubRelease   = "PUBLISH_GITHUB_RELEASE_DRAFT"
+	envReleaseGithubDraft   = "RELEASE_GITHUB_DRAFT"
 )
 
 var (
@@ -589,7 +591,8 @@ var (
 		return append(f,
 			helmIndexFlag(envHelmIndexLegacy, envPublishHelmIndex, envReleaseHelmIndex),
 			gitRefFlag,
-			githubReleaseFlag)
+			githubReleaseFlag,
+			draftGithubReleaseFlag)
 	}
 
 	imagesFlag = func(value bool, envVars ...string) *cli.BoolWithInverseFlag {
@@ -713,6 +716,13 @@ var (
 		Category: stepControlCategory,
 		Usage:    "Push the git ref(s) to the remote",
 		Sources:  cli.EnvVars(envPublishGitRefLegacy, envPublishGitRef, envReleaseGitRef),
+		Value:    true,
+	}
+	draftGithubReleaseFlag = &cli.BoolWithInverseFlag{
+		Name:     "draft-github-release",
+		Category: stepControlCategory,
+		Usage:    "Publish GitHub Release in drafts mode",
+		Sources:  cli.EnvVars(envDraftGithubRelease, envReleaseGithubDraft),
 		Value:    true,
 	}
 	githubReleaseFlag = &cli.BoolWithInverseFlag{

--- a/release/cmd/release.go
+++ b/release/cmd/release.go
@@ -180,6 +180,7 @@ var releaseSubCommands = func(cfg *Config) []*cli.Command {
 					calico.WithHelmIndex(c.Bool(helmIndexFlagName)),
 					calico.WithGitRef(c.Bool(gitRefFlag.Name)),
 					calico.WithGithubRelease(c.Bool(githubReleaseFlag.Name)),
+					calico.WithDraftRelease(c.Bool(draftGithubReleaseFlag.Name)),
 					calico.WithValidation(c.Bool(validationFlag.Name)),
 					calico.WithReleaseBranchValidation(c.Bool(branchCheckFlag.Name)),
 				}
@@ -213,41 +214,8 @@ var releaseSubCommands = func(cfg *Config) []*cli.Command {
 			},
 		},
 
-		// Publish a release to the public.
-		releasePublicSubCommands(cfg),
-
 		// Post-release validation.
 		releaseValidationSubCommand(cfg),
-	}
-}
-
-func releasePublicSubCommands(cfg *Config) *cli.Command {
-	flags := []cli.Flag{
-		orgFlag,
-		repoFlag,
-		repoRemoteFlag,
-	}
-	return &cli.Command{
-		Name:  "public",
-		Usage: "Make a published release available to the public",
-		Flags: flags,
-		Action: func(_ context.Context, c *cli.Command) error {
-			configureLogging("release-public.log")
-			ver, operatorVer, err := version.VersionsFromManifests(cfg.RepoRootDir)
-			if err != nil {
-				return err
-			}
-			opts := []calico.Option{
-				calico.WithRepoRoot(cfg.RepoRootDir),
-				calico.WithVersion(ver.FormattedString()),
-				calico.WithOperatorVersion(operatorVer.FormattedString()),
-				calico.WithGithubOrg(c.String(orgFlag.Name)),
-				calico.WithRepoName(c.String(repoFlag.Name)),
-				calico.WithRepoRemote(c.String(repoRemoteFlag.Name)),
-			}
-			m := calico.NewManager(opts...)
-			return m.ReleasePublic()
-		},
 	}
 }
 

--- a/release/deps.txt
+++ b/release/deps.txt
@@ -123,6 +123,7 @@ local:release/internal/charts
 local:release/internal/ci
 local:release/internal/command
 local:release/internal/defaults
+local:release/internal/distribution
 local:release/internal/github
 local:release/internal/hashreleaseserver
 local:release/internal/images

--- a/release/internal/charts/actions.go
+++ b/release/internal/charts/actions.go
@@ -226,7 +226,7 @@ func (s settings) buildIndex() error {
 	if err := os.MkdirAll(s.indexDir, utils.DirPerms); err != nil {
 		return s.Errorf("creating helm index dir: %w", err)
 	}
-	if err := utils.CopyFile(filepath.Join(staging, indexFileName), filepath.Join(s.indexDir, indexFileName)); err != nil {
+	if err := utils.CopyFile(IndexFilePath(staging), IndexFilePath(s.indexDir)); err != nil {
 		return s.Errorf("writing the helm index: %w", err)
 	}
 	return nil
@@ -237,7 +237,7 @@ func (s settings) downloadIndex() (string, error) {
 	if err != nil {
 		return "", s.Errorf("constructing helm index url: %w", err)
 	}
-	dest := filepath.Join(s.tmpDir, indexFileName)
+	dest := IndexFilePath(s.tmpDir)
 	if err := os.MkdirAll(filepath.Dir(dest), utils.DirPerms); err != nil {
 		return "", s.Errorf("creating dir for downloaded helm index: %w", err)
 	}

--- a/release/internal/charts/charts.go
+++ b/release/internal/charts/charts.go
@@ -88,6 +88,10 @@ var All = func() []string {
 	}
 }
 
+func IndexFilePath(baseDir string) string {
+	return filepath.Join(baseDir, indexFileName)
+}
+
 // Version qualifies the product version when the charts rev separately from
 // it. An empty suffix means the charts share the product version.
 func Version(productVersion, suffix string) string {

--- a/release/internal/distribution/actions.go
+++ b/release/internal/distribution/actions.go
@@ -1,0 +1,238 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package distribution
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/projectcalico/calico/release/internal/steps"
+)
+
+const filePerms = 0o644
+
+func BuildMetadata(m Metadata, dir string, opts ...MetadataOption) error {
+	s, err := newSettings(metadataStep, opts)
+	if err != nil {
+		return err
+	}
+	if err := m.validate(); err != nil {
+		return s.Errorf("%w", err)
+	}
+	if dir == "" {
+		return s.Errorf("no directory to write metadata to")
+	}
+
+	bs, err := yaml.Marshal(m)
+	if err != nil {
+		return s.Errorf("marshalling metadata: %w", err)
+	}
+	path := filepath.Join(dir, MetadataFileName)
+	if err := os.WriteFile(path, bs, filePerms); err != nil {
+		return s.Errorf("writing %s: %w", path, err)
+	}
+	s.Logger().WithField("path", path).Info("Wrote release metadata")
+	return nil
+}
+
+// Must be the last write into dir: a later write lands unchecksummed.
+func SHA256Sums(dir string, opts ...SumsOption) error {
+	s, err := newSettings(sumsStep, opts)
+	if err != nil {
+		return err
+	}
+	if dir == "" {
+		return s.Errorf("no directory to checksum")
+	}
+
+	names, err := sumCandidates(dir)
+	if err != nil {
+		return s.Errorf("%w", err)
+	}
+	if len(names) == 0 {
+		return s.Errorf("no files to checksum in %s", dir)
+	}
+
+	out, err := s.Runner().RunInDir(dir, "sha256sum", names, nil)
+	if err != nil {
+		s.Logger().Error(out)
+		return s.Errorf("checksumming %s: %w", dir, err)
+	}
+	path := filepath.Join(dir, SumsFileName)
+	if err := os.WriteFile(path, []byte(out), filePerms); err != nil {
+		return s.Errorf("writing %s: %w", path, err)
+	}
+	s.Logger().WithField("files", len(names)).Info("Wrote checksums")
+	return nil
+}
+
+// Only the top level is attached anywhere, so a nested checksum could never
+// be verified.
+func sumCandidates(dir string) ([]string, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, fmt.Errorf("reading %s: %w", dir, err)
+	}
+	var names []string
+	for _, e := range entries {
+		if e.IsDir() || e.Name() == SumsFileName {
+			continue
+		}
+		names = append(names, e.Name())
+	}
+	return names, nil
+}
+
+func Publish(uploads []Upload, confirm bool, opts ...PublishOption) error {
+	s, err := newSettings(artifactsStep, opts)
+	if err != nil {
+		return err
+	}
+	if len(uploads) == 0 {
+		return s.Errorf("no uploads to publish")
+	}
+	var errs []error
+	for _, u := range uploads {
+		if err := u.validate(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	if err := errors.Join(errs...); err != nil {
+		return s.Errorf("%w", err)
+	}
+	s.uploads, s.confirm = uploads, confirm
+	if !confirm {
+		// A dry run sends nothing, so a record would name unpublished artifacts.
+		s.refs = nil
+	}
+
+	pending, err := s.present()
+	if err != nil {
+		return err
+	}
+	if len(pending) == 0 {
+		s.Logger().Info("Nothing to publish")
+		return nil
+	}
+	if !confirm {
+		for _, u := range pending {
+			s.Logger().WithFields(map[string]any{"source": u.Source, "destination": u.Handler.Name()}).
+				Info("Dry run, not publishing")
+		}
+		return nil
+	}
+
+	s.Logger().WithField("uploads", len(pending)).Info("Publishing artifacts")
+	pubErr := s.push(pending)
+
+	// Record before reporting a failure: a partial publish is the run whose
+	// record decides what is already done.
+	if err := s.record(pending); err != nil {
+		return errors.Join(pubErr, err)
+	}
+	if pubErr != nil {
+		return pubErr
+	}
+	s.Logger().Info("Finished publishing artifacts")
+	return nil
+}
+
+func (s settings) present() ([]Upload, error) {
+	var (
+		out  []Upload
+		errs []error
+	)
+	for _, u := range s.uploads {
+		switch _, err := os.Stat(u.Source); {
+		case err == nil:
+			out = append(out, u)
+		case !errors.Is(err, os.ErrNotExist):
+			errs = append(errs, s.Errorf("reading %s: %w", u.Source, err))
+		case u.AllowMissing:
+			s.Logger().WithFields(map[string]any{"source": u.Source, "destination": u.Handler.Name()}).
+				Warn("Source does not exist, skipping")
+		default:
+			errs = append(errs, s.Errorf("%s is not built, and %s requires it", u.Source, u.Handler.Name()))
+		}
+	}
+	return out, errors.Join(errs...)
+}
+
+// Collected, not stopped at: a rerun needs every outstanding failure.
+func (s settings) push(uploads []Upload) error {
+	_, err := steps.Go(uploads, func(u Upload) (struct{}, error) {
+		return struct{}{}, s.publishOne(u)
+	})
+	return err
+}
+
+func (s settings) publishOne(u Upload) error {
+	log := s.Logger().WithFields(map[string]any{"source": u.Source, "destination": u.Handler.Name()})
+	for attempt := 0; ; attempt++ {
+		err := u.Handler.Publish(context.Background(), u.Source)
+		if err == nil {
+			log.Info("Published")
+			return nil
+		}
+		if attempt < steps.MaxRetries {
+			log.WithError(err).WithField("attempt", attempt).Warn("Publish failed, retrying")
+			continue
+		}
+		return s.Errorf("publishing %s to %s: %w", u.Source, u.Handler.Name(), err)
+	}
+}
+
+func (s settings) record(uploads []Upload) error {
+	if s.refs == nil {
+		return nil
+	}
+	refs := make([]string, 0, len(uploads))
+	for _, u := range uploads {
+		refs = append(refs, u.Handler.Name())
+	}
+	if err := s.refs.Add(refs...); err != nil {
+		return s.Errorf("recording published artifacts: %w", err)
+	}
+	return nil
+}
+
+func newSettings[O any](step string, opts []O) (settings, error) {
+	var s settings
+	s.Apply([]steps.Option{steps.WithName(step)})
+	for _, opt := range opts {
+		if err := applyTo(opt, &s); err != nil {
+			return s, s.Errorf("%w", err)
+		}
+	}
+	return s, nil
+}
+
+func applyTo(opt any, s *settings) error {
+	switch o := opt.(type) {
+	case PublishOption:
+		return o.applyPublish(s)
+	case MetadataOption:
+		return o.applyMetadata(s)
+	case SumsOption:
+		return o.applySums(s)
+	default:
+		return fmt.Errorf("unknown option type %T", opt)
+	}
+}

--- a/release/internal/distribution/actions.go
+++ b/release/internal/distribution/actions.go
@@ -22,7 +22,6 @@ import (
 	"path/filepath"
 
 	"github.com/sirupsen/logrus"
-	"gopkg.in/yaml.v3"
 
 	"github.com/projectcalico/calico/release/internal/steps"
 	"github.com/projectcalico/calico/release/internal/utils"
@@ -30,21 +29,21 @@ import (
 
 const filePerms = 0o644
 
-func BuildMetadata(m Metadata, dir string, opts ...MetadataOption) error {
+func BuildMetadata(a Attester, dir string, opts ...MetadataOption) error {
 	s, err := newSettings(metadataStep, opts)
 	if err != nil {
 		return err
 	}
-	if err := m.validate(); err != nil {
-		return s.Errorf("%w", err)
+	if a == nil {
+		return s.Errorf("no release to describe")
 	}
 	if dir == "" {
 		return s.Errorf("no directory to write metadata to")
 	}
 
-	bs, err := yaml.Marshal(m)
+	bs, err := a.Attest()
 	if err != nil {
-		return s.Errorf("marshalling metadata: %w", err)
+		return s.Errorf("%w", err)
 	}
 	path := filepath.Join(dir, MetadataFileName)
 	if err := os.WriteFile(path, bs, filePerms); err != nil {
@@ -123,21 +122,10 @@ func Publish(pipeline []Upload, confirm bool, opts ...PublishOption) error {
 		return s.Errorf("%w", err)
 	}
 	s.pipeline, s.confirm = pipeline, confirm
-	if !confirm {
-		// A dry run sends nothing, so a record would name unpublished artifacts.
-		s.refs = nil
-	}
 
 	s.Logger().WithField("uploads", len(s.pipeline)).Info("Publishing artifacts")
-	published, pubErr := s.push(s.pipeline)
-
-	// Record before reporting a failure: a partial publish is the run whose
-	// record decides what is already done.
-	if err := s.record(published); err != nil {
-		return errors.Join(pubErr, err)
-	}
-	if pubErr != nil {
-		return pubErr
+	if _, err := s.push(s.pipeline); err != nil {
+		return err
 	}
 	s.Logger().Info("Finished publishing artifacts")
 	return nil
@@ -190,20 +178,6 @@ func (s settings) publishOne(u Upload) error {
 		}
 		return s.Errorf("publishing %s to %s: %w", u.label(), u.dest(), err)
 	}
-}
-
-func (s settings) record(uploads []Upload) error {
-	if s.refs == nil {
-		return nil
-	}
-	refs := make([]string, 0, len(uploads))
-	for _, u := range uploads {
-		refs = append(refs, u.dest())
-	}
-	if err := s.refs.Add(refs...); err != nil {
-		return s.Errorf("recording published artifacts: %w", err)
-	}
-	return nil
 }
 
 func newSettings[O any](step string, opts []O) (settings, error) {

--- a/release/internal/distribution/actions.go
+++ b/release/internal/distribution/actions.go
@@ -21,9 +21,11 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v3"
 
 	"github.com/projectcalico/calico/release/internal/steps"
+	"github.com/projectcalico/calico/release/internal/utils"
 )
 
 const filePerms = 0o644
@@ -125,8 +127,9 @@ func Publish(pipeline []Upload, confirm bool, opts ...PublishOption) error {
 
 	if !confirm {
 		for _, u := range s.pipeline {
-			s.Logger().WithFields(map[string]any{"source": u.Source, "destination": u.Handler.Name()}).
-				Info("Dry run, not publishing")
+			s.Logger().WithFields(map[string]any{
+				"upload": u.label(), "source": u.Source, "destination": u.dest(),
+			}).Info("Dry run, not publishing")
 		}
 		return nil
 	}
@@ -146,8 +149,7 @@ func Publish(pipeline []Upload, confirm bool, opts ...PublishOption) error {
 	return nil
 }
 
-// Ordered, and stops at the first failure: a later upload may depend on an
-// earlier one having landed.
+// Ordered, and stops at the first failure as a later upload may depend on an earlier one.
 func (s settings) push(uploads []Upload) error {
 	for _, u := range uploads {
 		if err := s.publishOne(u); err != nil {
@@ -158,20 +160,23 @@ func (s settings) push(uploads []Upload) error {
 }
 
 func (s settings) publishOne(u Upload) error {
-	log := s.Logger().WithFields(map[string]any{"source": u.Source, "destination": u.Handler.Name()})
+	log := s.Logger().WithFields(logrus.Fields{
+		"upload": u.label(), "source": u.Source, "destination": u.dest(),
+	})
 
-	// Checked here rather than up front: an earlier upload in the list may be
-	// what creates this one's source.
+	if u.Skip {
+		log.Info("Skipping upload")
+		return nil
+	}
+	// Checked here rather than up front: an earlier upload in the list may
+	// be what creates this source.
 	if u.Source != "" {
-		switch _, err := os.Stat(u.Source); {
-		case err == nil:
-		case !errors.Is(err, os.ErrNotExist):
-			return s.Errorf("reading %s: %w", u.Source, err)
-		case u.AllowMissing:
-			log.Warn("Source does not exist, skipping")
-			return nil
-		default:
-			return s.Errorf("%s is not built, and %s requires it", u.Source, u.Handler.Name())
+		exists, err := utils.PathExists(u.Source)
+		if err != nil {
+			return s.Errorf("reading %s source (%s): %w", u.label(), u.Source, err)
+		}
+		if !exists {
+			return s.Errorf("%s source (%s) does not exist", u.label(), u.Source)
 		}
 	}
 
@@ -185,7 +190,7 @@ func (s settings) publishOne(u Upload) error {
 			log.WithError(err).WithField("attempt", attempt).Warn("Publish failed, retrying")
 			continue
 		}
-		return s.Errorf("publishing %s to %s: %w", u.Source, u.Handler.Name(), err)
+		return s.Errorf("publishing %s to %s: %w", u.label(), u.dest(), err)
 	}
 }
 
@@ -195,7 +200,7 @@ func (s settings) record(uploads []Upload) error {
 	}
 	refs := make([]string, 0, len(uploads))
 	for _, u := range uploads {
-		refs = append(refs, u.Handler.Name())
+		refs = append(refs, u.dest())
 	}
 	if err := s.refs.Add(refs...); err != nil {
 		return s.Errorf("recording published artifacts: %w", err)

--- a/release/internal/distribution/actions.go
+++ b/release/internal/distribution/actions.go
@@ -53,54 +53,6 @@ func BuildMetadata(a Attester, dir string, opts ...MetadataOption) error {
 	return nil
 }
 
-// Must be the last write into dir: a later write lands unchecksummed.
-func SHA256Sums(dir string, opts ...SumsOption) error {
-	s, err := newSettings(sumsStep, opts)
-	if err != nil {
-		return err
-	}
-	if dir == "" {
-		return s.Errorf("no directory to checksum")
-	}
-
-	names, err := sumCandidates(dir)
-	if err != nil {
-		return s.Errorf("%w", err)
-	}
-	if len(names) == 0 {
-		return s.Errorf("no files to checksum in %s", dir)
-	}
-
-	out, err := s.Runner().RunInDir(dir, "sha256sum", names, nil)
-	if err != nil {
-		s.Logger().Error(out)
-		return s.Errorf("checksumming %s: %w", dir, err)
-	}
-	path := filepath.Join(dir, SumsFileName)
-	if err := os.WriteFile(path, []byte(out), filePerms); err != nil {
-		return s.Errorf("writing %s: %w", path, err)
-	}
-	s.Logger().WithField("files", len(names)).Info("Wrote checksums")
-	return nil
-}
-
-// Only the top level is attached anywhere, so a nested checksum could never
-// be verified.
-func sumCandidates(dir string) ([]string, error) {
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		return nil, fmt.Errorf("reading %s: %w", dir, err)
-	}
-	var names []string
-	for _, e := range entries {
-		if e.IsDir() || e.Name() == SumsFileName {
-			continue
-		}
-		names = append(names, e.Name())
-	}
-	return names, nil
-}
-
 func Publish(pipeline []Upload, opts ...PublishOption) error {
 	s, err := newSettings(artifactsStep, opts)
 	if err != nil {
@@ -132,8 +84,7 @@ func Publish(pipeline []Upload, opts ...PublishOption) error {
 }
 
 // Ordered, and stops at the first failure as a later upload may depend on an earlier one.
-// Returns what published, so a record never names an upload that failed or
-// was never reached.
+// Returns what published, so a record never names an upload that failed or was never reached.
 func (s settings) push(uploads []Upload) ([]Upload, error) {
 	var done []Upload
 	for _, u := range uploads {

--- a/release/internal/distribution/actions.go
+++ b/release/internal/distribution/actions.go
@@ -100,16 +100,16 @@ func sumCandidates(dir string) ([]string, error) {
 	return names, nil
 }
 
-func Publish(uploads []Upload, confirm bool, opts ...PublishOption) error {
+func Publish(pipeline []Upload, confirm bool, opts ...PublishOption) error {
 	s, err := newSettings(artifactsStep, opts)
 	if err != nil {
 		return err
 	}
-	if len(uploads) == 0 {
+	if len(pipeline) == 0 {
 		return s.Errorf("no uploads to publish")
 	}
 	var errs []error
-	for _, u := range uploads {
+	for _, u := range pipeline {
 		if err := u.validate(); err != nil {
 			errs = append(errs, err)
 		}
@@ -117,34 +117,26 @@ func Publish(uploads []Upload, confirm bool, opts ...PublishOption) error {
 	if err := errors.Join(errs...); err != nil {
 		return s.Errorf("%w", err)
 	}
-	s.uploads, s.confirm = uploads, confirm
+	s.pipeline, s.confirm = pipeline, confirm
 	if !confirm {
 		// A dry run sends nothing, so a record would name unpublished artifacts.
 		s.refs = nil
 	}
 
-	pending, err := s.present()
-	if err != nil {
-		return err
-	}
-	if len(pending) == 0 {
-		s.Logger().Info("Nothing to publish")
-		return nil
-	}
 	if !confirm {
-		for _, u := range pending {
+		for _, u := range s.pipeline {
 			s.Logger().WithFields(map[string]any{"source": u.Source, "destination": u.Handler.Name()}).
 				Info("Dry run, not publishing")
 		}
 		return nil
 	}
 
-	s.Logger().WithField("uploads", len(pending)).Info("Publishing artifacts")
-	pubErr := s.push(pending)
+	s.Logger().WithField("uploads", len(s.pipeline)).Info("Publishing artifacts")
+	pubErr := s.push(s.pipeline)
 
 	// Record before reporting a failure: a partial publish is the run whose
 	// record decides what is already done.
-	if err := s.record(pending); err != nil {
+	if err := s.record(s.pipeline); err != nil {
 		return errors.Join(pubErr, err)
 	}
 	if pubErr != nil {
@@ -154,37 +146,35 @@ func Publish(uploads []Upload, confirm bool, opts ...PublishOption) error {
 	return nil
 }
 
-func (s settings) present() ([]Upload, error) {
-	var (
-		out  []Upload
-		errs []error
-	)
-	for _, u := range s.uploads {
-		switch _, err := os.Stat(u.Source); {
-		case err == nil:
-			out = append(out, u)
-		case !errors.Is(err, os.ErrNotExist):
-			errs = append(errs, s.Errorf("reading %s: %w", u.Source, err))
-		case u.AllowMissing:
-			s.Logger().WithFields(map[string]any{"source": u.Source, "destination": u.Handler.Name()}).
-				Warn("Source does not exist, skipping")
-		default:
-			errs = append(errs, s.Errorf("%s is not built, and %s requires it", u.Source, u.Handler.Name()))
+// Ordered, and stops at the first failure: a later upload may depend on an
+// earlier one having landed.
+func (s settings) push(uploads []Upload) error {
+	for _, u := range uploads {
+		if err := s.publishOne(u); err != nil {
+			return err
 		}
 	}
-	return out, errors.Join(errs...)
-}
-
-// Collected, not stopped at: a rerun needs every outstanding failure.
-func (s settings) push(uploads []Upload) error {
-	_, err := steps.Go(uploads, func(u Upload) (struct{}, error) {
-		return struct{}{}, s.publishOne(u)
-	})
-	return err
+	return nil
 }
 
 func (s settings) publishOne(u Upload) error {
 	log := s.Logger().WithFields(map[string]any{"source": u.Source, "destination": u.Handler.Name()})
+
+	// Checked here rather than up front: an earlier upload in the list may be
+	// what creates this one's source.
+	if u.Source != "" {
+		switch _, err := os.Stat(u.Source); {
+		case err == nil:
+		case !errors.Is(err, os.ErrNotExist):
+			return s.Errorf("reading %s: %w", u.Source, err)
+		case u.AllowMissing:
+			log.Warn("Source does not exist, skipping")
+			return nil
+		default:
+			return s.Errorf("%s is not built, and %s requires it", u.Source, u.Handler.Name())
+		}
+	}
+
 	for attempt := 0; ; attempt++ {
 		err := u.Handler.Publish(context.Background(), u.Source)
 		if err == nil {

--- a/release/internal/distribution/actions.go
+++ b/release/internal/distribution/actions.go
@@ -112,6 +112,9 @@ func Publish(pipeline []Upload, confirm bool, opts ...PublishOption) error {
 	}
 	var errs []error
 	for _, u := range pipeline {
+		if u.Skip {
+			continue
+		}
 		if err := u.validate(); err != nil {
 			errs = append(errs, err)
 		}
@@ -125,21 +128,12 @@ func Publish(pipeline []Upload, confirm bool, opts ...PublishOption) error {
 		s.refs = nil
 	}
 
-	if !confirm {
-		for _, u := range s.pipeline {
-			s.Logger().WithFields(map[string]any{
-				"upload": u.label(), "source": u.Source, "destination": u.dest(),
-			}).Info("Dry run, not publishing")
-		}
-		return nil
-	}
-
 	s.Logger().WithField("uploads", len(s.pipeline)).Info("Publishing artifacts")
-	pubErr := s.push(s.pipeline)
+	published, pubErr := s.push(s.pipeline)
 
 	// Record before reporting a failure: a partial publish is the run whose
 	// record decides what is already done.
-	if err := s.record(s.pipeline); err != nil {
+	if err := s.record(published); err != nil {
 		return errors.Join(pubErr, err)
 	}
 	if pubErr != nil {
@@ -150,13 +144,17 @@ func Publish(pipeline []Upload, confirm bool, opts ...PublishOption) error {
 }
 
 // Ordered, and stops at the first failure as a later upload may depend on an earlier one.
-func (s settings) push(uploads []Upload) error {
+// Returns what published, so a record never names an upload that failed or
+// was never reached.
+func (s settings) push(uploads []Upload) ([]Upload, error) {
+	var done []Upload
 	for _, u := range uploads {
 		if err := s.publishOne(u); err != nil {
-			return err
+			return done, err
 		}
+		done = append(done, u)
 	}
-	return nil
+	return done, nil
 }
 
 func (s settings) publishOne(u Upload) error {

--- a/release/internal/distribution/actions.go
+++ b/release/internal/distribution/actions.go
@@ -101,7 +101,7 @@ func sumCandidates(dir string) ([]string, error) {
 	return names, nil
 }
 
-func Publish(pipeline []Upload, confirm bool, opts ...PublishOption) error {
+func Publish(pipeline []Upload, opts ...PublishOption) error {
 	s, err := newSettings(artifactsStep, opts)
 	if err != nil {
 		return err
@@ -121,7 +121,7 @@ func Publish(pipeline []Upload, confirm bool, opts ...PublishOption) error {
 	if err := errors.Join(errs...); err != nil {
 		return s.Errorf("%w", err)
 	}
-	s.pipeline, s.confirm = pipeline, confirm
+	s.pipeline = pipeline
 
 	s.Logger().WithField("uploads", len(s.pipeline)).Info("Publishing artifacts")
 	if _, err := s.push(s.pipeline); err != nil {

--- a/release/internal/distribution/actions_test.go
+++ b/release/internal/distribution/actions_test.go
@@ -210,27 +210,22 @@ func TestPublishMissingSource(t *testing.T) {
 	}
 }
 
-func TestPublishCollectsEveryFailure(t *testing.T) {
+// A later upload can depend on an earlier one, so a failure stops the list
+// rather than publishing against a broken step.
+func TestPublishStopsAtTheFirstFailure(t *testing.T) {
 	dir := dirWith(t, "release.tgz")
 	bad := &fakeDest{name: "s3://bad/", err: errors.New("access denied")}
-	worse := &fakeDest{name: "gs://worse/", err: errors.New("no such bucket")}
-	good := &fakeDest{name: "github"}
+	after := &fakeDest{name: "github"}
 
 	err := Publish([]Upload{
 		{Source: dir, Handler: bad},
-		{Source: dir, Handler: worse},
-		{Source: dir, Handler: good},
+		{Source: dir, Handler: after},
 	}, true)
-	if err == nil {
-		t.Fatal("expected the failures reported")
+	if err == nil || !strings.Contains(err.Error(), "s3://bad/") {
+		t.Fatalf("expected the failure reported, got %v", err)
 	}
-	for _, want := range []string{"s3://bad/", "gs://worse/"} {
-		if !strings.Contains(err.Error(), want) {
-			t.Errorf("expected %s named in %v", want, err)
-		}
-	}
-	if got := good.got(); len(got) != 1 {
-		t.Errorf("expected the working destination still published, got %v", got)
+	if got := after.got(); len(got) != 0 {
+		t.Errorf("expected nothing published after the failure, got %v", got)
 	}
 }
 
@@ -250,6 +245,25 @@ func TestPublishRecordsWhatSucceededDespiteAFailure(t *testing.T) {
 	}
 }
 
+// A handler with its own rules rejects a bad upload before anything is sent.
+func TestPublishRejectsASourcelessUploadToADestinationThatNeedsOne(t *testing.T) {
+	err := Publish([]Upload{{Handler: S3{URI: "s3://bucket/charts/"}}}, true)
+	if err == nil || !strings.Contains(err.Error(), "no source") {
+		t.Errorf("expected a missing source to be rejected, got %v", err)
+	}
+}
+
+// A handler that finds its own content takes no source, so it runs.
+func TestPublishSourcelessHandlerRuns(t *testing.T) {
+	d := &fakeDest{name: "images"}
+	if err := Publish([]Upload{{Handler: d}}, true); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	if got := d.got(); len(got) != 1 || got[0] != "" {
+		t.Errorf("expected one call with an empty source, got %v", got)
+	}
+}
+
 func TestPublishRejectsIncompleteUploads(t *testing.T) {
 	for _, tc := range []struct {
 		name    string
@@ -257,7 +271,6 @@ func TestPublishRejectsIncompleteUploads(t *testing.T) {
 		want    string
 	}{
 		{"none", nil, "no uploads"},
-		{"no source", []Upload{{Handler: &fakeDest{name: "x"}}}, "no source"},
 		{"no destination", []Upload{{Source: "/tmp"}}, "no destination"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/release/internal/distribution/actions_test.go
+++ b/release/internal/distribution/actions_test.go
@@ -24,6 +24,10 @@ import (
 	"strings"
 	"sync"
 	"testing"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/projectcalico/calico/release/internal/registry"
 )
 
 type fakeDest struct {
@@ -49,16 +53,6 @@ func (d *fakeDest) got() []string {
 	return slices.Clone(d.srcs)
 }
 
-type fakeRecorder struct {
-	refs []string
-	err  error
-}
-
-func (r *fakeRecorder) Add(refs ...string) error {
-	r.refs = append(r.refs, refs...)
-	return r.err
-}
-
 func dirWith(t *testing.T, names ...string) string {
 	t.Helper()
 	dir := t.TempDir()
@@ -79,7 +73,7 @@ func TestBuildMetadata(t *testing.T) {
 	m := Metadata{
 		Version:         "v3.30.0",
 		OperatorVersion: "v1.38.0",
-		Images:          []string{"calico/node:v3.30.0"},
+		Images:          []Component{{registry.Component{Registry: "quay.io", Image: "calico/node", Version: "v3.30.0"}}},
 		ChartVersion:    "v3.30.0",
 	}
 	if err := BuildMetadata(m, dir); err != nil {
@@ -104,8 +98,8 @@ func TestBuildMetadataRejectsIncompleteInput(t *testing.T) {
 		m    Metadata
 		want string
 	}{
-		{"no version", Metadata{OperatorVersion: "v1", Images: []string{"i"}}, "version"},
-		{"no operator version", Metadata{Version: "v1", Images: []string{"i"}}, "operator version"},
+		{"no version", Metadata{OperatorVersion: "v1", Images: []Component{{}}}, "version"},
+		{"no operator version", Metadata{Version: "v1", Images: []Component{{}}}, "operator version"},
 		{"no images", Metadata{Version: "v1", OperatorVersion: "v1"}, "images"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -167,18 +161,12 @@ func TestPublishSendsEachSourceToItsDestination(t *testing.T) {
 func TestPublishDryRunStillRunsTheSteps(t *testing.T) {
 	dir := dirWith(t, "release.tgz")
 	d := &fakeDest{name: "github"}
-	rec := &fakeRecorder{}
 
-	if err := Publish([]Upload{{Source: dir, Handler: d}}, false, WithRecord(rec)); err != nil {
+	if err := Publish([]Upload{{Source: dir, Handler: d}}, false); err != nil {
 		t.Fatalf("Publish: %v", err)
 	}
 	if got := d.got(); len(got) != 1 {
 		t.Errorf("expected the handler run, got %v", got)
-	}
-	// Nothing reached a remote, so a record would name artifacts that are
-	// not there.
-	if len(rec.refs) != 0 {
-		t.Errorf("expected nothing recorded, got %v", rec.refs)
 	}
 }
 
@@ -229,22 +217,6 @@ func TestPublishStopsAtTheFirstFailure(t *testing.T) {
 	}
 	if got := after.got(); len(got) != 0 {
 		t.Errorf("expected nothing published after the failure, got %v", got)
-	}
-}
-
-func TestPublishRecordsWhatSucceededDespiteAFailure(t *testing.T) {
-	dir := dirWith(t, "release.tgz")
-	rec := &fakeRecorder{}
-
-	err := Publish([]Upload{
-		{Source: dir, Handler: &fakeDest{name: "github"}},
-		{Source: dir, Handler: &fakeDest{name: "s3://bad/", err: errors.New("denied")}},
-	}, true, WithRecord(rec))
-	if err == nil {
-		t.Fatal("expected the failure reported")
-	}
-	if !slices.Contains(rec.refs, "github") {
-		t.Errorf("expected the publish recorded, got %v", rec.refs)
 	}
 }
 
@@ -331,30 +303,6 @@ func TestUploadLabel(t *testing.T) {
 	}
 }
 
-// A record is what a resume reads to decide what is already done, so an
-// upload that failed or was never reached must not appear in it.
-func TestPublishRecordsOnlyWhatPublished(t *testing.T) {
-	dir := dirWith(t, "release.tgz")
-	rec := &fakeRecorder{}
-
-	err := Publish([]Upload{
-		{Source: dir, Handler: &fakeDest{name: "first"}},
-		{Source: dir, Handler: &fakeDest{name: "fails", err: errors.New("denied")}},
-		{Source: dir, Handler: &fakeDest{name: "never reached"}},
-	}, true, WithRecord(rec))
-	if err == nil {
-		t.Fatal("expected the failure reported")
-	}
-	if !slices.Contains(rec.refs, "first") {
-		t.Errorf("expected the published upload recorded, got %v", rec.refs)
-	}
-	for _, unwanted := range []string{"fails", "never reached"} {
-		if slices.Contains(rec.refs, unwanted) {
-			t.Errorf("recorded %q, which did not publish: %v", unwanted, rec.refs)
-		}
-	}
-}
-
 // A skipped upload never runs, so it has nothing for a handler's rules to
 // object to.
 func TestPublishSkipsValidationOfASkippedUpload(t *testing.T) {
@@ -367,5 +315,77 @@ func TestPublishSkipsValidationOfASkippedUpload(t *testing.T) {
 	}
 	if got := d.got(); len(got) != 1 {
 		t.Errorf("expected the unskipped upload to run, got %v", got)
+	}
+}
+
+// A product embeds Release for the shared fields and the checks, and writes
+// its own Attest so its own fields are marshalled too. Inheriting the
+// embedded one would silently drop them.
+func TestBuildMetadataWritesAProductsOwnFields(t *testing.T) {
+	dir := t.TempDir()
+	rel := productRelease{
+		Metadata: Metadata{
+			Version:         "v3.30.0",
+			OperatorVersion: "v1.38.0",
+			Images:          []Component{{registry.Component{Registry: "example.test", Image: "node", Version: "v3.30.0"}}},
+			ChartVersion:    "v3.30.0",
+		},
+		Upstream: "v3.30.0",
+	}
+	if err := BuildMetadata(rel, dir); err != nil {
+		t.Fatalf("BuildMetadata: %v", err)
+	}
+
+	bs, err := os.ReadFile(filepath.Join(dir, MetadataFileName))
+	if err != nil {
+		t.Fatalf("reading metadata: %v", err)
+	}
+	for _, want := range []string{"version: v3.30.0", "upstreamVersion: v3.30.0"} {
+		if !strings.Contains(string(bs), want) {
+			t.Errorf("expected %q in:\n%s", want, bs)
+		}
+	}
+}
+
+type productRelease struct {
+	Metadata  `yaml:",inline"`
+	Upstream string `yaml:"upstreamVersion"`
+}
+
+func (p productRelease) Attest() ([]byte, error) {
+	if _, err := p.Metadata.Attest(); err != nil {
+		return nil, err
+	}
+	return yaml.Marshal(p)
+}
+
+// The published file lists images as references, not as their parts: the one
+// consumer decodes them as strings and pulls what it finds.
+func TestBuildMetadataRendersImagesAsReferences(t *testing.T) {
+	dir := t.TempDir()
+	err := BuildMetadata(Metadata{
+		Version:         "v3.30.0",
+		OperatorVersion: "v1.38.0",
+		ChartVersion:    "v3.30.0",
+		Images: []Component{
+			{registry.Component{Registry: "quay.io", Image: "calico/node", Version: "v3.30.0"}},
+		},
+	}, dir)
+	if err != nil {
+		t.Fatalf("BuildMetadata: %v", err)
+	}
+
+	var got struct {
+		Images []string `yaml:"images"`
+	}
+	bs, err := os.ReadFile(filepath.Join(dir, MetadataFileName))
+	if err != nil {
+		t.Fatalf("reading metadata: %v", err)
+	}
+	if err := yaml.Unmarshal(bs, &got); err != nil {
+		t.Fatalf("decoding images as strings: %v", err)
+	}
+	if len(got.Images) != 1 || got.Images[0] != "quay.io/calico/node:v3.30.0" {
+		t.Errorf("images = %v, want [quay.io/calico/node:v3.30.0]", got.Images)
 	}
 }

--- a/release/internal/distribution/actions_test.go
+++ b/release/internal/distribution/actions_test.go
@@ -181,18 +181,18 @@ func TestPublishDryRunSendsNothing(t *testing.T) {
 
 func TestPublishMissingSource(t *testing.T) {
 	for _, tc := range []struct {
-		name         string
-		allowMissing bool
-		wantErr      string
+		name    string
+		skip    bool
+		wantErr string
 	}{
-		{name: "fails by default", wantErr: "not built"},
-		{name: "skips when allowed", allowMissing: true},
+		{name: "fails by default", wantErr: "does not exist"},
+		{name: "skips when allowed", skip: true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			d := &fakeDest{name: "s3://bucket/files/"}
 			absent := filepath.Join(t.TempDir(), "never-built")
 
-			err := Publish([]Upload{{Source: absent, Handler: d, AllowMissing: tc.allowMissing}}, true)
+			err := Publish([]Upload{{Source: absent, Handler: d, Skip: tc.skip}}, true)
 
 			if tc.wantErr != "" {
 				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
@@ -306,4 +306,24 @@ func (d *flakyDest) Publish(context.Context, string) error {
 		return fmt.Errorf("transient failure %d", d.calls)
 	}
 	return nil
+}
+
+// A log reader tells two uploads to one bucket apart by name, so an upload
+// with none falls back to its destination rather than logging nothing.
+func TestUploadLabel(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		up   Upload
+		want string
+	}{
+		{"names itself", Upload{Name: "chart index", Handler: S3{URI: "s3://b/charts/"}}, "chart index"},
+		{"falls back to the destination", Upload{Handler: S3{URI: "s3://b/charts/"}}, "s3://b/charts/"},
+		{"a preparer falls back to its kind", Upload{Handler: Preparer{Kind: "metadata"}}, "metadata"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.up.label(); got != tc.want {
+				t.Errorf("label() = %q, want %q", got, tc.want)
+			}
+		})
+	}
 }

--- a/release/internal/distribution/actions_test.go
+++ b/release/internal/distribution/actions_test.go
@@ -162,7 +162,9 @@ func TestPublishSendsEachSourceToItsDestination(t *testing.T) {
 	}
 }
 
-func TestPublishDryRunSendsNothing(t *testing.T) {
+// A dry run still runs every step, so it exercises everything a real run
+// does except the remote write — which each handler suppresses itself.
+func TestPublishDryRunStillRunsTheSteps(t *testing.T) {
 	dir := dirWith(t, "release.tgz")
 	d := &fakeDest{name: "github"}
 	rec := &fakeRecorder{}
@@ -170,10 +172,11 @@ func TestPublishDryRunSendsNothing(t *testing.T) {
 	if err := Publish([]Upload{{Source: dir, Handler: d}}, false, WithRecord(rec)); err != nil {
 		t.Fatalf("Publish: %v", err)
 	}
-	if got := d.got(); len(got) != 0 {
-		t.Errorf("expected nothing published, got %v", got)
+	if got := d.got(); len(got) != 1 {
+		t.Errorf("expected the handler run, got %v", got)
 	}
-	// Recording a dry run would name artifacts that were never sent.
+	// Nothing reached a remote, so a record would name artifacts that are
+	// not there.
 	if len(rec.refs) != 0 {
 		t.Errorf("expected nothing recorded, got %v", rec.refs)
 	}
@@ -325,5 +328,44 @@ func TestUploadLabel(t *testing.T) {
 				t.Errorf("label() = %q, want %q", got, tc.want)
 			}
 		})
+	}
+}
+
+// A record is what a resume reads to decide what is already done, so an
+// upload that failed or was never reached must not appear in it.
+func TestPublishRecordsOnlyWhatPublished(t *testing.T) {
+	dir := dirWith(t, "release.tgz")
+	rec := &fakeRecorder{}
+
+	err := Publish([]Upload{
+		{Source: dir, Handler: &fakeDest{name: "first"}},
+		{Source: dir, Handler: &fakeDest{name: "fails", err: errors.New("denied")}},
+		{Source: dir, Handler: &fakeDest{name: "never reached"}},
+	}, true, WithRecord(rec))
+	if err == nil {
+		t.Fatal("expected the failure reported")
+	}
+	if !slices.Contains(rec.refs, "first") {
+		t.Errorf("expected the published upload recorded, got %v", rec.refs)
+	}
+	for _, unwanted := range []string{"fails", "never reached"} {
+		if slices.Contains(rec.refs, unwanted) {
+			t.Errorf("recorded %q, which did not publish: %v", unwanted, rec.refs)
+		}
+	}
+}
+
+// A skipped upload never runs, so it has nothing for a handler's rules to
+// object to.
+func TestPublishSkipsValidationOfASkippedUpload(t *testing.T) {
+	d := &fakeDest{name: "s3://bucket/rpms/"}
+	if err := Publish([]Upload{
+		{Handler: S3{URI: "s3://bucket/rpms/"}, Skip: true},
+		{Source: dirWith(t, "x"), Handler: d},
+	}, true); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	if got := d.got(); len(got) != 1 {
+		t.Errorf("expected the unskipped upload to run, got %v", got)
 	}
 }

--- a/release/internal/distribution/actions_test.go
+++ b/release/internal/distribution/actions_test.go
@@ -24,10 +24,6 @@ import (
 	"strings"
 	"sync"
 	"testing"
-
-	"gopkg.in/yaml.v3"
-
-	"github.com/projectcalico/calico/release/internal/registry"
 )
 
 type fakeDest struct {
@@ -66,48 +62,6 @@ func dirWith(t *testing.T, names ...string) string {
 		}
 	}
 	return dir
-}
-
-func TestBuildMetadata(t *testing.T) {
-	dir := t.TempDir()
-	m := Metadata{
-		Version:         "v3.30.0",
-		OperatorVersion: "v1.38.0",
-		Images:          []Component{{registry.Component{Registry: "quay.io", Image: "calico/node", Version: "v3.30.0"}}},
-		ChartVersion:    "v3.30.0",
-	}
-	if err := BuildMetadata(m, dir); err != nil {
-		t.Fatalf("BuildMetadata: %v", err)
-	}
-
-	bs, err := os.ReadFile(filepath.Join(dir, MetadataFileName))
-	if err != nil {
-		t.Fatalf("reading metadata: %v", err)
-	}
-	// Pinned to literal keys: a round-trip would pass through a rename.
-	for _, want := range []string{"version: v3.30.0", "operatorVersion: v1.38.0", "helmChartVersion: v3.30.0"} {
-		if !strings.Contains(string(bs), want) {
-			t.Errorf("expected %q in:\n%s", want, bs)
-		}
-	}
-}
-
-func TestBuildMetadataRejectsIncompleteInput(t *testing.T) {
-	for _, tc := range []struct {
-		name string
-		m    Metadata
-		want string
-	}{
-		{"no version", Metadata{OperatorVersion: "v1", Images: []Component{{}}}, "version"},
-		{"no operator version", Metadata{Version: "v1", Images: []Component{{}}}, "operator version"},
-		{"no images", Metadata{Version: "v1", OperatorVersion: "v1"}, "images"},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			if err := BuildMetadata(tc.m, t.TempDir()); err == nil || !strings.Contains(err.Error(), tc.want) {
-				t.Errorf("expected an error naming %q, got %v", tc.want, err)
-			}
-		})
-	}
 }
 
 func TestSHA256SumsSkipsDirectoriesAndItself(t *testing.T) {
@@ -318,74 +272,44 @@ func TestPublishSkipsValidationOfASkippedUpload(t *testing.T) {
 	}
 }
 
-// A product embeds Release for the shared fields and the checks, and writes
-// its own Attest so its own fields are marshalled too. Inheriting the
-// embedded one would silently drop them.
-func TestBuildMetadataWritesAProductsOwnFields(t *testing.T) {
+// attestation is a product's record: it validates itself and marshals itself,
+// and the verb writes whatever bytes it hands back.
+type attestation struct {
+	body []byte
+	err  error
+}
+
+func (a attestation) Attest() ([]byte, error) { return a.body, a.err }
+
+func TestBuildMetadata(t *testing.T) {
 	dir := t.TempDir()
-	rel := productRelease{
-		Metadata: Metadata{
-			Version:         "v3.30.0",
-			OperatorVersion: "v1.38.0",
-			Images:          []Component{{registry.Component{Registry: "example.test", Image: "node", Version: "v3.30.0"}}},
-			ChartVersion:    "v3.30.0",
-		},
-		Upstream: "v3.30.0",
-	}
-	if err := BuildMetadata(rel, dir); err != nil {
+	if err := BuildMetadata(attestation{body: []byte("version: v3.30.0\n")}, dir); err != nil {
 		t.Fatalf("BuildMetadata: %v", err)
 	}
-
-	bs, err := os.ReadFile(filepath.Join(dir, MetadataFileName))
+	got, err := os.ReadFile(filepath.Join(dir, MetadataFileName))
 	if err != nil {
 		t.Fatalf("reading metadata: %v", err)
 	}
-	for _, want := range []string{"version: v3.30.0", "upstreamVersion: v3.30.0"} {
-		if !strings.Contains(string(bs), want) {
-			t.Errorf("expected %q in:\n%s", want, bs)
-		}
+	if string(got) != "version: v3.30.0\n" {
+		t.Errorf("wrote %q, want the bytes the record produced", got)
 	}
 }
 
-type productRelease struct {
-	Metadata `yaml:",inline"`
-	Upstream string `yaml:"upstreamVersion"`
-}
-
-func (p productRelease) Attest() ([]byte, error) {
-	if _, err := p.Metadata.Attest(); err != nil {
-		return nil, err
-	}
-	return yaml.Marshal(p)
-}
-
-// The published file lists images as references, not as their parts: the one
-// consumer decodes them as strings and pulls what it finds.
-func TestBuildMetadataRendersImagesAsReferences(t *testing.T) {
+// A record that cannot vouch for itself is not written at all, rather than
+// leaving a half-filled file for a consumer to read.
+func TestBuildMetadataWritesNothingWhenTheRecordFails(t *testing.T) {
 	dir := t.TempDir()
-	err := BuildMetadata(Metadata{
-		Version:         "v3.30.0",
-		OperatorVersion: "v1.38.0",
-		ChartVersion:    "v3.30.0",
-		Images: []Component{
-			{registry.Component{Registry: "quay.io", Image: "calico/node", Version: "v3.30.0"}},
-		},
-	}, dir)
-	if err != nil {
-		t.Fatalf("BuildMetadata: %v", err)
+	err := BuildMetadata(attestation{err: errors.New("no version specified")}, dir)
+	if err == nil || !strings.Contains(err.Error(), "no version specified") {
+		t.Fatalf("expected the record's own error, got %v", err)
 	}
+	if _, err := os.Stat(filepath.Join(dir, MetadataFileName)); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("expected no file written, got %v", err)
+	}
+}
 
-	var got struct {
-		Images []string `yaml:"images"`
-	}
-	bs, err := os.ReadFile(filepath.Join(dir, MetadataFileName))
-	if err != nil {
-		t.Fatalf("reading metadata: %v", err)
-	}
-	if err := yaml.Unmarshal(bs, &got); err != nil {
-		t.Fatalf("decoding images as strings: %v", err)
-	}
-	if len(got.Images) != 1 || got.Images[0] != "quay.io/calico/node:v3.30.0" {
-		t.Errorf("images = %v, want [quay.io/calico/node:v3.30.0]", got.Images)
+func TestBuildMetadataNeedsADirectory(t *testing.T) {
+	if err := BuildMetadata(attestation{body: []byte("x")}, ""); err == nil {
+		t.Error("expected an error with no directory to write to")
 	}
 }

--- a/release/internal/distribution/actions_test.go
+++ b/release/internal/distribution/actions_test.go
@@ -144,7 +144,7 @@ func TestPublishSendsEachSourceToItsDestination(t *testing.T) {
 	err := Publish([]Upload{
 		{Source: dir, Handler: gh},
 		{Source: filepath.Join(dir, "charts"), Handler: s3},
-	}, true)
+	})
 	if err != nil {
 		t.Fatalf("Publish: %v", err)
 	}
@@ -162,7 +162,7 @@ func TestPublishDryRunStillRunsTheSteps(t *testing.T) {
 	dir := dirWith(t, "release.tgz")
 	d := &fakeDest{name: "github"}
 
-	if err := Publish([]Upload{{Source: dir, Handler: d}}, false); err != nil {
+	if err := Publish([]Upload{{Source: dir, Handler: d}}); err != nil {
 		t.Fatalf("Publish: %v", err)
 	}
 	if got := d.got(); len(got) != 1 {
@@ -183,7 +183,7 @@ func TestPublishMissingSource(t *testing.T) {
 			d := &fakeDest{name: "s3://bucket/files/"}
 			absent := filepath.Join(t.TempDir(), "never-built")
 
-			err := Publish([]Upload{{Source: absent, Handler: d, Skip: tc.skip}}, true)
+			err := Publish([]Upload{{Source: absent, Handler: d, Skip: tc.skip}})
 
 			if tc.wantErr != "" {
 				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
@@ -211,7 +211,7 @@ func TestPublishStopsAtTheFirstFailure(t *testing.T) {
 	err := Publish([]Upload{
 		{Source: dir, Handler: bad},
 		{Source: dir, Handler: after},
-	}, true)
+	})
 	if err == nil || !strings.Contains(err.Error(), "s3://bad/") {
 		t.Fatalf("expected the failure reported, got %v", err)
 	}
@@ -222,7 +222,7 @@ func TestPublishStopsAtTheFirstFailure(t *testing.T) {
 
 // A handler with its own rules rejects a bad upload before anything is sent.
 func TestPublishRejectsASourcelessUploadToADestinationThatNeedsOne(t *testing.T) {
-	err := Publish([]Upload{{Handler: S3{URI: "s3://bucket/charts/"}}}, true)
+	err := Publish([]Upload{{Handler: S3{URI: "s3://bucket/charts/"}}})
 	if err == nil || !strings.Contains(err.Error(), "no source") {
 		t.Errorf("expected a missing source to be rejected, got %v", err)
 	}
@@ -231,7 +231,7 @@ func TestPublishRejectsASourcelessUploadToADestinationThatNeedsOne(t *testing.T)
 // A handler that finds its own content takes no source, so it runs.
 func TestPublishSourcelessHandlerRuns(t *testing.T) {
 	d := &fakeDest{name: "images"}
-	if err := Publish([]Upload{{Handler: d}}, true); err != nil {
+	if err := Publish([]Upload{{Handler: d}}); err != nil {
 		t.Fatalf("Publish: %v", err)
 	}
 	if got := d.got(); len(got) != 1 || got[0] != "" {
@@ -249,7 +249,7 @@ func TestPublishRejectsIncompleteUploads(t *testing.T) {
 		{"no destination", []Upload{{Source: "/tmp"}}, "no destination"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			if err := Publish(tc.uploads, true); err == nil || !strings.Contains(err.Error(), tc.want) {
+			if err := Publish(tc.uploads); err == nil || !strings.Contains(err.Error(), tc.want) {
 				t.Errorf("expected an error containing %q, got %v", tc.want, err)
 			}
 		})
@@ -260,7 +260,7 @@ func TestPublishRetriesBeforeGivingUp(t *testing.T) {
 	dir := dirWith(t, "release.tgz")
 	d := &flakyDest{failures: 1}
 
-	if err := Publish([]Upload{{Source: dir, Handler: d}}, true); err != nil {
+	if err := Publish([]Upload{{Source: dir, Handler: d}}); err != nil {
 		t.Fatalf("expected the retry to succeed, got %v", err)
 	}
 	if d.calls != 2 {
@@ -310,7 +310,7 @@ func TestPublishSkipsValidationOfASkippedUpload(t *testing.T) {
 	if err := Publish([]Upload{
 		{Handler: S3{URI: "s3://bucket/rpms/"}, Skip: true},
 		{Source: dirWith(t, "x"), Handler: d},
-	}, true); err != nil {
+	}); err != nil {
 		t.Fatalf("Publish: %v", err)
 	}
 	if got := d.got(); len(got) != 1 {
@@ -348,7 +348,7 @@ func TestBuildMetadataWritesAProductsOwnFields(t *testing.T) {
 }
 
 type productRelease struct {
-	Metadata  `yaml:",inline"`
+	Metadata `yaml:",inline"`
 	Upstream string `yaml:"upstreamVersion"`
 }
 

--- a/release/internal/distribution/actions_test.go
+++ b/release/internal/distribution/actions_test.go
@@ -1,0 +1,296 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package distribution
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"sync"
+	"testing"
+)
+
+type fakeDest struct {
+	name string
+	err  error
+
+	mu   sync.Mutex
+	srcs []string
+}
+
+func (d *fakeDest) Name() string { return d.name }
+
+func (d *fakeDest) Publish(_ context.Context, src string) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.srcs = append(d.srcs, src)
+	return d.err
+}
+
+func (d *fakeDest) got() []string {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return slices.Clone(d.srcs)
+}
+
+type fakeRecorder struct {
+	refs []string
+	err  error
+}
+
+func (r *fakeRecorder) Add(refs ...string) error {
+	r.refs = append(r.refs, refs...)
+	return r.err
+}
+
+func dirWith(t *testing.T, names ...string) string {
+	t.Helper()
+	dir := t.TempDir()
+	for _, n := range names {
+		path := filepath.Join(dir, n)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("creating %s: %v", path, err)
+		}
+		if err := os.WriteFile(path, []byte(n), 0o644); err != nil {
+			t.Fatalf("writing %s: %v", path, err)
+		}
+	}
+	return dir
+}
+
+func TestBuildMetadata(t *testing.T) {
+	dir := t.TempDir()
+	m := Metadata{
+		Version:         "v3.30.0",
+		OperatorVersion: "v1.38.0",
+		Images:          []string{"calico/node:v3.30.0"},
+		ChartVersion:    "v3.30.0",
+	}
+	if err := BuildMetadata(m, dir); err != nil {
+		t.Fatalf("BuildMetadata: %v", err)
+	}
+
+	bs, err := os.ReadFile(filepath.Join(dir, MetadataFileName))
+	if err != nil {
+		t.Fatalf("reading metadata: %v", err)
+	}
+	// Pinned to literal keys: a round-trip would pass through a rename.
+	for _, want := range []string{"version: v3.30.0", "operatorVersion: v1.38.0", "helmChartVersion: v3.30.0"} {
+		if !strings.Contains(string(bs), want) {
+			t.Errorf("expected %q in:\n%s", want, bs)
+		}
+	}
+}
+
+func TestBuildMetadataRejectsIncompleteInput(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		m    Metadata
+		want string
+	}{
+		{"no version", Metadata{OperatorVersion: "v1", Images: []string{"i"}}, "version"},
+		{"no operator version", Metadata{Version: "v1", Images: []string{"i"}}, "operator version"},
+		{"no images", Metadata{Version: "v1", OperatorVersion: "v1"}, "images"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := BuildMetadata(tc.m, t.TempDir()); err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("expected an error naming %q, got %v", tc.want, err)
+			}
+		})
+	}
+}
+
+func TestSHA256SumsSkipsDirectoriesAndItself(t *testing.T) {
+	dir := dirWith(t, "release.tgz", "metadata.yaml", "charts/index.yaml")
+	if err := os.WriteFile(filepath.Join(dir, SumsFileName), []byte("stale"), 0o644); err != nil {
+		t.Fatalf("seeding a stale sums file: %v", err)
+	}
+
+	if err := SHA256Sums(dir); err != nil {
+		t.Fatalf("SHA256Sums: %v", err)
+	}
+	bs, err := os.ReadFile(filepath.Join(dir, SumsFileName))
+	if err != nil {
+		t.Fatalf("reading sums: %v", err)
+	}
+	got := string(bs)
+	for _, want := range []string{"release.tgz", "metadata.yaml"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("expected %s checksummed, got:\n%s", want, got)
+		}
+	}
+	for _, unwanted := range []string{"charts", SumsFileName} {
+		if strings.Contains(got, unwanted) {
+			t.Errorf("expected %s left out, got:\n%s", unwanted, got)
+		}
+	}
+}
+
+func TestPublishSendsEachSourceToItsDestination(t *testing.T) {
+	dir := dirWith(t, "release.tgz", "charts/index.yaml")
+	gh := &fakeDest{name: "github"}
+	s3 := &fakeDest{name: "s3://bucket/charts/"}
+
+	err := Publish([]Upload{
+		{Source: dir, Handler: gh},
+		{Source: filepath.Join(dir, "charts"), Handler: s3},
+	}, true)
+	if err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	if got := gh.got(); len(got) != 1 || got[0] != dir {
+		t.Errorf("github got %v, want [%s]", got, dir)
+	}
+	if got := s3.got(); len(got) != 1 || got[0] != filepath.Join(dir, "charts") {
+		t.Errorf("s3 got %v", got)
+	}
+}
+
+func TestPublishDryRunSendsNothing(t *testing.T) {
+	dir := dirWith(t, "release.tgz")
+	d := &fakeDest{name: "github"}
+	rec := &fakeRecorder{}
+
+	if err := Publish([]Upload{{Source: dir, Handler: d}}, false, WithRecord(rec)); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	if got := d.got(); len(got) != 0 {
+		t.Errorf("expected nothing published, got %v", got)
+	}
+	// Recording a dry run would name artifacts that were never sent.
+	if len(rec.refs) != 0 {
+		t.Errorf("expected nothing recorded, got %v", rec.refs)
+	}
+}
+
+func TestPublishMissingSource(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		allowMissing bool
+		wantErr      string
+	}{
+		{name: "fails by default", wantErr: "not built"},
+		{name: "skips when allowed", allowMissing: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			d := &fakeDest{name: "s3://bucket/files/"}
+			absent := filepath.Join(t.TempDir(), "never-built")
+
+			err := Publish([]Upload{{Source: absent, Handler: d, AllowMissing: tc.allowMissing}}, true)
+
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("expected an error containing %q, got %v", tc.wantErr, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Publish: %v", err)
+			}
+			if got := d.got(); len(got) != 0 {
+				t.Errorf("expected the absent source skipped, got %v", got)
+			}
+		})
+	}
+}
+
+func TestPublishCollectsEveryFailure(t *testing.T) {
+	dir := dirWith(t, "release.tgz")
+	bad := &fakeDest{name: "s3://bad/", err: errors.New("access denied")}
+	worse := &fakeDest{name: "gs://worse/", err: errors.New("no such bucket")}
+	good := &fakeDest{name: "github"}
+
+	err := Publish([]Upload{
+		{Source: dir, Handler: bad},
+		{Source: dir, Handler: worse},
+		{Source: dir, Handler: good},
+	}, true)
+	if err == nil {
+		t.Fatal("expected the failures reported")
+	}
+	for _, want := range []string{"s3://bad/", "gs://worse/"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("expected %s named in %v", want, err)
+		}
+	}
+	if got := good.got(); len(got) != 1 {
+		t.Errorf("expected the working destination still published, got %v", got)
+	}
+}
+
+func TestPublishRecordsWhatSucceededDespiteAFailure(t *testing.T) {
+	dir := dirWith(t, "release.tgz")
+	rec := &fakeRecorder{}
+
+	err := Publish([]Upload{
+		{Source: dir, Handler: &fakeDest{name: "github"}},
+		{Source: dir, Handler: &fakeDest{name: "s3://bad/", err: errors.New("denied")}},
+	}, true, WithRecord(rec))
+	if err == nil {
+		t.Fatal("expected the failure reported")
+	}
+	if !slices.Contains(rec.refs, "github") {
+		t.Errorf("expected the publish recorded, got %v", rec.refs)
+	}
+}
+
+func TestPublishRejectsIncompleteUploads(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		uploads []Upload
+		want    string
+	}{
+		{"none", nil, "no uploads"},
+		{"no source", []Upload{{Handler: &fakeDest{name: "x"}}}, "no source"},
+		{"no destination", []Upload{{Source: "/tmp"}}, "no destination"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := Publish(tc.uploads, true); err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("expected an error containing %q, got %v", tc.want, err)
+			}
+		})
+	}
+}
+
+func TestPublishRetriesBeforeGivingUp(t *testing.T) {
+	dir := dirWith(t, "release.tgz")
+	d := &flakyDest{failures: 1}
+
+	if err := Publish([]Upload{{Source: dir, Handler: d}}, true); err != nil {
+		t.Fatalf("expected the retry to succeed, got %v", err)
+	}
+	if d.calls != 2 {
+		t.Errorf("published %d times, want 2", d.calls)
+	}
+}
+
+type flakyDest struct {
+	failures int
+	calls    int
+}
+
+func (d *flakyDest) Name() string { return "flaky" }
+
+func (d *flakyDest) Publish(context.Context, string) error {
+	d.calls++
+	if d.calls <= d.failures {
+		return fmt.Errorf("transient failure %d", d.calls)
+	}
+	return nil
+}

--- a/release/internal/distribution/actions_test.go
+++ b/release/internal/distribution/actions_test.go
@@ -64,32 +64,6 @@ func dirWith(t *testing.T, names ...string) string {
 	return dir
 }
 
-func TestSHA256SumsSkipsDirectoriesAndItself(t *testing.T) {
-	dir := dirWith(t, "release.tgz", "metadata.yaml", "charts/index.yaml")
-	if err := os.WriteFile(filepath.Join(dir, SumsFileName), []byte("stale"), 0o644); err != nil {
-		t.Fatalf("seeding a stale sums file: %v", err)
-	}
-
-	if err := SHA256Sums(dir); err != nil {
-		t.Fatalf("SHA256Sums: %v", err)
-	}
-	bs, err := os.ReadFile(filepath.Join(dir, SumsFileName))
-	if err != nil {
-		t.Fatalf("reading sums: %v", err)
-	}
-	got := string(bs)
-	for _, want := range []string{"release.tgz", "metadata.yaml"} {
-		if !strings.Contains(got, want) {
-			t.Errorf("expected %s checksummed, got:\n%s", want, got)
-		}
-	}
-	for _, unwanted := range []string{"charts", SumsFileName} {
-		if strings.Contains(got, unwanted) {
-			t.Errorf("expected %s left out, got:\n%s", unwanted, got)
-		}
-	}
-}
-
 func TestPublishSendsEachSourceToItsDestination(t *testing.T) {
 	dir := dirWith(t, "release.tgz", "charts/index.yaml")
 	gh := &fakeDest{name: "github"}

--- a/release/internal/distribution/destinations.go
+++ b/release/internal/distribution/destinations.go
@@ -1,0 +1,326 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package distribution
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/sirupsen/logrus"
+
+	"github.com/projectcalico/calico/release/internal/command"
+	"github.com/projectcalico/calico/release/internal/github"
+	"github.com/projectcalico/calico/release/internal/steps"
+)
+
+const (
+	gcloudCmd = "gcloud"
+	awsCmd    = "aws"
+
+	cpVerb    = "cp"
+	syncVerb  = "sync"
+	rsyncVerb = "rsync"
+
+	recursiveFlag = "--recursive"
+)
+
+var publicRead = []string{"--acl", "public-read"}
+
+var (
+	_ Destination = S3{}
+	_ Destination = GCS{}
+	_ Destination = GithubRelease{}
+)
+
+type S3 struct {
+	URI string
+
+	Sync bool
+
+	Profile string
+
+	Private bool
+
+	DryRun bool
+
+	Runner command.CommandRunner
+}
+
+func (d S3) Name() string { return d.URI }
+
+func (d S3) Publish(_ context.Context, src string) error {
+	args := []string{"s3"}
+	if d.Profile != "" {
+		args = append(args, "--profile", d.Profile)
+	}
+	verFn := d.cpArgs
+	if d.Sync {
+		verFn = d.syncArgs
+	}
+	verbArgs, err := verFn(src)
+	if err != nil {
+		return fmt.Errorf("action verb: %w", err)
+	}
+	args = append(args, verbArgs...)
+	args = append(args, src, d.URI)
+	if !d.Private {
+		args = append(args, publicRead...)
+	}
+	if d.DryRun {
+		args = append(args, "--dryrun")
+	}
+	if logrus.IsLevelEnabled(logrus.DebugLevel) {
+		args = append(args, "--debug")
+	}
+	logrus.WithField("args", args).Debug("Running aws command")
+	if _, err := d.runner().Run(awsCmd, args, nil); err != nil {
+		return fmt.Errorf("publish to %s:%w", d.Name(), err)
+	}
+	return nil
+}
+
+func (d S3) cpArgs(src string) ([]string, error) {
+	if d.Sync {
+		return d.syncArgs(src)
+	}
+	args := []string{cpVerb}
+	dir, err := isDir(src)
+	if err != nil {
+		return args, fmt.Errorf("isDir(%s): %w", src, err)
+	}
+	if dir {
+		args = append(args, recursiveFlag)
+	}
+	return args, nil
+}
+
+func (d S3) syncArgs(src string) ([]string, error) {
+	if !d.Sync {
+		return d.cpArgs(src)
+	}
+	// sync descends on its own, and the CLI rejects --recursive alongside it.
+	return []string{syncVerb}, nil
+}
+
+func (d S3) runner() command.CommandRunner {
+	if d.Runner == nil {
+		return &command.RealCommandRunner{}
+	}
+	return d.Runner
+}
+
+type GCS struct {
+	URI string
+
+	Sync bool
+
+	DryRun bool
+
+	Runner command.CommandRunner
+}
+
+func (d GCS) Name() string { return d.URI }
+
+func (d GCS) Publish(_ context.Context, src string) error {
+	verbFn := d.cpArgs
+	if d.Sync {
+		verbFn = d.rsyncArgs
+	}
+	verbArgs, err := verbFn(src)
+	if err != nil {
+		return fmt.Errorf("action verb: %w", err)
+	}
+	args := append(slices.Clone(verbArgs), src, d.URI)
+	if logrus.IsLevelEnabled(logrus.DebugLevel) {
+		args = append(args, "--verbosity=debug")
+	}
+	// gcloud storage has no dry-run flag, so the run has to be skipped.
+	if d.DryRun {
+		logrus.WithField("args", args).Info("Dry run, not uploading")
+		return nil
+	}
+
+	if _, err := d.runner().Run(gcloudCmd, args, nil); err != nil {
+		logrus.WithField("args", args).Debug("Running gcloud command")
+		return fmt.Errorf("publishing to %s: %w", d.URI, err)
+	}
+	return nil
+}
+
+func (d GCS) cpArgs(src string) ([]string, error) {
+	if d.Sync {
+		return d.rsyncArgs(src)
+	}
+	args := []string{cpVerb}
+	if d.DryRun {
+		args = []string{rsyncVerb}
+	}
+	dir, err := isDir(src)
+	if err != nil {
+		return nil, err
+	}
+	if dir || d.DryRun {
+		args = append(args, "--recursive")
+	}
+	return args, nil
+}
+
+func (d GCS) rsyncArgs(src string) ([]string, error) {
+	if !d.Sync {
+		return d.cpArgs(src)
+	}
+	args := []string{rsyncVerb, "--recursive", "--delete-unmatched-destination-objects"}
+
+	if d.DryRun {
+		args = append(args, "--dry-run")
+	}
+	return args, nil
+}
+
+func (d GCS) runner() command.CommandRunner {
+	if d.Runner == nil {
+		return &command.RealCommandRunner{}
+	}
+	return d.Runner
+}
+
+type GithubRelease struct {
+	Releases *github.Releases
+
+	Tag   string
+	Title string
+	Body  string
+
+	Draft  bool
+	DryRun bool
+
+	Log *logrus.Entry
+}
+
+func (d GithubRelease) Name() string { return fmt.Sprintf("%s github release", d.Tag) }
+
+func (d GithubRelease) Publish(ctx context.Context, src string) error {
+	files, err := topLevelFiles(src)
+	if err != nil {
+		return fmt.Errorf("get files: %w", err)
+	}
+	if len(files) == 0 {
+		return fmt.Errorf("no release files %s", d.Tag)
+	}
+	if d.DryRun {
+		d.log().WithField("files", files).Infof("Dry run, not creating %s", d.Name())
+		return nil
+	}
+
+	rel, err := d.Releases.CreateDraft(ctx, d.Tag, d.releaseName(), d.Body)
+	if err != nil {
+		return fmt.Errorf("create draft: %w", err)
+	}
+
+	// Collected rather than stopped at: one asset failing must not hide the
+	// rest, and a retry needs to know everything still outstanding.
+	_, err = steps.Go(files, func(path string) (struct{}, error) {
+		return struct{}{}, d.upload(ctx, rel.GetID(), path)
+	})
+	if err != nil {
+		return fmt.Errorf("upload assets: %w", err)
+	}
+	if d.Draft {
+		return nil
+	}
+	latest, err := d.makeLatest(ctx)
+	if err != nil {
+		return fmt.Errorf("make latest: %w", err)
+	}
+	return d.Releases.Publish(ctx, d.Tag, latest)
+}
+
+func (d GithubRelease) makeLatest(ctx context.Context) (bool, error) {
+	latest, err := d.Releases.LatestTag(ctx)
+	if err != nil {
+		return false, fmt.Errorf("get latest tag: %w", err)
+	}
+	curr, err := d.semver(latest)
+	if err != nil {
+		return false, fmt.Errorf("parse current tag: %w", err)
+	}
+	new, err := d.semver(d.Tag)
+	if err != nil {
+		return false, fmt.Errorf("parse latest tag: %w", err)
+	}
+	return new.GreaterThan(curr), nil
+}
+
+func (d GithubRelease) semver(tag string) (*semver.Version, error) {
+	return semver.NewVersion(strings.Trim(tag, "v"))
+}
+
+func (d GithubRelease) upload(ctx context.Context, releaseID int64, path string) error {
+	log := d.log().WithField("asset", filepath.Base(path))
+	for attempt := 0; ; attempt++ {
+		err := d.Releases.UploadAsset(ctx, releaseID, path)
+		if err == nil {
+			log.Debug("Attached release asset")
+			return nil
+		}
+		if attempt < steps.MaxRetries {
+			log.WithError(err).WithField("attempt", attempt).Warn("Asset upload failed, retrying")
+			continue
+		}
+		return fmt.Errorf("upload %s: %w", path, err)
+	}
+}
+
+func (d GithubRelease) releaseName() string {
+	if d.Title == "" {
+		return d.Tag
+	}
+	return d.Title
+}
+
+func (d GithubRelease) log() *logrus.Entry {
+	if d.Log == nil {
+		return logrus.NewEntry(logrus.StandardLogger())
+	}
+	return d.Log
+}
+
+func topLevelFiles(dir string) ([]string, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, fmt.Errorf("reading %s: %w", dir, err)
+	}
+	var out []string
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		out = append(out, filepath.Join(dir, e.Name()))
+	}
+	return out, nil
+}
+
+func isDir(path string) (bool, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return false, err
+	}
+	return info.IsDir(), nil
+}

--- a/release/internal/distribution/destinations_test.go
+++ b/release/internal/distribution/destinations_test.go
@@ -1,0 +1,197 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package distribution
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+)
+
+// fakeRunner records the command a destination built, so a test asserts on
+// the arguments rather than on a bucket.
+type fakeRunner struct {
+	name string
+	args []string
+	err  error
+}
+
+func (f *fakeRunner) Run(name string, args, _ []string) (string, error) {
+	f.name, f.args = name, args
+	return "", f.err
+}
+
+func (f *fakeRunner) RunInDir(_, name string, args, env []string) (string, error) {
+	return f.Run(name, args, env)
+}
+
+func (f *fakeRunner) RunInDirToFile(_, name string, args, env []string, _ string) (string, error) {
+	return f.Run(name, args, env)
+}
+
+func (f *fakeRunner) RunInDirNoCapture(_, name string, args, env []string) error {
+	_, err := f.Run(name, args, env)
+	return err
+}
+
+func (f *fakeRunner) RunNoCapture(name string, args, env []string) error {
+	_, err := f.Run(name, args, env)
+	return err
+}
+
+// The destination stats the source to pick its verb, so a test needs a real
+// path rather than a plausible string.
+func srcPath(t *testing.T, dir bool) string {
+	t.Helper()
+	if dir {
+		return t.TempDir()
+	}
+	path := filepath.Join(t.TempDir(), "artifact.tgz")
+	if err := os.WriteFile(path, []byte("x"), 0o644); err != nil {
+		t.Fatalf("writing fixture: %v", err)
+	}
+	return path
+}
+
+func (f *fakeRunner) has(flag string) bool { return slices.Contains(f.args, flag) }
+
+func (f *fakeRunner) valueAfter(flag string) string {
+	if i := slices.Index(f.args, flag); i >= 0 && i+1 < len(f.args) {
+		return f.args[i+1]
+	}
+	return ""
+}
+
+// An artifact users download must be readable, so the ACL is the default and
+// a private upload is what has to be asked for. Getting this the wrong way
+// round uploads successfully and leaves the object unreadable.
+func TestS3PublicReadIsTheDefault(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		private bool
+		wantACL bool
+	}{
+		{name: "public by default", wantACL: true},
+		{name: "private when asked", private: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			f := &fakeRunner{}
+			d := S3{URI: "s3://bucket/charts/", Private: tc.private, Runner: f}
+			if err := d.Publish(context.Background(), srcPath(t, true)); err != nil {
+				t.Fatalf("Publish: %v", err)
+			}
+			if got := f.has("--acl"); got != tc.wantACL {
+				t.Errorf("--acl present = %v, want %v (args %v)", got, tc.wantACL, f.args)
+			}
+			if tc.wantACL && f.valueAfter("--acl") != "public-read" {
+				t.Errorf("--acl = %q, want public-read", f.valueAfter("--acl"))
+			}
+		})
+	}
+}
+
+func TestS3Verb(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		sync     bool
+		dir      bool
+		wantVerb string
+		wantRec  bool
+	}{
+		{name: "copies a file", wantVerb: "cp"},
+		{name: "copies a directory recursively", dir: true, wantVerb: "cp", wantRec: true},
+		// sync descends on its own, and rejects --recursive.
+		{name: "syncs a tree", sync: true, dir: true, wantVerb: "sync"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			f := &fakeRunner{}
+			d := S3{URI: "s3://bucket/x/", Sync: tc.sync, Runner: f}
+			if err := d.Publish(context.Background(), srcPath(t, tc.dir)); err != nil {
+				t.Fatalf("Publish: %v", err)
+			}
+			if f.name != "aws" {
+				t.Errorf("ran %q, want aws", f.name)
+			}
+			if !f.has(tc.wantVerb) {
+				t.Errorf("verb = %v, want %s", f.args, tc.wantVerb)
+			}
+			if got := f.has("--recursive"); got != tc.wantRec {
+				t.Errorf("--recursive = %v, want %v (args %v)", got, tc.wantRec, f.args)
+			}
+		})
+	}
+}
+
+func TestS3ProfileOnlyWhenSet(t *testing.T) {
+	f := &fakeRunner{}
+	if err := (S3{URI: "s3://b/x/", Runner: f}).Publish(context.Background(), srcPath(t, false)); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	if f.has("--profile") {
+		t.Errorf("expected no --profile when unset, got %v", f.args)
+	}
+
+	f = &fakeRunner{}
+	if err := (S3{URI: "s3://b/x/", Profile: "release", Runner: f}).Publish(context.Background(), srcPath(t, false)); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	if f.valueAfter("--profile") != "release" {
+		t.Errorf("--profile = %q, want release", f.valueAfter("--profile"))
+	}
+}
+
+func TestGCSSyncDeletesWhatTheSourceDropped(t *testing.T) {
+	f := &fakeRunner{}
+	d := GCS{URI: "gs://bucket/hash", Sync: true, Runner: f}
+	if err := d.Publish(context.Background(), srcPath(t, true)); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	if f.name != "gcloud" {
+		t.Errorf("ran %q, want gcloud", f.name)
+	}
+	for _, want := range []string{"rsync", "--recursive", "--delete-unmatched-destination-objects"} {
+		if !f.has(want) {
+			t.Errorf("expected %s in %v", want, f.args)
+		}
+	}
+}
+
+// A dry run must reach no bucket at all, rather than passing a flag the
+// gcloud verb may not accept.
+func TestGCSDryRunRunsNothing(t *testing.T) {
+	f := &fakeRunner{}
+	d := GCS{URI: "gs://bucket/x", DryRun: true, Runner: f}
+	if err := d.Publish(context.Background(), srcPath(t, false)); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	if f.name != "" {
+		t.Errorf("expected no command run, got %q %v", f.name, f.args)
+	}
+}
+
+func TestDestinationNames(t *testing.T) {
+	if got := (S3{URI: "s3://b/k/"}).Name(); got != "s3://b/k/" {
+		t.Errorf("S3 name = %q", got)
+	}
+	if got := (GCS{URI: "gs://b/k"}).Name(); got != "gs://b/k" {
+		t.Errorf("GCS name = %q", got)
+	}
+	if got := (GithubRelease{Tag: "v3.30.0"}).Name(); !strings.Contains(got, "v3.30.0") {
+		t.Errorf("github name = %q, want the tag in it", got)
+	}
+}

--- a/release/internal/distribution/distribution.go
+++ b/release/internal/distribution/distribution.go
@@ -46,13 +46,32 @@ type Upload struct {
 
 	Handler Handler
 
-	AllowMissing bool
+	// Name is what is being sent, for a log a reader can follow. Two uploads
+	// to one bucket are otherwise told apart only by their paths.
+	Name string
+
+	// Skip when the step that produces Source did not run. A source that is
+	// missing without this is an error.
+	Skip bool
 }
 
 // validator is a handler that has its own rules about the upload it is given.
 // A handler that finds its own content does not implement it.
 type validator interface {
 	Validate(u Upload) error
+}
+
+// Falls back to the destination, so a log line reads even when a caller
+// names nothing.
+func (u Upload) label() string {
+	if u.Name != "" {
+		return u.Name
+	}
+	return u.Handler.Name()
+}
+
+func (u Upload) dest() string {
+	return u.Handler.Name()
 }
 
 func (u Upload) validate() error {

--- a/release/internal/distribution/distribution.go
+++ b/release/internal/distribution/distribution.go
@@ -17,10 +17,7 @@ package distribution
 
 import (
 	"context"
-	"errors"
 	"fmt"
-
-	"gopkg.in/yaml.v3"
 
 	"github.com/projectcalico/calico/release/internal/command"
 	"github.com/projectcalico/calico/release/internal/registry"
@@ -87,9 +84,6 @@ type Attester interface {
 	Attest() ([]byte, error)
 }
 
-// A product asserts the same in its own file.
-var _ Attester = Metadata{}
-
 type Component struct {
 	registry.Component `json:",inline" yaml:",inline"`
 }
@@ -98,33 +92,6 @@ type Component struct {
 // for something to pull.
 func (c Component) MarshalYAML() (any, error) {
 	return c.String(), nil
-}
-
-type Metadata struct {
-	Version string `json:"version"`
-
-	OperatorVersion string `json:"operator_version" yaml:"operatorVersion"`
-
-	Images []Component `json:"images"`
-
-	ChartVersion string `json:"helm_chart_version" yaml:"helmChartVersion"`
-}
-
-func (r Metadata) Attest() ([]byte, error) {
-	var errs []error
-	if r.Version == "" {
-		errs = append(errs, fmt.Errorf("no version specified"))
-	}
-	if r.OperatorVersion == "" {
-		errs = append(errs, fmt.Errorf("no operator version specified"))
-	}
-	if len(r.Images) == 0 {
-		errs = append(errs, fmt.Errorf("no images specified"))
-	}
-	if err := errors.Join(errs...); err != nil {
-		return nil, err
-	}
-	return yaml.Marshal(r)
 }
 
 type settings struct {

--- a/release/internal/distribution/distribution.go
+++ b/release/internal/distribution/distribution.go
@@ -1,0 +1,149 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package distribution sends a release's artifacts to where they are published.
+package distribution
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/projectcalico/calico/release/internal/command"
+	"github.com/projectcalico/calico/release/internal/steps"
+)
+
+// The name becomes the log directory, so it is qualified: a bare "publish"
+// would collide with another group's.
+const (
+	metadataStep     = "distribution-metadata"
+	sumsStep         = "distribution-sha256sums"
+	artifactsStep    = "distribution-publish-artifacts"
+	hashreleaseStep  = "distribution-publish-hashrelease"
+	MetadataFileName = "metadata.yaml"
+	SumsFileName     = "SHA256SUMS"
+)
+
+type Destination interface {
+	Name() string
+
+	Publish(ctx context.Context, src string) error
+}
+
+type Upload struct {
+	Source string
+
+	Dest Destination
+
+	AllowMissing bool
+}
+
+func (u Upload) validate() error {
+	var errs []error
+	if u.Source == "" {
+		errs = append(errs, fmt.Errorf("upload with no source"))
+	}
+	if u.Dest == nil {
+		errs = append(errs, fmt.Errorf("upload of %s has no destination", u.Source))
+	}
+	return errors.Join(errs...)
+}
+
+type Release struct {
+	Version string
+
+	OperatorVersion string
+
+	// Images are supplied rather than derived: image identity has two sources,
+	// the component Makefiles and the pinned-versions file, and only the
+	// caller knows which applies.
+	Images []string
+
+	ChartVersion string
+
+	Registry string
+}
+
+func (r Release) validate() error {
+	var errs []error
+	if r.Version == "" {
+		errs = append(errs, fmt.Errorf("no version specified"))
+	}
+	if r.OperatorVersion == "" {
+		errs = append(errs, fmt.Errorf("no operator version specified"))
+	}
+	return errors.Join(errs...)
+}
+
+type settings struct {
+	Release
+
+	uploads []Upload
+
+	confirm bool
+
+	steps.Step
+}
+
+// A step's options. Option reaches every step; the per-step interfaces let a
+// setting that belongs to one verb be rejected at compile time by the others.
+type (
+	MetadataOption interface{ applyMetadata(*settings) error }
+	SumsOption     interface{ applySums(*settings) error }
+	PublishOption  interface{ applyPublish(*settings) error }
+
+	Option interface {
+		applyMetadata(*settings) error
+		applySums(*settings) error
+		applyPublish(*settings) error
+	}
+)
+
+// Each adapter must satisfy the interfaces its options are returned as, so a
+// missing apply method fails here rather than at a call site.
+var (
+	_ Option        = setting(nil)
+	_ PublishOption = publishSetting(nil)
+)
+
+type setting func(*settings) error
+
+func (f setting) applyMetadata(s *settings) error { return f(s) }
+func (f setting) applySums(s *settings) error     { return f(s) }
+func (f setting) applyPublish(s *settings) error  { return f(s) }
+
+type publishSetting func(*settings) error
+
+func (f publishSetting) applyPublish(s *settings) error { return f(s) }
+
+func WithRunner(r command.CommandRunner) Option {
+	return setting(func(s *settings) error {
+		s.Apply([]steps.Option{steps.WithRunner(r)})
+		return nil
+	})
+}
+
+func WithLogsDir(dir string) Option {
+	return setting(func(s *settings) error {
+		s.Apply([]steps.Option{steps.WithLogsDir(dir)})
+		return nil
+	})
+}
+
+func WithDir(dir string) Option {
+	return setting(func(s *settings) error {
+		s.Apply([]steps.Option{steps.WithDir(dir)})
+		return nil
+	})
+}

--- a/release/internal/distribution/distribution.go
+++ b/release/internal/distribution/distribution.go
@@ -35,7 +35,7 @@ const (
 	SumsFileName     = "SHA256SUMS"
 )
 
-type Destination interface {
+type Handler interface {
 	Name() string
 
 	Publish(ctx context.Context, src string) error
@@ -44,7 +44,7 @@ type Destination interface {
 type Upload struct {
 	Source string
 
-	Dest Destination
+	Handler Handler
 
 	AllowMissing bool
 }
@@ -54,44 +54,45 @@ func (u Upload) validate() error {
 	if u.Source == "" {
 		errs = append(errs, fmt.Errorf("upload with no source"))
 	}
-	if u.Dest == nil {
+	if u.Handler == nil {
 		errs = append(errs, fmt.Errorf("upload of %s has no destination", u.Source))
 	}
 	return errors.Join(errs...)
 }
 
-type Release struct {
-	Version string
+// Metadata is what metadata.yaml records about a release.
+type Metadata struct {
+	Version string `json:"version"`
 
-	OperatorVersion string
+	OperatorVersion string `json:"operator_version" yaml:"operatorVersion"`
 
-	// Images are supplied rather than derived: image identity has two sources,
-	// the component Makefiles and the pinned-versions file, and only the
-	// caller knows which applies.
-	Images []string
+	// Supplied, not derived: a release and a hashrelease name images from
+	// different sources.
+	Images []string `json:"images"`
 
-	ChartVersion string
-
-	Registry string
+	ChartVersion string `json:"helm_chart_version" yaml:"helmChartVersion"`
 }
 
-func (r Release) validate() error {
+func (m Metadata) validate() error {
 	var errs []error
-	if r.Version == "" {
+	if m.Version == "" {
 		errs = append(errs, fmt.Errorf("no version specified"))
 	}
-	if r.OperatorVersion == "" {
+	if m.OperatorVersion == "" {
 		errs = append(errs, fmt.Errorf("no operator version specified"))
+	}
+	if len(m.Images) == 0 {
+		errs = append(errs, fmt.Errorf("no images specified"))
 	}
 	return errors.Join(errs...)
 }
 
 type settings struct {
-	Release
-
 	uploads []Upload
 
 	confirm bool
+
+	refs steps.RefRecorder
 
 	steps.Step
 }
@@ -144,6 +145,18 @@ func WithLogsDir(dir string) Option {
 func WithDir(dir string) Option {
 	return setting(func(s *settings) error {
 		s.Apply([]steps.Option{steps.WithDir(dir)})
+		return nil
+	})
+}
+
+// WithRecord writes a ref per completed upload, so a later step reads what
+// was published rather than what was planned.
+func WithRecord(rec steps.RefRecorder) PublishOption {
+	return publishSetting(func(s *settings) error {
+		if rec == nil {
+			return fmt.Errorf("no recorder to record published artifacts")
+		}
+		s.refs = rec
 		return nil
 	})
 }

--- a/release/internal/distribution/distribution.go
+++ b/release/internal/distribution/distribution.go
@@ -49,15 +49,20 @@ type Upload struct {
 	AllowMissing bool
 }
 
+// validator is a handler that has its own rules about the upload it is given.
+// A handler that finds its own content does not implement it.
+type validator interface {
+	Validate(u Upload) error
+}
+
 func (u Upload) validate() error {
-	var errs []error
-	if u.Source == "" {
-		errs = append(errs, fmt.Errorf("upload with no source"))
-	}
 	if u.Handler == nil {
-		errs = append(errs, fmt.Errorf("upload of %s has no destination", u.Source))
+		return fmt.Errorf("upload of %s has no destination", u.Source)
 	}
-	return errors.Join(errs...)
+	if v, ok := u.Handler.(validator); ok {
+		return v.Validate(u)
+	}
+	return nil
 }
 
 // Metadata is what metadata.yaml records about a release.
@@ -88,7 +93,7 @@ func (m Metadata) validate() error {
 }
 
 type settings struct {
-	uploads []Upload
+	pipeline []Upload
 
 	confirm bool
 

--- a/release/internal/distribution/distribution.go
+++ b/release/internal/distribution/distribution.go
@@ -20,7 +20,10 @@ import (
 	"errors"
 	"fmt"
 
+	"gopkg.in/yaml.v3"
+
 	"github.com/projectcalico/calico/release/internal/command"
+	"github.com/projectcalico/calico/release/internal/registry"
 	"github.com/projectcalico/calico/release/internal/steps"
 )
 
@@ -46,23 +49,18 @@ type Upload struct {
 
 	Handler Handler
 
-	// Name is what is being sent, for a log a reader can follow. Two uploads
-	// to one bucket are otherwise told apart only by their paths.
 	Name string
 
-	// Skip when the step that produces Source did not run. A source that is
-	// missing without this is an error.
+	//  when the step that produces Source did not run.
 	Skip bool
 }
 
-// validator is a handler that has its own rules about the upload it is given.
-// A handler that finds its own content does not implement it.
+// A handler that finds its own content does not implement this.
 type validator interface {
 	Validate(u Upload) error
 }
 
-// Falls back to the destination, so a log line reads even when a caller
-// names nothing.
+// Falls back to the destination, so a log line reads without a Name.
 func (u Upload) label() string {
 	if u.Name != "" {
 		return u.Name
@@ -84,39 +82,55 @@ func (u Upload) validate() error {
 	return nil
 }
 
-// Metadata is what metadata.yaml records about a release.
+// A product embeds Release and adds its own fields; the whole value is written.
+type Attester interface {
+	Attest() ([]byte, error)
+}
+
+// A product asserts the same in its own file.
+var _ Attester = Metadata{}
+
+type Component struct {
+	registry.Component `json:",inline" yaml:",inline"`
+}
+
+// Rendered as the reference rather than its parts: consumers read this file
+// for something to pull.
+func (c Component) MarshalYAML() (any, error) {
+	return c.String(), nil
+}
+
 type Metadata struct {
 	Version string `json:"version"`
 
 	OperatorVersion string `json:"operator_version" yaml:"operatorVersion"`
 
-	// Supplied, not derived: a release and a hashrelease name images from
-	// different sources.
-	Images []string `json:"images"`
+	Images []Component `json:"images"`
 
 	ChartVersion string `json:"helm_chart_version" yaml:"helmChartVersion"`
 }
 
-func (m Metadata) validate() error {
+func (r Metadata) Attest() ([]byte, error) {
 	var errs []error
-	if m.Version == "" {
+	if r.Version == "" {
 		errs = append(errs, fmt.Errorf("no version specified"))
 	}
-	if m.OperatorVersion == "" {
+	if r.OperatorVersion == "" {
 		errs = append(errs, fmt.Errorf("no operator version specified"))
 	}
-	if len(m.Images) == 0 {
+	if len(r.Images) == 0 {
 		errs = append(errs, fmt.Errorf("no images specified"))
 	}
-	return errors.Join(errs...)
+	if err := errors.Join(errs...); err != nil {
+		return nil, err
+	}
+	return yaml.Marshal(r)
 }
 
 type settings struct {
 	pipeline []Upload
 
 	confirm bool
-
-	refs steps.RefRecorder
 
 	steps.Step
 }
@@ -169,18 +183,6 @@ func WithLogsDir(dir string) Option {
 func WithDir(dir string) Option {
 	return setting(func(s *settings) error {
 		s.Apply([]steps.Option{steps.WithDir(dir)})
-		return nil
-	})
-}
-
-// WithRecord writes a ref per completed upload, so a later step reads what
-// was published rather than what was planned.
-func WithRecord(rec steps.RefRecorder) PublishOption {
-	return publishSetting(func(s *settings) error {
-		if rec == nil {
-			return fmt.Errorf("no recorder to record published artifacts")
-		}
-		s.refs = rec
 		return nil
 	})
 }

--- a/release/internal/distribution/distribution.go
+++ b/release/internal/distribution/distribution.go
@@ -130,8 +130,6 @@ func (r Metadata) Attest() ([]byte, error) {
 type settings struct {
 	pipeline []Upload
 
-	confirm bool
-
 	steps.Step
 }
 

--- a/release/internal/distribution/handlers.go
+++ b/release/internal/distribution/handlers.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/projectcalico/calico/release/internal/command"
 	"github.com/projectcalico/calico/release/internal/github"
+	"github.com/projectcalico/calico/release/internal/hashreleaseserver"
 	"github.com/projectcalico/calico/release/internal/steps"
 )
 
@@ -44,9 +45,10 @@ const (
 var publicRead = []string{"--acl", "public-read"}
 
 var (
-	_ Destination = S3{}
-	_ Destination = GCS{}
-	_ Destination = GithubRelease{}
+	_ Handler = S3{}
+	_ Handler = GCS{}
+	_ Handler = GithubRelease{}
+	_ Handler = HashreleaseServer{}
 )
 
 type S3 struct {
@@ -253,23 +255,27 @@ func (d GithubRelease) Publish(ctx context.Context, src string) error {
 }
 
 func (d GithubRelease) makeLatest(ctx context.Context) (bool, error) {
-	latest, err := d.Releases.LatestTag(ctx)
+	latestTag, err := d.Releases.LatestTag(ctx)
 	if err != nil {
 		return false, fmt.Errorf("get latest tag: %w", err)
 	}
-	curr, err := d.semver(latest)
-	if err != nil {
-		return false, fmt.Errorf("parse current tag: %w", err)
+	// Nothing published yet, so this release is the latest by default.
+	if latestTag == "" {
+		return true, nil
 	}
-	new, err := d.semver(d.Tag)
+	latest, err := d.semver(latestTag)
 	if err != nil {
-		return false, fmt.Errorf("parse latest tag: %w", err)
+		return false, fmt.Errorf("parse latest tag %q: %w", latestTag, err)
 	}
-	return new.GreaterThan(curr), nil
+	this, err := d.semver(d.Tag)
+	if err != nil {
+		return false, fmt.Errorf("parse release tag %q: %w", d.Tag, err)
+	}
+	return this.GreaterThan(latest), nil
 }
 
 func (d GithubRelease) semver(tag string) (*semver.Version, error) {
-	return semver.NewVersion(strings.Trim(tag, "v"))
+	return semver.NewVersion(strings.TrimPrefix(tag, "v"))
 }
 
 func (d GithubRelease) upload(ctx context.Context, releaseID int64, path string) error {
@@ -323,4 +329,37 @@ func isDir(path string) (bool, error) {
 		return false, err
 	}
 	return info.IsDir(), nil
+}
+
+// Hashrelease uploads the whole output tree, then records the hashrelease in
+// the server's library.
+type HashreleaseServer struct {
+	Release *hashreleaseserver.Hashrelease
+
+	Config *hashreleaseserver.Config
+
+	ProductCode string
+
+	DryRun bool
+
+	Runner command.CommandRunner
+}
+
+func (d HashreleaseServer) Name() string { return fmt.Sprintf("%s hashrelease", d.Release.Name) }
+
+func (d HashreleaseServer) Publish(ctx context.Context, src string) error {
+	bucket := GCS{
+		URI:    d.Release.BucketURI(d.Config),
+		Sync:   true,
+		DryRun: d.DryRun,
+		Runner: d.Runner,
+	}
+	if err := bucket.Publish(ctx, src); err != nil {
+		return err
+	}
+	if d.DryRun {
+		logrus.WithField("hashrelease", d.Release.Name).Info("Dry run, not recording hashrelease")
+		return nil
+	}
+	return hashreleaseserver.Record(d.ProductCode, d.Release, d.Config)
 }

--- a/release/internal/distribution/handlers.go
+++ b/release/internal/distribution/handlers.go
@@ -207,8 +207,7 @@ func (d GCS) Validate(u Upload) error {
 }
 
 type GithubRelease struct {
-	Releases *github.Releases
-
+	Repo  github.Repo
 	Tag   string
 	Title string
 	Body  string
@@ -217,9 +216,18 @@ type GithubRelease struct {
 	DryRun bool
 
 	Log *logrus.Entry
+
+	releases *github.Releases
 }
 
 func (d GithubRelease) Name() string { return fmt.Sprintf("%s github release", d.Tag) }
+
+func (d GithubRelease) github() (*github.Releases, error) {
+	if d.releases != nil {
+		return d.releases, nil
+	}
+	return github.NewReleases(d.Repo, nil)
+}
 
 func (d GithubRelease) Publish(ctx context.Context, src string) error {
 	files, err := topLevelFiles(src)
@@ -233,8 +241,15 @@ func (d GithubRelease) Publish(ctx context.Context, src string) error {
 		d.log().WithField("files", files).Infof("Dry run, not creating %s", d.Name())
 		return nil
 	}
-
-	rel, err := d.Releases.CreateDraft(ctx, d.Tag, d.releaseName(), d.Body)
+	if err := d.sha256Sums(src, files); err != nil {
+		return fmt.Errorf("checksums: %w", err)
+	}
+	files = append(files, filepath.Join(src, SumsFileName))
+	gh, err := d.github()
+	if err != nil {
+		return fmt.Errorf("github client: %w", err)
+	}
+	rel, err := gh.CreateDraft(ctx, d.Tag, d.releaseName(), d.Body)
 	if err != nil {
 		return fmt.Errorf("create draft: %w", err)
 	}
@@ -254,11 +269,15 @@ func (d GithubRelease) Publish(ctx context.Context, src string) error {
 	if err != nil {
 		return fmt.Errorf("make latest: %w", err)
 	}
-	return d.Releases.Publish(ctx, d.Tag, latest)
+	return gh.Publish(ctx, d.Tag, latest)
 }
 
 func (d GithubRelease) makeLatest(ctx context.Context) (bool, error) {
-	latestTag, err := d.Releases.LatestTag(ctx)
+	gh, err := d.github()
+	if err != nil {
+		return false, fmt.Errorf("github client: %w", err)
+	}
+	latestTag, err := gh.LatestTag(ctx)
 	if err != nil {
 		return false, fmt.Errorf("get latest tag: %w", err)
 	}
@@ -283,8 +302,12 @@ func (d GithubRelease) semver(tag string) (*semver.Version, error) {
 
 func (d GithubRelease) upload(ctx context.Context, releaseID int64, path string) error {
 	log := d.log().WithField("asset", filepath.Base(path))
+	gh, err := d.github()
+	if err != nil {
+		return fmt.Errorf("github client: %w", err)
+	}
 	for attempt := 0; ; attempt++ {
-		err := d.Releases.UploadAsset(ctx, releaseID, path)
+		err := gh.UploadAsset(ctx, releaseID, path)
 		if err == nil {
 			log.Debug("Attached release asset")
 			return nil
@@ -313,6 +336,33 @@ func (d GithubRelease) log() *logrus.Entry {
 
 func (d GithubRelease) Validate(u Upload) error {
 	return validSource(u)
+}
+
+// Create a SHA256 checksum file for all files and write it to the specified directory.
+func (d GithubRelease) sha256Sums(dir string, files []string, opts ...SumsOption) error {
+	s, err := newSettings(sumsStep, opts)
+	if err != nil {
+		return err
+	}
+	if len(files) == 0 {
+		return s.Errorf("no files to checksum")
+	}
+	// names are relative to dir so the file verifies wherever the assets land.
+	names := make([]string, len(files))
+	for i, f := range files {
+		names[i] = filepath.Base(f)
+	}
+	out, err := s.Runner().RunInDir(dir, "sha256sum", names, nil)
+	if err != nil {
+		s.Logger().Error(out)
+		return s.Errorf("checksumming files: %w", err)
+	}
+	path := filepath.Join(dir, SumsFileName)
+	if err := os.WriteFile(path, []byte(out), filePerms); err != nil {
+		return s.Errorf("writing %s: %w", path, err)
+	}
+	s.Logger().WithField("files", len(files)).Info("Wrote checksums")
+	return nil
 }
 
 func topLevelFiles(dir string) ([]string, error) {

--- a/release/internal/distribution/handlers.go
+++ b/release/internal/distribution/handlers.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"slices"
 	"strings"
 
 	"github.com/Masterminds/semver/v3"
@@ -35,6 +34,9 @@ import (
 const (
 	gcloudCmd = "gcloud"
 	awsCmd    = "aws"
+
+	s3Cmd      = "s3"
+	storageCmd = "storage"
 
 	cpVerb    = "cp"
 	syncVerb  = "sync"
@@ -59,6 +61,32 @@ var (
 	_ validator = HashreleaseServer{}
 )
 
+// paths is what cloud bucket handlers need to know.
+type paths struct {
+	src  string
+	dest string
+	dir  bool
+}
+
+func newPaths(src, dest string) (paths, error) {
+	dir, err := utils.DirExists(src)
+	if err != nil {
+		return paths{}, fmt.Errorf("reading %s: %w", src, err)
+	}
+	return paths{src: src, dest: dest, dir: dir}, nil
+}
+
+func (p paths) run(r command.CommandRunner, name string, args []string) error {
+	if r == nil {
+		r = &command.RealCommandRunner{}
+	}
+	logrus.WithField("args", args).Debugf("Running %s command", name)
+	if _, err := r.Run(name, args, nil); err != nil {
+		return fmt.Errorf("copying to %s: %w", p.dest, err)
+	}
+	return nil
+}
+
 type S3 struct {
 	URI string
 
@@ -76,20 +104,30 @@ type S3 struct {
 func (d S3) Name() string { return d.URI }
 
 func (d S3) Publish(_ context.Context, src string) error {
-	args := []string{"s3"}
+	p, err := newPaths(src, d.URI)
+	if err != nil {
+		return err
+	}
+	// A destination without the slash names one object rather than a prefix,
+	// so a directory upload would collapse into a single file.
+	if p.dir {
+		p.src, p.dest = addTrailingSlash(p.src), addTrailingSlash(p.dest)
+	}
+
+	args := []string{s3Cmd}
 	if d.Profile != "" {
 		args = append(args, "--profile", d.Profile)
 	}
-	verFn := d.cpArgs
 	if d.Sync {
-		verFn = d.syncArgs
+		// sync descends on its own, and the CLI rejects --recursive with it.
+		args = append(args, syncVerb)
+	} else {
+		args = append(args, cpVerb)
+		if p.dir {
+			args = append(args, recursiveFlag)
+		}
 	}
-	verbArgs, err := verFn(src)
-	if err != nil {
-		return fmt.Errorf("action verb: %w", err)
-	}
-	args = append(args, verbArgs...)
-	args = append(args, src, d.URI)
+	args = append(args, p.src, p.dest)
 	if !d.Private {
 		args = append(args, publicRead...)
 	}
@@ -99,45 +137,22 @@ func (d S3) Publish(_ context.Context, src string) error {
 	if logrus.IsLevelEnabled(logrus.DebugLevel) {
 		args = append(args, "--debug")
 	}
-	logrus.WithField("args", args).Debug("Running aws command")
-	if _, err := d.runner().Run(awsCmd, args, nil); err != nil {
-		return fmt.Errorf("publish to %s:%w", d.Name(), err)
+	err = p.run(d.Runner, awsCmd, args)
+	if err != nil {
+		return fmt.Errorf("%s %s: %w", awsCmd, s3Cmd, err)
 	}
 	return nil
 }
 
-func (d S3) cpArgs(src string) ([]string, error) {
-	if d.Sync {
-		return d.syncArgs(src)
-	}
-	args := []string{cpVerb}
-	dir, err := utils.DirExists(src)
-	if err != nil {
-		return args, fmt.Errorf("isDir(%s): %w", src, err)
-	}
-	if dir {
-		args = append(args, recursiveFlag)
-	}
-	return args, nil
-}
-
-func (d S3) syncArgs(src string) ([]string, error) {
-	if !d.Sync {
-		return d.cpArgs(src)
-	}
-	// sync descends on its own, and the CLI rejects --recursive alongside it.
-	return []string{syncVerb}, nil
-}
-
-func (d S3) runner() command.CommandRunner {
-	if d.Runner == nil {
-		return &command.RealCommandRunner{}
-	}
-	return d.Runner
-}
-
 func (d S3) Validate(u Upload) error {
 	return validSource(u)
+}
+
+func addTrailingSlash(s string) string {
+	if !strings.HasSuffix(s, "/") {
+		return s + "/"
+	}
+	return s
 }
 
 type GCS struct {
@@ -153,66 +168,33 @@ type GCS struct {
 func (d GCS) Name() string { return d.URI }
 
 func (d GCS) Publish(_ context.Context, src string) error {
-	verbFn := d.cpArgs
-	if d.Sync {
-		verbFn = d.rsyncArgs
-	}
-	verbArgs, err := verbFn(src)
+	p, err := newPaths(src, d.URI)
 	if err != nil {
-		return fmt.Errorf("action verb: %w", err)
-	}
-	args := append(slices.Clone(verbArgs), src, d.URI)
-	if logrus.IsLevelEnabled(logrus.DebugLevel) {
-		args = append(args, "--verbosity=debug")
-	}
-	// gcloud storage has no dry-run flag, so the run has to be skipped.
-	if d.DryRun {
-		logrus.WithField("args", args).Info("Dry run, not uploading")
-		return nil
+		return err
 	}
 
-	if _, err := d.runner().Run(gcloudCmd, args, nil); err != nil {
-		logrus.WithField("args", args).Debug("Running gcloud command")
-		return fmt.Errorf("publishing to %s: %w", d.URI, err)
+	// cp has no dry run of its own, so a preview uses rsync for both.
+	args := []string{storageCmd, cpVerb}
+	switch {
+	case d.Sync:
+		args = []string{storageCmd, rsyncVerb, recursiveFlag, "--delete-unmatched-destination-objects"}
+	case d.DryRun:
+		args = []string{storageCmd, rsyncVerb, recursiveFlag}
+	case p.dir:
+		args = append(args, recursiveFlag)
 	}
-	return nil
-}
-
-func (d GCS) cpArgs(src string) ([]string, error) {
-	if d.Sync {
-		return d.rsyncArgs(src)
-	}
-	args := []string{cpVerb}
-	if d.DryRun {
-		args = []string{rsyncVerb}
-	}
-	dir, err := utils.DirExists(src)
-	if err != nil {
-		return nil, err
-	}
-	if dir || d.DryRun {
-		args = append(args, "--recursive")
-	}
-	return args, nil
-}
-
-func (d GCS) rsyncArgs(src string) ([]string, error) {
-	if !d.Sync {
-		return d.cpArgs(src)
-	}
-	args := []string{rsyncVerb, "--recursive", "--delete-unmatched-destination-objects"}
-
 	if d.DryRun {
 		args = append(args, "--dry-run")
 	}
-	return args, nil
-}
-
-func (d GCS) runner() command.CommandRunner {
-	if d.Runner == nil {
-		return &command.RealCommandRunner{}
+	args = append(args, p.src, p.dest)
+	if logrus.IsLevelEnabled(logrus.DebugLevel) {
+		args = append(args, "--verbosity=debug")
 	}
-	return d.Runner
+	err = p.run(d.Runner, gcloudCmd, args)
+	if err != nil {
+		return fmt.Errorf("%s %s: %w", gcloudCmd, storageCmd, err)
+	}
+	return nil
 }
 
 func (d GCS) Validate(u Upload) error {

--- a/release/internal/distribution/handlers.go
+++ b/release/internal/distribution/handlers.go
@@ -173,13 +173,18 @@ func (d GCS) Publish(_ context.Context, src string) error {
 		return err
 	}
 
-	// cp has no dry run of its own, so a preview uses rsync for both.
 	args := []string{storageCmd, cpVerb}
 	switch {
 	case d.Sync:
 		args = []string{storageCmd, rsyncVerb, recursiveFlag, "--delete-unmatched-destination-objects"}
-	case d.DryRun:
+	case d.DryRun && p.dir:
 		args = []string{storageCmd, rsyncVerb, recursiveFlag}
+	case d.DryRun:
+		logrus.WithFields(logrus.Fields{
+			"cmd":  gcloudCmd,
+			"args": append(args, p.src, p.dest),
+		}).Info("Dry run, not copying")
+		return nil
 	case p.dir:
 		args = append(args, recursiveFlag)
 	}

--- a/release/internal/distribution/handlers.go
+++ b/release/internal/distribution/handlers.go
@@ -49,6 +49,13 @@ var (
 	_ Handler = GCS{}
 	_ Handler = GithubRelease{}
 	_ Handler = HashreleaseServer{}
+	_ Handler = Preparer{}
+	_ Handler = Publisher{}
+
+	_ validator = S3{}
+	_ validator = GCS{}
+	_ validator = GithubRelease{}
+	_ validator = HashreleaseServer{}
 )
 
 type S3 struct {
@@ -128,6 +135,10 @@ func (d S3) runner() command.CommandRunner {
 	return d.Runner
 }
 
+func (d S3) Validate(u Upload) error {
+	return validSource(u)
+}
+
 type GCS struct {
 	URI string
 
@@ -201,6 +212,10 @@ func (d GCS) runner() command.CommandRunner {
 		return &command.RealCommandRunner{}
 	}
 	return d.Runner
+}
+
+func (d GCS) Validate(u Upload) error {
+	return validSource(u)
 }
 
 type GithubRelease struct {
@@ -308,6 +323,10 @@ func (d GithubRelease) log() *logrus.Entry {
 	return d.Log
 }
 
+func (d GithubRelease) Validate(u Upload) error {
+	return validSource(u)
+}
+
 func topLevelFiles(dir string) ([]string, error) {
 	entries, err := os.ReadDir(dir)
 	if err != nil {
@@ -362,4 +381,28 @@ func (d HashreleaseServer) Publish(ctx context.Context, src string) error {
 		return nil
 	}
 	return hashreleaseserver.Record(d.ProductCode, d.Release, d.Config)
+}
+
+func (d HashreleaseServer) Validate(u Upload) error {
+	return validSource(u)
+}
+
+// Publisher adapts a group's own publish to the Handler interface,
+type Publisher = Preparer
+
+type Preparer struct {
+	Kind string
+
+	Action func() error
+}
+
+func (d Preparer) Name() string { return d.Kind }
+
+func (d Preparer) Publish(context.Context, string) error { return d.Action() }
+
+func validSource(u Upload) error {
+	if u.Source == "" {
+		return fmt.Errorf("upload to %s has no source", u.Handler.Name())
+	}
+	return nil
 }

--- a/release/internal/distribution/handlers.go
+++ b/release/internal/distribution/handlers.go
@@ -29,6 +29,7 @@ import (
 	"github.com/projectcalico/calico/release/internal/github"
 	"github.com/projectcalico/calico/release/internal/hashreleaseserver"
 	"github.com/projectcalico/calico/release/internal/steps"
+	"github.com/projectcalico/calico/release/internal/utils"
 )
 
 const (
@@ -110,7 +111,7 @@ func (d S3) cpArgs(src string) ([]string, error) {
 		return d.syncArgs(src)
 	}
 	args := []string{cpVerb}
-	dir, err := isDir(src)
+	dir, err := utils.DirExists(src)
 	if err != nil {
 		return args, fmt.Errorf("isDir(%s): %w", src, err)
 	}
@@ -185,7 +186,7 @@ func (d GCS) cpArgs(src string) ([]string, error) {
 	if d.DryRun {
 		args = []string{rsyncVerb}
 	}
-	dir, err := isDir(src)
+	dir, err := utils.DirExists(src)
 	if err != nil {
 		return nil, err
 	}
@@ -340,14 +341,6 @@ func topLevelFiles(dir string) ([]string, error) {
 		out = append(out, filepath.Join(dir, e.Name()))
 	}
 	return out, nil
-}
-
-func isDir(path string) (bool, error) {
-	info, err := os.Stat(path)
-	if err != nil {
-		return false, err
-	}
-	return info.IsDir(), nil
 }
 
 // Hashrelease uploads the whole output tree, then records the hashrelease in

--- a/release/internal/distribution/handlers.go
+++ b/release/internal/distribution/handlers.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/Masterminds/semver/v3"
@@ -241,10 +242,10 @@ func (d GithubRelease) Publish(ctx context.Context, src string) error {
 		d.log().WithField("files", files).Infof("Dry run, not creating %s", d.Name())
 		return nil
 	}
-	if err := d.sha256Sums(src, files); err != nil {
+	files, err = d.sha256Sums(src, files)
+	if err != nil {
 		return fmt.Errorf("checksums: %w", err)
 	}
-	files = append(files, filepath.Join(src, SumsFileName))
 	gh, err := d.github()
 	if err != nil {
 		return fmt.Errorf("github client: %w", err)
@@ -339,13 +340,19 @@ func (d GithubRelease) Validate(u Upload) error {
 }
 
 // Create a SHA256 checksum file for all files and write it to the specified directory.
-func (d GithubRelease) sha256Sums(dir string, files []string, opts ...SumsOption) error {
-	s, err := newSettings(sumsStep, opts)
+// Returns the release assets: the files checksummed, plus the sums file.
+func (d GithubRelease) sha256Sums(dir string, files []string) ([]string, error) {
+	s, err := newSettings[SumsOption](sumsStep, nil)
 	if err != nil {
-		return err
+		return nil, err
 	}
+	path := filepath.Join(dir, SumsFileName)
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return nil, s.Errorf("removing %s: %w", path, err)
+	}
+	files = slices.DeleteFunc(files, func(f string) bool { return f == path })
 	if len(files) == 0 {
-		return s.Errorf("no files to checksum")
+		return nil, s.Errorf("no files to checksum")
 	}
 	// names are relative to dir so the file verifies wherever the assets land.
 	names := make([]string, len(files))
@@ -355,14 +362,13 @@ func (d GithubRelease) sha256Sums(dir string, files []string, opts ...SumsOption
 	out, err := s.Runner().RunInDir(dir, "sha256sum", names, nil)
 	if err != nil {
 		s.Logger().Error(out)
-		return s.Errorf("checksumming files: %w", err)
+		return nil, s.Errorf("checksumming files: %w", err)
 	}
-	path := filepath.Join(dir, SumsFileName)
 	if err := os.WriteFile(path, []byte(out), filePerms); err != nil {
-		return s.Errorf("writing %s: %w", path, err)
+		return nil, s.Errorf("writing %s: %w", path, err)
 	}
 	s.Logger().WithField("files", len(files)).Info("Wrote checksums")
-	return nil
+	return append(files, path), nil
 }
 
 func topLevelFiles(dir string) ([]string, error) {

--- a/release/internal/distribution/handlers_test.go
+++ b/release/internal/distribution/handlers_test.go
@@ -22,6 +22,7 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
+	"sync"
 	"testing"
 
 	ghapi "github.com/google/go-github/v53/github"
@@ -267,6 +268,33 @@ func githubReleasesWithLatest(t *testing.T, tag string) *gh.Releases {
 type fakeReleaseService struct {
 	gh.ReleaseService
 	latest *ghapi.RepositoryRelease
+	draft  *ghapi.RepositoryRelease
+
+	mu       sync.Mutex
+	uploaded []string
+}
+
+func (f *fakeReleaseService) GetReleaseByTag(context.Context, string, string, string) (*ghapi.RepositoryRelease, *ghapi.Response, error) {
+	return nil, &ghapi.Response{Response: &http.Response{StatusCode: http.StatusNotFound}}, errors.New("not found")
+}
+
+func (f *fakeReleaseService) ListReleases(context.Context, string, string, *ghapi.ListOptions) ([]*ghapi.RepositoryRelease, *ghapi.Response, error) {
+	return nil, &ghapi.Response{}, nil
+}
+
+func (f *fakeReleaseService) CreateRelease(_ context.Context, _, _ string, r *ghapi.RepositoryRelease) (*ghapi.RepositoryRelease, *ghapi.Response, error) {
+	return f.draft, nil, nil
+}
+
+func (f *fakeReleaseService) ListReleaseAssets(context.Context, string, string, int64, *ghapi.ListOptions) ([]*ghapi.ReleaseAsset, *ghapi.Response, error) {
+	return nil, &ghapi.Response{}, nil
+}
+
+func (f *fakeReleaseService) UploadReleaseAsset(_ context.Context, _, _ string, _ int64, opts *ghapi.UploadOptions, _ *os.File) (*ghapi.ReleaseAsset, *ghapi.Response, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.uploaded = append(f.uploaded, opts.Name)
+	return nil, nil, nil
 }
 
 func (f *fakeReleaseService) GetLatestRelease(context.Context, string, string) (*ghapi.RepositoryRelease, *ghapi.Response, error) {
@@ -363,7 +391,7 @@ func TestSHA256SumsWritesNamesRelativeToTheDirectory(t *testing.T) {
 	if err != nil {
 		t.Fatalf("topLevelFiles: %v", err)
 	}
-	if err := (GithubRelease{}).sha256Sums(dir, files); err != nil {
+	if _, err := (GithubRelease{}).sha256Sums(dir, files); err != nil {
 		t.Fatalf("sha256Sums: %v", err)
 	}
 	bs, err := os.ReadFile(filepath.Join(dir, SumsFileName))
@@ -381,5 +409,48 @@ func TestSHA256SumsWritesNamesRelativeToTheDirectory(t *testing.T) {
 	}
 	if strings.Contains(got, "charts") {
 		t.Errorf("a directory was checksummed:\n%s", got)
+	}
+}
+
+// A release is re-run after a failure, so a second pass must not checksum the
+// sums file from the first, nor hand the same asset to the uploader twice.
+func TestPublishIsIdempotent(t *testing.T) {
+	dir := t.TempDir()
+	for _, n := range []string{"release.tgz", "metadata.yaml"} {
+		if err := os.WriteFile(filepath.Join(dir, n), []byte(n), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	var first string
+	for run := range 2 {
+		svc := &fakeReleaseService{draft: &ghapi.RepositoryRelease{ID: ghapi.Int64(1), Draft: ghapi.Bool(true)}}
+		rels, err := gh.NewReleases(gh.Repo{Org: "projectcalico", Name: "calico"}, svc)
+		if err != nil {
+			t.Fatal(err)
+		}
+		d := GithubRelease{releases: rels, Tag: "v3.30.0", Draft: true}
+		if err := d.Publish(context.Background(), dir); err != nil {
+			t.Fatalf("run %d: Publish: %v", run, err)
+		}
+		slices.Sort(svc.uploaded)
+		if got := slices.Compact(slices.Clone(svc.uploaded)); len(got) != len(svc.uploaded) {
+			t.Errorf("run %d: an asset was uploaded twice: %v", run, svc.uploaded)
+		}
+		want := []string{SumsFileName, "metadata.yaml", "release.tgz"}
+		if !slices.Equal(svc.uploaded, want) {
+			t.Errorf("run %d: uploaded %v, want %v", run, svc.uploaded, want)
+		}
+		bs, err := os.ReadFile(filepath.Join(dir, SumsFileName))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if strings.Contains(string(bs), SumsFileName) {
+			t.Errorf("run %d: the sums file checksums itself:\n%s", run, bs)
+		}
+		if run == 0 {
+			first = string(bs)
+		} else if string(bs) != first {
+			t.Errorf("a second run changed the sums file:\nfirst:\n%s\nsecond:\n%s", first, bs)
+		}
 	}
 }

--- a/release/internal/distribution/handlers_test.go
+++ b/release/internal/distribution/handlers_test.go
@@ -16,6 +16,7 @@ package distribution
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"slices"
@@ -168,23 +169,40 @@ func TestGCSSyncDeletesWhatTheSourceDropped(t *testing.T) {
 	if f.name != "gcloud" {
 		t.Errorf("ran %q, want gcloud", f.name)
 	}
-	for _, want := range []string{"rsync", "--recursive", "--delete-unmatched-destination-objects"} {
+	// gcloud's uploads live under a "storage" subcommand; without it the
+	// argv is not a valid command at all.
+	if len(f.args) < 2 || f.args[0] != "storage" || f.args[1] != "rsync" {
+		t.Errorf("args = %v, want them to start with storage rsync", f.args)
+	}
+	for _, want := range []string{"--recursive", "--delete-unmatched-destination-objects"} {
 		if !f.has(want) {
 			t.Errorf("expected %s in %v", want, f.args)
 		}
 	}
 }
 
-// A dry run must reach no bucket at all, rather than passing a flag the
-// gcloud verb may not accept.
-func TestGCSDryRunRunsNothing(t *testing.T) {
-	f := &fakeRunner{}
-	d := GCS{URI: "gs://bucket/x", DryRun: true, Runner: f}
-	if err := d.Publish(context.Background(), srcPath(t, false)); err != nil {
-		t.Fatalf("Publish: %v", err)
-	}
-	if f.name != "" {
-		t.Errorf("expected no command run, got %q %v", f.name, f.args)
+// A dry run reports what would change rather than doing nothing: rsync
+// --dry-run lists the writes, and the deletions the sync would make.
+func TestGCSDryRunPreviewsWithRsync(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		sync bool
+		dir  bool
+	}{
+		{name: "a file that would be copied"},
+		{name: "a tree that would be synced", sync: true, dir: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			f := &fakeRunner{}
+			d := GCS{URI: "gs://bucket/x", Sync: tc.sync, DryRun: true, Runner: f}
+			if err := d.Publish(context.Background(), srcPath(t, tc.dir)); err != nil {
+				t.Fatalf("Publish: %v", err)
+			}
+			// cp has no dry run of its own, so both paths preview with rsync.
+			if !f.has(rsyncVerb) || !f.has("--dry-run") {
+				t.Errorf("args = %v, want an rsync --dry-run preview", f.args)
+			}
+		})
 	}
 }
 
@@ -251,4 +269,75 @@ type fakeReleaseService struct {
 
 func (f *fakeReleaseService) ListReleases(context.Context, string, string, *ghapi.ListOptions) ([]*ghapi.RepositoryRelease, *ghapi.Response, error) {
 	return f.published, nil, nil
+}
+
+// Every gcloud invocation is a "storage" subcommand, whichever verb it uses.
+func TestGCSAlwaysUsesTheStorageSubcommand(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		sync bool
+		dir  bool
+	}{
+		{name: "copying a file"},
+		{name: "copying a directory", dir: true},
+		{name: "syncing a tree", sync: true, dir: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			f := &fakeRunner{}
+			d := GCS{URI: "gs://bucket/x", Sync: tc.sync, Runner: f}
+			if err := d.Publish(context.Background(), srcPath(t, tc.dir)); err != nil {
+				t.Fatalf("Publish: %v", err)
+			}
+			if len(f.args) == 0 || f.args[0] != "storage" {
+				t.Errorf("args = %v, want the storage subcommand first", f.args)
+			}
+		})
+	}
+}
+
+// The two CLIs disagree about the trailing slash: aws needs one on the
+// destination or a directory upload collapses into a single object, while
+// gcloud takes bare paths. Sharing the rule would break one of them.
+func TestTrailingSlashIsPerCLI(t *testing.T) {
+	dir := srcPath(t, true)
+
+	f := &fakeRunner{}
+	if err := (S3{URI: "s3://bucket/charts", Runner: f}).Publish(context.Background(), dir); err != nil {
+		t.Fatalf("S3 Publish: %v", err)
+	}
+	if !f.has("s3://bucket/charts/") {
+		t.Errorf("aws args = %v, want the destination to carry a trailing slash", f.args)
+	}
+
+	f = &fakeRunner{}
+	if err := (GCS{URI: "gs://bucket/hash", Runner: f}).Publish(context.Background(), dir); err != nil {
+		t.Fatalf("GCS Publish: %v", err)
+	}
+	if !f.has("gs://bucket/hash") {
+		t.Errorf("gcloud args = %v, want the destination left alone", f.args)
+	}
+}
+
+// The error has to name where the upload was going. A handler that reads its
+// destination from the wrong place still runs, and only the message is blank.
+func TestPublishErrorNamesTheDestination(t *testing.T) {
+	dir := srcPath(t, true)
+	for _, tc := range []struct {
+		name string
+		h    Handler
+		want string
+	}{
+		{"s3", S3{URI: "s3://bucket/charts/", Runner: &fakeRunner{err: errors.New("denied")}}, "s3://bucket/charts/"},
+		{"gcs", GCS{URI: "gs://bucket/hash", Runner: &fakeRunner{err: errors.New("denied")}}, "gs://bucket/hash"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.h.Publish(context.Background(), dir)
+			if err == nil {
+				t.Fatal("expected the failure reported")
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("error = %q, want it to name %s", err, tc.want)
+			}
+		})
+	}
 }

--- a/release/internal/distribution/handlers_test.go
+++ b/release/internal/distribution/handlers_test.go
@@ -17,6 +17,7 @@ package distribution
 import (
 	"context"
 	"errors"
+	"net/http"
 	"os"
 	"path/filepath"
 	"slices"
@@ -189,7 +190,8 @@ func TestGCSDryRunPreviewsWithRsync(t *testing.T) {
 		sync bool
 		dir  bool
 	}{
-		{name: "a file that would be copied"},
+		// A single file has no rsync preview, so it reports instead.
+		{name: "a tree that would be copied", dir: true},
 		{name: "a tree that would be synced", sync: true, dir: true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -253,7 +255,7 @@ func githubReleasesWithLatest(t *testing.T, tag string) *gh.Releases {
 	t.Helper()
 	svc := &fakeReleaseService{}
 	if tag != "" {
-		svc.published = []*ghapi.RepositoryRelease{{TagName: ghapi.String(tag)}}
+		svc.latest = &ghapi.RepositoryRelease{TagName: ghapi.String(tag)}
 	}
 	rels, err := gh.NewReleases(gh.Repo{Org: "projectcalico", Name: "calico"}, svc)
 	if err != nil {
@@ -264,11 +266,14 @@ func githubReleasesWithLatest(t *testing.T, tag string) *gh.Releases {
 
 type fakeReleaseService struct {
 	gh.ReleaseService
-	published []*ghapi.RepositoryRelease
+	latest *ghapi.RepositoryRelease
 }
 
-func (f *fakeReleaseService) ListReleases(context.Context, string, string, *ghapi.ListOptions) ([]*ghapi.RepositoryRelease, *ghapi.Response, error) {
-	return f.published, nil, nil
+func (f *fakeReleaseService) GetLatestRelease(context.Context, string, string) (*ghapi.RepositoryRelease, *ghapi.Response, error) {
+	if f.latest == nil {
+		return nil, &ghapi.Response{Response: &http.Response{StatusCode: http.StatusNotFound}}, errors.New("not found")
+	}
+	return f.latest, nil, nil
 }
 
 // Every gcloud invocation is a "storage" subcommand, whichever verb it uses.

--- a/release/internal/distribution/handlers_test.go
+++ b/release/internal/distribution/handlers_test.go
@@ -21,6 +21,10 @@ import (
 	"slices"
 	"strings"
 	"testing"
+
+	ghapi "github.com/google/go-github/v53/github"
+
+	gh "github.com/projectcalico/calico/release/internal/github"
 )
 
 // fakeRunner records the command a destination built, so a test asserts on
@@ -194,4 +198,57 @@ func TestDestinationNames(t *testing.T) {
 	if got := (GithubRelease{Tag: "v3.30.0"}).Name(); !strings.Contains(got, "v3.30.0") {
 		t.Errorf("github name = %q, want the tag in it", got)
 	}
+}
+
+// LatestTag returns an empty string when a repository has no published
+// release. Parsing that as a version fails, so a first release could never
+// be published.
+func TestGithubReleaseMakeLatest(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		published string
+		tag       string
+		want      bool
+	}{
+		{name: "first release in an empty repository", tag: "v3.30.0", want: true},
+		{name: "newer than what is published", published: "v3.29.0", tag: "v3.30.0", want: true},
+		{name: "a patch for an older stream", published: "v3.30.0", tag: "v3.29.2"},
+		// Trimming a "v" from both ends would corrupt this into 3.30.0-de.
+		{name: "a tag ending in v", published: "v3.29.0", tag: "v3.30.0-dev", want: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rels := githubReleasesWithLatest(t, tc.published)
+			got, err := GithubRelease{Releases: rels, Tag: tc.tag}.makeLatest(context.Background())
+			if err != nil {
+				t.Fatalf("makeLatest: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("makeLatest() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// A destination holds a real *github.Releases, so the fake goes in at the
+// service seam rather than the destination.
+func githubReleasesWithLatest(t *testing.T, tag string) *gh.Releases {
+	t.Helper()
+	svc := &fakeReleaseService{}
+	if tag != "" {
+		svc.published = []*ghapi.RepositoryRelease{{TagName: ghapi.String(tag)}}
+	}
+	rels, err := gh.NewReleases(gh.Repo{Org: "projectcalico", Name: "calico"}, svc)
+	if err != nil {
+		t.Fatalf("NewReleases: %v", err)
+	}
+	return rels
+}
+
+type fakeReleaseService struct {
+	gh.ReleaseService
+	published []*ghapi.RepositoryRelease
+}
+
+func (f *fakeReleaseService) ListReleases(context.Context, string, string, *ghapi.ListOptions) ([]*ghapi.RepositoryRelease, *ghapi.Response, error) {
+	return f.published, nil, nil
 }

--- a/release/internal/distribution/handlers_test.go
+++ b/release/internal/distribution/handlers_test.go
@@ -238,7 +238,7 @@ func TestGithubReleaseMakeLatest(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			rels := githubReleasesWithLatest(t, tc.published)
-			got, err := GithubRelease{Releases: rels, Tag: tc.tag}.makeLatest(context.Background())
+			got, err := GithubRelease{releases: rels, Tag: tc.tag}.makeLatest(context.Background())
 			if err != nil {
 				t.Fatalf("makeLatest: %v", err)
 			}
@@ -344,5 +344,42 @@ func TestPublishErrorNamesTheDestination(t *testing.T) {
 				t.Errorf("error = %q, want it to name %s", err, tc.want)
 			}
 		})
+	}
+}
+
+// A sums file holding absolute paths verifies nowhere but the machine that
+// built it, so the names must stay relative to the release directory.
+func TestSHA256SumsWritesNamesRelativeToTheDirectory(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "charts"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, n := range []string{"release.tgz", "metadata.yaml", "charts/index.yaml"} {
+		if err := os.WriteFile(filepath.Join(dir, n), []byte(n), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	files, err := topLevelFiles(dir)
+	if err != nil {
+		t.Fatalf("topLevelFiles: %v", err)
+	}
+	if err := (GithubRelease{}).sha256Sums(dir, files); err != nil {
+		t.Fatalf("sha256Sums: %v", err)
+	}
+	bs, err := os.ReadFile(filepath.Join(dir, SumsFileName))
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(bs)
+	for _, want := range []string{"  release.tgz", "  metadata.yaml"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("expected %q, got:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, dir) {
+		t.Errorf("an absolute path was written:\n%s", got)
+	}
+	if strings.Contains(got, "charts") {
+		t.Errorf("a directory was checksummed:\n%s", got)
 	}
 }

--- a/release/internal/github/github.go
+++ b/release/internal/github/github.go
@@ -19,6 +19,8 @@ import "net/url"
 
 const baseURL = "https://github.com"
 
+var tokenEnvVars = []string{"GITHUB_TOKEN", "GH_TOKEN"}
+
 // DownloadURL is where a release's artifacts are downloaded from.
 func DownloadURL(org, repo, version string, file ...string) (string, error) {
 	parts := append([]string{org, repo, "releases", "download", version}, file...)

--- a/release/internal/github/github.go
+++ b/release/internal/github/github.go
@@ -19,7 +19,7 @@ import "net/url"
 
 const baseURL = "https://github.com"
 
-var tokenEnvVars = []string{"GITHUB_TOKEN", "GH_TOKEN"}
+var TokenEnvVars = []string{"GITHUB_TOKEN", "GH_TOKEN"}
 
 // DownloadURL is where a release's artifacts are downloaded from.
 func DownloadURL(org, repo, version string, file ...string) (string, error) {

--- a/release/internal/github/release.go
+++ b/release/internal/github/release.go
@@ -79,12 +79,12 @@ func NewReleases(repo Repo, svc ReleaseService) (*Releases, error) {
 }
 
 func githubToken() (string, error) {
-	for _, key := range tokenEnvVars {
+	for _, key := range TokenEnvVars {
 		if v := os.Getenv(key); v != "" {
 			return v, nil
 		}
 	}
-	return "", fmt.Errorf("not found. checked environment variables %s", strings.Join(tokenEnvVars, " or "))
+	return "", fmt.Errorf("not found. checked environment variables %s", strings.Join(TokenEnvVars, " or "))
 }
 
 func githubClient() (*github.Client, error) {
@@ -186,8 +186,7 @@ func (r *Releases) assets(ctx context.Context, releaseID int64) ([]*github.Relea
 	}
 }
 
-// A draft has no git tag, so the by-tag endpoint 404s and only a listing
-// finds it.
+// find either a draft or a published release for the given tag
 func (r *Releases) forTag(ctx context.Context, tag string) (*github.RepositoryRelease, bool, error) {
 	if rel, found, err := r.Get(ctx, tag); err != nil || found {
 		return rel, found, err
@@ -213,8 +212,6 @@ func (r *Releases) forTag(ctx context.Context, tag string) (*github.RepositoryRe
 // Publish takes a draft live. It marks the release latest only when its
 // version is the newest published one, which the caller decides.
 func (r *Releases) Publish(ctx context.Context, tag string, latest bool) error {
-	// forTag rather than Get: what is being published is a draft, and a draft
-	// carries no git tag for the by-tag endpoint to find.
 	rel, found, err := r.forTag(ctx, tag)
 	if err != nil {
 		return err

--- a/release/internal/github/release.go
+++ b/release/internal/github/release.go
@@ -1,0 +1,254 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package github
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/google/go-github/v53/github"
+)
+
+type Repo struct {
+	Org  string
+	Name string
+}
+
+func (r Repo) validate() error {
+	var errs []error
+	if r.Org == "" {
+		errs = append(errs, fmt.Errorf("no github organization specified"))
+	}
+	if r.Name == "" {
+		errs = append(errs, fmt.Errorf("no github repository specified"))
+	}
+	return errors.Join(errs...)
+}
+
+func (r Repo) String() string {
+	return r.Org + "/" + r.Name
+}
+
+// Releases reads and writes a repository's GitHub releases.
+type Releases struct {
+	repo Repo
+	svc  ReleaseService
+}
+
+// ReleaseService is the part of the GitHub releases API a release uses.
+type ReleaseService interface {
+	GetReleaseByTag(ctx context.Context, owner, repo, tag string) (*github.RepositoryRelease, *github.Response, error)
+	CreateRelease(ctx context.Context, owner, repo string, release *github.RepositoryRelease) (*github.RepositoryRelease, *github.Response, error)
+	EditRelease(ctx context.Context, owner, repo string, id int64, release *github.RepositoryRelease) (*github.RepositoryRelease, *github.Response, error)
+	ListReleases(ctx context.Context, owner, repo string, opts *github.ListOptions) ([]*github.RepositoryRelease, *github.Response, error)
+	ListReleaseAssets(ctx context.Context, owner, repo string, id int64, opts *github.ListOptions) ([]*github.ReleaseAsset, *github.Response, error)
+	DeleteReleaseAsset(ctx context.Context, owner, repo string, id int64) (*github.Response, error)
+	UploadReleaseAsset(ctx context.Context, owner, repo string, id int64, opts *github.UploadOptions, file *os.File) (*github.ReleaseAsset, *github.Response, error)
+}
+
+func NewReleases(repo Repo, svc ReleaseService) (*Releases, error) {
+	if err := repo.validate(); err != nil {
+		return nil, err
+	}
+	if svc != nil {
+		return &Releases{repo: repo, svc: svc}, nil
+	}
+	cli, err := githubClient()
+	if err != nil {
+		return nil, fmt.Errorf("github client: %w", err)
+	}
+	return &Releases{repo: repo, svc: cli.Repositories}, nil
+}
+
+func githubToken() (string, error) {
+	for _, key := range tokenEnvVars {
+		if v := os.Getenv(key); v != "" {
+			return v, nil
+		}
+	}
+	return "", fmt.Errorf("not found. checked environment variables %s", strings.Join(tokenEnvVars, " or "))
+}
+
+func githubClient() (*github.Client, error) {
+	token, err := githubToken()
+	if err != nil {
+		return nil, fmt.Errorf("github token: %w", err)
+	}
+	return github.NewTokenClient(context.Background(), token), nil
+}
+
+// Get returns the release for a tag. exists is false with a nil error when no
+// release carries the tag.
+func (r *Releases) Get(ctx context.Context, tag string) (*github.RepositoryRelease, bool, error) {
+	rel, resp, err := r.svc.GetReleaseByTag(ctx, r.repo.Org, r.repo.Name, tag)
+	if err != nil {
+		if resp != nil && resp.StatusCode == http.StatusNotFound {
+			return nil, false, nil
+		}
+		return nil, false, fmt.Errorf("reading %s release %s: %w", r.repo, tag, err)
+	}
+	return rel, true, nil
+}
+
+// CreateDraft creates a draft release for a tag, returning the existing one if
+// a draft already carries it. A published release is an error: a release
+// nobody can unpublish must not be modified.
+func (r *Releases) CreateDraft(ctx context.Context, tag, name, body string) (*github.RepositoryRelease, error) {
+	switch existing, found, err := r.forTag(ctx, tag); {
+	case err != nil:
+		return nil, err
+	case found && !existing.GetDraft():
+		return nil, fmt.Errorf("%s release %s is already published; refusing to modify it", r.repo, tag)
+	case found:
+		return existing, nil
+	}
+
+	rel, _, err := r.svc.CreateRelease(ctx, r.repo.Org, r.repo.Name, &github.RepositoryRelease{
+		TagName: github.String(tag),
+		Name:    github.String(name),
+		Body:    github.String(body),
+		Draft:   github.Bool(true),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("creating %s release %s: %w", r.repo, tag, err)
+	}
+	return rel, nil
+}
+
+// UploadAsset attaches one file, replacing an asset of the same name. GitHub
+// rejects a duplicate name, so a re-run has to delete before it uploads.
+func (r *Releases) UploadAsset(ctx context.Context, releaseID int64, path string) error {
+	name := filepath.Base(path)
+	if err := r.deleteAsset(ctx, releaseID, name); err != nil {
+		return err
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		return fmt.Errorf("opening %s: %w", path, err)
+	}
+	defer func() { _ = f.Close() }()
+
+	if _, _, err := r.svc.UploadReleaseAsset(ctx, r.repo.Org, r.repo.Name, releaseID,
+		&github.UploadOptions{Name: name}, f); err != nil {
+		return fmt.Errorf("uploading %s: %w", name, err)
+	}
+	return nil
+}
+
+func (r *Releases) deleteAsset(ctx context.Context, releaseID int64, name string) error {
+	assets, err := r.assets(ctx, releaseID)
+	if err != nil {
+		return err
+	}
+	for _, a := range assets {
+		if a.GetName() != name {
+			continue
+		}
+		if _, err := r.svc.DeleteReleaseAsset(ctx, r.repo.Org, r.repo.Name, a.GetID()); err != nil {
+			return fmt.Errorf("replacing asset %s: %w", name, err)
+		}
+	}
+	return nil
+}
+
+func (r *Releases) assets(ctx context.Context, releaseID int64) ([]*github.ReleaseAsset, error) {
+	var out []*github.ReleaseAsset
+	opts := &github.ListOptions{PerPage: pageSize}
+	for {
+		page, resp, err := r.svc.ListReleaseAssets(ctx, r.repo.Org, r.repo.Name, releaseID, opts)
+		if err != nil {
+			return nil, fmt.Errorf("listing assets of %s release %d: %w", r.repo, releaseID, err)
+		}
+		out = append(out, page...)
+		if resp == nil || resp.NextPage == 0 {
+			return out, nil
+		}
+		opts.Page = resp.NextPage
+	}
+}
+
+// A draft has no git tag, so the by-tag endpoint 404s and only a listing
+// finds it.
+func (r *Releases) forTag(ctx context.Context, tag string) (*github.RepositoryRelease, bool, error) {
+	if rel, found, err := r.Get(ctx, tag); err != nil || found {
+		return rel, found, err
+	}
+	opts := &github.ListOptions{PerPage: pageSize}
+	for {
+		page, resp, err := r.svc.ListReleases(ctx, r.repo.Org, r.repo.Name, opts)
+		if err != nil {
+			return nil, false, fmt.Errorf("listing %s releases: %w", r.repo, err)
+		}
+		for _, rel := range page {
+			if rel.GetTagName() == tag {
+				return rel, true, nil
+			}
+		}
+		if resp == nil || resp.NextPage == 0 {
+			return nil, false, nil
+		}
+		opts.Page = resp.NextPage
+	}
+}
+
+// Publish takes a draft live. It marks the release latest only when its
+// version is the newest published one, which the caller decides.
+func (r *Releases) Publish(ctx context.Context, tag string, latest bool) error {
+	rel, found, err := r.Get(ctx, tag)
+	if err != nil {
+		return err
+	}
+	if !found {
+		return fmt.Errorf("no %s release %s to publish", r.repo, tag)
+	}
+
+	edit := &github.RepositoryRelease{Draft: github.Bool(false)}
+	if latest {
+		edit.MakeLatest = github.String("true")
+	}
+	if _, _, err := r.svc.EditRelease(ctx, r.repo.Org, r.repo.Name, rel.GetID(), edit); err != nil {
+		return fmt.Errorf("publishing %s release %s: %w", r.repo, tag, err)
+	}
+	return nil
+}
+
+// LatestTag is the tag of the newest published release, empty when the
+// repository has none. Drafts and prereleases do not count.
+func (r *Releases) LatestTag(ctx context.Context) (string, error) {
+	opts := &github.ListOptions{PerPage: pageSize}
+	for {
+		page, resp, err := r.svc.ListReleases(ctx, r.repo.Org, r.repo.Name, opts)
+		if err != nil {
+			return "", fmt.Errorf("listing %s releases: %w", r.repo, err)
+		}
+		for _, rel := range page {
+			if !rel.GetDraft() && !rel.GetPrerelease() {
+				return rel.GetTagName(), nil
+			}
+		}
+		if resp == nil || resp.NextPage == 0 {
+			return "", nil
+		}
+		opts.Page = resp.NextPage
+	}
+}
+
+const pageSize = 100

--- a/release/internal/github/release.go
+++ b/release/internal/github/release.go
@@ -58,6 +58,7 @@ type ReleaseService interface {
 	CreateRelease(ctx context.Context, owner, repo string, release *github.RepositoryRelease) (*github.RepositoryRelease, *github.Response, error)
 	EditRelease(ctx context.Context, owner, repo string, id int64, release *github.RepositoryRelease) (*github.RepositoryRelease, *github.Response, error)
 	ListReleases(ctx context.Context, owner, repo string, opts *github.ListOptions) ([]*github.RepositoryRelease, *github.Response, error)
+	GetLatestRelease(ctx context.Context, owner, repo string) (*github.RepositoryRelease, *github.Response, error)
 	ListReleaseAssets(ctx context.Context, owner, repo string, id int64, opts *github.ListOptions) ([]*github.ReleaseAsset, *github.Response, error)
 	DeleteReleaseAsset(ctx context.Context, owner, repo string, id int64) (*github.Response, error)
 	UploadReleaseAsset(ctx context.Context, owner, repo string, id int64, opts *github.UploadOptions, file *os.File) (*github.ReleaseAsset, *github.Response, error)
@@ -212,7 +213,9 @@ func (r *Releases) forTag(ctx context.Context, tag string) (*github.RepositoryRe
 // Publish takes a draft live. It marks the release latest only when its
 // version is the newest published one, which the caller decides.
 func (r *Releases) Publish(ctx context.Context, tag string, latest bool) error {
-	rel, found, err := r.Get(ctx, tag)
+	// forTag rather than Get: what is being published is a draft, and a draft
+	// carries no git tag for the by-tag endpoint to find.
+	rel, found, err := r.forTag(ctx, tag)
 	if err != nil {
 		return err
 	}
@@ -230,25 +233,16 @@ func (r *Releases) Publish(ctx context.Context, tag string, latest bool) error {
 	return nil
 }
 
-// LatestTag is the tag of the newest published release, empty when the
-// repository has none. Drafts and prereleases do not count.
+// LatestTag is the tag GitHub serves as the latest release
 func (r *Releases) LatestTag(ctx context.Context) (string, error) {
-	opts := &github.ListOptions{PerPage: pageSize}
-	for {
-		page, resp, err := r.svc.ListReleases(ctx, r.repo.Org, r.repo.Name, opts)
-		if err != nil {
-			return "", fmt.Errorf("listing %s releases: %w", r.repo, err)
-		}
-		for _, rel := range page {
-			if !rel.GetDraft() && !rel.GetPrerelease() {
-				return rel.GetTagName(), nil
-			}
-		}
-		if resp == nil || resp.NextPage == 0 {
+	rel, resp, err := r.svc.GetLatestRelease(ctx, r.repo.Org, r.repo.Name)
+	if err != nil {
+		if resp != nil && resp.StatusCode == http.StatusNotFound {
 			return "", nil
 		}
-		opts.Page = resp.NextPage
+		return "", fmt.Errorf("%s latest release: %w", r.repo, err)
 	}
+	return rel.GetTagName(), nil
 }
 
 const pageSize = 100

--- a/release/internal/github/release_test.go
+++ b/release/internal/github/release_test.go
@@ -1,0 +1,338 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package github
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/google/go-github/v53/github"
+)
+
+// fakeReleases records what a call did, so a test asserts on the request
+// rather than on the client that made it.
+type fakeReleases struct {
+	byTag    map[string]*github.RepositoryRelease
+	assets   []*github.ReleaseAsset
+	getErr   error
+	getResp  *github.Response
+	uploaded []string
+	deleted  []int64
+	created  *github.RepositoryRelease
+	edited   *github.RepositoryRelease
+	listed   []*github.RepositoryRelease
+}
+
+func (f *fakeReleases) GetReleaseByTag(_ context.Context, _, _, tag string) (*github.RepositoryRelease, *github.Response, error) {
+	if f.getErr != nil {
+		return nil, f.getResp, f.getErr
+	}
+	rel, ok := f.byTag[tag]
+	if !ok {
+		return nil, &github.Response{Response: &http.Response{StatusCode: http.StatusNotFound}}, errors.New("not found")
+	}
+	return rel, nil, nil
+}
+
+func (f *fakeReleases) CreateRelease(_ context.Context, _, _ string, rel *github.RepositoryRelease) (*github.RepositoryRelease, *github.Response, error) {
+	f.created = rel
+	rel.ID = github.Int64(1)
+	return rel, nil, nil
+}
+
+func (f *fakeReleases) EditRelease(_ context.Context, _, _ string, _ int64, rel *github.RepositoryRelease) (*github.RepositoryRelease, *github.Response, error) {
+	f.edited = rel
+	return rel, nil, nil
+}
+
+func (f *fakeReleases) ListReleases(_ context.Context, _, _ string, _ *github.ListOptions) ([]*github.RepositoryRelease, *github.Response, error) {
+	return f.listed, nil, nil
+}
+
+// A draft is only reachable by listing, so a fake that serves byTag alone
+// would let a duplicate-draft bug pass.
+func (f *fakeReleases) draft(tag string, rel *github.RepositoryRelease) {
+	rel.TagName = github.String(tag)
+	f.listed = append(f.listed, rel)
+}
+
+func (f *fakeReleases) ListReleaseAssets(_ context.Context, _, _ string, _ int64, _ *github.ListOptions) ([]*github.ReleaseAsset, *github.Response, error) {
+	return f.assets, nil, nil
+}
+
+func (f *fakeReleases) DeleteReleaseAsset(_ context.Context, _, _ string, id int64) (*github.Response, error) {
+	f.deleted = append(f.deleted, id)
+	return nil, nil
+}
+
+func (f *fakeReleases) UploadReleaseAsset(_ context.Context, _, _ string, _ int64, opts *github.UploadOptions, _ *os.File) (*github.ReleaseAsset, *github.Response, error) {
+	f.uploaded = append(f.uploaded, opts.Name)
+	return nil, nil, nil
+}
+
+func testReleases(t *testing.T, f *fakeReleases) *Releases {
+	t.Helper()
+	r, err := NewReleases(Repo{Org: "projectcalico", Name: "calico"}, f)
+	if err != nil {
+		t.Fatalf("NewReleases: %v", err)
+	}
+	return r
+}
+
+func TestNewReleasesRequiresRepo(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		repo Repo
+		want string
+	}{
+		{"no org", Repo{Name: "calico"}, "organization"},
+		{"no name", Repo{Org: "projectcalico"}, "repository"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := NewReleases(tc.repo, &fakeReleases{}); err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("expected an error naming %q, got %v", tc.want, err)
+			}
+		})
+	}
+}
+
+// A missing tag is not an error: the caller decides whether absence is a
+// problem, and a create has to be able to ask.
+func TestGetAbsentTagIsNotAnError(t *testing.T) {
+	got, found, err := testReleases(t, &fakeReleases{}).Get(context.Background(), "v3.30.0")
+	if err != nil || found || got != nil {
+		t.Errorf("got (%v, %v, %v), want (nil, false, nil)", got, found, err)
+	}
+}
+
+// An auth or network failure must not read as "no such release", which would
+// send the caller on to create one.
+func TestGetDistinguishesFailureFromAbsence(t *testing.T) {
+	f := &fakeReleases{
+		getErr:  errors.New("bad credentials"),
+		getResp: &github.Response{Response: &http.Response{StatusCode: http.StatusUnauthorized}},
+	}
+	if _, found, err := testReleases(t, f).Get(context.Background(), "v3.30.0"); err == nil || found {
+		t.Errorf("expected the failure reported, got found=%v err=%v", found, err)
+	}
+}
+
+func TestCreateDraft(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		existing *github.RepositoryRelease
+		wantErr  string
+		wantNew  bool
+	}{
+		{name: "creates when absent", wantNew: true},
+		{
+			name:     "reuses an existing draft",
+			existing: &github.RepositoryRelease{ID: github.Int64(7), Draft: github.Bool(true)},
+		},
+		{
+			name:     "refuses a published release",
+			existing: &github.RepositoryRelease{ID: github.Int64(7), Draft: github.Bool(false)},
+			wantErr:  "already published",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			f := &fakeReleases{}
+			if tc.existing != nil {
+				f.byTag = map[string]*github.RepositoryRelease{"v3.30.0": tc.existing}
+			}
+			rel, err := testReleases(t, f).CreateDraft(context.Background(), "v3.30.0", "v3.30.0", "notes")
+
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("expected an error containing %q, got %v", tc.wantErr, err)
+				}
+				if f.created != nil {
+					t.Error("expected no release created")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("CreateDraft: %v", err)
+			}
+			if tc.wantNew {
+				if f.created == nil {
+					t.Fatal("expected a release created")
+				}
+				if !f.created.GetDraft() {
+					t.Error("expected the new release to be a draft")
+				}
+				return
+			}
+			if f.created != nil {
+				t.Error("expected the existing draft reused, not a new one")
+			}
+			if rel.GetID() != tc.existing.GetID() {
+				t.Errorf("got release %d, want the existing %d", rel.GetID(), tc.existing.GetID())
+			}
+		})
+	}
+}
+
+// GitHub rejects a duplicate asset name, so a re-run has to replace rather
+// than add.
+func TestUploadAssetReplacesSameName(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "SHA256SUMS")
+	if err := os.WriteFile(path, []byte("sums"), 0o644); err != nil {
+		t.Fatalf("writing fixture: %v", err)
+	}
+	f := &fakeReleases{assets: []*github.ReleaseAsset{
+		{ID: github.Int64(11), Name: github.String("SHA256SUMS")},
+		{ID: github.Int64(12), Name: github.String("other.tgz")},
+	}}
+
+	if err := testReleases(t, f).UploadAsset(context.Background(), 1, path); err != nil {
+		t.Fatalf("UploadAsset: %v", err)
+	}
+	if len(f.deleted) != 1 || f.deleted[0] != 11 {
+		t.Errorf("expected only the same-named asset deleted, got %v", f.deleted)
+	}
+	if len(f.uploaded) != 1 || f.uploaded[0] != "SHA256SUMS" {
+		t.Errorf("uploaded = %v, want [SHA256SUMS]", f.uploaded)
+	}
+}
+
+func TestPublish(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		latest     bool
+		wantLatest string
+	}{
+		{name: "undrafts", latest: false},
+		{name: "marks latest when newest", latest: true, wantLatest: "true"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			f := &fakeReleases{byTag: map[string]*github.RepositoryRelease{
+				"v3.30.0": {ID: github.Int64(7), Draft: github.Bool(true)},
+			}}
+			if err := testReleases(t, f).Publish(context.Background(), "v3.30.0", tc.latest); err != nil {
+				t.Fatalf("Publish: %v", err)
+			}
+			if f.edited.GetDraft() {
+				t.Error("expected the release undrafted")
+			}
+			if got := f.edited.GetMakeLatest(); got != tc.wantLatest {
+				t.Errorf("MakeLatest = %q, want %q", got, tc.wantLatest)
+			}
+		})
+	}
+}
+
+func TestPublishAbsentReleaseFails(t *testing.T) {
+	if err := testReleases(t, &fakeReleases{}).Publish(context.Background(), "v3.30.0", false); err == nil {
+		t.Error("expected publishing a release that does not exist to fail")
+	}
+}
+
+// Drafts and prereleases are skipped: the latest tag decides whether the
+// release being published supersedes what users currently get.
+func TestLatestTagSkipsDraftsAndPrereleases(t *testing.T) {
+	f := &fakeReleases{listed: []*github.RepositoryRelease{
+		{TagName: github.String("v3.31.0-rc1"), Prerelease: github.Bool(true)},
+		{TagName: github.String("v3.30.1"), Draft: github.Bool(true)},
+		{TagName: github.String("v3.30.0")},
+	}}
+	got, err := testReleases(t, f).LatestTag(context.Background())
+	if err != nil {
+		t.Fatalf("LatestTag: %v", err)
+	}
+	if got != "v3.30.0" {
+		t.Errorf("LatestTag() = %q, want v3.30.0", got)
+	}
+}
+
+func TestLatestTagNoReleases(t *testing.T) {
+	got, err := testReleases(t, &fakeReleases{}).LatestTag(context.Background())
+	if err != nil || got != "" {
+		t.Errorf("got (%q, %v), want (\"\", nil)", got, err)
+	}
+}
+
+// The real client is only built when no service is injected, so this is where
+// a missing token has to be caught.
+func TestNewReleasesWithoutServiceNeedsAToken(t *testing.T) {
+	for _, name := range tokenEnvVars {
+		t.Setenv(name, "")
+	}
+	if _, err := NewReleases(Repo{Org: "projectcalico", Name: "calico"}, nil); err == nil ||
+		!strings.Contains(err.Error(), "GITHUB_TOKEN") {
+		t.Errorf("expected an error naming the token env vars, got %v", err)
+	}
+
+	t.Setenv("GH_TOKEN", "t")
+	if _, err := NewReleases(Repo{Org: "projectcalico", Name: "calico"}, nil); err != nil {
+		t.Errorf("expected the fallback env var honoured, got %v", err)
+	}
+}
+
+// A draft carries no git tag, so the by-tag lookup 404s on one. Without the
+// listing fallback every run would create another draft for the same tag.
+func TestCreateDraftReusesADraftTheTagLookupCannotSee(t *testing.T) {
+	f := &fakeReleases{}
+	f.draft("v3.30.0", &github.RepositoryRelease{ID: github.Int64(9), Draft: github.Bool(true)})
+
+	rel, err := testReleases(t, f).CreateDraft(context.Background(), "v3.30.0", "v3.30.0", "notes")
+	if err != nil {
+		t.Fatalf("CreateDraft: %v", err)
+	}
+	if f.created != nil {
+		t.Error("expected the existing draft reused, not a second one created")
+	}
+	if rel.GetID() != 9 {
+		t.Errorf("got release %d, want the existing draft 9", rel.GetID())
+	}
+}
+
+func TestCreateDraftRefusesAPublishedReleaseFoundByListing(t *testing.T) {
+	f := &fakeReleases{}
+	f.draft("v3.30.0", &github.RepositoryRelease{ID: github.Int64(9), Draft: github.Bool(false)})
+
+	if _, err := testReleases(t, f).CreateDraft(context.Background(), "v3.30.0", "v3.30.0", "notes"); err == nil ||
+		!strings.Contains(err.Error(), "already published") {
+		t.Errorf("expected a refusal to modify a published release, got %v", err)
+	}
+}
+
+// A failed token lookup must keep failing with the same message, rather than
+// handing back a client that panics at the first call.
+func TestClientBuildFailureRepeats(t *testing.T) {
+	for _, key := range tokenEnvVars {
+		t.Setenv(key, "")
+	}
+	for range 2 {
+		c, err := githubClient()
+		if err == nil {
+			t.Fatalf("expected an error with no token, got client=%v", c != nil)
+		}
+		if c != nil {
+			t.Errorf("expected no client alongside the error, got %v", c)
+		}
+	}
+
+	t.Setenv("GITHUB_TOKEN", "t")
+	if c, err := githubClient(); err != nil || c == nil {
+		t.Errorf("expected a client once the token is set, got (%v, %v)", c != nil, err)
+	}
+}

--- a/release/internal/github/release_test.go
+++ b/release/internal/github/release_test.go
@@ -62,6 +62,15 @@ func (f *fakeReleases) EditRelease(_ context.Context, _, _ string, _ int64, rel 
 	return rel, nil, nil
 }
 
+func (f *fakeReleases) GetLatestRelease(_ context.Context, _, _ string) (*github.RepositoryRelease, *github.Response, error) {
+	for _, rel := range f.listed {
+		if !rel.GetDraft() && !rel.GetPrerelease() {
+			return rel, nil, nil
+		}
+	}
+	return nil, &github.Response{Response: &http.Response{StatusCode: http.StatusNotFound}}, errors.New("not found")
+}
+
 func (f *fakeReleases) ListReleases(_ context.Context, _, _ string, _ *github.ListOptions) ([]*github.RepositoryRelease, *github.Response, error) {
 	return f.listed, nil, nil
 }
@@ -246,9 +255,8 @@ func TestPublishAbsentReleaseFails(t *testing.T) {
 	}
 }
 
-// Drafts and prereleases are skipped: the latest tag decides whether the
-// release being published supersedes what users currently get.
-func TestLatestTagSkipsDraftsAndPrereleases(t *testing.T) {
+// GitHub serves the latest release itself, so ours is whatever it reports.
+func TestLatestTagIsWhatGithubServes(t *testing.T) {
 	f := &fakeReleases{listed: []*github.RepositoryRelease{
 		{TagName: github.String("v3.31.0-rc1"), Prerelease: github.Bool(true)},
 		{TagName: github.String("v3.30.1"), Draft: github.Bool(true)},
@@ -334,5 +342,22 @@ func TestClientBuildFailureRepeats(t *testing.T) {
 	t.Setenv("GITHUB_TOKEN", "t")
 	if c, err := githubClient(); err != nil || c == nil {
 		t.Errorf("expected a client once the token is set, got (%v, %v)", c != nil, err)
+	}
+}
+
+// Publishing takes a draft live, and a draft is the one thing the by-tag
+// endpoint cannot see. Looking it up that way strands every release.
+func TestPublishFindsADraftTheTagLookupCannotSee(t *testing.T) {
+	f := &fakeReleases{}
+	f.draft("v3.30.0", &github.RepositoryRelease{ID: github.Int64(9), Draft: github.Bool(true)})
+
+	if err := testReleases(t, f).Publish(context.Background(), "v3.30.0", false); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	if f.edited == nil {
+		t.Fatal("expected the draft edited")
+	}
+	if f.edited.GetDraft() {
+		t.Error("expected the release undrafted")
 	}
 }

--- a/release/internal/github/release_test.go
+++ b/release/internal/github/release_test.go
@@ -281,7 +281,7 @@ func TestLatestTagNoReleases(t *testing.T) {
 // The real client is only built when no service is injected, so this is where
 // a missing token has to be caught.
 func TestNewReleasesWithoutServiceNeedsAToken(t *testing.T) {
-	for _, name := range tokenEnvVars {
+	for _, name := range TokenEnvVars {
 		t.Setenv(name, "")
 	}
 	if _, err := NewReleases(Repo{Org: "projectcalico", Name: "calico"}, nil); err == nil ||
@@ -326,7 +326,7 @@ func TestCreateDraftRefusesAPublishedReleaseFoundByListing(t *testing.T) {
 // A failed token lookup must keep failing with the same message, rather than
 // handing back a client that panics at the first call.
 func TestClientBuildFailureRepeats(t *testing.T) {
-	for _, key := range tokenEnvVars {
+	for _, key := range TokenEnvVars {
 		t.Setenv(key, "")
 	}
 	for range 2 {

--- a/release/internal/hashreleaseserver/server.go
+++ b/release/internal/hashreleaseserver/server.go
@@ -27,7 +27,6 @@ import (
 	"cloud.google.com/go/storage"
 	"github.com/sirupsen/logrus"
 
-	"github.com/projectcalico/calico/release/internal/command"
 	"github.com/projectcalico/calico/release/internal/registry"
 )
 
@@ -74,10 +73,11 @@ type Hashrelease struct {
 
 	// ImageScanResultURL is the URL to the image scan result for this hashrelease
 	ImageScanResultURL string `yaml:"iss_url,omitempty"`
+}
 
-	// UploadExcludes are regex patterns (matched against the source-relative
-	// path) for artifacts under Source that must not be uploaded to the server.
-	UploadExcludes []string `yaml:"-"`
+// BucketURI is where the hashrelease's content is served from.
+func (h *Hashrelease) BucketURI(cfg *Config) string {
+	return fmt.Sprintf("gs://%s/%s", cfg.BucketName, h.Name)
 }
 
 func (h *Hashrelease) URL() string {
@@ -88,26 +88,13 @@ func HashreleaseURL(hashreleaseName string) string {
 	return fmt.Sprintf("https://%s.%s", hashreleaseName, BaseDomain)
 }
 
-// PublishHashrelease publishes the hashrelease in 3 parts
-//
-// 1. It publishes the hashrelease to the server via SSH and to cloud storage.
-//
-// 2. It adds the hashrelease to the hashrelease library on the server and cloud storage.
-//
-// 3. It sets it as the latest for its product stream if specified.
-func Publish(productCode string, h *Hashrelease, cfg *Config) error {
+// Uploading the content is the caller's, not this.
+func Record(productCode string, h *Hashrelease, cfg *Config) error {
 	logrus.WithFields(logrus.Fields{
 		"hashrelease": h.Name,
-		"srcDir":      h.Source,
 		"latest":      h.Latest,
-	}).Info("Publishing hashrelease")
+	}).Info("Recording hashrelease")
 
-	if err := publishFiles(h, cfg); err != nil {
-		logrus.WithError(err).Error("Failed to publish hashrelease")
-		return fmt.Errorf("failed to publish hashrelease %s: %w", h.Name, err)
-	}
-
-	// add the hashrelease to the library
 	if err := addToHashreleaseLibrary(*h, cfg); err != nil {
 		logrus.WithError(err).Error("failed to add hashrelease to library")
 		return err
@@ -115,36 +102,11 @@ func Publish(productCode string, h *Hashrelease, cfg *Config) error {
 
 	if h.Latest {
 		if err := setHashreleaseAsLatest(*h, productCode, cfg); err != nil {
-			// We don't want to fail the publish if we can't set it as latest, but we should log the error
+			// Being unreachable as "latest" is not worth failing a publish over.
 			logrus.WithError(err).Error("failed to set hashrelease as latest")
 		}
 	}
 
-	return nil
-}
-
-func publishFiles(h *Hashrelease, cfg *Config) error {
-	// publish to cloud storage
-	logrus.WithFields(logrus.Fields{
-		"hashrelease": h.Name,
-		"srcDir":      h.Source,
-	}).Debug("Publishing hashrelease to cloud storage")
-	args := []string{
-		"storage", "rsync",
-		h.Source, fmt.Sprintf("gs://%s/%s", cfg.BucketName, h.Name),
-		"--recursive", "--delete-unmatched-destination-objects",
-	}
-	for _, e := range h.UploadExcludes {
-		args = append(args, "--exclude="+e)
-	}
-	if logrus.IsLevelEnabled(logrus.DebugLevel) {
-		args = append(args, "--verbosity=debug")
-	}
-	if _, err := command.Run("gcloud", args); err != nil {
-		logrus.WithError(err).Error("Failed to publish hashrelease to bucket")
-		return fmt.Errorf("failed to publish hashrelease %s to bucket: %w", h.Name, err)
-	}
-	logrus.WithField("hashrelease", h.Name).Debug("Published hashrelease without error")
 	return nil
 }
 

--- a/release/internal/yamledit/yamledit.go
+++ b/release/internal/yamledit/yamledit.go
@@ -95,6 +95,9 @@ func ApplyToFile(path string, edits ...Edit) error {
 }
 
 func (e Edit) spans(src []byte) ([]span, error) {
+	if e.Key == "" {
+		return nil, fmt.Errorf("no key to read")
+	}
 	var docs []*yaml.Node
 	dec := yaml.NewDecoder(bytes.NewReader(src))
 	for {
@@ -202,4 +205,22 @@ func lineSpan(src []byte, line int) (span, bool) {
 		end = start + i
 	}
 	return span{start, end}, true
+}
+
+// Read returns the value at each place key matches, in file order, matching
+// the same way an Edit does.
+func Read(path, key string) ([]string, error) {
+	src, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading %s: %w", path, err)
+	}
+	spans, err := Edit{Key: key}.spans(src)
+	if err != nil {
+		return nil, fmt.Errorf("reading %s: %w", path, err)
+	}
+	out := make([]string, 0, len(spans))
+	for _, s := range spans {
+		out = append(out, string(src[s.start:s.end]))
+	}
+	return out, nil
 }

--- a/release/internal/yamledit/yamledit_test.go
+++ b/release/internal/yamledit/yamledit_test.go
@@ -17,6 +17,7 @@ package yamledit
 import (
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 )
@@ -284,5 +285,46 @@ func TestApplyAcrossDocuments(t *testing.T) {
 	}
 	if want := "tag: X\n---\ntag: X\n"; string(got) != want {
 		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestRead(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "doc.yaml")
+	src := `apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: calicoctl
+---
+kind: Pod
+spec:
+  containers:
+    - name: one
+      image: quay.io/calico/calico:master
+    - name: two
+      image: docker.io/calico/node:master
+`
+	if err := os.WriteFile(path, []byte(src), 0o644); err != nil {
+		t.Fatalf("writing fixture: %v", err)
+	}
+
+	for _, tc := range []struct {
+		name string
+		key  string
+		want []string
+	}{
+		{"a full path across documents", "spec.containers.image", []string{"quay.io/calico/calico:master", "docker.io/calico/node:master"}},
+		{"a bare key at any depth", "name", []string{"calicoctl", "one", "two"}},
+		{"no match", "spec.missing", nil},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := Read(path, tc.key)
+			if err != nil {
+				t.Fatalf("Read: %v", err)
+			}
+			if !slices.Equal(got, tc.want) {
+				t.Errorf("Read(%q) = %v, want %v", tc.key, got, tc.want)
+			}
+		})
 	}
 }

--- a/release/pkg/manager/calico/manager.go
+++ b/release/pkg/manager/calico/manager.go
@@ -48,11 +48,12 @@ import (
 
 // Global configuration for releases.
 const (
-	calicoctlManifest = "calicoctl.yaml"
-
 	chartsDir    = "charts"
 	manifestsDir = "manifests"
+	metadataKey  = "metadata"
 )
+
+const calicoctlManifest = "calicoctl.yaml"
 
 var (
 	// Default defaultRegistries to which all release images are pushed.
@@ -707,26 +708,21 @@ func (r *CalicoManager) PublishRelease() error {
 		return err
 	}
 
-	// The registries go first: metadata records the digests they produce, and
-	// the github release references the tag.
+	// The registries go first: metadata records the digests they produce
 	uploads := []distribution.Upload{
 		{Handler: distribution.Publisher{Kind: "images", Action: r.publishContainerImages}},
 		{Handler: distribution.Publisher{Kind: chartsDir, Action: r.publishHelmCharts}},
 	}
 	uploads = append(uploads,
-		distribution.Upload{Handler: distribution.Preparer{Kind: "metadata", Action: r.buildMetadata}},
-		distribution.Upload{Handler: distribution.Preparer{Kind: "checksums", Action: r.writeChecksums}},
+		distribution.Upload{Handler: distribution.Preparer{Kind: metadataKey, Action: r.buildMetadata}},
 	)
 
 	if r.isHashRelease {
 		uploads = append(uploads, r.hashreleaseUpload()...)
 		return distribution.Publish(uploads, distribution.WithRunner(r.runner))
 	}
-	uploads = append(uploads, r.githubTagUpload(), r.helmIndexUpload())
-	github, err := r.githubReleaseUpload()
-	if err != nil {
-		return err
-	}
+	uploads = append(uploads, r.helmIndexUpload(), r.githubTagUpload())
+	github := r.githubReleaseUpload()
 	// nil when the github release is disabled.
 	if github != nil {
 		uploads = append(uploads, *github)
@@ -947,8 +943,8 @@ func (r *CalicoManager) publishPrereqs() error {
 	return r.assertImageVersions()
 }
 
-// collectArtifacts gathers everything a release publishes into the upload
-// directory.
+// gathers everything a release publishes into the upload directory.
+// TODO: remove, each step should handle putting its artifacts in the correct location.
 func (r *CalicoManager) collectArtifacts() error {
 	if err := r.collectBinaries(); err != nil {
 		return err
@@ -960,11 +956,6 @@ func (r *CalicoManager) collectArtifacts() error {
 		return err
 	}
 	return r.collectOCPBundle()
-}
-
-// Users verify a download with: sha256sum -c --ignore-missing SHA256SUMS
-func (r *CalicoManager) writeChecksums() error {
-	return distribution.SHA256Sums(r.uploadDir(), distribution.WithRunner(r.runner))
 }
 
 func (r *CalicoManager) collectBinaries() error {
@@ -1291,10 +1282,10 @@ func (r *CalicoManager) githubTagUpload() distribution.Upload {
 	return distribution.Upload{Handler: distribution.Preparer{Kind: "git tag", Action: r.publishGitTag}}
 }
 
-func (r *CalicoManager) githubReleaseUpload() (*distribution.Upload, error) {
+func (r *CalicoManager) githubReleaseUpload() *distribution.Upload {
 	if !r.githubRelease {
 		logrus.Info("Skipping github release")
-		return nil, nil
+		return nil
 	}
 
 	releaseNoteTemplate := `
@@ -1331,22 +1322,17 @@ Additional links:
 	replacer := strings.NewReplacer(formatters...)
 	releaseNote := replacer.Replace(releaseNoteTemplate)
 
-	releases, err := github.NewReleases(github.Repo{Org: r.githubOrg, Name: r.repo}, nil)
-	if err != nil {
-		return nil, fmt.Errorf("github releases: %w", err)
-	}
-
 	return &distribution.Upload{
 		Name:   "github release",
 		Source: r.uploadDir(),
 		Handler: distribution.GithubRelease{
-			Releases: releases,
-			Tag:      r.calicoVersion,
-			Body:     releaseNote,
-			Draft:    r.draftRelease,
-			DryRun:   r.dryRun,
+			Repo:   github.Repo{Org: r.githubOrg, Name: r.repo},
+			Tag:    r.calicoVersion,
+			Body:   releaseNote,
+			Draft:  r.draftRelease,
+			DryRun: r.dryRun,
 		},
-	}, nil
+	}
 }
 
 func (r *CalicoManager) publishContainerImages() error {

--- a/release/pkg/manager/calico/manager.go
+++ b/release/pkg/manager/calico/manager.go
@@ -181,6 +181,7 @@ type CalicoManager struct {
 	dryRun        bool
 	gitRef        bool
 	githubRelease bool
+	draftRelease  bool
 	awsProfile    string
 	s3Bucket      string
 	githubToken   string
@@ -700,7 +701,7 @@ func (r *CalicoManager) PublishRelease() error {
 		uploads = append(uploads, r.hashreleaseUpload()...)
 		return distribution.Publish(uploads, !r.dryRun, distribution.WithRunner(r.runner))
 	}
-	uploads = append(uploads, r.githubTagUpload(),  r.helmIndexUpload())
+	uploads = append(uploads, r.githubTagUpload(), r.helmIndexUpload())
 	github, err := r.githubReleaseUpload()
 	if err != nil {
 		return err
@@ -714,33 +715,6 @@ func (r *CalicoManager) PublishRelease() error {
 
 func (r *CalicoManager) buildMetadata() error {
 	return r.BuildMetadata(r.uploadDir())
-}
-
-func (r *CalicoManager) ReleasePublic() error {
-	// Get the latest version
-	args := []string{
-		"release", "list", "--repo", fmt.Sprintf("%s/%s", r.githubOrg, r.repo),
-		"--exclude-drafts", "--exclude-prereleases", "--json 'name,isLatest'",
-		"--jq '.[] | select(.isLatest) | .name'",
-	}
-	out, err := r.runner.RunInDir(r.repoRoot, "./bin/gh", args, nil)
-	if err != nil {
-		return fmt.Errorf("failed to get latest release: %s", err)
-	}
-	args = []string{
-		"release", "edit", r.calicoVersion, "--draft=false",
-		"--repo", fmt.Sprintf("%s/%s", r.githubOrg, r.repo),
-	}
-	latest := version.New(strings.TrimSpace(out))
-	current := version.New(r.calicoVersion)
-	if current.Semver().GreaterThan(latest.Semver()) {
-		args = append(args, "--latest")
-	}
-	_, err = r.runner.RunInDir(r.repoRoot, "./bin/gh", args, nil)
-	if err != nil {
-		return fmt.Errorf("failed to publish %s draft release: %s", r.calicoVersion, err)
-	}
-	return nil
 }
 
 // Check general prerequisites for cutting and publishing a release.
@@ -1342,7 +1316,7 @@ Additional links:
 			Releases: releases,
 			Tag:      r.calicoVersion,
 			Body:     releaseNote,
-			Draft:    true,
+			Draft:    r.draftRelease,
 			DryRun:   r.dryRun,
 		},
 	}, nil

--- a/release/pkg/manager/calico/manager.go
+++ b/release/pkg/manager/calico/manager.go
@@ -33,6 +33,7 @@ import (
 	"github.com/projectcalico/calico/release/internal/branch"
 	"github.com/projectcalico/calico/release/internal/charts"
 	"github.com/projectcalico/calico/release/internal/command"
+	"github.com/projectcalico/calico/release/internal/distribution"
 	"github.com/projectcalico/calico/release/internal/hashreleaseserver"
 	"github.com/projectcalico/calico/release/internal/images"
 	"github.com/projectcalico/calico/release/internal/imagescanner"
@@ -669,13 +670,17 @@ func (r *CalicoManager) publishToHashreleaseServer() error {
 		logrus.Info("Skipping publishing to hashrelease server")
 		return nil
 	}
-	logrus.WithFields(logrus.Fields{
-		"version": r.calicoVersion,
-		"name":    r.hashrelease.Name,
-		"note":    r.hashrelease.Note,
-	}).Info("Publishing hashrelease")
 
-	return hashreleaseserver.Publish(r.productCode, &r.hashrelease, &r.hashreleaseConfig)
+	return distribution.Publish([]distribution.Upload{{
+		Source: r.uploadDir(),
+		Handler: distribution.HashreleaseServer{
+			Release:     &r.hashrelease,
+			Config:      &r.hashreleaseConfig,
+			ProductCode: r.productCode,
+			DryRun:      r.dryRun,
+			Runner:      r.runner,
+		},
+	}}, !r.dryRun, distribution.WithRunner(r.runner))
 }
 
 func (r *CalicoManager) PublishRelease() error {

--- a/release/pkg/manager/calico/manager.go
+++ b/release/pkg/manager/calico/manager.go
@@ -27,6 +27,7 @@ import (
 	"strings"
 
 	"github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v3"
 
 	"github.com/projectcalico/calico/release/internal/branch"
 	"github.com/projectcalico/calico/release/internal/charts"
@@ -41,11 +42,14 @@ import (
 	"github.com/projectcalico/calico/release/internal/steps"
 	"github.com/projectcalico/calico/release/internal/utils"
 	"github.com/projectcalico/calico/release/internal/version"
+	"github.com/projectcalico/calico/release/internal/yamledit"
 	"github.com/projectcalico/calico/release/pkg/manager/operator"
 )
 
 // Global configuration for releases.
 const (
+	calicoctlManifest = "calicoctl.yaml"
+
 	chartsDir    = "charts"
 	manifestsDir = "manifests"
 )
@@ -379,6 +383,35 @@ func (r *CalicoManager) Build() error {
 	return r.collectArtifacts()
 }
 
+var _ distribution.Attester = metadata{}
+
+type metadata struct {
+	Version string `json:"version"`
+
+	OperatorVersion string `json:"operator_version" yaml:"operatorVersion"`
+
+	Images []distribution.Component `json:"images"`
+
+	ChartVersion string `json:"helm_chart_version" yaml:"helmChartVersion"`
+}
+
+func (r metadata) Attest() ([]byte, error) {
+	var errs []error
+	if r.Version == "" {
+		errs = append(errs, fmt.Errorf("no version specified"))
+	}
+	if r.OperatorVersion == "" {
+		errs = append(errs, fmt.Errorf("no operator version specified"))
+	}
+	if len(r.Images) == 0 {
+		errs = append(errs, fmt.Errorf("no images specified"))
+	}
+	if err := errors.Join(errs...); err != nil {
+		return nil, err
+	}
+	return yaml.Marshal(r)
+}
+
 func (r *CalicoManager) BuildMetadata(dir string) error {
 	reg, err := r.getRegistryFromManifests()
 	if err != nil {
@@ -396,7 +429,7 @@ func (r *CalicoManager) BuildMetadata(dir string) error {
 		components = append(components, distribution.Component{Registry: reg, Image: img, Version: r.calicoVersion})
 	}
 
-	return distribution.BuildMetadata(distribution.Metadata{
+	return distribution.BuildMetadata(metadata{
 		Version:         r.calicoVersion,
 		OperatorVersion: r.operatorVersion,
 		Images:          components,
@@ -404,20 +437,31 @@ func (r *CalicoManager) BuildMetadata(dir string) error {
 	}, dir, distribution.WithRunner(r.runner))
 }
 
+// Fetch the registry from the calicoctl manifest file.
+// For hashrelease, it looks in the hashrelease source directory.
 func (r *CalicoManager) getRegistryFromManifests() (string, error) {
-	args := []string{"-Po", `image:\K(.*)`, "calicoctl.yaml"}
-	out, err := r.runner.RunInDir(filepath.Join(r.repoRoot, manifestsDir), "grep", args, nil)
+	dir := filepath.Join(r.repoRoot, manifestsDir)
+	if r.isHashRelease {
+		dir = filepath.Join(r.hashrelease.Source, manifestsDir)
+	}
+	key := "spec.containers.image"
+	path := filepath.Join(dir, calicoctlManifest)
+	imgs, err := yamledit.Read(path, key)
 	if err != nil {
-		return "", fmt.Errorf("error getting registry from calicoctl.yaml manifest: %w", err)
+		return "", err
 	}
-	imgs := strings.SplitSeq(out, "\n")
-	for i := range imgs {
-		parts := strings.Split(i, "/")
-		if len(parts) > 1 {
-			return strings.Join(parts[:len(parts)-1], "/"), nil
+	for _, img := range imgs {
+		if !strings.Contains(img, "calico") {
+			continue
 		}
+		// registry/image:tag, so everything before the last slash.
+		// A registry may carry a path of its own e.g. example/path/to/image:tag
+		if i := strings.LastIndex(img, "/"); i > 0 {
+			return img[:i], nil
+		}
+		return "", nil
 	}
-	return "", fmt.Errorf("failed to find registry from manifests")
+	return "", fmt.Errorf("no registry found in %s using key(%s)", path, key)
 }
 
 func (r *CalicoManager) PreHashreleaseValidate() error {

--- a/release/pkg/manager/calico/manager.go
+++ b/release/pkg/manager/calico/manager.go
@@ -45,6 +45,11 @@ import (
 )
 
 // Global configuration for releases.
+const (
+	chartsDir    = "charts"
+	manifestsDir = "manifests"
+)
+
 var (
 	// Default defaultRegistries to which all release images are pushed.
 	defaultRegistries = registry.DefaultCalicoRegistries
@@ -401,7 +406,7 @@ func (r *CalicoManager) BuildMetadata(dir string) error {
 
 func (r *CalicoManager) getRegistryFromManifests() (string, error) {
 	args := []string{"-Po", `image:\K(.*)`, "calicoctl.yaml"}
-	out, err := r.runner.RunInDir(filepath.Join(r.repoRoot, "manifests"), "grep", args, nil)
+	out, err := r.runner.RunInDir(filepath.Join(r.repoRoot, manifestsDir), "grep", args, nil)
 	if err != nil {
 		return "", fmt.Errorf("error getting registry from calicoctl.yaml manifest: %w", err)
 	}
@@ -662,7 +667,7 @@ func (r *CalicoManager) PublishRelease() error {
 	// the github release references the tag.
 	uploads := []distribution.Upload{
 		{Handler: distribution.Publisher{Kind: "images", Action: r.publishContainerImages}},
-		{Handler: distribution.Publisher{Kind: "charts", Action: r.publishHelmCharts}},
+		{Handler: distribution.Publisher{Kind: chartsDir, Action: r.publishHelmCharts}},
 	}
 	uploads = append(uploads,
 		distribution.Upload{Handler: distribution.Preparer{Kind: "metadata", Action: r.buildMetadata}},
@@ -671,7 +676,7 @@ func (r *CalicoManager) PublishRelease() error {
 
 	if r.isHashRelease {
 		uploads = append(uploads, r.hashreleaseUpload()...)
-		return distribution.Publish(uploads, !r.dryRun, distribution.WithRunner(r.runner))
+		return distribution.Publish(uploads, distribution.WithRunner(r.runner))
 	}
 	uploads = append(uploads, r.githubTagUpload(), r.helmIndexUpload())
 	github, err := r.githubReleaseUpload()
@@ -682,7 +687,7 @@ func (r *CalicoManager) PublishRelease() error {
 	if github != nil {
 		uploads = append(uploads, *github)
 	}
-	return distribution.Publish(uploads, !r.dryRun, distribution.WithRunner(r.runner))
+	return distribution.Publish(uploads, distribution.WithRunner(r.runner))
 }
 
 func (r *CalicoManager) buildMetadata() error {
@@ -943,7 +948,7 @@ func (r *CalicoManager) collectManifests() error {
 	if r.isHashRelease {
 		uploadDir := r.uploadDir()
 		// Hashrelease include manifests in a different way, instead of just in the release tarball.
-		if _, err := r.runner.Run("cp", []string{"-r", filepath.Join(r.repoRoot, "manifests"), uploadDir}, nil); err != nil {
+		if _, err := r.runner.Run("cp", []string{"-r", filepath.Join(r.repoRoot, manifestsDir), uploadDir}, nil); err != nil {
 			logrus.WithError(err).Error("Failed to copy manifests to output directory")
 			return fmt.Errorf("failed to copy manifests: %w", err)
 		}
@@ -1005,7 +1010,7 @@ func (r *CalicoManager) resetManifests() {
 	if !r.manifests {
 		return
 	}
-	if _, err := r.runner.RunInDir(r.repoRoot, "git", []string{"checkout", "manifests", "test-tools/mocknode/mock-node.yaml"}, nil); err != nil {
+	if _, err := r.runner.RunInDir(r.repoRoot, "git", []string{"checkout", manifestsDir, "test-tools/mocknode/mock-node.yaml"}, nil); err != nil {
 		logrus.WithError(err).Error("Failed to reset manifests")
 	}
 }
@@ -1064,7 +1069,7 @@ func (r *CalicoManager) buildReleaseTar() error {
 
 	// Add in manifests directory generated from the docs.
 	if r.manifests {
-		if _, err := r.runner.RunInDir(r.repoRoot, "cp", []string{"-al", "manifests", releaseBase}, nil); err != nil {
+		if _, err := r.runner.RunInDir(r.repoRoot, "cp", []string{"-al", manifestsDir, releaseBase}, nil); err != nil {
 			return fmt.Errorf("failed to copy manifests: %w", err)
 		}
 	}
@@ -1472,7 +1477,7 @@ func (r *CalicoManager) helmIndexUpload() distribution.Upload {
 		Source: charts.IndexFilePath(r.chart().BaseDir),
 		Skip:   !r.helmCharts || !r.helmIndex,
 		Handler: distribution.S3{
-			URI:     r.s3URI("charts"),
+			URI:     r.s3URI(chartsDir),
 			Profile: r.awsProfile,
 			DryRun:  r.dryRun,
 			Runner:  r.runner,
@@ -1509,7 +1514,7 @@ func (r *CalicoManager) assertManifestVersions(ver string) error {
 
 	for _, m := range manifests {
 		args := []string{"-Po", `image:\K(.*)`, m}
-		out, err := r.runner.RunInDir(filepath.Join(r.repoRoot, "manifests"), "grep", args, nil)
+		out, err := r.runner.RunInDir(filepath.Join(r.repoRoot, manifestsDir), "grep", args, nil)
 		if err != nil {
 			return fmt.Errorf("failed to get images from manifest %s: %w", m, err)
 		}
@@ -1595,8 +1600,8 @@ func (r *CalicoManager) releaseBranchPrereqs() error {
 // branchChangedPaths are the trees the prepareDerived hook rewrites; it reports
 // them so the branch flow stages them into the cut commit.
 var branchChangedPaths = []string{
-	"charts",
-	"manifests",
+	chartsDir,
+	manifestsDir,
 	".semaphore",
 	"test-tools/mocknode",
 }
@@ -1793,8 +1798,8 @@ func (r *CalicoManager) updateAndCommitPrep() error {
 	}
 
 	if _, err := r.git("add",
-		filepath.Join(r.repoRoot, "charts"),
-		filepath.Join(r.repoRoot, "manifests"),
+		filepath.Join(r.repoRoot, chartsDir),
+		filepath.Join(r.repoRoot, manifestsDir),
 		filepath.Join(r.repoRoot, outputs.ReleaseNotesDir),
 	); err != nil {
 		return fmt.Errorf("failed to stage files: %w", err)

--- a/release/pkg/manager/calico/manager.go
+++ b/release/pkg/manager/calico/manager.go
@@ -56,8 +56,6 @@ var (
 
 	metadataFileName = "metadata.yaml"
 
-	helmIndexFileName = "index.yaml"
-
 	branchTagTarget = "retag-build-images-with-registries push-images-to-registries push-manifests"
 
 	// Windows images are published as a single manifest, so their branch tag
@@ -1230,7 +1228,12 @@ func (r *CalicoManager) publishGitTag() error {
 		return fmt.Errorf("remote tag %s already exists at %s but local tag is %s", r.calicoVersion, remoteSHA, localSHA)
 	}
 
-	if _, err := r.git("push", r.remote, r.calicoVersion); err != nil {
+	args := []string{"push", r.remote, r.calicoVersion}
+
+	if r.dryRun {
+		args = append(args, "--dry-run")
+	}
+	if _, err := r.git(args...); err != nil {
 		return fmt.Errorf("failed to push git tag: %w", err)
 	}
 	return nil
@@ -1494,12 +1497,16 @@ func (r *CalicoManager) helmIndexUpload() distribution.Upload {
 		Source: charts.IndexFilePath(r.chart().BaseDir),
 		Skip:   !r.helmCharts || !r.helmIndex,
 		Handler: distribution.S3{
-			URI:     fmt.Sprintf("s3://%s/charts", r.s3Bucket),
+			URI:     r.s3URI("charts"),
 			Profile: r.awsProfile,
 			DryRun:  r.dryRun,
 			Runner:  r.runner,
 		},
 	}
+}
+
+func (r *CalicoManager) s3URI(path ...string) string {
+	return fmt.Sprintf("s3://%s/%s/", r.s3Bucket, strings.Join(path, "/"))
 }
 
 func (r *CalicoManager) assertReleaseNotesPresent(ver string) error {
@@ -1596,29 +1603,6 @@ func (r *CalicoManager) makeInDirectoryWithOutput(dir, target string, env ...str
 func (r *CalicoManager) makeInDirectoryIgnoreOutput(dir, target string, env ...string) error {
 	_, err := r.makeInDirectoryWithOutput(dir, target, env...)
 	return err
-}
-
-func (r *CalicoManager) s3Cp(src, dest string, additionalFlags ...string) error {
-	args := []string{
-		"s3", "cp",
-		src, dest,
-	}
-	if r.awsProfile != "" {
-		args = append(args, "--profile", r.awsProfile)
-	}
-	if strings.HasSuffix(src, "/") {
-		args = append(args, "--recursive")
-	}
-	if logrus.IsLevelEnabled(logrus.DebugLevel) {
-		args = append(args, "--debug")
-	}
-	if len(additionalFlags) > 0 {
-		args = append(args, additionalFlags...)
-	}
-	if _, err := r.runner.Run("aws", args, nil); err != nil {
-		return err
-	}
-	return nil
 }
 
 func (r *CalicoManager) releaseBranchPrereqs() error {

--- a/release/pkg/manager/calico/manager.go
+++ b/release/pkg/manager/calico/manager.go
@@ -15,7 +15,6 @@
 package calico
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"maps"
@@ -34,6 +33,7 @@ import (
 	"github.com/projectcalico/calico/release/internal/charts"
 	"github.com/projectcalico/calico/release/internal/command"
 	"github.com/projectcalico/calico/release/internal/distribution"
+	"github.com/projectcalico/calico/release/internal/github"
 	"github.com/projectcalico/calico/release/internal/hashreleaseserver"
 	"github.com/projectcalico/calico/release/internal/images"
 	"github.com/projectcalico/calico/release/internal/imagescanner"
@@ -385,10 +385,7 @@ func (r *CalicoManager) Build() error {
 		return err
 	}
 
-	if err = r.collectGithubArtifacts(); err != nil {
-		return err
-	}
-	return nil
+	return r.collectArtifacts()
 }
 
 type metadata struct {
@@ -665,13 +662,13 @@ func (r *CalicoManager) buildOCPBundle() error {
 	return nil
 }
 
-func (r *CalicoManager) publishToHashreleaseServer() error {
+func (r *CalicoManager) hashreleaseUpload() []distribution.Upload {
 	if !r.publishHashrelease {
 		logrus.Info("Skipping publishing to hashrelease server")
 		return nil
 	}
 
-	return distribution.Publish([]distribution.Upload{{
+	return []distribution.Upload{{
 		Source: r.uploadDir(),
 		Handler: distribution.HashreleaseServer{
 			Release:     &r.hashrelease,
@@ -680,47 +677,43 @@ func (r *CalicoManager) publishToHashreleaseServer() error {
 			DryRun:      r.dryRun,
 			Runner:      r.runner,
 		},
-	}}, !r.dryRun, distribution.WithRunner(r.runner))
+	}}
 }
 
 func (r *CalicoManager) PublishRelease() error {
-	// Check that the environment has the necessary prereqs.
 	if err := r.publishPrereqs(); err != nil {
 		return err
 	}
 
-	// Publish container images.
-	if err := r.publishContainerImages(); err != nil {
-		return err
+	// The registries go first: metadata records the digests they produce, and
+	// the github release references the tag.
+	uploads := []distribution.Upload{
+		{Handler: distribution.Publisher{Kind: "images", Action: r.publishContainerImages}},
+		{Handler: distribution.Publisher{Kind: "charts", Action: r.publishHelmCharts}},
 	}
-
-	// Publish helm charts.
-	if err := r.publishHelmCharts(); err != nil {
-		return fmt.Errorf("failed to publish helm charts: %s", err)
-	}
+	uploads = append(uploads,
+		distribution.Upload{Handler: distribution.Preparer{Kind: "metadata", Action: r.buildMetadata}},
+		distribution.Upload{Handler: distribution.Preparer{Kind: "checksums", Action: r.writeChecksums}},
+	)
 
 	if r.isHashRelease {
-		if err := r.publishToHashreleaseServer(); err != nil {
-			return fmt.Errorf("failed to publish hashrelease: %s", err)
-		}
-	} else {
-		// Publish the git tag.
-		if err := r.publishGitTag(); err != nil {
-			return fmt.Errorf("failed to publish git tag: %s", err)
-		}
-
-		// Publish the release to github.
-		if err := r.publishGithubRelease(); err != nil {
-			return fmt.Errorf("failed to publish github release: %s", err)
-		}
-
-		// Update helm chart index
-		if err := r.updateHelmChartIndex(); err != nil {
-			return fmt.Errorf("update helm chart index: %s", err)
-		}
+		uploads = append(uploads, r.hashreleaseUpload()...)
+		return distribution.Publish(uploads, !r.dryRun, distribution.WithRunner(r.runner))
 	}
+	uploads = append(uploads, r.githubTagUpload(),  r.helmIndexUpload())
+	github, err := r.githubReleaseUpload()
+	if err != nil {
+		return err
+	}
+	// nil when the github release is disabled.
+	if github != nil {
+		uploads = append(uploads, *github)
+	}
+	return distribution.Publish(uploads, !r.dryRun, distribution.WithRunner(r.runner))
+}
 
-	return nil
+func (r *CalicoManager) buildMetadata() error {
+	return r.BuildMetadata(r.uploadDir())
 }
 
 func (r *CalicoManager) ReleasePublic() error {
@@ -959,28 +952,9 @@ func (r *CalicoManager) publishPrereqs() error {
 	return r.assertImageVersions()
 }
 
-// Collect artifacts to be included on each release to GitHub.
-// It builds the metadata file.
-// It assumes that all other artifacts already been built, and simply wraps them up.
-//   - release-vX.Y.Z.tgz: contains images, manifests, and binaries.
-//   - ocp-vX.Y.Z.tgz: contains the OCP bundle.
-//   - tigera-operator-vX.Y.Z.tgz: contains the helm v3 chart.
-//   - calico-windows-vX.Y.Z.zip: Calico for Windows zip archive for non-HPC installation.
-//   - calicoctl/bin: All calicoctl binaries.
-//
-// For hashreleases, include the manifests directly.
-//
-// Finally it generates checksums for each artifact that is uploaded to the release.
-func (r *CalicoManager) collectGithubArtifacts() error {
-	// Artifacts will be moved here.
-	uploadDir := r.uploadDir()
-
-	// Add in a release metadata file.
-	err := r.BuildMetadata(uploadDir)
-	if err != nil {
-		return fmt.Errorf("failed to build release metadata file: %s", err)
-	}
-
+// collectArtifacts gathers everything a release publishes into the upload
+// directory.
+func (r *CalicoManager) collectArtifacts() error {
 	if err := r.collectBinaries(); err != nil {
 		return err
 	}
@@ -990,33 +964,12 @@ func (r *CalicoManager) collectGithubArtifacts() error {
 	if err := r.collectWindowsArchive(); err != nil {
 		return err
 	}
-	if err := r.collectOCPBundle(); err != nil {
-		return err
-	}
+	return r.collectOCPBundle()
+}
 
-	// Generate a SHA256SUMS file containing the checksums for each artifact
-	// that we attach to the release. These can be confirmed by end users via the following command:
-	// sha256sum -c --ignore-missing SHA256SUMS
-	files, err := os.ReadDir(uploadDir)
-	if err != nil {
-		return fmt.Errorf("failed to read upload directory: %w", err)
-	}
-	sha256args := []string{}
-	for _, f := range files {
-		if !f.IsDir() {
-			sha256args = append(sha256args, f.Name())
-		}
-	}
-	output, err := r.runner.RunInDir(uploadDir, "sha256sum", sha256args, nil)
-	if err != nil {
-		return fmt.Errorf("failed to generate sha256sums: %w", err)
-	}
-	err = os.WriteFile(fmt.Sprintf("%s/SHA256SUMS", uploadDir), []byte(output), 0o644)
-	if err != nil {
-		return fmt.Errorf("failed to write SHA256SUMS file: %w", err)
-	}
-
-	return nil
+// Users verify a download with: sha256sum -c --ignore-missing SHA256SUMS
+func (r *CalicoManager) writeChecksums() error {
+	return distribution.SHA256Sums(r.uploadDir(), distribution.WithRunner(r.runner))
 }
 
 func (r *CalicoManager) collectBinaries() error {
@@ -1334,10 +1287,14 @@ func remoteTagCommit(lsRemoteOutput, ver string) string {
 	return tagObjSHA
 }
 
-func (r *CalicoManager) publishGithubRelease() error {
+func (r *CalicoManager) githubTagUpload() distribution.Upload {
+	return distribution.Upload{Handler: distribution.Preparer{Kind: "git tag", Action: r.publishGitTag}}
+}
+
+func (r *CalicoManager) githubReleaseUpload() (*distribution.Upload, error) {
 	if !r.githubRelease {
 		logrus.Info("Skipping github release")
-		return nil
+		return nil, nil
 	}
 
 	releaseNoteTemplate := `
@@ -1374,49 +1331,21 @@ Additional links:
 	replacer := strings.NewReplacer(formatters...)
 	releaseNote := replacer.Replace(releaseNoteTemplate)
 
-	// if a release is already published, stop instead.
-	if published, err := r.publishedReleaseExists(); err != nil {
-		return fmt.Errorf("publishing github release: %w", err)
-	} else if published {
-		return fmt.Errorf("github release %s is already published; refusing to modify it", r.calicoVersion)
+	releases, err := github.NewReleases(github.Repo{Org: r.githubOrg, Name: r.repo}, nil)
+	if err != nil {
+		return nil, fmt.Errorf("github releases: %w", err)
 	}
 
-	args := []string{
-		"-username", r.githubOrg,
-		"-repository", r.repo,
-		"-name", r.calicoVersion,
-		"-body", releaseNote,
-		"-draft",
-		r.calicoVersion,
-		r.uploadDir(),
-	}
-	_, err := r.runner.RunInDir(r.repoRoot, "./bin/ghr", args, nil)
-	if err != nil {
-		return fmt.Errorf("failed to publish github release: %w", err)
-	}
-	return nil
-}
-
-// publishedReleaseExists reports whether a non-draft GitHub release exists for the tag.
-func (r *CalicoManager) publishedReleaseExists() (bool, error) {
-	out, err := r.runner.RunInDir(r.repoRoot, "./bin/gh", []string{
-		"release", "view", r.calicoVersion,
-		"--repo", fmt.Sprintf("%s/%s", r.githubOrg, r.repo),
-		"--json", "isDraft",
-	}, nil)
-	if err != nil {
-		if strings.Contains(out, "release not found") || strings.Contains(err.Error(), "release not found") {
-			return false, nil
-		}
-		return false, fmt.Errorf("query github release: %w", err)
-	}
-	var rel struct {
-		IsDraft bool `json:"isDraft"`
-	}
-	if err := json.Unmarshal([]byte(out), &rel); err != nil {
-		return false, fmt.Errorf("parse github release: %w", err)
-	}
-	return !rel.IsDraft, nil
+	return &distribution.Upload{
+		Source: r.uploadDir(),
+		Handler: distribution.GithubRelease{
+			Releases: releases,
+			Tag:      r.calicoVersion,
+			Body:     releaseNote,
+			Draft:    true,
+			DryRun:   r.dryRun,
+		},
+	}, nil
 }
 
 func (r *CalicoManager) publishContainerImages() error {
@@ -1585,19 +1514,16 @@ func (r *CalicoManager) publishHelmCharts() error {
 	return charts.Publish(chart, r.helmRegistries, !r.dryRun, opts...)
 }
 
-func (r *CalicoManager) updateHelmChartIndex() error {
-	if !r.helmCharts {
-		logrus.Info("Skipping updating helm index (charts disabled)")
-		return nil
+func (r *CalicoManager) helmIndexUpload() distribution.Upload {
+	return distribution.Upload{
+		Source: filepath.Join(r.chart().BaseDir, helmIndexFileName),
+		Handler: distribution.S3{
+			URI:     fmt.Sprintf("s3://%s/charts", r.s3Bucket),
+			Profile: r.awsProfile,
+			DryRun:  r.dryRun,
+			Runner:  r.runner,
+		},
 	}
-	if !r.helmIndex {
-		logrus.Info("Skipping updating helm index")
-		return nil
-	}
-	if err := r.s3Cp(filepath.Join(r.chart().BaseDir, helmIndexFileName), fmt.Sprintf("s3://%s/charts/", r.s3Bucket), s3ACLPublicRead...); err != nil {
-		return fmt.Errorf("update helm index: %w", err)
-	}
-	return nil
 }
 
 func (r *CalicoManager) assertReleaseNotesPresent(ver string) error {

--- a/release/pkg/manager/calico/manager.go
+++ b/release/pkg/manager/calico/manager.go
@@ -441,12 +441,16 @@ func (r *CalicoManager) BuildMetadata(dir string) error {
 // Fetch the registry from the calicoctl manifest file.
 // For hashrelease, it looks in the hashrelease source directory.
 func (r *CalicoManager) getRegistryFromManifests() (string, error) {
-	dir := filepath.Join(r.repoRoot, manifestsDir)
-	if r.isHashRelease {
-		dir = filepath.Join(r.hashrelease.Source, manifestsDir)
-	}
 	key := "spec.containers.image"
-	path := filepath.Join(dir, calicoctlManifest)
+	path := filepath.Join(r.repoRoot, manifestsDir, calicoctlManifest)
+	if r.isHashRelease {
+		p := filepath.Join(r.hashrelease.Source, manifestsDir, calicoctlManifest)
+		if _, err := os.Stat(p); err != nil {
+			// if the file does not exist, fall back to the default image registry.
+			return r.imageRegistries[0], nil
+		}
+		path = p
+	}
 	imgs, err := yamledit.Read(path, key)
 	if err != nil {
 		return "", err
@@ -707,7 +711,10 @@ func (r *CalicoManager) PublishRelease() error {
 	if err := r.publishPrereqs(); err != nil {
 		return err
 	}
+	return distribution.Publish(r.uploads(), distribution.WithRunner(r.runner))
+}
 
+func (r *CalicoManager) uploads() []distribution.Upload {
 	// The registries go first: metadata records the digests they produce
 	uploads := []distribution.Upload{
 		{Handler: distribution.Publisher{Kind: "images", Action: r.publishContainerImages}},
@@ -718,16 +725,17 @@ func (r *CalicoManager) PublishRelease() error {
 	)
 
 	if r.isHashRelease {
-		uploads = append(uploads, r.hashreleaseUpload()...)
-		return distribution.Publish(uploads, distribution.WithRunner(r.runner))
+		return append(uploads, r.hashreleaseUpload()...)
 	}
-	uploads = append(uploads, r.helmIndexUpload(), r.githubTagUpload())
+	uploads = append(uploads, r.githubTagUpload())
 	github := r.githubReleaseUpload()
 	// nil when the github release is disabled.
 	if github != nil {
 		uploads = append(uploads, *github)
 	}
-	return distribution.Publish(uploads, distribution.WithRunner(r.runner))
+	// Last: the index it writes points at the github release's download URLs,
+	// which 404 until that release exists.
+	return append(uploads, r.helmIndexUpload())
 }
 
 func (r *CalicoManager) buildMetadata() error {

--- a/release/pkg/manager/calico/manager.go
+++ b/release/pkg/manager/calico/manager.go
@@ -58,8 +58,6 @@ var (
 
 	helmIndexFileName = "index.yaml"
 
-	s3ACLPublicRead = []string{"--acl", "public-read"}
-
 	branchTagTarget = "retag-build-images-with-registries push-images-to-registries push-manifests"
 
 	// Windows images are published as a single manifest, so their branch tag
@@ -670,6 +668,7 @@ func (r *CalicoManager) hashreleaseUpload() []distribution.Upload {
 	}
 
 	return []distribution.Upload{{
+		Name:   "hashrelease",
 		Source: r.uploadDir(),
 		Handler: distribution.HashreleaseServer{
 			Release:     &r.hashrelease,
@@ -1311,6 +1310,7 @@ Additional links:
 	}
 
 	return &distribution.Upload{
+		Name:   "github release",
 		Source: r.uploadDir(),
 		Handler: distribution.GithubRelease{
 			Releases: releases,
@@ -1490,7 +1490,9 @@ func (r *CalicoManager) publishHelmCharts() error {
 
 func (r *CalicoManager) helmIndexUpload() distribution.Upload {
 	return distribution.Upload{
-		Source: filepath.Join(r.chart().BaseDir, helmIndexFileName),
+		Name:   "chart index",
+		Source: charts.IndexFilePath(r.chart().BaseDir),
+		Skip:   !r.helmCharts || !r.helmIndex,
 		Handler: distribution.S3{
 			URI:     fmt.Sprintf("s3://%s/charts", r.s3Bucket),
 			Profile: r.awsProfile,

--- a/release/pkg/manager/calico/manager.go
+++ b/release/pkg/manager/calico/manager.go
@@ -27,7 +27,6 @@ import (
 	"strings"
 
 	"github.com/sirupsen/logrus"
-	"go.yaml.in/yaml/v3"
 
 	"github.com/projectcalico/calico/release/internal/branch"
 	"github.com/projectcalico/calico/release/internal/charts"
@@ -53,8 +52,6 @@ var (
 	defaultOrg    = utils.ProjectCalicoOrg
 	defaultRepo   = utils.CalicoRepoName
 	defaultBranch = utils.DefaultBranch
-
-	metadataFileName = "metadata.yaml"
 
 	branchTagTarget = "retag-build-images-with-registries push-images-to-registries push-manifests"
 
@@ -246,14 +243,6 @@ type CalicoManager struct {
 	fromTag      string
 }
 
-func releaseImages(images []string, version, registry, operatorImage, operatorVersion, operatorRegistry string) []string {
-	imgList := []string{fmt.Sprintf("%s/%s:%s", operatorRegistry, operatorImage, operatorVersion)}
-	for _, img := range images {
-		imgList = append(imgList, fmt.Sprintf("%s/%s:%s", registry, img, version))
-	}
-	return imgList
-}
-
 func (r *CalicoManager) PreBuildValidation() error {
 	var errStack error
 	if r.calicoVersion == "" {
@@ -385,15 +374,8 @@ func (r *CalicoManager) Build() error {
 	return r.collectArtifacts()
 }
 
-type metadata struct {
-	Version          string   `json:"version"`
-	OperatorVersion  string   `json:"operator_version" yaml:"operatorVersion"`
-	Images           []string `json:"images"`
-	HelmChartVersion string   `json:"helm_chart_version" yaml:"helmChartVersion"`
-}
-
 func (r *CalicoManager) BuildMetadata(dir string) error {
-	registry, err := r.getRegistryFromManifests()
+	reg, err := r.getRegistryFromManifests()
 	if err != nil {
 		return fmt.Errorf("failed to get registry from manifests: %w", err)
 	}
@@ -402,26 +384,19 @@ func (r *CalicoManager) BuildMetadata(dir string) error {
 	if err != nil {
 		return fmt.Errorf("failed to determine release images: %w", err)
 	}
-
-	m := metadata{
-		Version:          r.calicoVersion,
-		OperatorVersion:  r.operatorVersion,
-		Images:           releaseImages(imgs, r.calicoVersion, registry, r.operatorImage, r.operatorVersion, r.operatorRegistry),
-		HelmChartVersion: r.chart().Version(),
+	components := []distribution.Component{
+		{Registry: r.operatorRegistry, Image: r.operatorImage, Version: r.operatorVersion},
+	}
+	for _, img := range imgs {
+		components = append(components, distribution.Component{Registry: reg, Image: img, Version: r.calicoVersion})
 	}
 
-	// Render it as yaml and write it to a file.
-	bs, err := yaml.Marshal(m)
-	if err != nil {
-		return fmt.Errorf("failed to marshal metadata: %s", err)
-	}
-
-	err = os.WriteFile(filepath.Join(dir, metadataFileName), []byte(bs), 0o644)
-	if err != nil {
-		return fmt.Errorf("failed to write metadata file: %s", err)
-	}
-
-	return nil
+	return distribution.BuildMetadata(distribution.Metadata{
+		Version:         r.calicoVersion,
+		OperatorVersion: r.operatorVersion,
+		Images:          components,
+		ChartVersion:    r.chart().Version(),
+	}, dir, distribution.WithRunner(r.runner))
 }
 
 func (r *CalicoManager) getRegistryFromManifests() (string, error) {

--- a/release/pkg/manager/calico/manager_test.go
+++ b/release/pkg/manager/calico/manager_test.go
@@ -1022,12 +1022,12 @@ func TestGithubReleaseDraftFlag(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Setenv("GITHUB_TOKEN", "test-token")
 			r := &CalicoManager{
-				githubRelease:  true,
+				githubRelease: true,
 				draftRelease:  tc.draft,
-				calicoVersion:  "v3.30.0",
-				githubOrg:      "projectcalico",
-				repo:           "calico",
-				outputDir:      t.TempDir(),
+				calicoVersion: "v3.30.0",
+				githubOrg:     "projectcalico",
+				repo:          "calico",
+				outputDir:     t.TempDir(),
 			}
 			upload, err := r.githubReleaseUpload()
 			if err != nil {
@@ -1039,6 +1039,34 @@ func TestGithubReleaseDraftFlag(t *testing.T) {
 			}
 			if got.Draft != tc.draft {
 				t.Errorf("Draft = %v, want %v", got.Draft, tc.draft)
+			}
+		})
+	}
+}
+
+// The index is only written when both steps ran, so the upload has to say it
+// may be absent rather than failing a release that did not build one.
+func TestHelmIndexUploadAllowsAMissingIndex(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		helmCharts bool
+		helmIndex  bool
+		wantAllow  bool
+	}{
+		{name: "both steps ran", helmCharts: true, helmIndex: true},
+		{name: "charts disabled", helmIndex: true, wantAllow: true},
+		{name: "index disabled", helmCharts: true, wantAllow: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			r := &CalicoManager{
+				helmCharts:    tc.helmCharts,
+				helmIndex:     tc.helmIndex,
+				calicoVersion: "v3.30.0",
+				s3Bucket:      "bucket",
+				outputDir:     t.TempDir(),
+			}
+			if got := r.helmIndexUpload().Skip; got != tc.wantAllow {
+				t.Errorf("Skip = %v, want %v", got, tc.wantAllow)
 			}
 		})
 	}

--- a/release/pkg/manager/calico/manager_test.go
+++ b/release/pkg/manager/calico/manager_test.go
@@ -1071,3 +1071,36 @@ func TestHelmIndexUploadAllowsAMissingIndex(t *testing.T) {
 		})
 	}
 }
+
+// aws s3 cp to a key with no trailing slash writes an object named for the
+// prefix rather than a file inside it, so the index silently stops updating.
+func TestHelmIndexUploadTargetsTheChartsPrefix(t *testing.T) {
+	r := &CalicoManager{helmCharts: true, helmIndex: true, s3Bucket: "bucket", outputDir: t.TempDir()}
+	got, ok := r.helmIndexUpload().Handler.(distribution.S3)
+	if !ok {
+		t.Fatalf("handler is %T, want distribution.S3", r.helmIndexUpload().Handler)
+	}
+	if want := "s3://bucket/charts/"; got.URI != want {
+		t.Errorf("URI = %q, want %q", got.URI, want)
+	}
+}
+
+func TestPublishGitTagPreviewsThePushOnADryRun(t *testing.T) {
+	f := newFakeRunner()
+	f.on("git ls-remote --tags origin refs/tags/v3.30.0", "", nil)
+
+	r := &CalicoManager{
+		runner:        f,
+		gitRef:        true,
+		dryRun:        true,
+		calicoVersion: "v3.30.0",
+		remote:        "origin",
+		repoRoot:      t.TempDir(),
+	}
+	if err := r.publishGitTag(); err != nil {
+		t.Fatalf("publishGitTag() = %v, want nil", err)
+	}
+	if !f.ran("git push origin v3.30.0 --dry-run") {
+		t.Errorf("expected a previewed push, got %v", f.calls)
+	}
+}

--- a/release/pkg/manager/calico/manager_test.go
+++ b/release/pkg/manager/calico/manager_test.go
@@ -356,12 +356,9 @@ func TestPublishGithubReleaseSkipped(t *testing.T) {
 		repo:          "calico",
 		outputDir:     t.TempDir(),
 	}
-	uploads, err := r.githubReleaseUpload()
-	if err != nil {
-		t.Fatalf("githubReleaseUpload() = %v, want nil", err)
-	}
-	if uploads != nil {
-		t.Errorf("expected no upload with the flag off, got %+v", uploads)
+	upload := r.githubReleaseUpload()
+	if upload != nil {
+		t.Errorf("expected no upload with the flag off, got %+v", upload)
 	}
 	if len(f.calls) != 0 {
 		t.Errorf("expected nothing run with the flag off, got %v", f.calls)
@@ -1044,7 +1041,6 @@ func TestGithubReleaseDraftFlag(t *testing.T) {
 		{name: "publishes when the draft flag is off"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			t.Setenv("GITHUB_TOKEN", "test-token")
 			r := &CalicoManager{
 				githubRelease: true,
 				draftRelease:  tc.draft,
@@ -1053,10 +1049,7 @@ func TestGithubReleaseDraftFlag(t *testing.T) {
 				repo:          "calico",
 				outputDir:     t.TempDir(),
 			}
-			upload, err := r.githubReleaseUpload()
-			if err != nil {
-				t.Fatalf("githubReleaseUpload() = %v", err)
-			}
+			upload := r.githubReleaseUpload()
 			got, ok := upload.Handler.(distribution.GithubRelease)
 			if !ok {
 				t.Fatalf("handler is %T, want distribution.GithubRelease", upload.Handler)

--- a/release/pkg/manager/calico/manager_test.go
+++ b/release/pkg/manager/calico/manager_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/projectcalico/calico/release/internal/charts"
 	"github.com/projectcalico/calico/release/internal/command"
 	"github.com/projectcalico/calico/release/internal/distribution"
+	"github.com/projectcalico/calico/release/internal/hashreleaseserver"
 	"github.com/projectcalico/calico/release/internal/images"
 	"github.com/projectcalico/calico/release/internal/outputs"
 	"github.com/projectcalico/calico/release/pkg/manager/operator"
@@ -563,13 +564,13 @@ func TestBuildBinariesBuildsFelixWhateverTheImagesFlagIs(t *testing.T) {
 	for _, images := range []bool{true, false} {
 		t.Run(fmt.Sprintf("images=%t", images), func(t *testing.T) {
 			f := newFakeRunner()
-			m := imageManager(t, f, "")
+			m, root := imageManager(t, f, "")
 			m.images = images
 			m.binaries = true
 			if err := m.buildBinaries(); err != nil {
 				t.Fatalf("buildBinaries: %v", err)
 			}
-			for _, want := range []string{"make -C /repo/felix release-build", "make -C /repo/calicoctl build-all"} {
+			for _, want := range []string{"make -C " + root + "/felix release-build", "make -C " + root + "/calicoctl build-all"} {
 				if !f.ran(want) {
 					t.Errorf("did not run %q, ran: %v", want, f.calls)
 				}
@@ -578,18 +579,35 @@ func TestBuildBinariesBuildsFelixWhateverTheImagesFlagIs(t *testing.T) {
 	}
 }
 
-func imageManager(t *testing.T, f *fakeRunner, logsDir string) *CalicoManager {
+// manifestRepo is a repo root holding the one manifest a release reads its
+// registry from.
+func manifestRepo(t *testing.T, image string) string {
 	t.Helper()
+	root := t.TempDir()
+	dir := filepath.Join(root, manifestsDir)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("creating manifests dir: %v", err)
+	}
+	doc := fmt.Sprintf("kind: Pod\nspec:\n  containers:\n    - name: calicoctl\n      image: %s\n", image)
+	if err := os.WriteFile(filepath.Join(dir, calicoctlManifest), []byte(doc), 0o644); err != nil {
+		t.Fatalf("writing manifest: %v", err)
+	}
+	return root
+}
+
+// Returns the repo root it built, since the registry now comes from a real
+// file and callers assert on paths under it.
+func imageManager(t *testing.T, f *fakeRunner, logsDir string) (*CalicoManager, string) {
+	t.Helper()
+	root := manifestRepo(t, "quay.io/calico/ctl:v3.30.0")
 	// A publish asks each directory for its image names before recording refs.
 	for _, dir := range images.VariantDirs(images.PublishVariants) {
 		base := path.Base(dir)
-		f.on(fmt.Sprintf("make -C /repo/%s -s build-images", dir), base+" "+base+"-windows", nil)
+		f.on(fmt.Sprintf("make -C %s/%s -s build-images", root, dir), base+" "+base+"-windows", nil)
 	}
-	// The branch tag is published into the registry the manifests name.
-	f.on(`grep -Po image:\K(.*) calicoctl.yaml`, "quay.io/calico/ctl:v3.30.0", nil)
 	return &CalicoManager{
 		runner:              f,
-		repoRoot:            "/repo",
+		repoRoot:            root,
 		calicoVersion:       "v3.30.0",
 		imageRegistries:     []string{"quay.io/tigera"},
 		images:              true,
@@ -599,20 +617,21 @@ func imageManager(t *testing.T, f *fakeRunner, logsDir string) *CalicoManager {
 		resolveDigest: func(string) (string, bool, error) {
 			return "sha256:aaa", true, nil
 		},
-	}
+	}, root
 }
 
 // A publish must latch CONFIRM; DRYRUN pushes nothing and still reports
 // success.
 func TestPublishContainerImagesConfirms(t *testing.T) {
 	f := newFakeRunner()
-	if err := imageManager(t, f, "").publishContainerImages(); err != nil {
+	m, root := imageManager(t, f, "")
+	if err := m.publishContainerImages(); err != nil {
 		t.Fatalf("publishContainerImages: %v", err)
 	}
-	if !f.ran("make -C /repo/cmd/calico release-publish") {
+	if !f.ran("make -C " + root + "/cmd/calico release-publish") {
 		t.Errorf("publish did not run release-publish in cmd/calico, calls: %v", f.calls)
 	}
-	env := f.envForDir("/repo/cmd/calico ")
+	env := f.envForDir(root + "/cmd/calico ")
 	if !slices.Contains(env, "CONFIRM=true") {
 		t.Error("publish env missing CONFIRM=true")
 	}
@@ -643,11 +662,12 @@ func TestImageStepsWriteLogFiles(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			f := newFakeRunner()
-			if err := tc.run(imageManager(t, f, "/logs")); err != nil {
+			m, root := imageManager(t, f, "/logs")
+			if err := tc.run(m); err != nil {
 				t.Fatalf("%s: %v", tc.name, err)
 			}
 			// node ships both variants, so its two units must not share a file.
-			got := f.logPathsForDir("/repo/node ")
+			got := f.logPathsForDir(root + "/node ")
 			slices.Sort(got)
 			if !slices.Equal(got, tc.want) {
 				t.Errorf("node log paths\n got %v\nwant %v", got, tc.want)
@@ -723,9 +743,11 @@ func TestPublishContainerImagesBranchTag(t *testing.T) {
 			if prefix == "" && !tt.wantErr {
 				prefix = "release"
 			}
-			r := imageManager(t, f, "")
+			r, root := imageManager(t, f, "")
 			r.images = tt.images
 			r.isHashRelease = tt.isHashRelease
+			// A hashrelease reads its registry from its own source tree.
+			r.hashrelease.Source = root
 			r.calicoVersion = tt.version
 			r.releaseBranchPrefix = prefix
 
@@ -740,20 +762,20 @@ func TestPublishContainerImagesBranchTag(t *testing.T) {
 				t.Fatalf("publishContainerImages() unexpected error: %v", err)
 			}
 
-			if got := f.ran("make -C /repo/cmd/calico release-publish"); got != tt.wantPublish {
+			if got := f.ran("make -C " + root + "/cmd/calico release-publish"); got != tt.wantPublish {
 				t.Errorf("release-publish ran = %v, want %v (calls: %v)", got, tt.wantPublish, f.calls)
 			}
-			if got := f.ran("make -C /repo/cmd/calico " + branchTagTarget); got != tt.wantBranchTag {
+			if got := f.ran("make -C " + root + "/cmd/calico " + branchTagTarget); got != tt.wantBranchTag {
 				t.Errorf("branch tag publish ran = %v, want %v (calls: %v)", got, tt.wantBranchTag, f.calls)
 			}
 			if tt.wantBranchTag {
-				if got := f.envFor("make -C /repo/cmd/calico " + branchTagTarget); !slices.Contains(got, "IMAGETAG="+tt.wantTag) {
+				if got := f.envFor("make -C " + root + "/cmd/calico " + branchTagTarget); !slices.Contains(got, "IMAGETAG="+tt.wantTag) {
 					t.Errorf("branch tag env = %v, want IMAGETAG=%s", got, tt.wantTag)
 				}
 			}
 
 			// The operator carries the branch tag too, published to its own registries.
-			opTarget := "make -C /repo/operator retag-build-images-with-registries"
+			opTarget := "make -C " + root + "/operator retag-build-images-with-registries"
 			if got := f.ran(opTarget); got != tt.wantBranchTag {
 				t.Errorf("operator branch tag publish ran = %v, want %v (calls: %v)", got, tt.wantBranchTag, f.calls)
 			}
@@ -775,13 +797,14 @@ func TestPublishContainerImagesBranchTag(t *testing.T) {
 // there retags arch images that were never built.
 func TestPublishBranchTagSplitsWindowsFromStandard(t *testing.T) {
 	f := newFakeRunner()
-	if err := imageManager(t, f, "").publishContainerImages(); err != nil {
+	m, root := imageManager(t, f, "")
+	if err := m.publishContainerImages(); err != nil {
 		t.Fatalf("publishContainerImages: %v", err)
 	}
-	if got := "make -C /repo/cni-plugin " + branchTagTarget; f.ran(got) {
+	if got := "make -C " + root + "/cni-plugin " + branchTagTarget; f.ran(got) {
 		t.Errorf("branch tag ran %q, which has no arch images to retag (calls: %v)", got, f.calls)
 	}
-	want := "make -C /repo/cni-plugin " + windowsBranchTagTarget
+	want := "make -C " + root + "/cni-plugin " + windowsBranchTagTarget
 	if !f.ran(want) {
 		t.Errorf("did not run %q, ran: %v", want, f.calls)
 	}
@@ -804,7 +827,7 @@ func TestImageStepsNarrowedToReleaseDirs(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			f := newFakeRunner()
-			m := imageManager(t, f, "")
+			m, root := imageManager(t, f, "")
 			m.imageReleaseDirs = []string{"whisker"}
 			if err := tc.run(m); err != nil {
 				t.Fatalf("%s: %v", tc.name, err)
@@ -813,7 +836,7 @@ func TestImageStepsNarrowedToReleaseDirs(t *testing.T) {
 			if len(units) != 1 {
 				t.Fatalf("expected one unit for whisker, ran: %v", units)
 			}
-			if !f.ran("make -C /repo/whisker " + tc.target) {
+			if !f.ran("make -C " + root + "/whisker " + tc.target) {
 				t.Errorf("did not run %s in whisker, ran: %v", tc.target, f.calls)
 			}
 		})
@@ -823,7 +846,8 @@ func TestImageStepsNarrowedToReleaseDirs(t *testing.T) {
 // An empty list leaves every directory in play.
 func TestImageStepsUnnarrowedByDefault(t *testing.T) {
 	f := newFakeRunner()
-	if err := imageManager(t, f, "").publishContainerImages(); err != nil {
+	m, _ := imageManager(t, f, "")
+	if err := m.publishContainerImages(); err != nil {
 		t.Fatalf("publishContainerImages: %v", err)
 	}
 	want := len(images.VariantDirs([]images.Variant{images.PublishVariants[0]}))
@@ -1102,5 +1126,56 @@ func TestPublishGitTagPreviewsThePushOnADryRun(t *testing.T) {
 	}
 	if !f.ran("git push origin v3.30.0 --dry-run") {
 		t.Errorf("expected a previewed push, got %v", f.calls)
+	}
+}
+
+func TestGetRegistryFromManifests(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		image string
+		want  string
+	}{
+		{"a plain registry", "quay.io/calico/calico:master", "quay.io/calico"},
+		{"a registry with a path", "gcr.io/unique-caldron-775/cnx/tigera/calico:master", "gcr.io/unique-caldron-775/cnx/tigera"},
+		{"no registry at all", "calico:master", ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			dir := filepath.Join(root, "manifests")
+			if err := os.MkdirAll(dir, 0o755); err != nil {
+				t.Fatalf("creating manifests dir: %v", err)
+			}
+			// Several documents, image in the last, so a decoder that stops at
+			// the first would fail here.
+			doc := fmt.Sprintf("kind: ServiceAccount\n---\nkind: Pod\nspec:\n  containers:\n    - name: calicoctl\n      image: %s\n", tc.image)
+			if err := os.WriteFile(filepath.Join(dir, "calicoctl.yaml"), []byte(doc), 0o644); err != nil {
+				t.Fatalf("writing manifest: %v", err)
+			}
+
+			// A hashrelease reads its own source tree, so point the repo root
+			// somewhere empty to catch a lookup that ignores the flag.
+			for _, hashrelease := range []bool{false, true} {
+				m := &CalicoManager{repoRoot: root}
+				if hashrelease {
+					m = &CalicoManager{
+						repoRoot:      t.TempDir(),
+						isHashRelease: true,
+						hashrelease:   hashreleaseserver.Hashrelease{Source: root},
+					}
+				}
+				assertRegistry(t, m, tc.want)
+			}
+		})
+	}
+}
+
+func assertRegistry(t *testing.T, m *CalicoManager, want string) {
+	t.Helper()
+	got, err := m.getRegistryFromManifests()
+	if err != nil {
+		t.Fatalf("getRegistryFromManifests: %v", err)
+	}
+	if got != want {
+		t.Errorf("registry = %q, want %q", got, want)
 	}
 }

--- a/release/pkg/manager/calico/manager_test.go
+++ b/release/pkg/manager/calico/manager_test.go
@@ -344,81 +344,25 @@ func TestPublishGitTag(t *testing.T) {
 	}
 }
 
-func TestPublishGithubRelease(t *testing.T) {
-	const (
-		ver  = "v3.30.0"
-		org  = "projectcalico"
-		repo = "calico"
-	)
-	repoFlag := fmt.Sprintf("--repo %s/%s", org, repo)
-	notFound := fmt.Errorf("release not found")
-
-	tests := []struct {
-		name          string
-		githubRelease bool
-		viewOut       string
-		viewErr       error
-		wantGhr       bool
-		wantErr       bool
-	}{
-		{
-			name:          "skip flag disabled does nothing",
-			githubRelease: false,
-		},
-		{
-			name:          "no release runs ghr",
-			githubRelease: true,
-			viewOut:       "release not found",
-			viewErr:       notFound,
-			wantGhr:       true,
-		},
-		{
-			name:          "draft release runs ghr",
-			githubRelease: true,
-			viewOut:       `{"isDraft":true}`,
-			wantGhr:       true,
-		},
-		{
-			name:          "published release errors without running ghr",
-			githubRelease: true,
-			viewOut:       `{"isDraft":false}`,
-			wantGhr:       false,
-			wantErr:       true,
-		},
+func TestPublishGithubReleaseSkipped(t *testing.T) {
+	f := newFakeRunner()
+	r := &CalicoManager{
+		runner:        f,
+		githubRelease: false,
+		calicoVersion: "v3.30.0",
+		githubOrg:     "projectcalico",
+		repo:          "calico",
+		outputDir:     t.TempDir(),
 	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			f := newFakeRunner()
-			f.on(fmt.Sprintf("./bin/gh release view %s %s --json isDraft", ver, repoFlag), tt.viewOut, tt.viewErr)
-			f.on("./bin/ghr", "", nil)
-
-			r := &CalicoManager{
-				runner:        f,
-				githubRelease: tt.githubRelease,
-				calicoVersion: ver,
-				githubOrg:     org,
-				repo:          repo,
-				outputDir:     t.TempDir(),
-			}
-			err := r.publishGithubRelease()
-
-			if tt.wantErr {
-				if err == nil {
-					t.Fatalf("publishGithubRelease() = nil, want error")
-				}
-				if f.ran("./bin/ghr") {
-					t.Errorf("ghr was invoked for a published release (calls: %v)", f.calls)
-				}
-				return
-			}
-			if err != nil {
-				t.Fatalf("publishGithubRelease() unexpected error: %v", err)
-			}
-			if got := f.ran("./bin/ghr"); got != tt.wantGhr {
-				t.Errorf("ghr issued = %v, want %v (calls: %v)", got, tt.wantGhr, f.calls)
-			}
-		})
+	uploads, err := r.githubReleaseUpload()
+	if err != nil {
+		t.Fatalf("githubReleaseUpload() = %v, want nil", err)
+	}
+	if uploads != nil {
+		t.Errorf("expected no upload with the flag off, got %+v", uploads)
+	}
+	if len(f.calls) != 0 {
+		t.Errorf("expected nothing run with the flag off, got %v", f.calls)
 	}
 }
 

--- a/release/pkg/manager/calico/manager_test.go
+++ b/release/pkg/manager/calico/manager_test.go
@@ -1172,3 +1172,42 @@ func assertRegistry(t *testing.T, m *CalicoManager, want string) {
 		t.Errorf("registry = %q, want %q", got, want)
 	}
 }
+
+// The chart index lists download URLs served by the github release, so
+// publishing it first advertises links that 404 until the release is live.
+func TestChartIndexPublishesAfterTheGithubRelease(t *testing.T) {
+	r := &CalicoManager{
+		githubRelease: true,
+		helmCharts:    true,
+		helmIndex:     true,
+		calicoVersion: "v3.30.0",
+		githubOrg:     "projectcalico",
+		repo:          "calico",
+		s3Bucket:      "bucket",
+		outputDir:     t.TempDir(),
+	}
+	var names []string
+	for _, u := range r.uploads() {
+		names = append(names, u.Name)
+	}
+	index := slices.Index(names, "chart index")
+	release := slices.Index(names, "github release")
+	if index < 0 || release < 0 {
+		t.Fatalf("expected both uploads, got %v", names)
+	}
+	if index < release {
+		t.Errorf("chart index publishes before the github release: %v", names)
+	}
+}
+
+// A hashrelease built with --no-manifests never writes a manifest copy, so the
+// registry has to come from the flags rather than failing the publish.
+func TestGetRegistryFromManifestsFallsBackWhenAbsent(t *testing.T) {
+	m := &CalicoManager{
+		repoRoot:        t.TempDir(),
+		isHashRelease:   true,
+		hashrelease:     hashreleaseserver.Hashrelease{Source: t.TempDir()},
+		imageRegistries: []string{"gcr.io/unique-caldron-775/cnx"},
+	}
+	assertRegistry(t, m, "gcr.io/unique-caldron-775/cnx")
+}

--- a/release/pkg/manager/calico/manager_test.go
+++ b/release/pkg/manager/calico/manager_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/projectcalico/calico/release/internal/charts"
 	"github.com/projectcalico/calico/release/internal/command"
+	"github.com/projectcalico/calico/release/internal/distribution"
 	"github.com/projectcalico/calico/release/internal/images"
 	"github.com/projectcalico/calico/release/internal/outputs"
 	"github.com/projectcalico/calico/release/pkg/manager/operator"
@@ -1005,5 +1006,40 @@ func TestPublishHelmChartsRecordsWhatItPushed(t *testing.T) {
 	}
 	if len(refs) != len(charts.All()) {
 		t.Errorf("recorded %d refs, want %d", len(refs), len(charts.All()))
+	}
+}
+
+// The flag decides whether a release goes public, so a wrong default either
+// strands every release in draft or publishes one nobody approved.
+func TestGithubReleaseDraftFlag(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		draft bool
+	}{
+		{name: "drafts when asked", draft: true},
+		{name: "publishes when the draft flag is off"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("GITHUB_TOKEN", "test-token")
+			r := &CalicoManager{
+				githubRelease:  true,
+				draftRelease:  tc.draft,
+				calicoVersion:  "v3.30.0",
+				githubOrg:      "projectcalico",
+				repo:           "calico",
+				outputDir:      t.TempDir(),
+			}
+			upload, err := r.githubReleaseUpload()
+			if err != nil {
+				t.Fatalf("githubReleaseUpload() = %v", err)
+			}
+			got, ok := upload.Handler.(distribution.GithubRelease)
+			if !ok {
+				t.Fatalf("handler is %T, want distribution.GithubRelease", upload.Handler)
+			}
+			if got.Draft != tc.draft {
+				t.Errorf("Draft = %v, want %v", got.Draft, tc.draft)
+			}
+		})
 	}
 }

--- a/release/pkg/manager/calico/options.go
+++ b/release/pkg/manager/calico/options.go
@@ -132,6 +132,14 @@ func WithGithubRelease(enabled bool) Option {
 	}
 }
 
+// WithDraftRelease determines whether the GitHub release is published in draft mode.
+func WithDraftRelease(draft bool) Option {
+	return func(r *CalicoManager) error {
+		r.draftRelease = draft
+		return nil
+	}
+}
+
 func WithWindowsArchive(enabled bool) Option {
 	return func(r *CalicoManager) error {
 		r.windowsArchive = enabled


### PR DESCRIPTION
Publishing artifacts moves into its own package. A flow now assembles an ordered list of what goes where, instead of a function per destination, so the difference between a release and a hashrelease is the list rather than a branch in the code. Release publishing talks to the GitHub API instead of shelling out to ghr and gh.

Additionally:

- `release publish` is now re-runnable. If a run fails partway, re-running it finds the draft release the earlier run left and takes it live, rather than creating a second one alongside it.
- Hashreleases get a working dry run for the first time to allow testing without actually uploading to the bucket.

**Release note:**
```release-note
None
```

**AI assistance:** Claude Code wrote most of the code and tests. Design decisions and review are mine.
