### PR TITLE
[v3.32] Aggregate the per-flow log spam from Dikastes policy eval

### DIFF
--- a/app-policy/checker/bench_egress_test.go
+++ b/app-policy/checker/bench_egress_test.go
@@ -155,7 +155,7 @@ func egressFlow(destIP string, destPort int32) *MockFlow {
 }
 
 func benchEvaluateEgressAllowList(b *testing.B, caseFor egressCaseFunc) {
-	_, restoreLogging := withBenchLogging(log.WarnLevel)
+	restoreLogging := withBenchLogging(log.WarnLevel)
 	defer restoreLogging()
 
 	store, ep, target := buildEgressAllowListStore()

--- a/app-policy/checker/bench_test.go
+++ b/app-policy/checker/bench_test.go
@@ -24,21 +24,22 @@ package checker
 //	go test ./app-policy/checker/ -run '^$' -bench BenchmarkEvaluateBaselinePolicyScale \
 //	    -benchmem -benchtime 100x -cpu 1
 //
-// The MissingSets variant deletes some referenced IP sets from the store, which makes
-// each evaluation log "IPSet not found" warnings — the signature seen in production
-// logs when the policy store is out of sync. The warnings/op metric ties the two
-// together: if production logs show those warnings spaced T apart, the implied
-// per-evaluation wall time is T x warnings/op, which can be compared against the
-// measured ns/op to judge whether a node is evaluation-bound or pacing on something
-// else. Note that the benchmark discards log output, so a real deployment pays the
-// log write on top of the formatting cost measured here.
+// The MissingSets variants delete some referenced IP sets from the store, so every
+// evaluation looks up sets that are not there — the condition behind the "IPSet not
+// found" logs seen in production when the policy store is out of sync. Those lookups
+// are aggregated into one line per interval, so the variants measure what that leaves
+// on the hot path: MissingSets pays the aggregator's per-lookup bookkeeping, LogsOff
+// has the level gate closed so it pays nothing at all, and Unaggregated writes a line
+// per lookup, as this call site did before it was aggregated. The misses/op metric is
+// the number of missing-set lookups one evaluation makes, checked against the analytic
+// count before the timed loop. Note that the benchmark discards log output, so a real
+// deployment pays the log write on top of the formatting cost measured here.
 
 import (
 	"fmt"
 	"io"
 	"math/rand"
 	"net"
-	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -107,35 +108,80 @@ const (
 var benchTraceSink []*calc.RuleID
 
 func BenchmarkEvaluateBaselinePolicyScale(b *testing.B) {
+	missingSetsParams := func() baselinePolicyScaleParams {
+		p := defaultBaselinePolicyScaleParams()
+		p.numMissingIPSets = 8
+		return p
+	}
+
 	b.Run("AllSetsPresent", func(b *testing.B) {
-		benchEvaluateBaselinePolicyScale(b, defaultBaselinePolicyScaleParams(), log.WarnLevel, false)
+		benchEvaluateBaselinePolicyScale(b, benchRun{
+			params: defaultBaselinePolicyScaleParams(), logLevel: log.WarnLevel,
+		})
 	})
 	b.Run("MissingSets", func(b *testing.B) {
-		p := defaultBaselinePolicyScaleParams()
-		p.numMissingIPSets = 8
-		benchEvaluateBaselinePolicyScale(b, p, log.WarnLevel, false)
+		benchEvaluateBaselinePolicyScale(b, benchRun{
+			params: missingSetsParams(), logLevel: log.WarnLevel,
+		})
 	})
-	// As MissingSets but with warnings disabled, to isolate the cost of formatting the
-	// "IPSet not found" warnings.
+	// As MissingSets but with warnings disabled, so the aggregator drops each miss at its
+	// level gate: what separates this from MissingSets is the aggregator's bookkeeping.
 	b.Run("MissingSetsLogsOff", func(b *testing.B) {
-		p := defaultBaselinePolicyScaleParams()
-		p.numMissingIPSets = 8
-		benchEvaluateBaselinePolicyScale(b, p, log.ErrorLevel, false)
+		benchEvaluateBaselinePolicyScale(b, benchRun{
+			params: missingSetsParams(), logLevel: log.ErrorLevel,
+		})
+	})
+	// As MissingSets but writing a line per miss, which is what this call site did before
+	// it was aggregated: what separates this from MissingSets is what aggregation saves.
+	b.Run("MissingSetsUnaggregated", func(b *testing.B) {
+		benchEvaluateBaselinePolicyScale(b, benchRun{
+			params: missingSetsParams(), logLevel: log.WarnLevel, unaggregated: true,
+		})
 	})
 	// Fixed per-Evaluate overhead: the first rule of the first policy matches, so the
 	// walk short-circuits immediately.
 	b.Run("MatchEarly", func(b *testing.B) {
-		benchEvaluateBaselinePolicyScale(b, defaultBaselinePolicyScaleParams(), log.WarnLevel, true)
+		benchEvaluateBaselinePolicyScale(b, benchRun{
+			params: defaultBaselinePolicyScaleParams(), logLevel: log.WarnLevel, matchEarly: true,
+		})
 	})
 }
 
-func benchEvaluateBaselinePolicyScale(b *testing.B, p baselinePolicyScaleParams, level log.Level, matchEarly bool) {
-	logger := log.StandardLogger()
-	counter, restoreLogging := withBenchLogging(level)
-	defer restoreLogging()
+// benchRun is one variant: the store to evaluate against, and how the logging the
+// evaluation provokes is set up.
+type benchRun struct {
+	params baselinePolicyScaleParams
 
-	store, ep, expectedWarns := buildBaselinePolicyStore(p)
-	if matchEarly {
+	// Level the logger is set to. The missing-set line is reported at Warn, so anything
+	// above that closes its level gate.
+	logLevel log.Level
+
+	// unaggregated makes the missing-set logger write one line per occurrence rather than
+	// one per interval, reproducing what this call site cost before it was aggregated.
+	unaggregated bool
+
+	matchEarly bool
+}
+
+func benchEvaluateBaselinePolicyScale(b *testing.B, run benchRun) {
+	p := run.params
+
+	logger := log.StandardLogger()
+	restoreLogging := withBenchLogging(run.logLevel)
+	// The counter hooks the standard logger, which is where the checker's aggregator writes.
+	counter := &ipsetMissCounter{}
+	hooks := make(log.LevelHooks)
+	hooks.Add(counter)
+	oldHooks := logger.ReplaceHooks(hooks)
+	oldMissingIPSets := missingIPSets
+	defer func() {
+		logger.ReplaceHooks(oldHooks)
+		restoreLogging()
+		missingIPSets = oldMissingIPSets
+	}()
+
+	store, ep, expectedMisses := buildBaselinePolicyStore(p)
+	if run.matchEarly {
 		addMatchEarlyPolicy(store, ep)
 	}
 	flow := &MockFlow{
@@ -146,10 +192,17 @@ func benchEvaluateBaselinePolicyScale(b *testing.B, p baselinePolicyScaleParams,
 		Protocol:   6, // TCP
 	}
 
-	// Pre-flight outside the timed loop: prove the walk is the intended one and that
-	// the warning count matches the analytic count, so that warnings/op is exact.
-	trace, _ := Evaluate(EnforcedOnly, rules.RuleDirIngress, store, ep, flow)
-	if matchEarly {
+	// Pre-flight outside the timed loop: prove the walk is the intended one and that the
+	// number of missing-set lookups matches the analytic count, so misses/op is exact.
+	// Counting them means seeing every one, so for this single evaluation the aggregator
+	// is given a zero interval, which writes a line per occurrence.
+	missingIPSets = newMissingIPSetsLogger()
+
+	trace, err := Evaluate(EnforcedOnly, rules.RuleDirIngress, store, ep, flow)
+	if err != nil {
+		b.Fatalf("pre-flight Evaluate failed: %v", err)
+	}
+	if run.matchEarly {
 		if len(trace) != 1 || trace[0].Action != rules.RuleActionAllow || trace[0].Index != 0 {
 			b.Fatalf("expected an immediate allow from the match-early policy, got %v", trace)
 		}
@@ -158,11 +211,17 @@ func benchEvaluateBaselinePolicyScale(b *testing.B, p baselinePolicyScaleParams,
 			b.Fatalf("expected a full walk ending in the tier default deny, got %v", trace)
 		}
 	}
-	if logger.IsLevelEnabled(log.WarnLevel) && counter.count.Load() != int64(expectedWarns) {
-		b.Fatalf("expected %d 'IPSet not found' warnings per Evaluate, got %d",
-			expectedWarns, counter.count.Load())
+	if logger.IsLevelEnabled(log.WarnLevel) && counter.count.Load() != int64(expectedMisses) {
+		b.Fatalf("expected %d missing IP set lookups per Evaluate, got %d",
+			expectedMisses, counter.count.Load())
 	}
-	counter.count.Store(0)
+
+	// The timed loop runs the real logger, at the production interval — unless this is the
+	// variant measuring what that interval saves.
+	missingIPSets = oldMissingIPSets
+	if run.unaggregated {
+		missingIPSets = newMissingIPSetsLogger()
+	}
 
 	b.ReportAllocs()
 	b.ResetTimer()
@@ -170,18 +229,24 @@ func benchEvaluateBaselinePolicyScale(b *testing.B, p baselinePolicyScaleParams,
 		benchTraceSink, _ = Evaluate(EnforcedOnly, rules.RuleDirIngress, store, ep, flow)
 	}
 	b.StopTimer()
-	b.ReportMetric(float64(counter.count.Load())/float64(b.N), "warnings/op")
+	b.ReportMetric(float64(expectedMisses), "misses/op")
 	rulesWalked := p.numPolicies * p.rulesPerPolicy
-	if matchEarly {
+	if run.matchEarly {
 		rulesWalked = 1
 	}
 	b.ReportMetric(float64(rulesWalked), "rules/op")
 }
 
+// newMissingIPSetsLogger builds a stand-in for the checker's missing-IP-set logger that
+// writes a line per occurrence rather than one per interval.
+func newMissingIPSetsLogger() *logutils.AggregatingLogger {
+	return logutils.NewAggregatingLogger("IPSet not found", "ipsets", logutils.OptAggregationInterval(0))
+}
+
 // buildBaselinePolicyStore builds a policy store at the given scale, plus an endpoint
 // whose single "perimeter" tier applies every policy. It returns the number of rule
-// references to deleted (missing) IP sets, which is exactly the number of "IPSet not
-// found" warnings one Evaluate of a non-matching flow emits.
+// references to deleted (missing) IP sets, which is exactly the number of missing-set
+// lookups one Evaluate of a non-matching flow makes.
 func buildBaselinePolicyStore(p baselinePolicyScaleParams) (*policystore.PolicyStore, *proto.WorkloadEndpoint, int) {
 	rng := rand.New(rand.NewSource(p.seed))
 	store := policystore.NewPolicyStore()
@@ -231,14 +296,14 @@ func buildBaselinePolicyStore(p baselinePolicyScaleParams) (*policystore.PolicyS
 	rng.Shuffle(len(referencedIDs), func(a, b int) {
 		referencedIDs[a], referencedIDs[b] = referencedIDs[b], referencedIDs[a]
 	})
-	expectedWarns := 0
+	expectedMisses := 0
 	for _, id := range referencedIDs[:p.numMissingIPSets] {
 		delete(store.IPSetByID, id)
-		expectedWarns += refCount[id]
+		expectedMisses += refCount[id]
 	}
 
 	ep := &proto.WorkloadEndpoint{Tiers: []*proto.TierInfo{tier}}
-	return store, ep, expectedWarns
+	return store, ep, expectedMisses
 }
 
 // makeScaleIPSets populates the store with NET-type IP sets (the dominant type in the
@@ -305,8 +370,9 @@ func addMatchEarlyPolicy(store *policystore.PolicyStore, ep *proto.WorkloadEndpo
 	ep.Tiers[0].IngressPolicies = append([]*proto.PolicyID{policyID}, ep.Tiers[0].IngressPolicies...)
 }
 
-// ipsetMissCounter is a logrus hook that counts "IPSet not found" warnings, so the
-// benchmark can report warnings per evaluation.
+// ipsetMissCounter is a logrus hook that counts the "IPSet not found" lines written, so
+// the benchmark can check the missing-set lookups one evaluation makes while they still
+// cost what they cost in production.
 type ipsetMissCounter struct {
 	count atomic.Int64
 }
@@ -314,44 +380,39 @@ type ipsetMissCounter struct {
 func (c *ipsetMissCounter) Levels() []log.Level { return []log.Level{log.WarnLevel} }
 
 func (c *ipsetMissCounter) Fire(e *log.Entry) error {
-	// The message carries the set ID, so match on the prefix.
-	if strings.HasPrefix(e.Message, "IPSet not found") {
+	if e.Message == "IPSet not found" {
 		c.count.Add(1)
 	}
 	return nil
 }
 
 // withBenchLogging sets the log level, discards output so the terminal is not part of the
-// measurement, installs the "IPSet not found" counter, and unthrottles the evaluation path's
-// rate-limited loggers. It returns the counter and a function restoring everything.
-func withBenchLogging(level log.Level) (*ipsetMissCounter, func()) {
+// measurement, and unthrottles the evaluation path's rate-limited loggers. It returns a
+// function restoring all of it.
+func withBenchLogging(level log.Level) func() {
 	logger := log.StandardLogger()
 	oldLevel, oldOut := logger.GetLevel(), logger.Out
-	counter := &ipsetMissCounter{}
-	hooks := make(log.LevelHooks)
-	hooks.Add(counter)
-	oldHooks := logger.ReplaceHooks(hooks)
 	restoreLoggers := withUnthrottledEvalPathLogs()
 
 	logger.SetLevel(level)
 	// The formatting cost stays in the measurement; a real deployment pays the write too.
 	logger.SetOutput(io.Discard)
 
-	return counter, func() {
+	return func() {
 		logger.SetLevel(oldLevel)
 		logger.SetOutput(oldOut)
-		logger.ReplaceHooks(oldHooks)
 		restoreLoggers()
 	}
 }
 
 // withUnthrottledEvalPathLogs replaces the evaluation path's rate-limited loggers with ones
-// that never suppress, and returns a function restoring them. The warnings/op metric counts
-// every occurrence, which is the point of it — production gets the throttled loggers, and the
-// emitted line's "logsSkipped" field carries the count this benchmark reports directly.
+// that never suppress, and returns a function restoring them, so that a benchmark measures
+// the cost of every line rather than of whichever few the limiter let through. The
+// missing-set and bad-principal sites aggregate instead; see benchEvaluateBaselinePolicyScale
+// for how those are handled.
 func withUnthrottledEvalPathLogs() func() {
 	saved := []**logutils.RateLimitedLogger{
-		&rlogIPSetMissing, &rlogBadPrincipal, &rlogBadProtocol, &rlogBadProtocolName,
+		&rlogBadProtocol, &rlogBadProtocolName,
 		&rlogBadCIDR, &rlogBadSelector, &rlogBadRulePath,
 	}
 	originals := make([]*logutils.RateLimitedLogger, len(saved))

--- a/app-policy/checker/bench_test.go
+++ b/app-policy/checker/bench_test.go
@@ -147,7 +147,7 @@ func BenchmarkEvaluateBaselinePolicyScale(b *testing.B) {
 	})
 }
 
-// benchRun is one variant: the store to evaluate against, and how the logging the
+// benchRun is one variant: the store to evaluate against, and how the logging that the
 // evaluation provokes is set up.
 type benchRun struct {
 	params baselinePolicyScaleParams
@@ -215,6 +215,9 @@ func benchEvaluateBaselinePolicyScale(b *testing.B, run benchRun) {
 		b.Fatalf("expected %d missing IP set lookups per Evaluate, got %d",
 			expectedMisses, counter.count.Load())
 	}
+	// The counter has done its job. Take the hook out before timing, so that its dispatch is not
+	// charged to the lines the loop below writes.
+	logger.ReplaceHooks(oldHooks)
 
 	// The timed loop runs the real logger, at the production interval — unless this is the
 	// variant measuring what that interval saves.

--- a/app-policy/checker/check.go
+++ b/app-policy/checker/check.go
@@ -64,19 +64,22 @@ const (
 	StagedAsEnforced
 )
 
-// Every log site on the per-request evaluation path needs its own rate limiter.
+// Every log site on the per-request evaluation path is either rate limited, through one of the
+// loggers below, or aggregated; none writes a line per occurrence.
 //
 // A rule set that applies tens of thousands of rules to one endpoint turns any per-rule log
 // into a storm: the conditions below are all "shouldn't happen, but does" — a malformed CIDR
 // or selector that got past validation, a flow that is not IP at all — and each one repeats
 // for every rule in the set, on every request. Rate limiting is per logger instance, so
 // sharing one across sites would let the noisiest message starve the rest; sites that report
-// the same condition do share one. The sites that key on a value that varies aggregate instead;
-// see missingIPSets and unparseablePrincipals in requestcache.go.
+// the same condition do share one. The two sites whose condition keys on a value that varies - a
+// missing IP set, an unparseable principal - aggregate instead, so that one line names every value
+// seen; see missingIPSets and unparseablePrincipals in requestcache.go.
 //
-// These sites must not use the WithField/WithError builders: those allocate a fields map, a
-// logrus.Entry and a wrapper *before* the rate limiter gets to drop the message, which is the
-// per-rule allocation this path has been optimised to avoid. Pass the value to Warnf instead.
+// The rate-limited sites must not use the WithField/WithError builders: those allocate a fields
+// map, a logrus.Entry and a wrapper *before* the rate limiter gets to drop the message, which is
+// the per-rule allocation this path has been optimised to avoid. Pass the value to Warnf instead.
+// The aggregated sites pass the value to Record, which costs a map lookup.
 var (
 	rlogBadProtocol = newEvalPathLogger()
 	// The adapter warns when Envoy names a protocol it cannot map. requestCache memoizes

--- a/app-policy/checker/check.go
+++ b/app-policy/checker/check.go
@@ -67,19 +67,18 @@ const (
 // Every log site on the per-request evaluation path needs its own rate limiter.
 //
 // A rule set that applies tens of thousands of rules to one endpoint turns any per-rule log
-// into a storm: the conditions below are all "shouldn't happen, but does" — a dangling IP set
-// reference while the store catches up, a malformed CIDR or selector that got past validation,
-// a flow that is not IP at all — and each one repeats for every rule in the set, on every
-// request. Rate limiting is per logger instance, so sharing one across sites would let the
-// noisiest message starve the rest; sites that report the same condition do share one.
+// into a storm: the conditions below are all "shouldn't happen, but does" — a malformed CIDR
+// or selector that got past validation, a flow that is not IP at all — and each one repeats
+// for every rule in the set, on every request. Rate limiting is per logger instance, so
+// sharing one across sites would let the noisiest message starve the rest; sites that report
+// the same condition do share one. The sites that key on a value that varies aggregate instead;
+// see missingIPSets and unparseablePrincipals in requestcache.go.
 //
 // These sites must not use the WithField/WithError builders: those allocate a fields map, a
 // logrus.Entry and a wrapper *before* the rate limiter gets to drop the message, which is the
 // per-rule allocation this path has been optimised to avoid. Pass the value to Warnf instead.
 var (
-	rlogIPSetMissing = newEvalPathLogger()
-	rlogBadPrincipal = newEvalPathLogger()
-	rlogBadProtocol  = newEvalPathLogger()
+	rlogBadProtocol = newEvalPathLogger()
 	// The adapter warns when Envoy names a protocol it cannot map. requestCache memoizes
 	// the resolved protocol, so this fires once per request rather than once per rule.
 	rlogBadProtocolName = newEvalPathLogger()

--- a/app-policy/checker/match_test.go
+++ b/app-policy/checker/match_test.go
@@ -16,18 +16,22 @@ package checker
 
 import (
 	"fmt"
+	"io"
 	"math"
 	"strings"
 	"testing"
+	"time"
 
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	auth "github.com/envoyproxy/go-control-plane/envoy/service/auth/v3"
 	. "github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
 
 	"github.com/projectcalico/calico/app-policy/checker/mocks"
 	"github.com/projectcalico/calico/app-policy/policystore"
 	"github.com/projectcalico/calico/felix/proto"
 	"github.com/projectcalico/calico/felix/types"
+	"github.com/projectcalico/calico/libcalico-go/lib/logutils"
 	libnet "github.com/projectcalico/calico/libcalico-go/lib/net"
 )
 
@@ -1351,4 +1355,57 @@ func TestMatchUnsupportedL4Protocol(t *testing.T) {
 			Expect(match("testns", &proto.Rule{}, req)).To(BeFalse())
 		})
 	}
+}
+
+// Repeated failures on the evaluation path are rate limited: one line, then a count of what
+// was suppressed. Without this a single malformed CIDR logs once per rule, for every request.
+// The other eval-path loggers in check.go share this limiter's configuration.
+func TestEvalPathWarningsAreRateLimited(t *testing.T) {
+	RegisterTestingT(t)
+
+	logger := logrus.StandardLogger()
+	oldLevel, oldOut := logger.GetLevel(), logger.Out
+	counter := &entryCounter{}
+	hooks := make(logrus.LevelHooks)
+	hooks.Add(counter)
+	oldHooks := logger.ReplaceHooks(hooks)
+	savedLogger := rlogBadCIDR
+	defer func() {
+		logger.SetLevel(oldLevel)
+		logger.SetOutput(oldOut)
+		logger.ReplaceHooks(oldHooks)
+		rlogBadCIDR = savedLogger
+	}()
+	logger.SetLevel(logrus.WarnLevel)
+	logger.SetOutput(io.Discard)
+	// A long interval with no burst allowance: the first message is written, the rest are
+	// counted.
+	rlogBadCIDR = logutils.NewRateLimitedLogger(logutils.OptInterval(time.Hour))
+
+	ip := libnet.ParseIP("192.168.5.6")
+	for range 100 {
+		Expect(matchNet("test", []string{"192.168.0.0.0/16"}, ip.Network().IP)).To(BeFalse())
+	}
+
+	Expect(counter.entries).To(HaveLen(1), "expected one emitted warning for 100 bad CIDRs")
+	Expect(counter.entries[0].Message).To(ContainSubstring("192.168.0.0.0/16"))
+	Expect(counter.entries[0].Data).NotTo(HaveKey("logsSkipped"))
+
+	// The suppressed count surfaces on the next line that is allowed through, so the storm is
+	// still visible in the log.
+	rlogBadCIDR.Force().Warnf("unable to parse CIDR %s", "192.168.0.0.0/16")
+	Expect(counter.entries).To(HaveLen(2))
+	Expect(counter.entries[1].Data).To(HaveKeyWithValue("logsSkipped", 99))
+}
+
+// entryCounter collects the log entries written during a test.
+type entryCounter struct {
+	entries []*logrus.Entry
+}
+
+func (c *entryCounter) Levels() []logrus.Level { return logrus.AllLevels }
+
+func (c *entryCounter) Fire(e *logrus.Entry) error {
+	c.entries = append(c.entries, e)
+	return nil
 }

--- a/app-policy/checker/requestcache.go
+++ b/app-policy/checker/requestcache.go
@@ -25,9 +25,17 @@ import (
 	"github.com/projectcalico/calico/app-policy/policystore"
 	"github.com/projectcalico/calico/felix/proto"
 	"github.com/projectcalico/calico/felix/types"
+	"github.com/projectcalico/calico/libcalico-go/lib/logutils"
 )
 
 const SPIFFEIDPattern = "^spiffe://[^/]+/ns/([^/]+)/sa/([^/]+)$"
+
+// Levels the two aggregated conditions report at. Named so the tests build their stand-in
+// loggers from the same values rather than restating them, which would let the two drift.
+const (
+	missingIPSetsLevel         = log.WarnLevel
+	unparseablePrincipalsLevel = log.ErrorLevel
+)
 
 var (
 	protocolMap = map[string]int{
@@ -38,6 +46,20 @@ var (
 
 	spiffeIdRegExp     *regexp.Regexp
 	spiffeIdRegExpOnce = sync.Once{}
+
+	// A principal we cannot parse would otherwise log once for every flow it sources. Aggregating on
+	// the principal loses nothing: parseSpiffeID's only failure names the principal and the pattern
+	// it did not match, and that pattern is a constant.
+	unparseablePrincipals = logutils.NewAggregatingLogger("failed to parse principal", "principals",
+		logutils.OptAggregationLevel(unparseablePrincipalsLevel))
+
+	// A missing IP set is looked up once per rule that references it, for every flow the policy
+	// applies to, so one bad reference logs at flow rate. Aggregate rather than plain rate-limit so
+	// that the one line per window names every set that went missing, not just whichever one
+	// happened to trip the timer - with several missing at once that is the difference between
+	// seeing one stale reference and seeing that a whole sync is behind.
+	missingIPSets = logutils.NewAggregatingLogger("IPSet not found", "ipsets",
+		logutils.OptAggregationLevel(missingIPSetsLevel))
 )
 
 type requestCache struct {
@@ -187,7 +209,7 @@ func (r *requestCache) getDstIPProtoPortStr() string {
 func (r *requestCache) getIPSet(id string) policystore.IPSet {
 	s, ok := r.store.IPSetByID[id]
 	if !ok {
-		rlogIPSetMissing.Warnf("IPSet not found: %s", id)
+		missingIPSets.Record(id)
 		return nil
 	}
 	return s
@@ -210,7 +232,7 @@ func (r *requestCache) initNamespace(name string) *namespace {
 func (r *requestCache) initPeer(principal string, labels map[string]string) *peer {
 	peer, err := parseSpiffeID(principal)
 	if err != nil {
-		rlogBadPrincipal.Errorf("failed to parse principal: %v", err)
+		unparseablePrincipals.Record(principal)
 		return nil
 	}
 	peer.Labels = make(map[string]string)

--- a/app-policy/checker/requestcache_test.go
+++ b/app-policy/checker/requestcache_test.go
@@ -16,6 +16,8 @@ package checker
 
 import (
 	"io"
+	"slices"
+	"sync"
 	"testing"
 	"time"
 
@@ -28,6 +30,175 @@ import (
 	"github.com/projectcalico/calico/felix/types"
 	"github.com/projectcalico/calico/libcalico-go/lib/logutils"
 )
+
+// TestGetIPSetAggregatesMisses covers the wiring rather than the aggregator itself (which has its
+// own tests in libcalico-go/lib/logutils): a store miss must still return nil, and the repeated
+// misses a single flow provokes must collapse to one line naming the sets that went missing, not
+// one line each.
+func TestGetIPSetAggregatesMisses(t *testing.T) {
+	RegisterTestingT(t)
+
+	capture, restore := captureCheckerLogs()
+	defer restore()
+
+	req := &authz.CheckRequest{Attributes: &authz.AttributeContext{
+		Source:      &authz.AttributeContext_Peer{Principal: ""},
+		Destination: &authz.AttributeContext_Peer{Principal: ""},
+	}}
+	rc := NewRequestCache(policystore.NewPolicyStore(), NewCheckRequestToFlowAdapter(req))
+
+	// The store is empty, so every lookup misses. Aggregation changes only the logging: the value
+	// getIPSet returns is what it always was.
+	for range 100 {
+		Expect(rc.getIPSet("missing-a")).To(BeNil())
+		Expect(rc.getIPSet("missing-b")).To(BeNil())
+	}
+
+	// The first miss is reported as it happens, carrying only itself.
+	lines := capture.snapshot()
+	Expect(lines).To(HaveLen(1))
+	Expect(lines[0].Message).To(Equal("IPSet not found"))
+	Expect(lines[0].Level).To(Equal(missingIPSetsLevel))
+	Expect(lines[0].Data).To(HaveKeyWithValue("ipsets", logutils.AggregatedValues{"missing-a"}))
+
+	// The other 199 fold into the window behind it, which closes on its own and names both sets that
+	// went missing. Without aggregation these 200 misses were 200 lines.
+	Eventually(capture.snapshot, "5s", "10ms").Should(HaveLen(2))
+	lines = capture.snapshot()
+	Expect(lines[1].Data).To(HaveKeyWithValue("ipsets", logutils.AggregatedValues{"missing-a", "missing-b"}))
+	Expect(lines[1].Data).To(HaveKeyWithValue("totalEvents", 199))
+}
+
+// TestAggregatedConditionLevels pins the severities themselves. captureCheckerLogs builds its
+// stand-ins from these same constants, so the other tests follow production wherever it goes;
+// this one is what makes moving it a deliberate edit rather than a silent one.
+func TestAggregatedConditionLevels(t *testing.T) {
+	RegisterTestingT(t)
+
+	Expect(missingIPSetsLevel).To(Equal(log.WarnLevel))
+	Expect(unparseablePrincipalsLevel).To(Equal(log.ErrorLevel))
+}
+
+// TestGetIPSetHit confirms the hit path is untouched: a set that is present is returned as-is and
+// logs nothing.
+func TestGetIPSetHit(t *testing.T) {
+	RegisterTestingT(t)
+
+	capture, restore := captureCheckerLogs()
+	defer restore()
+
+	store := policystore.NewPolicyStore()
+	store.IPSetByID["present"] = policystore.NewIPSet(proto.IPSetUpdate_IP)
+
+	req := &authz.CheckRequest{Attributes: &authz.AttributeContext{
+		Source:      &authz.AttributeContext_Peer{Principal: ""},
+		Destination: &authz.AttributeContext_Peer{Principal: ""},
+	}}
+	rc := NewRequestCache(store, NewCheckRequestToFlowAdapter(req))
+
+	Expect(rc.getIPSet("present")).NotTo(BeNil())
+	Expect(capture.snapshot()).To(BeEmpty())
+}
+
+// captureCheckerLogs points this package's aggregating loggers at one capturing logger, and returns
+// that capture alongside the func that puts the originals back. They are package-level because an
+// aggregation window is shared process-wide, so a test driving the real ones would leak both their
+// window state and their output into every other test in the package.
+//
+// The interval is cut to a fraction of the production five minutes so that a test can watch a window
+// close without waiting on one.
+func captureCheckerLogs() (*captureLogger, func()) {
+	capture := newCaptureLogger()
+	savedIPSets, savedPrincipals := missingIPSets, unparseablePrincipals
+	// Built from the production levels, not from restated literals: without OptAggregationLevel
+	// both would default to Warn, and the principal site would be exercised a level below the one
+	// it reports at. Taking the constants means a change to either severity reaches these tests.
+	missingIPSets = logutils.NewAggregatingLogger("IPSet not found", "ipsets",
+		logutils.OptAggregationLogger(capture.Logger), logutils.OptAggregationInterval(captureInterval),
+		logutils.OptAggregationLevel(missingIPSetsLevel))
+	unparseablePrincipals = logutils.NewAggregatingLogger("failed to parse principal", "principals",
+		logutils.OptAggregationLogger(capture.Logger), logutils.OptAggregationInterval(captureInterval),
+		logutils.OptAggregationLevel(unparseablePrincipalsLevel))
+	return capture, func() {
+		missingIPSets, unparseablePrincipals = savedIPSets, savedPrincipals
+	}
+}
+
+// captureInterval is long enough that a test's whole burst lands in one window, short enough that
+// waiting for that window to close costs nothing worth measuring.
+const captureInterval = 100 * time.Millisecond
+
+// captureLogger is a logrus logger recording what it was asked to write, so a test can assert on
+// it. Windows close on a timer, so lines arrive on a goroutine of their own; the mutex is what lets
+// a test read them while that is happening.
+type captureLogger struct {
+	*log.Logger
+	mu    sync.Mutex
+	lines []*log.Entry
+}
+
+func newCaptureLogger() *captureLogger {
+	c := &captureLogger{Logger: log.New()}
+	c.SetOutput(io.Discard)
+	c.SetLevel(log.DebugLevel)
+	c.AddHook(c)
+	return c
+}
+
+func (c *captureLogger) Levels() []log.Level { return log.AllLevels }
+
+func (c *captureLogger) Fire(e *log.Entry) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.lines = append(c.lines, e)
+	return nil
+}
+
+// snapshot returns the lines written so far. Gomega polls it, so it must copy rather than hand out
+// the slice the writer is appending to.
+func (c *captureLogger) snapshot() []*log.Entry {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return slices.Clone(c.lines)
+}
+
+// TestInitPeerAggregatesParseFailures covers the other converted site. A peer whose principal will
+// not parse provokes the same failure on every flow it sources, so those must collapse to one line
+// naming the principals rather than one line per flow. Aggregating on the principal is what makes
+// dropping the error harmless - parseSpiffeID's only failure is a function of the principal.
+func TestInitPeerAggregatesParseFailures(t *testing.T) {
+	RegisterTestingT(t)
+
+	capture, restore := captureCheckerLogs()
+	defer restore()
+
+	req := &authz.CheckRequest{Attributes: &authz.AttributeContext{
+		Source:      &authz.AttributeContext_Peer{Principal: ""},
+		Destination: &authz.AttributeContext_Peer{Principal: ""},
+	}}
+	rc := NewRequestCache(policystore.NewPolicyStore(), NewCheckRequestToFlowAdapter(req))
+
+	// Neither principal is a SPIFFE ID, so every call fails to parse and returns nil.
+	for range 100 {
+		Expect(rc.initPeer("not-a-spiffe-id", nil)).To(BeNil())
+		Expect(rc.initPeer("spiffe://missing-the-rest", nil)).To(BeNil())
+	}
+
+	// The first failure is reported as it happens, naming the principal rather than an error string.
+	lines := capture.snapshot()
+	Expect(lines).To(HaveLen(1))
+	Expect(lines[0].Message).To(Equal("failed to parse principal"))
+	Expect(lines[0].Level).To(Equal(unparseablePrincipalsLevel))
+	Expect(lines[0].Data).To(HaveKeyWithValue("principals", logutils.AggregatedValues{"not-a-spiffe-id"}))
+
+	// The remaining 199 fold into the window behind it, which closes on its own naming both bad
+	// principals.
+	Eventually(capture.snapshot, "5s", "10ms").Should(HaveLen(2))
+	lines = capture.snapshot()
+	Expect(lines[1].Data).To(HaveKeyWithValue("principals",
+		logutils.AggregatedValues{"not-a-spiffe-id", "spiffe://missing-the-rest"}))
+	Expect(lines[1].Data).To(HaveKeyWithValue("totalEvents", 199))
+}
 
 // Successful parse should return name and namespace.
 func TestParseSpiffeIdOk(t *testing.T) {
@@ -271,58 +442,4 @@ func TestUnparseablePrincipalIsMemoized(t *testing.T) {
 	// and re-logs the failure.
 	Expect(uut.identities[sourceSide].resolved).To(BeTrue())
 	Expect(matchServiceAccounts(nil, uut.getSrcPeer())).To(BeTrue())
-}
-
-// Repeated failures on the evaluation path are rate limited: one line, then a count of what
-// was suppressed. Without this a single dangling IP set reference logs once per rule, for
-// every request.
-func TestEvalPathWarningsAreRateLimited(t *testing.T) {
-	RegisterTestingT(t)
-
-	logger := log.StandardLogger()
-	oldLevel, oldOut := logger.GetLevel(), logger.Out
-	counter := &entryCounter{}
-	hooks := make(log.LevelHooks)
-	hooks.Add(counter)
-	oldHooks := logger.ReplaceHooks(hooks)
-	savedLogger := rlogIPSetMissing
-	defer func() {
-		logger.SetLevel(oldLevel)
-		logger.SetOutput(oldOut)
-		logger.ReplaceHooks(oldHooks)
-		rlogIPSetMissing = savedLogger
-	}()
-	logger.SetLevel(log.WarnLevel)
-	logger.SetOutput(io.Discard)
-	// A long interval with no burst allowance: the first message is written, the rest are
-	// counted.
-	rlogIPSetMissing = logutils.NewRateLimitedLogger(logutils.OptInterval(time.Hour))
-
-	uut := NewRequestCache(policystore.NewPolicyStore(), NewCheckRequestToFlowAdapter(
-		&authz.CheckRequest{Attributes: &authz.AttributeContext{}}))
-	for range 100 {
-		Expect(uut.getIPSet("missing-set")).To(BeNil())
-	}
-
-	Expect(counter.entries).To(HaveLen(1), "expected one emitted warning for 100 misses")
-	Expect(counter.entries[0].Message).To(ContainSubstring("missing-set"))
-	Expect(counter.entries[0].Data).NotTo(HaveKey("logsSkipped"))
-
-	// The suppressed count surfaces on the next line that is allowed through, so the storm is
-	// still visible in the log.
-	rlogIPSetMissing.Force().Warnf("IPSet not found: %s", "missing-set")
-	Expect(counter.entries).To(HaveLen(2))
-	Expect(counter.entries[1].Data).To(HaveKeyWithValue("logsSkipped", 99))
-}
-
-// entryCounter collects the log entries written during a test.
-type entryCounter struct {
-	entries []*log.Entry
-}
-
-func (c *entryCounter) Levels() []log.Level { return log.AllLevels }
-
-func (c *entryCounter) Fire(e *log.Entry) error {
-	c.entries = append(c.entries, e)
-	return nil
 }

--- a/libcalico-go/lib/logutils/aggregatinglogger.go
+++ b/libcalico-go/lib/logutils/aggregatinglogger.go
@@ -1,0 +1,284 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logutils
+
+import (
+	"maps"
+	"slices"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	fieldTotalEvents   = "totalEvents"
+	fieldUnnamedEvents = "unnamedEvents"
+	fieldMaxNamed      = "maxNamed"
+
+	defaultAggregationInterval = 5 * time.Minute
+	defaultAggregationLevel    = logrus.WarnLevel
+	defaultMaxNamed            = 100
+)
+
+// NewAggregatingLogger returns an AggregatingLogger that writes msg at most once per interval,
+// listing under field the distinct values that provoked it since the last line.
+//
+// Reach for it on a hot path where the same "should not happen" condition recurs keyed on some
+// value - an ID, a name, an address. Logging each occurrence floods the output; logging only the
+// first loses the fact that it is still happening; rate limiting to one arbitrary occurrence per
+// interval, as RateLimitedLogger does, cannot tell one bad value from a hundred. AggregatingLogger
+// names every distinct value it saw in the interval on a single line, so the flood is suppressed
+// without losing what caused it.
+//
+// Typical use is a package-level variable, since the aggregation window is shared process-wide:
+//
+//	var missingIPSets = logutils.NewAggregatingLogger("IPSet not found", "ipsets")
+//
+//	func lookup(id string) *ipSet {
+//	  s, ok := store[id]
+//	  if !ok {
+//	    missingIPSets.Record(id)
+//	    return nil
+//	  }
+//	  return s
+//	}
+//
+// The options are optional; see the OptAggregation* functions for the defaults. A given condition
+// is reported at one severity, so the level is set here rather than per call - use
+// OptAggregationLevel to report at anything other than Warn.
+func NewAggregatingLogger(msg, field string, opts ...AggregatingLoggerOpt) *AggregatingLogger {
+	a := &AggregatingLogger{
+		msg:       msg,
+		field:     field,
+		level:     defaultAggregationLevel,
+		interval:  defaultAggregationInterval,
+		maxNamed:  defaultMaxNamed,
+		named:     map[string]struct{}{},
+		afterFunc: func(d time.Duration, f func()) { time.AfterFunc(d, f) },
+	}
+	for _, opt := range opts {
+		opt(a)
+	}
+	return a
+}
+
+// AggregatingLoggerOpt configures an AggregatingLogger. The options are named OptAggregation* to
+// keep them apart from the RateLimitedLogger options that share this package.
+type AggregatingLoggerOpt func(*AggregatingLogger)
+
+// OptAggregationLevel sets the level the aggregated line is written at, and so also the level below
+// which Record does nothing at all. Defaults to logrus.WarnLevel. Meant for the levels between
+// Debug and Error: a line written at Fatal or Panic through this logger neither exits nor panics
+// the way a direct logrus call would.
+func OptAggregationLevel(l logrus.Level) AggregatingLoggerOpt {
+	return func(a *AggregatingLogger) {
+		a.level = l
+	}
+}
+
+// OptAggregationInterval sets the minimum gap between two emitted lines. Defaults to five minutes.
+func OptAggregationInterval(d time.Duration) AggregatingLoggerOpt {
+	return func(a *AggregatingLogger) {
+		a.interval = d
+	}
+}
+
+// OptAggregationMaxNamed caps how many distinct values one line will name, which also caps how many
+// the logger holds between lines. Defaults to 100. Occurrences of further values are counted rather
+// than named - see AggregatingLogger.Record.
+func OptAggregationMaxNamed(n int) AggregatingLoggerOpt {
+	return func(a *AggregatingLogger) {
+		a.maxNamed = n
+	}
+}
+
+// OptAggregationLogger writes to the given logrus.Logger rather than to the standard logger. Mostly
+// useful in tests; production callers should leave it unset so their output follows the process-wide
+// configuration.
+func OptAggregationLogger(l *logrus.Logger) AggregatingLoggerOpt {
+	return func(a *AggregatingLogger) {
+		a.logger = l
+	}
+}
+
+// AggregatingLogger collapses a flood of one recurring log line into a single line per interval
+// naming the distinct values behind it. Construct one with NewAggregatingLogger. Safe for
+// concurrent use.
+type AggregatingLogger struct {
+	msg   string // the message every emitted line carries
+	field string // key the list of distinct values is written under
+
+	level    logrus.Level // level every emitted line is written at
+	interval time.Duration
+	maxNamed int
+
+	// Logger to write to, or nil to use the logrus standard logger at the time a line is emitted.
+	logger *logrus.Logger
+
+	// How a window's close is scheduled. time.AfterFunc in production; tests replace it to fire the
+	// close where a real timer would, without a sleep.
+	afterFunc func(time.Duration, func())
+
+	// Lock over the window state below. Never held while writing a log.
+	mu         sync.Mutex
+	named      map[string]struct{} // distinct values to name next line, at most maxNamed of them
+	unnamed    int                 // occurrences of values maxNamed kept out of named
+	total      int                 // occurrences this window, named and unnamed alike
+	nextEmit   time.Time
+	started    bool   // whether a line has ever been emitted; until then the next Record emits
+	closeArmed bool   // whether this window's close is already scheduled
+	gen        uint64 // counts windows, so a close that a Record beat to the drain can tell
+}
+
+// Record notes one occurrence of the condition for value. It writes the aggregated line if this
+// occurrence is the first ever, or the first since the interval elapsed; otherwise the occurrence
+// folds into the current window silently and costs only a mutex and a map lookup. Below the level
+// the logger reports at it costs nothing at all, since nothing would be written.
+//
+// A window is written out when the interval elapses, whether or not anything else has happened by
+// then, so a burst that stops as abruptly as it started is still reported one interval later. It is
+// not held until the condition next recurs, which for a transient fault could be hours away, or
+// never - and which would report a flood that is long over as though it were happening now.
+//
+// Once maxNamed distinct values are held, occurrences of further values are counted into the
+// unnamedEvents field rather than named. That count is a number of occurrences, not of distinct
+// values: how many distinct values sit behind them cannot be known without retaining them, which is
+// what the cap exists to prevent.
+func (a *AggregatingLogger) Record(value string) {
+	logger := a.target()
+	if !logger.IsLevelEnabled(a.level) {
+		// Nothing would be written, so skip the bookkeeping too.
+		return
+	}
+	if w := a.sample(value, time.Now()); w != nil {
+		a.emit(logger, w)
+	}
+}
+
+// target resolves the logger to write to. When none was given it reads the standard logger on
+// every use rather than capturing it once, so that what it writes follows whatever the process
+// configures on the standard logger after this AggregatingLogger was constructed - which for a
+// package-level variable is during package initialisation, before main runs.
+func (a *AggregatingLogger) target() *logrus.Logger {
+	if a.logger != nil {
+		return a.logger
+	}
+	return logrus.StandardLogger()
+}
+
+// sample folds one occurrence of value into the current window, and returns the drained window when
+// this occurrence trips the interval gate. Otherwise it returns nil, meaning nothing to write yet,
+// and schedules the close that will write the window out when the interval elapses. Taking now as a
+// parameter is what keeps the tests off the wall clock.
+func (a *AggregatingLogger) sample(value string, now time.Time) *aggregateWindow {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	a.total++
+	if _, ok := a.named[value]; !ok {
+		if len(a.named) < a.maxNamed {
+			a.named[value] = struct{}{}
+		} else {
+			a.unnamed++
+		}
+	}
+
+	if a.started && now.Before(a.nextEmit) {
+		a.armCloseLocked(now)
+		return nil
+	}
+	return a.drainLocked(now)
+}
+
+// armCloseLocked schedules the close of the window this occurrence has just joined, unless the
+// window's close is scheduled already. Without it a window would only be written by the next
+// occurrence to arrive after the interval, so the tail of a burst that stops would sit unreported
+// until the condition recurred.
+func (a *AggregatingLogger) armCloseLocked(now time.Time) {
+	if a.closeArmed {
+		return
+	}
+	a.closeArmed = true
+	// The deadline stands in for the clock at close time. Using it rather than whenever the callback
+	// happens to run keeps windows exactly one interval apart, however late the timer is.
+	deadline, gen := a.nextEmit, a.gen
+	a.afterFunc(deadline.Sub(now), func() { a.closeWindow(gen, deadline) })
+}
+
+// closeWindow writes out the window the timer was armed for. A Record may have drained that window
+// first, in which case the generation has moved on and this timer has nothing to do.
+func (a *AggregatingLogger) closeWindow(gen uint64, deadline time.Time) {
+	logger := a.target()
+
+	a.mu.Lock()
+	if a.gen != gen || a.total == 0 {
+		a.mu.Unlock()
+		return
+	}
+	w := a.drainLocked(deadline)
+	a.mu.Unlock()
+
+	a.emit(logger, w)
+}
+
+// drainLocked takes everything the current window holds, leaving an empty one behind that runs for
+// the next interval from now.
+func (a *AggregatingLogger) drainLocked(now time.Time) *aggregateWindow {
+	w := &aggregateWindow{
+		named:   AggregatedValues(slices.Sorted(maps.Keys(a.named))), // sorted so repeated lines are comparable
+		unnamed: a.unnamed,
+		total:   a.total,
+	}
+
+	clear(a.named)
+	a.unnamed = 0
+	a.total = 0
+	a.nextEmit = now.Add(a.interval)
+	a.started = true
+	a.closeArmed = false
+	a.gen++
+	return w
+}
+
+func (a *AggregatingLogger) emit(logger *logrus.Logger, w *aggregateWindow) {
+	fields := logrus.Fields{a.field: w.named, fieldTotalEvents: w.total}
+	if w.unnamed > 0 {
+		// The value list is short of the whole story. Say how many occurrences went unnamed and what
+		// cap caused it, so a reader knows the list is partial.
+		fields[fieldUnnamedEvents] = w.unnamed
+		fields[fieldMaxNamed] = a.maxNamed
+	}
+	logger.WithFields(fields).Log(a.level, a.msg)
+}
+
+// aggregateWindow is one interval's worth of drained state, ready to be written as a single line.
+type aggregateWindow struct {
+	named   AggregatedValues // distinct values seen this window, sorted, at most maxNamed of them
+	unnamed int              // occurrences whose value the cap kept out of named
+	total   int              // occurrences this window, named and unnamed alike
+}
+
+// AggregatedValues is the list of distinct values an emitted line names. It is a type of its own so
+// that the text formatters render it as a bracketed comma-separated list - a plain []string is
+// written as a Go slice literal, which is the difference between reading a hundred IP set IDs and
+// reading a hundred IP set IDs wrapped in quotes, commas and a type name. A structured formatter
+// still sees a list of strings.
+type AggregatedValues []string
+
+func (v AggregatedValues) String() string {
+	return "[" + strings.Join(v, ",") + "]"
+}

--- a/libcalico-go/lib/logutils/aggregatinglogger.go
+++ b/libcalico-go/lib/logutils/aggregatinglogger.go
@@ -15,11 +15,14 @@
 package logutils
 
 import (
+	"fmt"
 	"maps"
 	"slices"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
+	"unicode"
 
 	"github.com/sirupsen/logrus"
 )
@@ -60,7 +63,14 @@ const (
 // The options are optional; see the OptAggregation* functions for the defaults. A given condition
 // is reported at one severity, so the level is set here rather than per call - use
 // OptAggregationLevel to report at anything other than Warn.
+//
+// The emitted line also carries the counters totalEvents, unnamedEvents and maxNamed, so field must
+// not be one of those: NewAggregatingLogger panics if it is, since an aggregator is built during
+// package initialisation and a collision is a programming error best caught there.
 func NewAggregatingLogger(msg, field string, opts ...AggregatingLoggerOpt) *AggregatingLogger {
+	if isReservedField(field) {
+		panic(fmt.Sprintf("logutils: AggregatingLogger field %q is reserved for the line's own counters", field))
+	}
 	a := &AggregatingLogger{
 		msg:       msg,
 		field:     field,
@@ -81,16 +91,22 @@ func NewAggregatingLogger(msg, field string, opts ...AggregatingLoggerOpt) *Aggr
 type AggregatingLoggerOpt func(*AggregatingLogger)
 
 // OptAggregationLevel sets the level the aggregated line is written at, and so also the level below
-// which Record does nothing at all. Defaults to logrus.WarnLevel. Meant for the levels between
-// Debug and Error: a line written at Fatal or Panic through this logger neither exits nor panics
-// the way a direct logrus call would.
+// which Record does nothing at all. Defaults to logrus.WarnLevel. An aggregated line is a report of
+// something that keeps happening, never a reason to stop the process, so a level more severe than
+// Error is written at Error: logrus panics on a line written at Panic and a direct Fatal call exits,
+// and neither belongs on the timer goroutine that closes a window.
 func OptAggregationLevel(l logrus.Level) AggregatingLoggerOpt {
 	return func(a *AggregatingLogger) {
-		a.level = l
+		// logrus orders its levels from most severe: Panic is 0, Fatal 1, Error 2.
+		a.level = max(l, logrus.ErrorLevel)
 	}
 }
 
-// OptAggregationInterval sets the minimum gap between two emitted lines. Defaults to five minutes.
+// OptAggregationInterval sets the length of an aggregation window, and so how often at most a line
+// is written. Defaults to five minutes. Windows are measured from their scheduled closes rather
+// than from when a close actually ran, so a timer that fires late does not shift the windows after
+// it - which also means the line a late close writes and the next line can be less than one
+// interval apart.
 func OptAggregationInterval(d time.Duration) AggregatingLoggerOpt {
 	return func(a *AggregatingLogger) {
 		a.interval = d
@@ -277,8 +293,49 @@ type aggregateWindow struct {
 // written as a Go slice literal, which is the difference between reading a hundred IP set IDs and
 // reading a hundred IP set IDs wrapped in quotes, commas and a type name. A structured formatter
 // still sees a list of strings.
+//
+// The text formatters in this package write a Stringer's output verbatim, so the list has to be
+// unambiguous on its own. A value that could be misread - one that is empty or contains a comma, a
+// bracket, a quote, a backslash, whitespace or anything unprintable - is written as a Go quoted
+// string; every other value is written as it is. IP set IDs and SPIFFE IDs never need quoting; an
+// arbitrary string a peer presented as its principal might.
 type AggregatedValues []string
 
 func (v AggregatedValues) String() string {
-	return "[" + strings.Join(v, ",") + "]"
+	var b strings.Builder
+	b.WriteByte('[')
+	for i, s := range v {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		if needsQuoting(s) {
+			b.WriteString(strconv.Quote(s))
+		} else {
+			b.WriteString(s)
+		}
+	}
+	b.WriteByte(']')
+	return b.String()
+}
+
+// needsQuoting reports whether s could be misread inside a bracketed comma-separated list.
+func needsQuoting(s string) bool {
+	if s == "" {
+		return true
+	}
+	for _, r := range s {
+		switch {
+		case r == ',', r == '[', r == ']', r == '"', r == '\\':
+			return true
+		case unicode.IsSpace(r), !unicode.IsPrint(r):
+			return true
+		}
+	}
+	return false
+}
+
+// isReservedField reports whether name is one of the counters every emitted line carries, which the
+// list of values therefore cannot also be written under.
+func isReservedField(name string) bool {
+	return name == fieldTotalEvents || name == fieldUnnamedEvents || name == fieldMaxNamed
 }

--- a/libcalico-go/lib/logutils/aggregatinglogger_test.go
+++ b/libcalico-go/lib/logutils/aggregatinglogger_test.go
@@ -1,0 +1,590 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// These tests sit inside the package so they can drive sample() with an explicit clock, which keeps
+// them off the wall clock and out of sleeps.
+package logutils
+
+import (
+	"fmt"
+	"io"
+	"slices"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+// t0 anchors every test to a fixed instant, so results never depend on when the suite runs.
+var t0 = time.Unix(1_700_000_000, 0)
+
+const testInterval = 5 * time.Minute
+
+// TestAggregatingLoggerFloodOfOneValue covers the simplest flood shape: one value recurring over and
+// over on a hot path. The repeats must collapse to one window per interval, and that window must
+// still account for every occurrence it swallowed.
+func TestAggregatingLoggerFloodOfOneValue(t *testing.T) {
+	a := NewAggregatingLogger("IPSet not found", "ipsets", OptAggregationInterval(testInterval))
+
+	const occurrences = 100
+	var emitted []*aggregateWindow
+	for i := range occurrences {
+		// All inside one interval, so only the very first occurrence emits.
+		if w := a.sample("s:missing", t0.Add(time.Duration(i)*time.Millisecond)); w != nil {
+			emitted = append(emitted, w)
+		}
+	}
+
+	if len(emitted) != 1 {
+		t.Fatalf("expected 1 emitted window within the interval, got %d", len(emitted))
+	}
+	// The first occurrence emits immediately, with nothing accumulated behind it yet.
+	mustNameExactly(t, emitted[0], "s:missing")
+	mustTotal(t, emitted[0], 1)
+	mustUnnamed(t, emitted[0], 0)
+
+	// Once the interval elapses the next occurrence emits, reporting every repeat it suppressed.
+	w := a.sample("s:missing", t0.Add(testInterval+time.Second))
+	if w == nil {
+		t.Fatal("expected an emitted window once the interval had elapsed")
+	}
+	mustNameExactly(t, w, "s:missing")
+	mustUnnamed(t, w, 0)
+	// occurrences-1 suppressed (the first emitted in its own window), plus this emitting one.
+	mustTotal(t, w, occurrences)
+}
+
+// TestAggregatingLoggerNamesEveryDistinctValue covers the shape that motivates this type: not one
+// value repeated but many distinct ones, each hit at volume. Suppressing by time alone would name
+// only whichever value tripped the timer; this must name them all.
+func TestAggregatingLoggerNamesEveryDistinctValue(t *testing.T) {
+	a := NewAggregatingLogger("IPSet not found", "ipsets", OptAggregationInterval(testInterval))
+
+	// The first occurrence emits immediately, carrying only itself.
+	first := a.sample("s:missing-00", t0)
+	if first == nil {
+		t.Fatal("expected the first occurrence to emit")
+	}
+	mustNameExactly(t, first, "s:missing-00")
+
+	// A burst of further distinct values inside the interval: all folded in, none emitted.
+	const distinct = 50
+	var want []string
+	for i := 1; i < distinct; i++ {
+		value := fmt.Sprintf("s:missing-%02d", i)
+		want = append(want, value)
+		if w := a.sample(value, t0.Add(time.Duration(i)*time.Millisecond)); w != nil {
+			t.Fatalf("occurrence %d emitted inside the interval, expected it to be folded in", i)
+		}
+	}
+
+	// The next occurrence after the interval emits, naming every value accumulated in the window.
+	// s:missing-00 emitted in its own window and so is not carried into this one.
+	want = append(want, "s:missing-final")
+	slices.Sort(want)
+
+	w := a.sample("s:missing-final", t0.Add(testInterval+time.Second))
+	if w == nil {
+		t.Fatal("expected an emitted window once the interval had elapsed")
+	}
+	mustNameExactly(t, w, want...)
+	mustUnnamed(t, w, 0)
+	mustTotal(t, w, distinct)
+}
+
+// TestAggregatingLoggerClosesAWindowThatGoesQuiet covers the burst that stops. Draining only when
+// the next occurrence arrives would leave everything the burst accumulated unreported until the
+// condition recurred - hours later for a transient fault, or never - and would then report it as
+// though it were happening at that moment. The window must close on its own instead.
+func TestAggregatingLoggerClosesAWindowThatGoesQuiet(t *testing.T) {
+	capture := newCaptureLogger(logrus.DebugLevel)
+	timer := &fakeTimer{}
+	a := NewAggregatingLogger("IPSet not found", "ipsets",
+		OptAggregationInterval(testInterval), OptAggregationLogger(capture.Logger))
+	a.afterFunc = timer.afterFunc
+
+	// The first occurrence emits on its own, as Record would write it.
+	w := a.sample("s:missing-00", t0)
+	if w == nil {
+		t.Fatal("expected the first occurrence to emit")
+	}
+	a.emit(capture.Logger, w)
+
+	// The rest of the burst folds in behind it, and then the condition clears: nothing arrives after
+	// this to drain what they left.
+	const distinct = 20
+	var want []string
+	for i := 1; i < distinct; i++ {
+		value := fmt.Sprintf("s:missing-%02d", i)
+		want = append(want, value)
+		if w := a.sample(value, t0.Add(time.Duration(i)*time.Millisecond)); w != nil {
+			t.Fatalf("occurrence %d emitted inside the interval, expected it to be folded in", i)
+		}
+	}
+	slices.Sort(want)
+
+	// One close per window, however many occurrences join it, and scheduled for the end of the
+	// window rather than an interval after whichever occurrence happened to schedule it.
+	if len(timer.armed) != 1 {
+		t.Fatalf("scheduled %d closes for one window, expected 1", len(timer.armed))
+	}
+	if got := timer.armed[0].after; got != testInterval-time.Millisecond {
+		t.Errorf("close scheduled in %v, expected %v", got, testInterval-time.Millisecond)
+	}
+
+	// The window closes on its own, naming everything held in it.
+	timer.armed[0].fire()
+	if n := capture.count(); n != 2 {
+		t.Fatalf("wrote %d lines, expected the first occurrence and then the closed window", n)
+	}
+	mustLoggedFields(t, capture.last(), logrus.Fields{
+		"ipsets": AggregatedValues(want), fieldTotalEvents: distinct - 1,
+	})
+}
+
+// TestAggregatingLoggerCloseYieldsToARecordThatDrainedFirst covers the two ways a window can end
+// meeting each other. An occurrence arriving after the interval drains the window itself, so the
+// close scheduled for that window must do nothing rather than write a second, empty line - while the
+// window opened behind it still gets a close of its own.
+func TestAggregatingLoggerCloseYieldsToARecordThatDrainedFirst(t *testing.T) {
+	capture := newCaptureLogger(logrus.DebugLevel)
+	timer := &fakeTimer{}
+	a := NewAggregatingLogger("IPSet not found", "ipsets",
+		OptAggregationInterval(testInterval), OptAggregationLogger(capture.Logger))
+	a.afterFunc = timer.afterFunc
+
+	if w := a.sample("s:seed", t0); w == nil {
+		t.Fatal("expected the first occurrence to emit")
+	}
+	if w := a.sample("s:held", t0.Add(time.Second)); w != nil {
+		t.Fatal("expected the second occurrence to fold into the window")
+	}
+
+	// An occurrence after the interval drains the window, taking what was held with it.
+	w := a.sample("s:drains-it", t0.Add(testInterval+time.Second))
+	if w == nil {
+		t.Fatal("expected the occurrence after the interval to emit")
+	}
+	mustNameExactly(t, w, "s:drains-it", "s:held")
+	a.emit(capture.Logger, w)
+
+	// So the close scheduled for that window has nothing left to write.
+	timer.armed[0].fire()
+	if n := capture.count(); n != 1 {
+		t.Fatalf("wrote %d lines, expected the overtaken close to write nothing", n)
+	}
+
+	// The window the drain opened schedules its own close, and that one does write.
+	if w := a.sample("s:next", t0.Add(testInterval+2*time.Second)); w != nil {
+		t.Fatal("expected the next occurrence to fold into the new window")
+	}
+	if len(timer.armed) != 2 {
+		t.Fatalf("scheduled %d closes, expected one per window", len(timer.armed))
+	}
+	timer.armed[1].fire()
+	if n := capture.count(); n != 2 {
+		t.Fatalf("wrote %d lines, expected the new window to close too", n)
+	}
+	mustLoggedFields(t, capture.last(), logrus.Fields{
+		"ipsets": AggregatedValues{"s:next"}, fieldTotalEvents: 1,
+	})
+}
+
+// fakeTimer stands in for time.AfterFunc, holding the window closes an AggregatingLogger schedules
+// so that a test can fire them where a real timer would, with no sleep and no wall clock.
+type fakeTimer struct {
+	armed []scheduledClose
+}
+
+type scheduledClose struct {
+	after time.Duration
+	fire  func()
+}
+
+func (f *fakeTimer) afterFunc(d time.Duration, fn func()) {
+	f.armed = append(f.armed, scheduledClose{after: d, fire: fn})
+}
+
+// TestAggregatingLoggerCapsNamedValues asserts the cap bounds both the emitted line and the memory
+// held behind it: past maxNamed distinct values, further ones are counted, not named.
+func TestAggregatingLoggerCapsNamedValues(t *testing.T) {
+	const maxNamed = 10
+	a := NewAggregatingLogger("IPSet not found", "ipsets",
+		OptAggregationInterval(testInterval), OptAggregationMaxNamed(maxNamed))
+
+	// Emit and reset the initial window so the next one starts empty.
+	if w := a.sample("s:seed", t0); w == nil {
+		t.Fatal("expected the first occurrence to emit")
+	}
+
+	// Feed far more distinct values than the cap, all inside the interval.
+	const distinct = 100
+	for i := range distinct {
+		a.sample(fmt.Sprintf("s:over-%03d", i), t0.Add(time.Duration(i+1)*time.Millisecond))
+	}
+
+	w := a.sample("s:trigger", t0.Add(testInterval+time.Second))
+	if w == nil {
+		t.Fatal("expected an emitted window once the interval had elapsed")
+	}
+	if len(w.named) != maxNamed {
+		t.Errorf("named %d values, expected the cap of %d", len(w.named), maxNamed)
+	}
+	// Everything that did not fit under the cap is counted instead: the distinct over-values plus
+	// the triggering one, less the maxNamed that were named.
+	mustUnnamed(t, w, distinct+1-maxNamed)
+	mustTotal(t, w, distinct+1)
+	// The accumulator itself never grew past the cap either.
+	if len(a.named) != 0 {
+		t.Errorf("accumulator holds %d values after draining, expected 0", len(a.named))
+	}
+}
+
+// TestAggregatingLoggerCountsOverflowOccurrences pins down what the overflow counter means, which is
+// the thing easiest to get wrong: it counts *occurrences* that could not be named, never distinct
+// values. One value hammering the hot path past the cap must not read as thousands of distinct
+// values - inferring a distinct count from these occurrences would overstate the problem by three
+// orders of magnitude, exactly when someone is trying to size it.
+func TestAggregatingLoggerCountsOverflowOccurrences(t *testing.T) {
+	const maxNamed = 3
+	capture := newCaptureLogger(logrus.DebugLevel)
+	a := NewAggregatingLogger("IPSet not found", "ipsets",
+		OptAggregationInterval(testInterval), OptAggregationMaxNamed(maxNamed),
+		OptAggregationLogger(capture.Logger))
+
+	if w := a.sample("s:seed", t0); w == nil {
+		t.Fatal("expected the first occurrence to emit")
+	}
+
+	// Fill the cap.
+	for i := range maxNamed {
+		a.sample(fmt.Sprintf("s:in-cap-%d", i), t0.Add(time.Duration(i+1)*time.Millisecond))
+	}
+	// Then a single further value, recurring the way a hot path makes it recur.
+	const repeats = 1000
+	for i := range repeats {
+		a.sample("s:overflow", t0.Add(time.Duration(maxNamed+1+i)*time.Millisecond))
+	}
+
+	w := a.sample("s:overflow", t0.Add(testInterval+time.Second))
+	if w == nil {
+		t.Fatal("expected an emitted window once the interval had elapsed")
+	}
+	mustNameExactly(t, w, "s:in-cap-0", "s:in-cap-1", "s:in-cap-2")
+	// Four distinct values occurred; 1001 occurrences of the fourth went unnamed.
+	mustUnnamed(t, w, repeats+1)
+	mustTotal(t, w, maxNamed+repeats+1)
+
+	// And the emitted line says so in those terms. The fields are asserted exhaustively: a line
+	// carrying anything that reads as a distinct-value count would be claiming 1004 where the truth
+	// is 4, and would do so precisely when a reader is trying to size the problem.
+	a.emit(capture.Logger, w)
+	mustLoggedFields(t, capture.last(), logrus.Fields{
+		"ipsets":           w.named,
+		fieldTotalEvents:   maxNamed + repeats + 1,
+		fieldUnnamedEvents: repeats + 1,
+		fieldMaxNamed:      maxNamed,
+	})
+}
+
+// TestAggregatingLoggerEmittedFields covers the shape of the line itself: an uncapped window says
+// only what it saw, and a capped one adds the two values that flag the list as partial.
+func TestAggregatingLoggerEmittedFields(t *testing.T) {
+	const maxNamed = 2
+	capture := newCaptureLogger(logrus.DebugLevel)
+	a := NewAggregatingLogger("IPSet not found", "ipsets",
+		OptAggregationInterval(testInterval), OptAggregationMaxNamed(maxNamed),
+		OptAggregationLogger(capture.Logger))
+
+	// An uncapped window: the value list is complete, so nothing flags it as partial.
+	a.emit(capture.Logger, &aggregateWindow{named: AggregatedValues{"s:a", "s:b"}, total: 7})
+	if got := capture.last().Message; got != "IPSet not found" {
+		t.Errorf("message %q, expected %q", got, "IPSet not found")
+	}
+	mustLoggedFields(t, capture.last(), logrus.Fields{
+		"ipsets": AggregatedValues{"s:a", "s:b"}, fieldTotalEvents: 7,
+	})
+
+	// A capped window: same values plus the two that say the list is short of the whole story.
+	a.emit(capture.Logger, &aggregateWindow{named: AggregatedValues{"s:a", "s:b"}, unnamed: 40, total: 47})
+	mustLoggedFields(t, capture.last(), logrus.Fields{
+		"ipsets":           AggregatedValues{"s:a", "s:b"},
+		fieldTotalEvents:   47,
+		fieldUnnamedEvents: 40,
+		fieldMaxNamed:      maxNamed,
+	})
+}
+
+// TestAggregatingLoggerReportsAtItsLevel asserts the level is the aggregator's, not a fixed Warn:
+// whatever OptAggregationLevel names is the level the line goes out at. The conditions worth
+// aggregating span Debug through Error - a missing entry is a warning, an uncompilable expression
+// is an error - and each wants reporting at its own severity.
+func TestAggregatingLoggerReportsAtItsLevel(t *testing.T) {
+	for _, level := range []logrus.Level{
+		logrus.ErrorLevel, logrus.WarnLevel, logrus.InfoLevel, logrus.DebugLevel,
+	} {
+		t.Run(level.String(), func(t *testing.T) {
+			capture := newCaptureLogger(logrus.DebugLevel)
+			a := NewAggregatingLogger("condition", "values",
+				OptAggregationLevel(level), OptAggregationLogger(capture.Logger))
+
+			a.Record("v:one")
+
+			if n := capture.count(); n != 1 {
+				t.Fatalf("wrote %d lines, expected 1", n)
+			}
+			if got := capture.last().Level; got != level {
+				t.Errorf("wrote at %v, expected %v", got, level)
+			}
+		})
+	}
+}
+
+// TestAggregatingLoggerDefaultsToWarn pins the default, since most callers will not name a level.
+func TestAggregatingLoggerDefaultsToWarn(t *testing.T) {
+	capture := newCaptureLogger(logrus.DebugLevel)
+	a := NewAggregatingLogger("condition", "values", OptAggregationLogger(capture.Logger))
+
+	a.Record("v:one")
+
+	if n := capture.count(); n != 1 {
+		t.Fatalf("wrote %d lines, expected 1", n)
+	}
+	if got := capture.last().Level; got != logrus.WarnLevel {
+		t.Errorf("wrote at %v, expected Warn", got)
+	}
+}
+
+// TestAggregatingLoggerSkipsWorkBelowItsLevel asserts the level guard, and that it tracks the
+// aggregator's own level rather than a fixed one: when the logger is not writing at that level,
+// Record must cost nothing at all, not merely write nothing. Being cheap on a hot path is the whole
+// point of the type.
+func TestAggregatingLoggerSkipsWorkBelowItsLevel(t *testing.T) {
+	// An Info-level aggregator against a logger writing only Warn and above: nothing it records
+	// would ever reach the output.
+	capture := newCaptureLogger(logrus.WarnLevel)
+	a := NewAggregatingLogger("condition", "values",
+		OptAggregationLevel(logrus.InfoLevel), OptAggregationInterval(testInterval),
+		OptAggregationLogger(capture.Logger))
+
+	for range 100 {
+		a.Record("v:one")
+	}
+
+	if n := capture.count(); n != 0 {
+		t.Errorf("wrote %d lines below its level, expected none", n)
+	}
+	if a.total != 0 || len(a.named) != 0 {
+		t.Errorf("accumulated total=%d named=%d below its level, expected no bookkeeping at all",
+			a.total, len(a.named))
+	}
+
+	// Turning the logger up to Info resumes both.
+	capture.SetLevel(logrus.InfoLevel)
+	a.Record("v:one")
+	if n := capture.count(); n != 1 {
+		t.Errorf("wrote %d lines once the logger reached Info, expected 1", n)
+	}
+}
+
+// TestAggregatingLoggerFollowsTheStandardLogger covers the trap this type is most likely to fall
+// into. An AggregatingLogger is meant to be a package-level variable, so it is constructed during
+// package initialisation - before main configures logging. Whatever it captured of the standard
+// logger's configuration at that point would be stale; it must consult the standard logger at the
+// point it writes, so that a level set later is the level it honours.
+func TestAggregatingLoggerFollowsTheStandardLogger(t *testing.T) {
+	std := logrus.StandardLogger()
+	savedLevel, savedOut := std.GetLevel(), std.Out
+	savedHooks := std.ReplaceHooks(make(logrus.LevelHooks))
+	t.Cleanup(func() {
+		std.SetLevel(savedLevel)
+		std.SetOutput(savedOut)
+		std.ReplaceHooks(savedHooks)
+	})
+	std.SetOutput(io.Discard)
+	recorder := &entryRecorder{}
+	std.AddHook(recorder)
+
+	// Construct while the standard logger sits above the aggregator's level, as a package-level
+	// variable might before main has configured logging.
+	std.SetLevel(logrus.ErrorLevel)
+	a := NewAggregatingLogger("condition", "values")
+
+	// Nothing is written, and since nothing would be, nothing accumulates either.
+	a.Record("v:one")
+	if n := recorder.count(); n != 0 {
+		t.Fatalf("wrote %d lines while the standard logger was above Warn, expected none", n)
+	}
+	if a.total != 0 {
+		t.Fatalf("accumulated total=%d while the standard logger was above Warn, expected 0", a.total)
+	}
+
+	// Now main configures the level, and the aggregator follows.
+	std.SetLevel(logrus.WarnLevel)
+	a.Record("v:two")
+
+	if n := recorder.count(); n != 1 {
+		t.Fatalf("wrote %d lines after the standard logger reached Warn, expected 1", n)
+	}
+	mustLoggedFields(t, recorder.last(), logrus.Fields{
+		"values": AggregatedValues{"v:two"}, fieldTotalEvents: 1,
+	})
+}
+
+// TestAggregatingLoggerRecordUsesWallClock covers the one thing sample() cannot: that Record wires
+// itself to the real clock, so a second call inside the interval is suppressed.
+func TestAggregatingLoggerRecordUsesWallClock(t *testing.T) {
+	capture := newCaptureLogger(logrus.DebugLevel)
+	a := NewAggregatingLogger("condition", "values",
+		OptAggregationInterval(time.Hour), OptAggregationLogger(capture.Logger))
+
+	a.Record("v:first")
+	a.Record("v:second")
+
+	if n := capture.count(); n != 1 {
+		t.Fatalf("wrote %d lines within the interval, expected 1", n)
+	}
+	mustLoggedFields(t, capture.last(), logrus.Fields{
+		"values": AggregatedValues{"v:first"}, fieldTotalEvents: 1,
+	})
+}
+
+// TestAggregatingLoggerRecordSchedulesTheWindowClose covers the other half of that wiring: Record
+// schedules the close as well as folding the occurrence in, so what it folded in is written out
+// without a further Record to drain it.
+func TestAggregatingLoggerRecordSchedulesTheWindowClose(t *testing.T) {
+	capture := newCaptureLogger(logrus.DebugLevel)
+	timer := &fakeTimer{}
+	a := NewAggregatingLogger("condition", "values",
+		OptAggregationInterval(time.Hour), OptAggregationLogger(capture.Logger))
+	a.afterFunc = timer.afterFunc
+
+	a.Record("v:first")  // Emits immediately.
+	a.Record("v:second") // Folds into the window behind it, and schedules that window's close.
+
+	if len(timer.armed) != 1 {
+		t.Fatalf("scheduled %d closes, expected 1", len(timer.armed))
+	}
+	timer.armed[0].fire()
+
+	if n := capture.count(); n != 2 {
+		t.Fatalf("wrote %d lines, expected the first occurrence and then the closed window", n)
+	}
+	mustLoggedFields(t, capture.last(), logrus.Fields{
+		"values": AggregatedValues{"v:second"}, fieldTotalEvents: 1,
+	})
+}
+
+// TestAggregatedValuesRenderAsAList pins the text form the formatters in this package write: a
+// bracketed comma-separated list, not a Go slice literal.
+func TestAggregatedValuesRenderAsAList(t *testing.T) {
+	got := AggregatedValues{"s:a", "s:b"}.String()
+	if got != "[s:a,s:b]" {
+		t.Errorf("rendered %q, expected %q", got, "[s:a,s:b]")
+	}
+}
+
+// captureLogger is a logrus.Logger that records what it was asked to write, so a test can assert
+// on it. Windows close on a timer, so lines can arrive on a goroutine of their own; the recorder's
+// mutex is what lets a test read them while that is happening.
+type captureLogger struct {
+	*logrus.Logger
+	entryRecorder
+}
+
+func newCaptureLogger(level logrus.Level) *captureLogger {
+	c := &captureLogger{Logger: logrus.New()}
+	c.SetOutput(io.Discard)
+	c.SetLevel(level)
+	c.AddHook(&c.entryRecorder)
+	return c
+}
+
+// entryRecorder is a logrus hook that keeps every entry written through it.
+type entryRecorder struct {
+	mu      sync.Mutex
+	entries []*logrus.Entry
+}
+
+func (r *entryRecorder) Levels() []logrus.Level { return logrus.AllLevels }
+
+func (r *entryRecorder) Fire(e *logrus.Entry) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.entries = append(r.entries, e)
+	return nil
+}
+
+func (r *entryRecorder) count() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.entries)
+}
+
+func (r *entryRecorder) last() *logrus.Entry {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if len(r.entries) == 0 {
+		return &logrus.Entry{}
+	}
+	return r.entries[len(r.entries)-1]
+}
+
+// mustLoggedFields asserts the entry carried exactly the given fields. Exhaustive by design: an
+// extra field is as much a defect as a missing one.
+func mustLoggedFields(t *testing.T, entry *logrus.Entry, want logrus.Fields) {
+	t.Helper()
+	if len(entry.Data) != len(want) {
+		t.Fatalf("line carried %d fields %v, expected %d %v", len(entry.Data), entry.Data, len(want), want)
+	}
+	for key, expected := range want {
+		got, ok := entry.Data[key]
+		if !ok {
+			t.Errorf("field %q missing from %v", key, entry.Data)
+			continue
+		}
+		if gotSlice, ok := got.(AggregatedValues); ok {
+			expectedSlice, ok := expected.(AggregatedValues)
+			if !ok || !slices.Equal(gotSlice, expectedSlice) {
+				t.Errorf("field %q is %v, expected %v", key, got, expected)
+			}
+			continue
+		}
+		if got != expected {
+			t.Errorf("field %q is %v, expected %v", key, got, expected)
+		}
+	}
+}
+
+func mustNameExactly(t *testing.T, w *aggregateWindow, want ...string) {
+	t.Helper()
+	if !slices.Equal(w.named, AggregatedValues(want)) {
+		t.Errorf("named %v, expected %v", w.named, want)
+	}
+}
+
+func mustTotal(t *testing.T, w *aggregateWindow, want int) {
+	t.Helper()
+	if w.total != want {
+		t.Errorf("total %d, expected %d", w.total, want)
+	}
+}
+
+func mustUnnamed(t *testing.T, w *aggregateWindow, want int) {
+	t.Helper()
+	if w.unnamed != want {
+		t.Errorf("unnamed %d, expected %d", w.unnamed, want)
+	}
+}

--- a/libcalico-go/lib/logutils/aggregatinglogger_test.go
+++ b/libcalico-go/lib/logutils/aggregatinglogger_test.go
@@ -488,11 +488,67 @@ func TestAggregatingLoggerRecordSchedulesTheWindowClose(t *testing.T) {
 }
 
 // TestAggregatedValuesRenderAsAList pins the text form the formatters in this package write: a
-// bracketed comma-separated list, not a Go slice literal.
+// bracketed comma-separated list, not a Go slice literal, in which a value that could be misread
+// is quoted and every other value is written as it is. The formatters write a Stringer verbatim,
+// so this is the only place the list can be made unambiguous - and the principal site feeds it
+// whatever string a peer presented.
 func TestAggregatedValuesRenderAsAList(t *testing.T) {
-	got := AggregatedValues{"s:a", "s:b"}.String()
-	if got != "[s:a,s:b]" {
-		t.Errorf("rendered %q, expected %q", got, "[s:a,s:b]")
+	for _, tc := range []struct {
+		values AggregatedValues
+		want   string
+	}{
+		{AggregatedValues{"s:a", "s:b"}, "[s:a,s:b]"},
+		{AggregatedValues{"spiffe://cluster.local/ns/a/sa/b"}, "[spiffe://cluster.local/ns/a/sa/b]"},
+		// Two values that would otherwise read as one, and one that would read as two.
+		{AggregatedValues{"a", "b", "a,b"}, `[a,b,"a,b"]`},
+		{AggregatedValues{"has space", "tab\there"}, `["has space","tab\there"]`},
+		{AggregatedValues{"line\nbreak"}, `["line\nbreak"]`},
+		{AggregatedValues{`q"uote`, `back\slash`, "[bracketed]"}, `["q\"uote","back\\slash","[bracketed]"]`},
+		{AggregatedValues{""}, `[""]`},
+		{AggregatedValues{}, "[]"},
+	} {
+		if got := tc.values.String(); got != tc.want {
+			t.Errorf("%q rendered as %s, expected %s", []string(tc.values), got, tc.want)
+		}
+	}
+}
+
+// TestAggregatingLoggerClampsLevelsAboveError pins the contract OptAggregationLevel documents: a
+// level more severe than Error is written at Error. logrus panics on a line written at Panic, and
+// this logger writes from a timer goroutine, where that panic would take the process down.
+func TestAggregatingLoggerClampsLevelsAboveError(t *testing.T) {
+	for _, level := range []logrus.Level{logrus.PanicLevel, logrus.FatalLevel} {
+		t.Run(level.String(), func(t *testing.T) {
+			capture := newCaptureLogger(logrus.DebugLevel)
+			capture.ExitFunc = func(int) { t.Fatal("the logger exited the process") }
+			a := NewAggregatingLogger("condition", "values",
+				OptAggregationLevel(level), OptAggregationLogger(capture.Logger))
+
+			a.Record("v:one") // Must neither panic nor exit.
+
+			if n := capture.count(); n != 1 {
+				t.Fatalf("wrote %d lines, expected 1", n)
+			}
+			if got := capture.last().Level; got != logrus.ErrorLevel {
+				t.Errorf("wrote at %v, expected Error", got)
+			}
+		})
+	}
+}
+
+// TestAggregatingLoggerRejectsReservedFields pins the other constructor contract: the list of values
+// cannot be written under the name of one of the counters the same line carries, or one would
+// silently overwrite the other.
+func TestAggregatingLoggerRejectsReservedFields(t *testing.T) {
+	for _, field := range []string{fieldTotalEvents, fieldUnnamedEvents, fieldMaxNamed} {
+		t.Run(field, func(t *testing.T) {
+			defer func() {
+				if recover() == nil {
+					t.Errorf("NewAggregatingLogger accepted the reserved field %q", field)
+				}
+			}()
+			NewAggregatingLogger("condition", field)
+		})
 	}
 }
 


### PR DESCRIPTION
Backport to `release-v3.32` of the Dikastes log-aggregation change that is on master as #13889 (from tigera/calico-private#13119).

Dikastes evaluates policy per flow, and two log lines in that path fire once per flow whenever a single bad rule or a transient store gap exists:

- "IPSet not found", from `getIPSet`, which every rule carrying an IP set reference reaches for each of its Src/Dst/NotSrc/NotDst set IDs; and
- "failed to parse principal", from `initPeer`, for every flow a peer with an unparseable principal sources.

On this branch both are rate-limited through `libcalico-go/lib/logutils`. That suppresses the flood but keeps only whichever occurrence happened to trip the timer, which cannot distinguish one stale reference from a sync that is wholly behind - the thing a reader needs to know.

So this adds `AggregatingLogger`, which holds one window per interval and emits a single line naming every distinct value seen in it. The suppressed path costs a mutex and a map lookup, and below the level the aggregator reports at it costs nothing. A cap (100 by default) bounds both the emitted line and the map behind it; occurrences past the cap are counted as `unnamedEvents` rather than named. A window is written out when its interval elapses rather than when the next occurrence arrives, so a burst that stops as abruptly as it started is still reported one interval later. The level is the aggregator's own: a missing IP set is a warning, an unparseable principal is an error.

**How this differs from master.** This branch predates the `lib/std/log` facade and `lib/logrusr`, so rather than pulling the facade onto a release branch, `AggregatingLogger` lands in `libcalico-go/lib/logutils` beside `RateLimitedLogger` and writes through logrus directly. Its behaviour and tests are those of the master implementation; the option names carry an `OptAggregation` prefix to keep clear of the `RateLimitedLogger` options in the same package. The facade registration in dikastes and Felix and the `lib/logrusr` caller-lookup change have no counterpart here. This is the same implementation the Enterprise release branches carry (tigera/calico-private#13847).

The checker changes follow the master pick: both sites convert to the aggregators and their rate limiters go; the Evaluate benchmark grows the `MissingSetsUnaggregated` variant, which measures what aggregation saves per evaluation (roughly 51 allocs and 0.6 KB with aggregation against roughly 700 allocs and 41 KB writing a line per miss, at the scale the benchmark models); `requestcache_test.go` gains the aggregation tests, driving the aggregators through a capturing logrus logger; and `TestEvalPathWarningsAreRateLimited`, which drove the missing-IP-set limiter, now drives the bad-CIDR limiter instead.

**Testing:** `go test ./libcalico-go/lib/logutils/ ./app-policy/checker/` passes; `golangci-lint run --new-from-rev upstream/release-v3.32` over both packages reports no issues; the benchmark's pre-flight check confirms the per-evaluation miss count against the analytic count.

**Release note:**
```release-note
Dikastes and Felix now report the recurring policy-evaluation conditions "IPSet not found" and "failed to parse principal" as one aggregated log line per five-minute window, naming every IP set or principal seen in that window, in place of a rate-limited line per flow. The aggregated lines carry the IP set IDs and principals in list-valued "ipsets" and "principals" fields rather than in the message text, and no longer carry the rate limiter's "logsSkipped" count.
```

**AI assistance:** Claude Code. Claude Opus 5 helped write the original change in calico-private; Claude Fable 5.1 performed this pick and its adaptation to this branch.

By opening this PR you take responsibility for every line in it, and you agree to explain the change yourself during review rather than routing review comments back through an agent. See [AI_POLICY.md](../AI_POLICY.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
